### PR TITLE
Skip registration check for central miner

### DIFF
--- a/neurons/miners/src/core/miner.py
+++ b/neurons/miners/src/core/miner.py
@@ -122,6 +122,15 @@ class Miner:
         await self.initialize_subtensor()
 
     async def check_registered(self):
+        if settings.CENTRAL_MODE:
+            logger.info(
+                _m(
+                    "[check_registered] Skipping registration check (CENTRAL_MODE)",
+                    extra=get_extra_info(self.default_extra),
+                ),
+            )
+            return
+
         try:
             logger.info(
                 _m(


### PR DESCRIPTION
## Summary

---

## Problem

Central miner crashes on startup with error: `Wallet central_miner is not registered on netuid 51`, followed by `exit()` which kills the process. The `CENTRAL_MODE` miner doesn't need to be registered on the subnet to function.

## Solution

Skip the `check_registered()` call when `CENTRAL_MODE=true`. Added an early return with a log message at the top of the method.

## Changes

- `neurons/miners/src/core/miner.py`: Added `CENTRAL_MODE` check at the beginning of `check_registered()` to skip registration verification for central miner

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

None

## Risks

- None. Only affects central miner (`CENTRAL_MODE=true`). Standard miners continue to check registration as before.

## Test Cases

### Test Case 1

**Actions**
Deploy central miner with `CENTRAL_MODE=true` and wallet not registered on netuid 51.

**Expected Output**
Miner starts successfully, logs `[check_registered] Skipping registration check (CENTRAL_MODE)` instead of crashing.

## Checklist

- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described