### PR TITLE
fix/show raw specs in logs.

### DIFF
--- a/neurons/validators/src/services/task/checks/machine_spec_scrape.py
+++ b/neurons/validators/src/services/task/checks/machine_spec_scrape.py
@@ -116,7 +116,7 @@ class MachineSpecScrapeCheck:
                 what={
                     "gpu_count": gpu_count,
                     "gpu_model": gpu_model,
-                    "specs": specs,
+                    "network": specs.get("network"),
                 },
                 extra=extra_info,
             )


### PR DESCRIPTION
to find why upload_speed is empty - need to understand what the specs script was returned, so I added it to the section 'what we saw.