### PR TITLE
fix(validator): json serialize error in structured logging

### DIFF
--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -25,14 +25,14 @@ from payload_models.payloads import (
     FailedContainerRequest,
     MinerJobRequestPayload,
 )
+from protocol.vc_protocol.compute_requests import RentedMachine
 
 from core.config import settings
 from core.utils import _m, get_extra_info
 from services.docker_service import DockerService
+from services.redis_service import MACHINE_SPEC_CHANNEL_NAME, RedisService
 from services.ssh_service import SSHService
 from services.task_service import TaskService
-from services.redis_service import RedisService, MACHINE_SPEC_CHANNEL_NAME
-from protocol.vc_protocol.compute_requests import RentedMachine
 
 logger = logging.getLogger(__name__)
 
@@ -320,7 +320,9 @@ class MinerService:
                             miner_hotkey=payload.miner_hotkey,
                             executor_id=payload.executor_id,
                             executor_ip_address=executor.address,
-                            executor_ip_port=str(executor.port,)
+                            executor_ip_port=str(
+                                executor.port,
+                            ),
                         )
                     )
 
@@ -335,7 +337,7 @@ class MinerService:
                         logger.info(
                             _m(
                                 "Creating container",
-                                extra=get_extra_info({**default_extra, "payload": payload}),
+                                extra=get_extra_info({**default_extra, "payload": str(payload)}),
                             ),
                         )
                         result = await self.docker_service.create_container(
@@ -348,7 +350,7 @@ class MinerService:
                         logger.info(
                             _m(
                                 "Created Container",
-                                extra=get_extra_info({**default_extra, "result": result}),
+                                extra=get_extra_info({**default_extra, "result": str(result)}),
                             ),
                         )
                         await miner_client.send_model(
@@ -368,7 +370,7 @@ class MinerService:
                         logger.info(
                             _m(
                                 "Starting container",
-                                extra=get_extra_info({**default_extra, "payload": payload}),
+                                extra=get_extra_info({**default_extra, "payload": str(payload)}),
                             ),
                         )
                         await self.docker_service.start_container(
@@ -381,7 +383,7 @@ class MinerService:
                         logger.info(
                             _m(
                                 "Started Container",
-                                extra=get_extra_info({**default_extra, "payload": payload}),
+                                extra=get_extra_info({**default_extra, "payload": str(payload)}),
                             ),
                         )
                         await miner_client.send_model(
@@ -417,7 +419,7 @@ class MinerService:
                         logger.info(
                             _m(
                                 "Deleting container",
-                                extra=get_extra_info({**default_extra, "payload": payload}),
+                                extra=get_extra_info({**default_extra, "payload": str(payload)}),
                             ),
                         )
                         await self.docker_service.delete_container(
@@ -430,7 +432,7 @@ class MinerService:
                         logger.info(
                             _m(
                                 "Deleted Container",
-                                extra=get_extra_info({**default_extra, "payload": payload}),
+                                extra=get_extra_info({**default_extra, "payload": str(payload)}),
                             ),
                         )
                         await miner_client.send_model(
@@ -449,7 +451,7 @@ class MinerService:
                         logger.error(
                             _m(
                                 "Unexpected request",
-                                extra=get_extra_info({**default_extra, "payload": payload}),
+                                extra=get_extra_info({**default_extra, "payload": str(payload)}),
                             ),
                         )
                         return FailedContainerRequest(


### PR DESCRIPTION
## Describe your changes

- Pydantic models is not JSON serializable. So, when we build structured message, we must convert it to string in advance. 

## Issue ticket number and link

I noticed following error on server in renting workflow. You can check detailed logs [here](https://app.mezmo.com/f257535617/logs/view?b=1729778226000.1802620535500513297&e=1729779133000.1802624340719554571&tags=tav-vali-connector)
```
Oct 24 07:04:16 23ee964e26f7 connector error --- Logging error ---
Oct 24 07:04:16 23ee964e26f7 connector Traceback (most recent call last):
Oct 24 07:04:16 23ee964e26f7 connector   File "/usr/local/lib/python3.11/logging/__init__.py", line 1110, in emit
Oct 24 07:04:16 23ee964e26f7 connector     msg = self.format(record)
Oct 24 07:04:16 23ee964e26f7 connector           ^^^^^^^^^^^^^^^^^^^
Oct 24 07:04:16 23ee964e26f7 connector   File "/usr/local/lib/python3.11/logging/__init__.py", line 953, in format
Oct 24 07:04:16 23ee964e26f7 connector     return fmt.format(record)
Oct 24 07:04:16 23ee964e26f7 connector            ^^^^^^^^^^^^^^^^^^
Oct 24 07:04:16 23ee964e26f7 connector   File "/usr/local/lib/python3.11/logging/__init__.py", line 687, in format
Oct 24 07:04:16 23ee964e26f7 connector     record.message = record.getMessage()
Oct 24 07:04:16 23ee964e26f7 connector                      ^^^^^^^^^^^^^^^^^^^
Oct 24 07:04:16 23ee964e26f7 connector   File "/usr/local/lib/python3.11/logging/__init__.py", line 375, in getMessage
Oct 24 07:04:16 23ee964e26f7 connector     msg = str(self.msg)
Oct 24 07:04:16 23ee964e26f7 connector           ^^^^^^^^^^^^^
Oct 24 07:04:16 23ee964e26f7 connector   File "/root/app/src/core/utils.py", line 128, in __str__
Oct 24 07:04:16 23ee964e26f7 connector     return "%s >>> %s" % (self.message, json.dumps(self.extra))  # noqa
Oct 24 07:04:16 23ee964e26f7 connector                                         ^^^^^^^^^^^^^^^^^^^^^^
Oct 24 07:04:16 23ee964e26f7 connector   File "/usr/local/lib/python3.11/json/__init__.py", line 231, in dumps
Oct 24 07:04:16 23ee964e26f7 connector     return _default_encoder.encode(obj)
Oct 24 07:04:16 23ee964e26f7 connector            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 24 07:04:16 23ee964e26f7 connector   File "/usr/local/lib/python3.11/json/encoder.py", line 200, in encode
Oct 24 07:04:16 23ee964e26f7 connector     chunks = self.iterencode(o, _one_shot=True)
Oct 24 07:04:16 23ee964e26f7 connector              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 24 07:04:16 23ee964e26f7 connector   File "/usr/local/lib/python3.11/json/encoder.py", line 258, in iterencode
Oct 24 07:04:16 23ee964e26f7 connector     return _iterencode(o, 0)
Oct 24 07:04:16 23ee964e26f7 connector            ^^^^^^^^^^^^^^^^^
Oct 24 07:04:16 23ee964e26f7 connector   File "/usr/local/lib/python3.11/json/encoder.py", line 180, in default
Oct 24 07:04:16 23ee964e26f7 connector     raise TypeError(f'Object of type {o.__class__.__name__} '
Oct 24 07:04:16 23ee964e26f7 connector TypeError: Object of type ContainerCreatedResult is not JSON serializable
Oct 24 07:04:16 23ee964e26f7 connector Call stack:
Oct 24 07:04:16 23ee964e26f7 connector   File "/root/app/src/connector.py", line 34, in <module>
Oct 24 07:04:16 23ee964e26f7 connector     start_process()
Oct 24 07:04:16 23ee964e26f7 connector   File "/root/app/src/connector.py", line 30, in start_process
Oct 24 07:04:16 23ee964e26f7 connector     loop.run_until_complete(run_forever())
Oct 24 07:04:16 23ee964e26f7 connector   File "/opt/pypackages/lib/nest_asyncio.py", line 92, in run_until_complete
Oct 24 07:04:16 23ee964e26f7 connector     self._run_once()
Oct 24 07:04:16 23ee964e26f7 connector   File "/opt/pypackages/lib/nest_asyncio.py", line 133, in _run_once
Oct 24 07:04:16 23ee964e26f7 connector     handle._run()
Oct 24 07:04:16 23ee964e26f7 connector   File "/usr/local/lib/python3.11/asyncio/events.py", line 84, in _run
Oct 24 07:04:16 23ee964e26f7 connector     self._context.run(self._callback, *self._args)
Oct 24 07:04:16 23ee964e26f7 connector   File "/usr/local/lib/python3.11/asyncio/tasks.py", line 360, in __wakeup
Oct 24 07:04:16 23ee964e26f7 connector     self.__step()
Oct 24 07:04:16 23ee964e26f7 connector   File "/usr/local/lib/python3.11/asyncio/tasks.py", line 277, in __step
Oct 24 07:04:16 23ee964e26f7 connector     result = coro.send(None)
Oct 24 07:04:16 23ee964e26f7 connector   File "/root/app/src/clients/compute_client.py", line 413, in miner_driver
Oct 24 07:04:16 23ee964e26f7 connector     container_created: ContainerCreated = await self.miner_service.handle_container(
Oct 24 07:04:16 23ee964e26f7 connector   File "/root/app/src/services/miner_service.py", line 348, in handle_container
Oct 24 07:04:16 23ee964e26f7 connector     logger.info(
Oct 24 07:04:16 23ee964e26f7 connector Message: <core.utils.StructuredMessage object at 0x7575fb398590>
Oct 24 07:04:16 23ee964e26f7 connector Arguments: ()
```
