### PR TITLE
fix: remove limit in fetching validators

### DIFF
--- a/neurons/miners/src/core/config.py
+++ b/neurons/miners/src/core/config.py
@@ -32,6 +32,9 @@ class Settings(BaseSettings):
     ENV: str = Field(env="ENV", default="dev")
     DEBUG: bool = Field(env="DEBUG", default=False)
 
+    MIN_ALPHA_STAKE: int = Field(env="MIN_ALPHA_STAKE", default=10)
+    MIN_TOTAL_STAKE: int = Field(env="MIN_TOTAL_STAKE", default=20000)
+
     def get_bittensor_wallet(self) -> "bittensor_wallet":
         if not self.BITTENSOR_WALLET_NAME or not self.BITTENSOR_WALLET_HOTKEY_NAME:
             raise RuntimeError("Wallet not configured")

--- a/neurons/miners/src/core/miner.py
+++ b/neurons/miners/src/core/miner.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-MIN_STAKE = 10
 VALIDATORS_LIMIT = 24
 SYNC_CYCLE = 2 * 60
 
@@ -155,8 +154,12 @@ class Miner:
             )
 
     async def fetch_validators(self):
+        a = self.subtensor.get_metagraph_info(self.netuid)
         metagraph = self.subtensor.metagraph(netuid=self.netuid)
-        neurons = [n for n in metagraph.neurons if (n.stake.tao >= MIN_STAKE)]
+        neurons = [
+            n for n in metagraph.neurons
+            if (n.stake.tao >= settings.MIN_ALPHA_STAKE and a.total_stake[n.uid] >= settings.MIN_TOTAL_STAKE)
+        ]
         return neurons
 
     async def save_validators(self, validators):

--- a/neurons/miners/src/core/miner.py
+++ b/neurons/miners/src/core/miner.py
@@ -157,7 +157,7 @@ class Miner:
     async def fetch_validators(self):
         metagraph = self.subtensor.metagraph(netuid=self.netuid)
         neurons = [n for n in metagraph.neurons if (n.stake.tao >= MIN_STAKE)]
-        return neurons[:VALIDATORS_LIMIT]
+        return neurons
 
     async def save_validators(self, validators):
         logger.info(


### PR DESCRIPTION
## Describe your changes

Miner are storing only 24 neurons into validators which have more than 10 TAO stake. But, in subnet 51, there are 45 neurons that have more than 10 TAO stake. So, miner doesn't know the validator which has bigger uid (which is registered lately). 

Especially, when validator switched to new hotkey which has bigger UID, validators had `Unauthorized` error from miners. 
