### PR TITLE
feat(validator): DAH-1586, fix executors check.

### DIFF
--- a/neurons/miners/src/routes/validator_interface.py
+++ b/neurons/miners/src/routes/validator_interface.py
@@ -47,7 +47,7 @@ async def get_executors_for_validator(
     """
     try:
         miner_hotkey = settings.get_bittensor_wallet().get_hotkey().ss58_address
-        executors = executor_service.get_executors_for_validator(authenticated_validator, miner_hotkey)
+        executors = await executor_service.get_executors_for_validator(authenticated_validator, miner_hotkey)
     except Exception as e:
         logger.error(
             "Failed to retrieve executors for validator %s: %s",


### PR DESCRIPTION
  ## Summary
  Fix `/executors` endpoint by adding missing `await` for async executor service call.

  ## Problem
  The `get_executors_for_validator()` method in `executor_service` was updated to async, but the parent endpoint handler wasn't updated  accordingly - it was calling the async method without `await`.

  ## Solution
  Added `await` keyword when calling `executor_service.get_executors_for_validator()` in the `/executors` endpoint handler.

  ## Changes
  - `neurons/miners/src/routes/validator_interface.py`: Added `await` for async executor service call
