### PR TITLE
fix: Fix incorrect wallet name argument Update install_staging.sh

### DIFF
--- a/scripts/install_staging.sh
+++ b/scripts/install_staging.sh
@@ -141,5 +141,5 @@ if [ -z "$TMUX" ]; then
 else
     # If already in a tmux session, create two panes in the current window
     tmux split-window -h 'python neurons/miner.py --netuid 1 --subtensor.chain_endpoint ws://127.0.0.1:9946 --wallet.name miner --wallet.hotkey default --logging.debug'
-    tmux split-window -v -t 0 'python neurons/validator.py --netuid 1 --subtensor.chain_endpoint ws://127.0.0.1:9946 --wallet.name3 validator --wallet.hotkey default --logging.debug'
+    tmux split-window -v -t 0 'python neurons/validator.py --netuid 1 --subtensor.chain_endpoint ws://127.0.0.1:9946 --wallet.name validator --wallet.hotkey default --logging.debug'
 fi


### PR DESCRIPTION
## Describe your changes

There was a small issue in the script where the parameter for the wallet name was incorrectly specified. Specifically, in the following line:  

```sh
tmux split-window -v -t 0 'python neurons/validator.py --netuid 1 --subtensor.chain_endpoint ws://127.0.0.1:9946 --wallet.name3 validator --wallet.hotkey default --logging.debug'
```  

The `--wallet.name3` parameter was mistakenly used instead of the correct `--wallet.name`. This has now been fixed to ensure the command runs properly:

```sh
tmux split-window -v -t 0 'python neurons/validator.py --netuid 1 --subtensor.chain_endpoint ws://127.0.0.1:9946 --wallet.name validator --wallet.hotkey default --logging.debug'
```

This update resolves the issue and ensures the script works without errors when specifying the wallet name.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I wrote tests.
- [ ] Need to take care of performance?
