### PR TITLE
feat: DAH-1352 - internal member rented pods as available

### DIFF
--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -68,10 +68,17 @@ class ContainerBaseRequest(BaseRequest):
     executor_id: str
 
 
+class ContainerDeleteRequest(ContainerBaseRequest):
+    message_type: ContainerRequestType = ContainerRequestType.ContainerDeleteRequest
+    container_name: str
+    volume_name: str
+
+
 class ContainerCreateRequest(ContainerBaseRequest):
     message_type: ContainerRequestType = ContainerRequestType.ContainerCreateRequest
     docker_image: str
     user_public_keys: list[str] = []
+    internal_member_pod_container_delete_request: ContainerDeleteRequest | None = None
     custom_options: CustomOptions | None = None
     debug: bool | None = None
     volume_name: str | None = None  # when edit pod, volume_name is required
@@ -99,11 +106,6 @@ class ContainerStopRequest(ContainerBaseRequest):
     message_type: ContainerRequestType = ContainerRequestType.ContainerStopRequest
     container_name: str
 
-
-class ContainerDeleteRequest(ContainerBaseRequest):
-    message_type: ContainerRequestType = ContainerRequestType.ContainerDeleteRequest
-    container_name: str
-    volume_name: str
 
 
 class GetPodLogsRequestFromServer(ContainerBaseRequest):

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -417,8 +417,8 @@ class DockerService:
                             extra=get_extra_info(
                                 {
                                     **default_extra,
-                                    "container_name": payload.old_pod_container_delete_request.container_name,
-                                    "volume_name": payload.old_pod_container_delete_request.volume_name,
+                                    "container_name": payload.internal_member_pod_container_delete_request.container_name,
+                                    "volume_name": payload.internal_member_pod_container_delete_request.volume_name,
                                 }
                             ),
                         ),
@@ -429,7 +429,7 @@ class DockerService:
                     logger.info(
                         _m(
                             "Deleted Docker Container",
-                            extra=get_extra_info({**default_extra, "payload": str(payload.old_pod_container_delete_request)}),
+                            extra=get_extra_info({**default_extra, "payload": str(payload.internal_member_pod_container_delete_request)}),
                         ),
                     )
                 # set real-time logging


### PR DESCRIPTION
## Describe your changes

- We have some accounts in the celium that are using idle GPUs for mining in other subnets. But we might want to keep the GPUs rentable that are rented by this kind of accounts. 

## Issue ticket number and link

[Subnet/Backend - Show slickroot or bt’s rented pods as available](https://www.notion.so/Subnet-Backend-Show-slickroot-or-bt-s-rented-pods-as-available-20fb8bfdbde980c5be58f6018882b487)


## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I wrote tests.
- [ ] Need to take care of performance?
