### PR TITLE
feat(validator): DAH-1569 - add detailed validation results for GPU capability check

### DIFF
--- a/neurons/validators/tests/test_pipeline_default_scenarios.py
+++ b/neurons/validators/tests/test_pipeline_default_scenarios.py
@@ -8,6 +8,7 @@ complete validation flow.
 import pytest
 from unittest.mock import Mock
 
+from neurons.validators.src.services.matrix_validation_service import ValidationResult
 from neurons.validators.src.services.task.pipeline import Pipeline, LoggerSink
 from neurons.validators.src.services.task.checks import (
     BannedGpuCheck,
@@ -178,7 +179,13 @@ class DummyValidationService:
     """Mock validation service for GPU capability checks."""
 
     async def validate_gpu_model_and_process_job(self, *, ssh_client, executor_info, default_extra, machine_spec):
-        return True
+        return ValidationResult(
+            success=True,
+            expected_uuid="test-uuid-123",
+            returned_uuid="test-uuid-123",
+            stdout="UUID: test-uuid-123",
+            stderr=""
+        )
 
 
 class DummyVerifyXService:


### PR DESCRIPTION
## Describe your changes
The matrix validation service was return only False when failing, hiding the actual failure causes, I'm returning a new `ValidationResult` object with fields that make it a lot easier to know what happened exactly.

## Issue ticket number and link

[GPU capability verification failed with empty what_we_saw](https://www.notion.so/GPU-capability-verification-failed-with-empty-what_we_saw-2a3b8bfdbde980ecb45ee2eb50106f31)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?
