### PR TITLE
fix(validator): Don't crash if no gpus available on the executor

### DIFF
--- a/neurons/validators/src/miner_jobs/machine_scrape.py
+++ b/neurons/validators/src/miner_jobs/machine_scrape.py
@@ -995,7 +995,26 @@ def _encrypt(key: str, payload: str) -> str:
     return Fernet(key_bytes).encrypt(payload.encode("utf-8")).decode("utf-8")
 
 
+KEYS_FOR_ENCRYPTION_KEY_GENERATION = [
+    "gpu.name",
+    "gpu.uuid",
+    "gpu.capacity",
+    "gpu.cuda",
+    "gpu.power_limit",
+    "gpu.graphics_speed",
+    "gpu.memory_speed",
+    "gpu.pcie",
+    "gpu.speed_pcie",
+    "gpu.utilization",
+    "gpu.memory_utilization",
+]
+
 machine_specs = get_machine_specs()
-encryption_key = "".join(machine_specs["data_gpu"]["gpu_details"][0].keys())
+gpu_details = machine_specs.get("data_gpu", {}).get("gpu_details", [])
+if gpu_details:
+    encryption_key = "".join(gpu_details[0].keys())
+else:
+    encryption_key = "".join(KEYS_FOR_ENCRYPTION_KEY_GENERATION)
+
 encoded_str = _encrypt(encryption_key, json.dumps(machine_specs))
 print(encoded_str)


### PR DESCRIPTION
The scrape script throws an IndexError when no GPU is detected. Returning an empty GPU list allows the validator to handle this gracefully.

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I wrote tests.
- [ ] Need to take care of performance?
