### PR TITLE
fix: improve executor healthcheck to handle GPU infoROM warnings

### DIFF
--- a/neurons/executor/docker-compose.app.dev.yml
+++ b/neurons/executor/docker-compose.app.dev.yml
@@ -33,7 +33,7 @@ services:
     labels:
       autoheal-app: true
     healthcheck:
-      test: [ "CMD-SHELL", "nvidia-smi || exit 1" ]
+      test: ["CMD-SHELL", "nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | grep -q ."]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/neurons/executor/docker-compose.app.yml
+++ b/neurons/executor/docker-compose.app.yml
@@ -33,7 +33,7 @@ services:
     labels:
       autoheal-app: true
     healthcheck:
-      test: [ "CMD-SHELL", "nvidia-smi || exit 1" ]
+      test: ["CMD-SHELL", "nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | grep -q ."]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Fixes executor container health check failures when GPU has infoROM warnings.

**Changes:**
- Updated healthcheck to query GPU name instead of relying on nvidia-smi exit code
- Healthcheck now verifies GPU is accessible while ignoring non-critical warnings

**Problem:**
Previous healthcheck failed when nvidia-smi returned exit code 1 due to infoROM corruption warnings, causing containers to restart and SSH connections to drop during validation.