### PR TITLE
Fix/DAH-1536 batch verification with p

### DIFF
--- a/neurons/validators/src/services/executor_connectivity_service.py
+++ b/neurons/validators/src/services/executor_connectivity_service.py
@@ -231,7 +231,7 @@ class ExecutorConnectivityService:
         port_mappings = " ".join([f"-p {int_}:{int_}" for int_, _ in all_port_maps])
 
         command = (
-            f"/usr/bin/docker run -d -it --name {container_name} "
+            f"/usr/bin/docker run -d --name {container_name} "
             f"{port_mappings} "
             f"-e API_PORT={api_internal} {BATCH_VERIFIER_IMAGE}"
         )


### PR DESCRIPTION
## Summary
  Fixes batch port verification by switching from `--network=host` to explicit port mappings.

  ## Problem
  The batch verifier used `--network=host` because it seemed impossible to pass all ports with `-p` flags. However, this
  approach:
  - Is inconsistent with real container creation (which uses explicit `-p` mappings)
  - Seems not working with some of real executors.

  ## Solution
  Use explicit port mappings (`-p internal:internal`) for all ports in the batch, matching the approach used in real
  container creation.

  **Changes:**
  - Modified `_docker_start` to accept `all_port_maps` parameter
  - Dynamically builds `-p internal:internal` for each port
  - Removed `--network=host` flag
  - Improved logging (debug → info for docker commands)

https://www.notion.so/Subnet-Troubleshoot-Port-Verification-Failure-on-Some-Nodes-Add-audit-logs-296b8bfdbde98093be1eeff77332baef?source=copy_link