### PR TITLE
feat(validator): DAH-1364 - Store environment variables into /env/environment for SSH connection

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -4,6 +4,7 @@ import logging
 import time
 from typing import Annotated
 from uuid import uuid4
+import shlex
 
 import aiohttp
 import asyncssh
@@ -499,7 +500,7 @@ class DockerService:
                 env_flags = (
                     " ".join(
                         [
-                            f"-e {key}={value}"
+                            f"-e '{key}={value}'"
                             for key, value in custom_options.environment.items()
                             if key and value and key.strip() and value.strip()
                         ]
@@ -649,6 +650,19 @@ class DockerService:
                 for public_key in payload.user_public_keys:
                     command = f"/usr/bin/docker exec {container_name} sh -c 'echo \"{public_key}\" >> ~/.ssh/authorized_keys'"
                     await ssh_client.run(command)
+
+                # add environment variables 
+                if custom_options and custom_options.environment:
+                    for k, v in custom_options.environment.items():
+                        if k and v and k.strip() and str(v).strip():
+                            env_line = f"{k}={v}"
+                            # Execute each variable addition separately for better error handling
+                            script = f'printf "%s\\n" {shlex.quote(env_line)} >> /etc/environment'
+                            command = f"/usr/bin/docker exec {container_name} sh -c {shlex.quote(script)}"
+                            try:
+                                await ssh_client.run(command)
+                            except Exception as e:
+                                print(f"Failed to set environment variable {k}: {e}")
 
                 # Add profiler for adding public keys
                 profilers.append({"name": "Adding public keys step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})


### PR DESCRIPTION
## Describe your changes

Env vars that are set in the dashboard weren't available in SSH connection/session. 

## Issue ticket number and link

DAH-1364
[Subnet - Environment Variable Issue in Creating Container](https://www.notion.so/Subnet-Environment-Variable-Issue-in-Creating-Container-223b8bfdbde9803dabcfce8cae52ae25?pvs=23)
