### PR TITLE
feat: add silent mode for local development

### DIFF
--- a/neurons/miners/.env.template
+++ b/neurons/miners/.env.template
@@ -20,4 +20,6 @@ EXTERNAL_PORT=8000  # make sure this port is open to external connections
 
 # RENTAL_REQUEST_HOOK=  # executor hook url(will be provided by miner), miners will close chutes program in seconds
 
-HOST_WALLET_DIR=/home/ubuntu/.bittensor/wallets
+# DISABLE_MINER_PORTAL=true  # Optional: Disable miner portal connection for local testing
+
+HOST_WALLET_DIR=$HOME/.bittensor/wallets

--- a/neurons/miners/src/connector.py
+++ b/neurons/miners/src/connector.py
@@ -1,6 +1,7 @@
 import asyncio
 import time
 import logging
+import os
 
 from clients.miner_portal_client import MinerPortalClient
 
@@ -16,6 +17,11 @@ logger = logging.getLogger(__name__)
 async def run_forever():
     initiate_services()
 
+    # Silent mode for local testing - no portal, no logs, no errors
+    if os.getenv("DISABLE_MINER_PORTAL", "false").lower() == "true":
+        while True:
+            await asyncio.sleep(3600)  # Just keep alive
+    
     logger.info("Miner portal connector started")
     miner_portal_client = MinerPortalClient()
     async with miner_portal_client:

--- a/neurons/validators/.env.template
+++ b/neurons/validators/.env.template
@@ -23,4 +23,6 @@ REDIS_PORT=6379
 
 COMPUTE_APP_URI=wss://lium.io
 
-HOST_WALLET_DIR=/home/ubuntu/.bittensor/wallets
+# DISABLE_COMPUTE_APP=true # Optional: Disable compute app connection for local testing
+
+HOST_WALLET_DIR=$HOME/.bittensor/wallets

--- a/neurons/validators/src/connector.py
+++ b/neurons/validators/src/connector.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import time
 
 from clients.compute_client import ComputeClient
@@ -12,8 +13,14 @@ wait_for_services_sync()
 
 
 async def run_forever():
-    logger.info("Compute app connector started")
     await initiate_services()
+    
+    # Silent mode for local testing - no compute app connection, no logs, no errors
+    if os.getenv("DISABLE_COMPUTE_APP", "false").lower() == "true":
+        while True:
+            await asyncio.sleep(3600)  # Just keep alive
+    
+    logger.info("Compute app connector started")
     keypair = settings.get_bittensor_wallet().get_hotkey()
     compute_app_client = ComputeClient(
         keypair, f"{settings.COMPUTE_APP_URI}/validator/{keypair.ss58_address}", ioc["MinerService"]


### PR DESCRIPTION
## Summary
- Add silent mode for miner and validator connectors to improve local development experience
- Prevent spam errors when external services (miner portal, compute app) are not available
- Make wallet directory portable across different systems

## Changes
- Add `DISABLE_MINER_PORTAL` env var to disable miner portal connection
- Add `DISABLE_COMPUTE_APP` env var to disable validator compute app connection  
- Document new env vars in .env.template files with helpful comments
- Fix `HOST_WALLET_DIR` to use `$HOME` instead of hardcoded `/home/ubuntu`

## Test Plan
- [x] Set `DISABLE_MINER_PORTAL=true` in miner .env
- [x] Set `DISABLE_COMPUTE_APP=true` in validator .env
- [x] Run miner with `docker compose -f docker-compose.app.dev.yml up`
- [x] Run validator with `docker compose -f docker-compose.app.dev.yml up`
- [x] Verify no connection errors in logs
- [x] Verify services stay running without spam logs