### PR TITLE
Fix typos in documentation strings

### DIFF
--- a/neurons/validators/src/miner_jobs/machine_scrape.py
+++ b/neurons/validators/src/miner_jobs/machine_scrape.py
@@ -102,7 +102,7 @@ class _PrintableStructure(Structure):
     e.g. class that has _field_ 'hex_value', c_uint could be formatted with
       _fmt_ = {"hex_value" : "%08X"}
     to produce nicer output.
-    Default fomratting string for all fields can be set with key "<default>" like:
+    Default formatting string for all fields can be set with key "<default>" like:
       _fmt_ = {"<default>" : "%d MHz"} # e.g all values are numbers in MHz.
     If not set it's assumed to be just "%s"
 

--- a/neurons/validators/src/services/task_service.py
+++ b/neurons/validators/src/services/task_service.py
@@ -662,7 +662,7 @@ class TaskService:
                     if gpu_model:
                         extra_info["gpu_model"] = gpu_model
                         extra_info["help_text"] = (
-                            "If you have the gpu machine and encountering this issue consistantly, "
+                            "If you have the gpu machine and encountering this issue consistently, "
                             "then please pull the latest version of github repository and follow the installation guide here: "
                             "https://github.com/Datura-ai/compute-subnet/tree/main/neurons/executor. "
                             "Also, please configure the nvidia-container-runtime correctly. Check out here: "


### PR DESCRIPTION


"This PR fixes two typos in documentation strings:
- Corrects 'fomratting' to 'formatting' in machine_scrape.py
- Corrects 'consistantly' to 'consistently' in task_service.py

