### PR TITLE
fix(validator): DAH-408 - remove rent though no executor is returned

### DIFF
--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -50,7 +50,10 @@ class Validator:
         )
         docker_service = DockerService(ssh_service=ssh_service, executor_dao=executor_dao)
         self.miner_service = MinerService(
-            ssh_service=ssh_service, task_service=task_service, docker_service=docker_service
+            ssh_service=ssh_service,
+            task_service=task_service,
+            docker_service=docker_service,
+            executor_dao=executor_dao,
         )
 
     def get_subtensor(self):

--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -68,7 +68,7 @@ class ContainerDeleteRequest(ContainerBaseRequest):
 
 class ContainerResponseType(enum.Enum):
     ContainerCreated = "ContainerCreated"
-    ContainerStarted = ("ContainerStarted",)
+    ContainerStarted = "ContainerStarted"
     ContainerStopped = "ContainerStopped"
     ContainerDeleted = "ContainerDeleted"
     FailedRequest = "FailedRequest"

--- a/neurons/validators/src/services/ioc.py
+++ b/neurons/validators/src/services/ioc.py
@@ -26,6 +26,7 @@ def initiate_services():
         ssh_service=ioc["SSHService"],
         task_service=ioc["TaskService"],
         docker_service=ioc["DockerService"],
+        executor_dao=ioc["ExecutorDao"],
     )
 
 


### PR DESCRIPTION
## Describe your changes

If the miner doesn't return an executor to the validator, despite the validator providing the correct executor id, the process of removing the rent fails. Fixed this issue so that the validator will mark the executor as not rented and won't assign the maximum score, even if the miner doesn't return an executor.

## Issue ticket number and link

[Subnet - Unrent Executor If Miner returns no executor](https://www.notion.so/Compute-SN-c27d35dd084e4c4d92374f55cdd293f2?p=11cb8bfdbde9805795daf1a45c8a8fe6&pm=s)

