### PR TITLE
fix(subnet): upgrading to a more maintained watchtower repository

### DIFF
--- a/neurons/executor/docker-compose.dev.yml
+++ b/neurons/executor/docker-compose.dev.yml
@@ -12,7 +12,7 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
 
   watchtower:
-    image: containrrr/watchtower:1.7.1
+    image: nickfedor/watchtower
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/neurons/executor/docker-compose.yml
+++ b/neurons/executor/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
 
   watchtower:
-    image: containrrr/watchtower:1.7.1
+    image: nickfedor/watchtower
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/neurons/miners/docker-compose.dev.yml
+++ b/neurons/miners/docker-compose.dev.yml
@@ -12,7 +12,7 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
 
   watchtower:
-    image: containrrr/watchtower:1.7.1
+    image: nickfedor/watchtower
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/neurons/miners/docker-compose.yml
+++ b/neurons/miners/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
 
   watchtower:
-    image: containrrr/watchtower:1.7.1
+    image: nickfedor/watchtower
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/neurons/validators/docker-compose.dev.yml
+++ b/neurons/validators/docker-compose.dev.yml
@@ -12,7 +12,7 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
 
   watchtower:
-    image: containrrr/watchtower:1.7.1
+    image: nickfedor/watchtower
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/neurons/validators/docker-compose.yml
+++ b/neurons/validators/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
 
   watchtower:
-    image: containrrr/watchtower:1.7.1
+    image: nickfedor/watchtower
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 REPOSITORIES = [
     "daturaai/compute-subnet-executor:latest",
     "daturaai/compute-subnet-executor-runner:latest",
-    "containrrr/watchtower:1.7.1",
+    "nickfedor/watchtower",
     "daturaai/pytorch",
     "daturaai/ubuntu",
 ]


### PR DESCRIPTION
## Describe your changes
Upgrading to a more maintained `watchtower` docker repository after `containrrr/watchtower` stopped supporting the last version of Docker `29`

The old watchtower gave this log with docker v29:
```bash
watchtower-1  | time="2025-11-19T01:22:50Z" level=error msg="Error response from daemon: client version 1.25 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version"
```

The updated watchtower gave this log with docker v29:
```bash
watchtower-1  | time="2025-11-19T01:35:49Z" level=info msg="Watchtower 1.12.3 using Docker API v1.51"
watchtower-1  | time="2025-11-19T01:35:49Z" level=info msg="Using no notifications"
watchtower-1  | time="2025-11-19T01:35:49Z" level=info msg="Next scheduled run: 2025-11-19 01:36:49 UTC in 59 seconds"
watchtower-1  | time="2025-11-19T01:36:52Z" level=info msg="Found new image" container=executor-executor-runner-1 image="daturaai/compute-subnet-executor-runner:latest" new_id=5da42426de7c
```

We should prefer the updated version of watchtower now.

## Issue ticket number and link

[Watchtower not maintained](https://www.notion.so/Watchtower-not-working-anymore-2aeb8bfdbde980adb935ceb35a3b549c?source=copy_link)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I wrote tests.
- [ ] Need to take care of performance?
