### PR TITLE
feat(validator): DAH-1542, insrease docker run timeout.

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -873,7 +873,7 @@ class DockerService:
                     log_tag=log_tag,
                     log_text="Creating docker container",
                     log_extra=default_extra,
-                    timeout=30
+                    timeout=60
                 )
 
                 # check if the container is running correctly


### PR DESCRIPTION
## Describe your changes
Increase container creation timeout

Some container creation requests for the image `axolotlai/axolotl-cloud:main-latest` occasionally fail with a **"Process timed out"** error during the `docker run` step.  
Successful deployments show that the `Docker container creation step finished` duration is typically **25–30 seconds**, but sometimes it takes longer — likely due to using the **sysbox runtime**.

To make this process more resilient, the timeout was increased **from 30 to 60 seconds**.

**Change summary:**
- Increased container creation timeout from `30s` → `60s`.
- No other logic or behavior was modified.

**Rationale:**
Improves reliability for slower `docker run` executions without affecting normal flow.


[feat(validator): DAH-1542, insrease docker run timeout.](https://www.notion.so/Subnet-Pod-deployment-failure-run-timed-out-29bb8bfdbde98035bdadf282f18c1f0a?source=copy_link)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I wrote tests.
- [ ] Need to take care of performance?
