### PR TITLE
track exeuctors count per miner

### DIFF
--- a/neurons/validators/.gitignore
+++ b/neurons/validators/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+logs

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -72,6 +72,13 @@ class Validator:
         try:
             if await self.should_set_weights(subtensor):
                 self.miner_scores = {}
+
+                # clear executor_counts
+                try:
+                    await self.redis_service.clear_all_executor_counts()
+                    bittensor.logging.info(f"Cleared executor_counts")
+                except Exception as e:
+                    bittensor.logging.error(f"Failed to clear executor_counts: {str(e)}")
             else:
                 miner_scores_json = await self.redis_service.get(MINER_SCORES_KEY)
                 if miner_scores_json is None:
@@ -207,6 +214,13 @@ class Validator:
 
         bittensor.logging.info("Reset miner scores")
         self.miner_scores = {}
+
+        # clear executor_counts
+        try:
+            await self.redis_service.clear_all_executor_counts()
+            bittensor.logging.info(f"Cleared executor_counts")
+        except Exception as e:
+            bittensor.logging.error(f"Failed to clear executor_counts: {str(e)}")
 
     def get_last_update(self, subtensor: bittensor.subtensor, block):
         try:

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -15,7 +15,7 @@ from payload_models.payloads import MinerJobRequestPayload
 from core.config import settings
 from services.docker_service import DockerService
 from services.miner_service import MinerService
-from services.redis_service import RedisService
+from services.redis_service import RedisService, EXECUTOR_COUNT_PREFIX
 from services.ssh_service import SSHService
 from services.task_service import TaskService
 
@@ -343,27 +343,34 @@ class Validator:
                             bittensor.logging.info(f"Job score: {result}", "sync", "sync")
                             miner_hotkey = result.get("miner_hotkey")
                             job_score = result.get("score")
+
+                            key = f"{EXECUTOR_COUNT_PREFIX}:{miner_hotkey}"
+
+                            try:
+                                executor_counts = await self.redis_service.hgetall(key)
+                                parsed_counts = [
+                                    {
+                                        "job_batch_id": job_id.decode('utf-8'),
+                                        **json.loads(data.decode('utf-8')),
+                                    }
+                                    for job_id, data in executor_counts.items()
+                                ]
+
+                                if parsed_counts:
+                                    bittensor.logging.info(f"[executor_counts_list] miner_hotkey: {miner_hotkey}, list: {parsed_counts}")
+                                    
+                                    max_executors = max(parsed_counts, key=lambda x: x['total'])['total']
+                                    min_executors = min(parsed_counts, key=lambda x: x['total'])['total']
+
+                                    bittensor.logging.info(f"[executor_counts] miner_hotkey: {miner_hotkey}, job_batch_id: {job_batch_id}, Max: {max_executors}, Min: {min_executors}")
+
+                            except Exception as e:
+                                bittensor.logging.error(f"[Get executor_counts] miner_hotkey: {miner_hotkey}, job_batch_id: {job_batch_id}", "sync", "sync")
+
                             if miner_hotkey in self.miner_scores:
                                 self.miner_scores[miner_hotkey] += job_score
                             else:
                                 self.miner_scores[miner_hotkey] = job_score
-
-                    bittensor.logging.info(f"miner scores: {self.miner_scores}", "sync", "sync")
-
-                    for index, result in enumerate(results):
-                        miner = miners[index]
-                        if isinstance(result, Exception):
-                            bittensor.logging.error(
-                                f"Job for miner({miner.hotkey}-{miner.axon_info.ip}:{miner.axon_info.port}) resulted in an exception: {result}",
-                                "sync",
-                                "sync",
-                            )
-                        else:
-                            bittensor.logging.info(
-                                f"Job for miner({miner.hotkey}-{miner.axon_info.ip}:{miner.axon_info.port}) completed successfully: {result}",
-                                "sync",
-                                "sync",
-                            )
 
                     bittensor.logging.info("All Jobs finished", "sync", "sync")
                     bittensor.logging.info(f"miner_scores: {self.miner_scores}", "sync", "sync")

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from typing import Annotated
+import json
 
 import bittensor
 from clients.miner_client import MinerClient
@@ -30,7 +31,7 @@ from protocol.vc_protocol.compute_requests import RentedMachine
 from core.config import settings
 from core.utils import _m, get_extra_info
 from services.docker_service import DockerService
-from services.redis_service import MACHINE_SPEC_CHANNEL_NAME, RedisService
+from services.redis_service import RedisService, MACHINE_SPEC_CHANNEL_NAME, EXECUTOR_COUNT_PREFIX
 from services.ssh_service import SSHService
 from services.task_service import TaskService
 
@@ -135,8 +136,12 @@ class MinerService:
                             extra=get_extra_info({**default_extra, "executors": len(results)}),
                         ),
                     )
-                    await self.publish_machine_specs(results, miner_client.miner_hotkey)
+
                     await miner_client.send_model(SSHPubKeyRemoveRequest(public_key=public_key))
+
+                    await self.publish_machine_specs(results, miner_client.miner_hotkey)
+
+                    await self.store_executor_counts(payload.miner_hotkey, payload.job_batch_id, len(msg.executors), results)
 
                     total_score = 0
                     for _, _, score, _, _, _ in results:
@@ -230,6 +235,68 @@ class MinerService:
                     ),
                     exc_info=True,
                 )
+
+    async def store_executor_counts(self, miner_hotkey: str, job_batch_id: str, total: int, results: list[dict]):
+        default_extra = {
+            "job_batch_id": job_batch_id,
+            "miner_hotkey": miner_hotkey,
+        }
+
+        success = 0
+        failed = 0
+
+        for _, _, score, _, _, _ in results:
+            if score > 0:
+                success += 1
+            else:
+                failed += 1
+
+        data = {
+            "total": total,
+            "success": success,
+            "failed": failed
+        }
+
+        key = f"{EXECUTOR_COUNT_PREFIX}:{miner_hotkey}"
+
+        try:
+            await self.redis_service.hset(key, job_batch_id, json.dumps(data))
+
+            logger.info(
+                _m(
+                    "Stored executor counts",
+                    extra=get_extra_info({**default_extra, **data}),
+                ),
+            )
+        except Exception as e:
+            logger.error(
+                _m(
+                    "Failed storing executor counts",
+                    extra=get_extra_info({**default_extra, **data, "error": str(e)}),
+                ),
+                exc_info=True,
+            )
+
+        # # test - get all executor_counts
+        # try:
+        #     executor_counts = await self.redis_service.hgetall(key)
+        #     parsed_counts = [
+        #         {
+        #             "job_batch_id": job_batch_id.decode('utf-8'),
+        #             **json.loads(data.decode('utf-8')),
+        #         }
+        #         for job_batch_id, data in executor_counts.items()
+        #     ]
+
+        #     print('parsed_counts ========>', parsed_counts)
+        # except Exception as e:
+        #     logger.error(
+        #         _m(
+        #             "Failed get all executor counts",
+        #             extra=get_extra_info({**default_extra, "error": str(e)}),
+        #         ),
+        #         exc_info=True,
+        #     )
 
     async def handle_container(self, payload: ContainerBaseRequest):
         loop = asyncio.get_event_loop()

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -277,27 +277,6 @@ class MinerService:
                 exc_info=True,
             )
 
-        # # test - get all executor_counts
-        # try:
-        #     executor_counts = await self.redis_service.hgetall(key)
-        #     parsed_counts = [
-        #         {
-        #             "job_batch_id": job_batch_id.decode('utf-8'),
-        #             **json.loads(data.decode('utf-8')),
-        #         }
-        #         for job_batch_id, data in executor_counts.items()
-        #     ]
-
-        #     print('parsed_counts ========>', parsed_counts)
-        # except Exception as e:
-        #     logger.error(
-        #         _m(
-        #             "Failed get all executor counts",
-        #             extra=get_extra_info({**default_extra, "error": str(e)}),
-        #         ),
-        #         exc_info=True,
-        #     )
-
     async def handle_container(self, payload: ContainerBaseRequest):
         loop = asyncio.get_event_loop()
         my_key: bittensor.Keypair = settings.get_bittensor_wallet().get_hotkey()

--- a/neurons/validators/src/services/redis_service.py
+++ b/neurons/validators/src/services/redis_service.py
@@ -6,6 +6,7 @@ from core.config import settings
 
 MACHINE_SPEC_CHANNEL_NAME = "channel:1"
 RENTED_MACHINE_SET = "rented_machines"
+EXECUTOR_COUNT_PREFIX = "executor_counts"
 
 
 class RedisService:
@@ -63,3 +64,36 @@ class RedisService:
 
     async def remove_rented_machine(self, machine: RentedMachine):
         await self.srem(RENTED_MACHINE_SET, f"{machine.miner_hotkey}:{machine.executor_id}")
+
+    async def hset(self, key: str, field: str, value: str):
+        async with self.lock:
+            await self.redis.hset(key, field, value)
+
+    async def hget(self, key: str, field: str):
+        async with self.lock:
+            return await self.redis.hget(key, field)
+
+    async def hgetall(self, key: str):
+        async with self.lock:
+            return await self.redis.hgetall(key)
+
+    async def hdel(self, key: str, *fields: str):
+        async with self.lock:
+            await self.redis.hdel(key, *fields)
+
+    async def delete_executor_count_hash(self, miner_hotkey: str):
+        redis_key = f"{EXECUTOR_COUNT_PREFIX}:{miner_hotkey}"
+        async with self.lock:
+            await self.redis.delete(redis_key)
+
+    async def clear_all_executor_counts(self):
+        pattern = f"{EXECUTOR_COUNT_PREFIX}:*"
+        cursor = 0
+
+        async with self.lock:
+            while True:
+                cursor, keys = await self.redis.scan(cursor, match=pattern, count=100)
+                if keys:
+                    await self.redis.delete(*keys)
+                if cursor == 0:
+                    break


### PR DESCRIPTION
## Changes
- Tracking the total executors per miner on redis
- Clear the cache per epoch
- Calculate the min, max executors per miner

## Issue ticket number and link
DAH-614
[Subnet - Track total number of executors per miner on validator side](https://www.notion.so/Subnet-Track-total-number-of-executors-per-miner-on-validator-side-135b8bfdbde9800c9fa0db29324b08f6)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I wrote tests.
- [ ] Need to take care of performance?
