### PR TITLE
feat: DAH-1285 - add sysbox GPU compatibility check function

### DIFF
--- a/neurons/validators/src/miner_jobs/machine_scrape.py
+++ b/neurons/validators/src/miner_jobs/machine_scrape.py
@@ -88,6 +88,15 @@ class struct_c_nvmlDevice_t(Structure):
 
 c_nvmlDevice_t = POINTER(struct_c_nvmlDevice_t)
 
+COMMANDS = {
+    "CHECK_SYSBOX_COMPATIBILITY": [
+        "docker", "run", "--rm",
+        "--runtime=sysbox-runc",
+        "--gpus", "all",
+        "daturaai/compute-subnet-executor:latest", "nvidia-smi"
+    ],
+}
+
 
 class _PrintableStructure(Structure):
     """
@@ -748,12 +757,7 @@ def check_sysbox_gpu_compatibility() -> tuple[bool, str]:
     Returns:
         Tuple[bool, str]: A tuple containing a boolean indicating compatibility and a message.
     """
-    test_command = [
-        "docker", "run", "--rm",
-        "--runtime=sysbox-runc",
-        "--gpus", "all",
-        "daturaai/compute-subnet-executor:latest", "nvidia-smi"
-    ]
+    test_command = COMMANDS["CHECK_SYSBOX_COMPATIBILITY"]
 
     try:
         result = subprocess.run(

--- a/neurons/validators/src/miner_jobs/obfuscator.py
+++ b/neurons/validators/src/miner_jobs/obfuscator.py
@@ -26,7 +26,7 @@ python_keywords = [
     'NVML_ERROR_MEMORY', 'NVML_ERROR_UNKNOWN', 'Exception', 'wrapper', 'args', 'kwargs', 'wraps', 'sys',
     'c_char_p', 'AttributeError', '_nvmlLib_refcount', 'nvmlLib', 'CDLL', 'os', 'tempfile', 'NVMLError',
     'OSError', 'c_uint', 'byref', 'create_string_buffer', 'c_int',  'setattr', 'subprocess', 'RuntimeError', 'hashlib',
-    'iter', 'repr', 'exc', 'e', 're', 'psutil', 'shutil', 'b64encode', 'Fernet', 'json', 'machine_specs', 'hasattr'
+    'iter', 'repr', 'exc', 'e', 're', 'psutil', 'shutil', 'b64encode', 'Fernet', 'json', 'machine_specs', 'hasattr', 'bool'
 ]
 
 


### PR DESCRIPTION
## Problem

There are some executors that are failed in creating docker container with `sysbox-runc` and `--gpus all` , although they have `sysbox` installed in OS.


## Solutions
- Check if docker container is created successfully when `sysbox-runc` and `--gpus all` are passed together in subnet. 

## Issue ticket number and link

DAH-1285
[Subnet/Backend - DinD Support Issue](https://www.notion.so/Subnet-Backend-DinD-Support-Issue-1e3b8bfdbde98066aabeefe4a1612e1f?pvs=23)
