### PR TITLE
feat(subnet): Miners can see that we couldn't reach them

### DIFF
--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -275,7 +275,8 @@ class MinerService:
 
     def _build_failed_job_result(self, payload: MinerJobRequestPayload, reason: str):
         executor_info = ExecutorSSHInfo(
-            uuid=f"{payload.job_batch_id}:{payload.miner_hotkey}",
+            # Special uuid for failed miners
+            uuid="11111111-1111-1111-1111-111111111111",
             address=payload.miner_address,
             port=payload.miner_port,
             ssh_username="unknown",


### PR DESCRIPTION
## Describe your changes
When a problem arises earlier in the job we just return `None` as result, let's make it in a way that all miners can see that we actually tried them and failed.


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I wrote tests.
- [ ] Need to take care of performance?
