### PR TITLE
feat(docker_service): DAH-1542, increase container creation timeout

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -844,7 +844,9 @@ class DockerService:
                     f'{startup_commands}'
                 )
 
-                logger.info(f"Running command: {command}")
+                timeout = 120
+                logger.info(f"Running command: {command} with timeout={timeout}")
+
 
                 await self.execute_and_stream_logs(
                     ssh_client=ssh_client,
@@ -852,7 +854,7 @@ class DockerService:
                     log_tag=log_tag,
                     log_text="Creating docker container",
                     log_extra=default_extra,
-                    timeout=60
+                    timeout=timeout
                 )
                 logger.info(f"Container creation step finished")
 


### PR DESCRIPTION
To start a Docker container, the 60-second timeout is not sufficient. Sometimes it takes 20-45 seconds, but we sometimes encounter a timeout. Therefore, I suggest increasing it to 120 seconds. Waris confirmed on yesterday's call.
