### PR TITLE
Fix typo

### DIFF
--- a/contrib/STYLE.md
+++ b/contrib/STYLE.md
@@ -58,7 +58,7 @@ Python's official style guide is PEP 8, which provides conventions for writing c
 
 #### More details
 
-Use `black` to format your python code before commiting for consistency across such a large pool of contributors. Black's code [style](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#code-style) ensures consistent and opinionated code formatting. It automatically formats your Python code according to the Black style guide, enhancing code readability and maintainability.
+Use `black` to format your python code before committing for consistency across such a large pool of contributors. Black's code [style](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#code-style) ensures consistent and opinionated code formatting. It automatically formats your Python code according to the Black style guide, enhancing code readability and maintainability.
 
 Key Features of Black:
 

--- a/neurons/miners/src/core/miner.py
+++ b/neurons/miners/src/core/miner.py
@@ -146,7 +146,7 @@ class Miner:
         except Exception as e:
             logger.error(
                 _m(
-                    '[announce] Annoucing miner error',
+                    '[announce] Announcing miner error',
                     extra=get_extra_info({
                         **self.default_extra,
                         "error": str(e)


### PR DESCRIPTION
### Typo Fixes in `STYLE.md` and `miner.py`

This pull request addresses minor typographical errors in the `STYLE.md` and `miner.py` files to improve clarity and consistency across the codebase.

#### Changes:
1. **`STYLE.md`**:
   - The sentence "Use `black` to format your python code before commiting for consistency across such a large pool of contributors." was corrected. The word "commiting" has been changed to "committing".
   - This fix ensures the text adheres to standard English spelling conventions.

2. **`miner.py`**:
   - The word "Annoucing" was corrected to "Announcing" in the error message in the `announce` function.
   - This small change improves the clarity of the log message and ensures accurate spelling.

---

These fixes contribute to a cleaner and more professional codebase, ensuring that documentation and code comments are clear and error-free for all contributors.
