### PR TITLE
fix(validator): add delay to prevent ws connection flood

### DIFF
--- a/neurons/validators/src/clients/miner_client.py
+++ b/neurons/validators/src/clients/miner_client.py
@@ -141,6 +141,8 @@ class MinerClient(abc.ABC):
 
                     async for raw_msg in self.ws:
                         await self.read_messages(raw_msg)
+
+                    await asyncio.sleep(self.sleep_time())
             except (websockets.WebSocketException, OSError) as ex:
                 self.debounce_counter += 1
 


### PR DESCRIPTION
Add sleep after message loop completion to prevent thousands of WebSocket connections per second from validator to miner when the miner has no executors.

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I wrote tests.
- [ ] Need to take care of performance?
