### PR TITLE
DAH-1917, add CVM (TDX-attested) incentive bonuses with independent GPU caps

### DIFF
--- a/neurons/validators/src/clients/compute_client.py
+++ b/neurons/validators/src/clients/compute_client.py
@@ -666,6 +666,7 @@ class ComputeClient:
                 gpu_splitting_min_count=req.gpu_splitting_min_count,
                 sysbox_runtime=req.sysbox_runtime,
                 collateral_deposited=req.collateral_deposited,
+                tdx_attestation_passed=req.tdx_attestation_passed,
             ),
         )
         async with self.lock:

--- a/neurons/validators/src/incentive/config.py
+++ b/neurons/validators/src/incentive/config.py
@@ -51,12 +51,8 @@ MAX_UNRENTED_GPUS_BY_TYPE = {
     "A40": 0,
     "A30": 0,
     # CVM (TDX-attested) variants — independent caps, separate from plain GPU types
+    # Only H200 CVM is enabled for the unrented pool; all others are zeroed out.
     "H200 CVM": 8,
-    "H100 CVM": 8,
-    "A100 CVM": 8,
-    "RTX 4090 CVM": 8,
-    "RTX A6000 CVM": 8,
-    "RTX 3090 CVM": 8,
 }
 # Per-(gpu_model, gpu_count) hourly prices in USD.
 # Keys are full NVIDIA GPU names; values are dicts of {count_str: price_or_default}.

--- a/neurons/validators/src/incentive/config.py
+++ b/neurons/validators/src/incentive/config.py
@@ -26,6 +26,8 @@ DEFAULT_PRICE = DefaultPrice()
 # High-end GPUs have lower caps (12-24) due to scarcity and high value
 # Mid-tier GPUs have moderate caps (24-48) for balanced incentives
 # Lower-tier GPUs have higher caps (48-96) to accommodate larger deployments
+# CVM variants ("<base> CVM") are separate buckets for TDX-attested executors;
+# they never share cap dilution with their non-CVM counterparts.
 MAX_UNRENTED_GPUS_BY_TYPE = {
     "B300": 0,
     "B200": 8,
@@ -48,6 +50,13 @@ MAX_UNRENTED_GPUS_BY_TYPE = {
     "RTX A4000": 0,
     "A40": 0,
     "A30": 0,
+    # CVM (TDX-attested) variants — independent caps, separate from plain GPU types
+    "H200 CVM": 8,
+    "H100 CVM": 8,
+    "A100 CVM": 8,
+    "RTX 4090 CVM": 8,
+    "RTX A6000 CVM": 8,
+    "RTX 3090 CVM": 8,
 }
 # Per-(gpu_model, gpu_count) hourly prices in USD.
 # Keys are full NVIDIA GPU names; values are dicts of {count_str: price_or_default}.
@@ -142,6 +151,24 @@ class IncentiveConfig(BaseModel):
         default=GPU_COUNT_CUSTOM_PRICES,
         description="Per-(gpu_model, gpu_count) hourly prices. Use DEFAULT_PRICE for MACHINE_PRICES fallback."
     )
+
+    cvm_rate_multiplier: float = Field(
+        default=1.5,
+        description="Rate multiplier applied to unrented CVM (TDX-attested) executor hourly_rate (e.g. 1.5 = +50%)"
+    )
+
+    cvm_mining_multiplier: float = Field(
+        default=1.3,
+        description="Mining score multiplier for rented CVM (TDX-attested) executors (e.g. 1.3 = +30%)"
+    )
+
+    @field_validator("cvm_rate_multiplier", "cvm_mining_multiplier")
+    @classmethod
+    def validate_cvm_multipliers(cls, v: float) -> float:
+        """Validate that CVM multipliers are >= 1.0 (bonus, not penalty)."""
+        if v < 1.0:
+            raise ValueError(f"CVM multipliers must be >= 1.0, got: {v}")
+        return v
 
     @field_validator("algorithm")
     @classmethod

--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -149,10 +149,16 @@ class DefaultIncentive(BaseIncentive):
         else:
             job_result.uptime_multiplier = 1
 
-        # Apply multiplier
+        # Apply sysbox and uptime multipliers
         job_result.mining_score *= job_result.sysbox_multiplier * job_result.uptime_multiplier
+
+        # CVM multiplier: bonus for TDX-attested executors
+        if job_result.tdx_attestation_passed and job_result.mining_score:
+            job_result.cvm_multiplier = self.config.cvm_mining_multiplier
+            job_result.mining_score *= job_result.cvm_multiplier
+
         log = _m(
-            "Mining score is calculated successfully. Formula: score * gpu_portion * gpu_count / total_gpu_count * sysbox_multiplier * uptime_multiplier",
+            "Mining score is calculated successfully. Formula: score * gpu_portion * gpu_count / total_gpu_count * sysbox_multiplier * uptime_multiplier * cvm_multiplier",
             extra=get_extra_info(
                 {
                     "executor_id": str(job_result.executor_info.uuid),
@@ -160,6 +166,7 @@ class DefaultIncentive(BaseIncentive):
                     "gpu_count": job_result.gpu_count,
                     "sysbox_multiplier": job_result.sysbox_multiplier,
                     "uptime_multiplier": job_result.uptime_multiplier,
+                    "cvm_multiplier": job_result.cvm_multiplier,
                     "mining_score": job_result.mining_score,
                     "gpu_portion": job_result.gpu_portion,
                     "total_gpu_count": job_result.total_gpu_count,

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -372,22 +372,8 @@ class RentalPriceIncentive(DefaultIncentive):
             job_result.mining_score = 0
             return job_result
 
-        # Rented path: use parent's default scoring logic, then apply CVM bonus if attested
-        job_result = await super().calculate_executor_score(job_result)
-        if job_result.tdx_attestation_passed and job_result.mining_score:
-            job_result.mining_score *= self.config.cvm_mining_multiplier
-            job_result.cvm_multiplier = self.config.cvm_mining_multiplier
-            job_result.incentive_logs.append(
-                _m(
-                    "CVM mining multiplier applied",
-                    extra={
-                        "executor_id": str(job_result.executor_info.uuid),
-                        "cvm_mining_multiplier": self.config.cvm_mining_multiplier,
-                        "mining_score_after": job_result.mining_score,
-                    },
-                ).to_full_string()
-            )
-        return job_result
+        # Rented path: use parent's default scoring logic (includes CVM multiplier)
+        return await super().calculate_executor_score(job_result)
 
     async def estimate_executor(
         self,

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -70,6 +70,7 @@ class ExecutorEstimateParams(BaseModel):
     gpu_splitting_min_count: int | None = None
     sysbox_runtime: bool = True
     collateral_deposited: bool = True
+    tdx_attestation_passed: bool = False
 
 
 # ── Estimate model ────────────────────────────────────────────────────────────
@@ -136,9 +137,10 @@ class RentalPriceIncentive(DefaultIncentive):
         # Store the snapshot so estimation can derive per-model totals from it.
         self._seed_snapshot = snapshot
 
-        # validate configs
+        # validate configs — allow "<base> CVM" variants alongside plain base model names
         for base_model in self.config.rental_incentive_gpu_types:
-            assert base_model in BASE_GPU_MAP.values(), f"Base model {base_model} not found in BASE_GPU_MAP"
+            plain = base_model.removesuffix(" CVM")
+            assert plain in BASE_GPU_MAP.values(), f"Base model {base_model} not found in BASE_GPU_MAP"
 
         for gpu_type in self.config.rental_prices_per_hour.keys():
             assert gpu_type in BASE_GPU_MAP.keys(), f"GPU type {gpu_type} not found in BASE_GPU_MAP"
@@ -154,6 +156,20 @@ class RentalPriceIncentive(DefaultIncentive):
         base_model = BASE_GPU_MAP[gpu_model]
         return base_model
 
+    def get_effective_base_model(self, gpu_model: str, tdx_attestation_passed: bool) -> str:
+        """Return the bucket key for this executor.
+
+        For TDX-attested executors, returns '<base> CVM' if that variant has a
+        non-zero cap configured, providing an independent pool. Falls back to the
+        plain base model for non-attested executors or unconfigured CVM types.
+        """
+        base = BASE_GPU_MAP[gpu_model]
+        if tdx_attestation_passed:
+            cvm_key = f"{base} CVM"
+            if self.config.max_unrented_gpus.get(cvm_key, 0) > 0:
+                return cvm_key
+        return base
+
     async def _pre_process_job_result(self, hotkey: str, result: JobResult):
         """Process a job result.
         Aggregate metrics from job result.
@@ -165,8 +181,8 @@ class RentalPriceIncentive(DefaultIncentive):
 
         await super()._pre_process_job_result(hotkey, result)
 
-        # Check if GPU is eligible
-        base_model = self.get_base_model_for_gpu(result.gpu_model)
+        # Check if GPU is eligible — CVM executors may map to a separate "<base> CVM" bucket
+        base_model = self.get_effective_base_model(result.gpu_model, result.tdx_attestation_passed)
         if base_model not in self.config.rental_incentive_gpu_types:
             return
 
@@ -184,6 +200,10 @@ class RentalPriceIncentive(DefaultIncentive):
                     self.config.gpu_count_custom_prices, self.config.rental_prices_per_hour,
                 )
                 result.hourly_rate = max(result.hourly_rate, rate_for_min)
+
+            # CVM rate premium: applied before accumulation so it's baked into weighted_rate_sum
+            if result.tdx_attestation_passed and base_model.endswith(" CVM"):
+                result.hourly_rate *= self.config.cvm_rate_multiplier
 
             # Sysbox penalty: applied later via effective_rate, not baked into hourly_rate
             result.sysbox_multiplier = 1.0 if result.sysbox_runtime else 1 - settings.PORTION_FOR_SYSBOX_UNRENTED
@@ -259,8 +279,8 @@ class RentalPriceIncentive(DefaultIncentive):
         if not result.eligible_for_rental_share:
             return await super()._post_process_job_result(hotkey, result) # use default incentive logic.
 
-        # state updates
-        base_model = self.get_base_model_for_gpu(result.gpu_model)
+        # state updates — use effective base model so CVM executors look up their own bucket
+        base_model = self.get_effective_base_model(result.gpu_model, result.tdx_attestation_passed)
         result.total_unrented_by_gpu_type = self.unrented_count_by_type.get(base_model, 0)
         result.cap_dilution_applied = result.total_unrented_by_gpu_type > result.max_cap
         result.rental_share = self.rental_share
@@ -322,8 +342,8 @@ class RentalPriceIncentive(DefaultIncentive):
         Returns:
             Calculated score (0 for unrented eligible GPUs, normal score otherwise)
         """
-        # Check if GPU is unrented and eligible (has defined cap in max_unrented_gpus)
-        base_model = self.get_base_model_for_gpu(job_result.gpu_model)
+        # Check if GPU is unrented and eligible — CVM executors may route to "<base> CVM" bucket
+        base_model = self.get_effective_base_model(job_result.gpu_model, job_result.tdx_attestation_passed)
         job_result.eligible_for_rental_share = (
             not job_result.is_rented
             and (base_model in self.config.rental_incentive_gpu_types)
@@ -340,6 +360,8 @@ class RentalPriceIncentive(DefaultIncentive):
                         "reason": "unrented_and_eligible",
                         "score": 0,
                         "pool": "rental_only",
+                        "tdx_attestation_passed": job_result.tdx_attestation_passed,
+                        "effective_base_model": base_model,
                     },
                 )
             )
@@ -350,8 +372,22 @@ class RentalPriceIncentive(DefaultIncentive):
             job_result.mining_score = 0
             return job_result
 
-        # For rented or non-eligible GPUs, use parent's default scoring logic
-        return await super().calculate_executor_score(job_result)
+        # Rented path: use parent's default scoring logic, then apply CVM bonus if attested
+        job_result = await super().calculate_executor_score(job_result)
+        if job_result.tdx_attestation_passed and job_result.mining_score:
+            job_result.mining_score *= self.config.cvm_mining_multiplier
+            job_result.cvm_multiplier = self.config.cvm_mining_multiplier
+            job_result.incentive_logs.append(
+                _m(
+                    "CVM mining multiplier applied",
+                    extra={
+                        "executor_id": str(job_result.executor_info.uuid),
+                        "cvm_mining_multiplier": self.config.cvm_mining_multiplier,
+                        "mining_score_after": job_result.mining_score,
+                    },
+                ).to_full_string()
+            )
+        return job_result
 
     async def estimate_executor(
         self,
@@ -375,9 +411,10 @@ class RentalPriceIncentive(DefaultIncentive):
         is_rented = params.is_rented
 
         base_model = BASE_GPU_MAP.get(gpu_model)
+        effective_base = self.get_effective_base_model(gpu_model, params.tdx_attestation_passed) if base_model else None
         eligible_for_unrented_estimate = (
-            base_model is not None
-            and self.config.max_unrented_gpus.get(base_model, 0) > 0
+            effective_base is not None
+            and self.config.max_unrented_gpus.get(effective_base, 0) > 0
         )
         if base_model is None or (not is_rented and not eligible_for_unrented_estimate):
             return RentalPriceEstimate(
@@ -418,6 +455,7 @@ class RentalPriceIncentive(DefaultIncentive):
             gpu_splitting_min_count=params.gpu_splitting_min_count,
             collateral_deposited=params.collateral_deposited,
             sysbox_runtime=params.sysbox_runtime,
+            tdx_attestation_passed=params.tdx_attestation_passed,
         )
 
         await self._pre_process_job_result("estimate", fake_result)

--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -468,3 +468,4 @@ class GetEstimateRequest(BaseModel):
     gpu_splitting_min_count: int | None = None
     sysbox_runtime: bool = True
     collateral_deposited: bool = True
+    tdx_attestation_passed: bool = False

--- a/neurons/validators/src/services/task/models.py
+++ b/neurons/validators/src/services/task/models.py
@@ -30,6 +30,9 @@ class JobResult(BaseModel):
     tee_type: str | None = None
     tdx_attestation_passed: bool = False
 
+    # CVM incentive tracking
+    cvm_multiplier: float | None = None   # Set when a CVM bonus multiplier is applied
+
     # Incentive relevant fields 
     mining_score: float | None = None                   # Score for mining pool for scoring logic
     sysbox_multiplier: float | None = None              # Multiplier for sysbox runtime for scoring logic

--- a/neurons/validators/tests/test_rental_price_incentive_flow.py
+++ b/neurons/validators/tests/test_rental_price_incentive_flow.py
@@ -2287,3 +2287,306 @@ async def test_sync_logs_successful_gpu_estimate_precompute(
     assert len(success_logs) == 1
     assert success_logs[0].extra["duration_ms"] == 500.0
     assert success_logs[0].extra["gpu_models_count"] == 1
+
+
+# ── CVM (TDX-attested) incentive tests ───────────────────────────────────────
+
+CVM_RATE_MULTIPLIER = 1.5
+CVM_MINING_MULTIPLIER = 1.3
+
+# Config with CVM variants enabled alongside regular GPU types
+MAX_UNRENTED_GPUS_CVM = {
+    **MAX_UNRENTED_GPUS_BY_TYPE,
+    "H100 CVM": 8,
+    "H200 CVM": 8,
+}
+
+
+@pytest.fixture
+def rental_price_config_cvm(rental_price_config):
+    """IncentiveConfig with CVM variants enabled."""
+    return IncentiveConfig(
+        algorithm=ALGORITHM,
+        rental_incentive_gpu_types=[
+            gpu_type for gpu_type, cap in MAX_UNRENTED_GPUS_CVM.items() if cap > 0
+        ],
+        max_unrented_gpus=MAX_UNRENTED_GPUS_CVM,
+        rental_prices_per_hour=RENTAL_PRICES_PER_HOUR,
+        gpu_count_custom_prices={"*": {"*": DEFAULT_PRICE}},
+        cvm_rate_multiplier=CVM_RATE_MULTIPLIER,
+        cvm_mining_multiplier=CVM_MINING_MULTIPLIER,
+    )
+
+
+@pytest.fixture
+def validator_with_cvm(
+    validator_with_mocks,
+    incentive_redis_service,
+    rental_price_config_cvm,
+    price_provider_holder,
+    monkeypatch,
+):
+    original_create = IncentiveFactory.create
+
+    def create_with_price_provider(*args, **kwargs):
+        incentive = original_create(*args, **kwargs)
+        if hasattr(incentive, "price_provider"):
+            incentive.price_provider = price_provider_holder["provider"]
+        return incentive
+
+    monkeypatch.setattr(IncentiveFactory, "create", create_with_price_provider)
+    monkeypatch.setattr(settings, "incentive", rental_price_config_cvm)
+    monkeypatch.setattr(rental_price_module, "BASE_GPU_MAP", BASE_GPU_MAP)
+    validator_with_mocks.incentive = rental_price_config_cvm
+    return validator_with_mocks
+
+
+def _cvm_job(create_job_result, *, executor_id: str, gpu_model: str, gpu_count: int,
+             is_rented: bool, tdx_attestation_passed: bool = False, **kwargs):
+    result = create_job_result(executor_id=executor_id, gpu_model=gpu_model, gpu_count=gpu_count, **kwargs)
+    result.is_rented = is_rented
+    result.tdx_attestation_passed = tdx_attestation_passed
+    return result
+
+
+@pytest.mark.asyncio
+async def test_cvm_unrented_uses_separate_bucket(
+    validator_with_cvm,
+    mock_subtensor_client,
+    mock_settings,
+    create_job_result,
+    create_neuron_info,
+    mock_price_provider,
+):
+    """CVM unrented executor routes to '<base> CVM' bucket, not plain base bucket."""
+    validator = validator_with_cvm
+    validator.miner_scores = {}
+
+    miners = [
+        create_neuron_info(uid=100, hotkey="burner1"),
+        create_neuron_info(uid=101, hotkey="burner2"),
+        create_neuron_info(uid=2, hotkey="miner_cvm"),
+        create_neuron_info(uid=3, hotkey="miner_plain"),
+    ]
+
+    # Both miners have unrented H100 GPUs within the cap (8 GPUs), but one is CVM
+    all_job_results = {
+        "miner_cvm": [
+            _cvm_job(create_job_result, executor_id="exec-cvm", gpu_model="H100", gpu_count=8,
+                     is_rented=False, tdx_attestation_passed=True),
+        ],
+        "miner_plain": [
+            _cvm_job(create_job_result, executor_id="exec-plain", gpu_model="H100", gpu_count=8,
+                     is_rented=False, tdx_attestation_passed=False),
+        ],
+    }
+
+    validator.backend_client.get_all_rented_executors = AsyncMock(return_value=_make_rented_data([]))
+
+    await _run_sync_with_jobs(validator, miners, all_job_results)
+
+    # Both miners should earn rental share (each within their own cap)
+    assert validator.miner_scores.get("miner_cvm", 0) > 0, "CVM miner should earn rental share"
+    assert validator.miner_scores.get("miner_plain", 0) > 0, "Plain miner should earn rental share"
+
+    # CVM miner earns more due to cvm_rate_multiplier applied to hourly_rate
+    # Effective rate for CVM: H100_HOURLY_RATE * CVM_RATE_MULTIPLIER * cap_mult
+    # Effective rate for plain: H100_HOURLY_RATE * cap_mult
+    assert validator.miner_scores["miner_cvm"] > validator.miner_scores["miner_plain"], (
+        "CVM miner should earn more than plain miner due to cvm_rate_multiplier"
+    )
+    # Ratio should equal CVM_RATE_MULTIPLIER since both have equal GPU counts and are within cap
+    ratio = validator.miner_scores["miner_cvm"] / validator.miner_scores["miner_plain"]
+    assert ratio == pytest.approx(CVM_RATE_MULTIPLIER, rel=0.01)
+
+
+@pytest.mark.asyncio
+async def test_cvm_caps_are_independent_from_plain(
+    validator_with_mocks,
+    mock_subtensor_client,
+    mock_settings,
+    create_job_result,
+    create_neuron_info,
+    price_provider_holder,
+    monkeypatch,
+):
+    """CVM and plain GPU-type caps dilute independently — CVM is not penalized by non-CVM abundance.
+
+    Scenario: plain H100 pool is over cap (100 GPUs, cap=8) → heavy dilution.
+              CVM H100 pool is exactly at cap (8 GPUs, cap=8) → no dilution.
+    If they shared a bucket, the CVM executor would also be diluted. Because they're separate,
+    CVM still gets full (undiluted) rate.
+    """
+    # Use a config where the plain H100 cap is small (8) so over-cap dilution is visible
+    small_cap_max = {
+        "H100": 8,
+        "H100 CVM": 8,
+        "H200": 8,
+        "A100": 0,
+    }
+    cvm_config = IncentiveConfig(
+        algorithm=ALGORITHM,
+        rental_incentive_gpu_types=[k for k, v in small_cap_max.items() if v > 0],
+        max_unrented_gpus=small_cap_max,
+        rental_prices_per_hour=RENTAL_PRICES_PER_HOUR,
+        gpu_count_custom_prices={"*": {"*": DEFAULT_PRICE}},
+        cvm_rate_multiplier=CVM_RATE_MULTIPLIER,
+        cvm_mining_multiplier=CVM_MINING_MULTIPLIER,
+    )
+
+    original_create = IncentiveFactory.create
+
+    def create_with_price_provider(*args, **kwargs):
+        incentive = original_create(*args, **kwargs)
+        if hasattr(incentive, "price_provider"):
+            incentive.price_provider = price_provider_holder["provider"]
+        return incentive
+
+    monkeypatch.setattr(IncentiveFactory, "create", create_with_price_provider)
+    monkeypatch.setattr(settings, "incentive", cvm_config)
+    monkeypatch.setattr(rental_price_module, "BASE_GPU_MAP", BASE_GPU_MAP)
+    validator = validator_with_mocks
+    validator.incentive = cvm_config
+    validator.miner_scores = {}
+
+    miners = [
+        create_neuron_info(uid=100, hotkey="burner1"),
+        create_neuron_info(uid=101, hotkey="burner2"),
+        create_neuron_info(uid=2, hotkey="miner_cvm"),
+        create_neuron_info(uid=3, hotkey="miner_plain"),
+    ]
+
+    # Plain H100: 100 GPUs, cap=8 → diluted (cap_multiplier=8/100=0.08)
+    # CVM H100:   8 GPUs,  cap=8 → no dilution (cap_multiplier=1.0)
+    PLAIN_GPU_COUNT = 100
+    CVM_GPU_COUNT = 8
+    PLAIN_CAP = 8
+
+    all_job_results = {
+        "miner_cvm": [
+            _cvm_job(create_job_result, executor_id="exec-cvm", gpu_model="H100", gpu_count=CVM_GPU_COUNT,
+                     is_rented=False, tdx_attestation_passed=True),
+        ],
+        "miner_plain": [
+            _cvm_job(create_job_result, executor_id="exec-plain", gpu_model="H100", gpu_count=PLAIN_GPU_COUNT,
+                     is_rented=False, tdx_attestation_passed=False),
+        ],
+    }
+
+    validator.backend_client.get_all_rented_executors = AsyncMock(return_value=_make_rented_data([]))
+
+    await _run_sync_with_jobs(validator, miners, all_job_results)
+
+    cvm_score = validator.miner_scores.get("miner_cvm", 0)
+    plain_score = validator.miner_scores.get("miner_plain", 0)
+
+    assert cvm_score > 0
+    assert plain_score > 0
+
+    # CVM: 8 GPUs * H100_rate * 1.5 (CVM mult) * 1.0 (no dilution) = 8 * 3.5 * 1.5 = 42
+    # Plain: 100 GPUs * H100_rate * (8/100) (diluted to cap) = 100 * 3.5 * 0.08 = 28
+    # total = 70; CVM fraction = 42/70 = 0.6; Plain fraction = 28/70 = 0.4
+    cvm_effective = CVM_GPU_COUNT * H100_HOURLY_RATE * CVM_RATE_MULTIPLIER * 1.0
+    plain_effective = PLAIN_GPU_COUNT * H100_HOURLY_RATE * (PLAIN_CAP / PLAIN_GPU_COUNT)
+    expected_cvm_fraction = cvm_effective / (cvm_effective + plain_effective)
+
+    total_rental_score = cvm_score + plain_score
+    actual_cvm_fraction = cvm_score / total_rental_score
+    assert actual_cvm_fraction == pytest.approx(expected_cvm_fraction, rel=0.01)
+
+
+@pytest.mark.asyncio
+async def test_cvm_rented_gets_mining_multiplier(
+    validator_with_cvm,
+    mock_subtensor_client,
+    mock_settings,
+    create_job_result,
+    create_neuron_info,
+    mock_price_provider,
+):
+    """Rented CVM executor's mining score is multiplied by cvm_mining_multiplier."""
+    validator = validator_with_cvm
+    validator.miner_scores = {}
+
+    miners = [
+        create_neuron_info(uid=100, hotkey="burner1"),
+        create_neuron_info(uid=101, hotkey="burner2"),
+        create_neuron_info(uid=2, hotkey="miner_cvm"),
+        create_neuron_info(uid=3, hotkey="miner_plain"),
+    ]
+
+    # Both have same GPU count and GPU model, rented; only CVM miner has TDX attestation
+    all_job_results = {
+        "miner_cvm": [
+            _cvm_job(create_job_result, executor_id="exec-cvm", gpu_model="H100", gpu_count=1,
+                     is_rented=True, tdx_attestation_passed=True),
+        ],
+        "miner_plain": [
+            _cvm_job(create_job_result, executor_id="exec-plain", gpu_model="H100", gpu_count=1,
+                     is_rented=True, tdx_attestation_passed=False),
+        ],
+    }
+
+    validator.backend_client.get_all_rented_executors = AsyncMock(
+        return_value=_make_rented_data(["exec-cvm", "exec-plain"])
+    )
+
+    await _run_sync_with_jobs(validator, miners, all_job_results)
+
+    cvm_score = validator.miner_scores.get("miner_cvm", 0)
+    plain_score = validator.miner_scores.get("miner_plain", 0)
+
+    assert cvm_score > 0
+    assert plain_score > 0
+    # CVM gets cvm_mining_multiplier applied to its mining_score, so its final weight is proportionally higher
+    # mining_score_cvm = base * CVM_MINING_MULTIPLIER
+    # mining_score_plain = base
+    # total = base * (1 + CVM_MINING_MULTIPLIER)
+    # incentive_cvm / incentive_plain = CVM_MINING_MULTIPLIER
+    ratio = cvm_score / plain_score
+    assert ratio == pytest.approx(CVM_MINING_MULTIPLIER, rel=0.01)
+
+
+@pytest.mark.asyncio
+async def test_cvm_falls_back_to_plain_when_no_cvm_cap_configured(
+    validator_with_rental_price,
+    mock_subtensor_client,
+    mock_settings,
+    create_job_result,
+    create_neuron_info,
+    mock_price_provider,
+):
+    """CVM executor with GPU type that has no CVM variant configured falls back to plain bucket."""
+    validator = validator_with_rental_price  # config has NO CVM variants
+    validator.miner_scores = {}
+
+    miners = [
+        create_neuron_info(uid=100, hotkey="burner1"),
+        create_neuron_info(uid=101, hotkey="burner2"),
+        create_neuron_info(uid=2, hotkey="miner_cvm"),
+        create_neuron_info(uid=3, hotkey="miner_plain"),
+    ]
+
+    # Both unrented H100; CVM flag is set but no "H100 CVM" in config → falls back to "H100"
+    all_job_results = {
+        "miner_cvm": [
+            _cvm_job(create_job_result, executor_id="exec-cvm", gpu_model="H100", gpu_count=1,
+                     is_rented=False, tdx_attestation_passed=True),
+        ],
+        "miner_plain": [
+            _cvm_job(create_job_result, executor_id="exec-plain", gpu_model="H100", gpu_count=1,
+                     is_rented=False, tdx_attestation_passed=False),
+        ],
+    }
+
+    validator.backend_client.get_all_rented_executors = AsyncMock(return_value=_make_rented_data([]))
+
+    await _run_sync_with_jobs(validator, miners, all_job_results)
+
+    # Both compete in the same "H100" bucket, same rate → equal scores
+    cvm_score = validator.miner_scores.get("miner_cvm", 0)
+    plain_score = validator.miner_scores.get("miner_plain", 0)
+
+    assert cvm_score > 0
+    assert plain_score > 0
+    assert cvm_score == pytest.approx(plain_score, rel=0.001)


### PR DESCRIPTION
## Summary
- Add `cvm_rate_multiplier` (default 1.5) and `cvm_mining_multiplier` (default 1.3) to `IncentiveConfig` for TDX-attested executor bonuses
- Introduce `get_effective_base_model()` so CVM executors route to separate `"<base> CVM"` buckets (e.g. `"H100 CVM"`), preventing cap dilution with non-CVM executors
- Add `tdx_attestation_passed` to `ExecutorEstimateParams` and `cvm_multiplier` tracking field to `JobResult`
- Add CVM variant caps to `MAX_UNRENTED_GPUS_BY_TYPE` (H200/H100/A100/RTX4090/RTXA6000/RTX3090)
- Add 4 integration tests covering: separate buckets, independent cap dilution, rented mining multiplier, and fallback to plain when no CVM cap configured

## Test plan
- [ ] `test_cvm_unrented_uses_separate_bucket` — CVM unrented earns more (rate multiplier), routes to own bucket
- [ ] `test_cvm_caps_are_independent_from_plain` — CVM cap not diluted by over-cap plain pool
- [ ] `test_cvm_rented_gets_mining_multiplier` — rented CVM score ratio equals `cvm_mining_multiplier`
- [ ] `test_cvm_falls_back_to_plain_when_no_cvm_cap_configured` — unconfigured CVM type falls back to plain bucket, equal scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)