### PR TITLE
fix: DAH-827 - runtime error for default templates

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -296,7 +296,9 @@ class DockerService:
                 )
 
                 # Prepare extra options
-                sanitized_volumes = [volume for volume in custom_options.volumes if volume.strip()]
+                sanitized_volumes = [
+                    volume for volume in custom_options.volumes or [] if volume.strip()
+                ]
                 volume_flags = (
                     " ".join([f"-v {volume}" for volume in sanitized_volumes])
                     if custom_options and custom_options.volumes


### PR DESCRIPTION
## Describe your changes

Runtime error happened for default template, which miss volumes by default. This is caused by last commit in this branch for sanitizing volumes. 

## Issue ticket number and link

