### PR TITLE
Remove SSH public key build arg and add executor env template - DAH-1906

### DIFF
--- a/neurons/executor/.env.dev.template
+++ b/neurons/executor/.env.dev.template
@@ -1,0 +1,26 @@
+INTERNAL_PORT=8001 # interal port of docker
+EXTERNAL_PORT=8001 # external port of docker
+
+SSH_PORT=2200 # external ssh port of docker map into 22
+SSH_PUBLIC_PORT=2200 # Optional. in case you are using proxy and public port is different from internal port in your server
+
+# NOTE: please use either RENTING_PORT_RANGE or RENTING_PORT_MAPPINGS, both are not allowed
+# Note: If you are not using proxy and all ports are available publicly,
+# then you don't have to set RENTING_PORT_RANGE and RENTING_PORT_MAPPINGS
+
+# (optional) If your internal port and external port are THE SAME
+# configure available ports for renting. 
+# define the ports comma separated or range with dash "-"
+# Please define at least 2 ports
+# example
+# RENTING_PORT_RANGE="40000-65535"
+# RENTING_PORT_RANGE="9001,9002,9003"
+
+# (optional) If your internal port and external port are NOT THE SAME
+# add an array of [internal_port, external_port] mappings
+# example: if internal port 46681 is mapped to 56681 external port
+# and internal port 46682 is mapped to 56682 external port, then
+# RENTING_PORT_MAPPINGS="[[46681, 56681], [46682, 56682]]"
+
+MINER_HOTKEY_SS58_ADDRESS=5DfbmGgkgYoYKJk7rA9UFgeJFacfkBMhaeFZgJk7c4mCv7DT
+DEFAULT_MINER_HOTKEY=5E9mXBKNan8FbRGs71LnXaP8dAVkCVViDvkhbuNsfLwBzLsi

--- a/neurons/executor/Dockerfile
+++ b/neurons/executor/Dockerfile
@@ -50,12 +50,9 @@ RUN mkdir -p /etc/docker \
   && mkdir -p /etc/nvidia-container-runtime \
   && mkdir -p /root/.ssh
 
-ARG SSH_PUBLIC_KEY
-
 RUN useradd -m -s /bin/bash liumuser && \
     mkdir -p /home/liumuser/.ssh && \
-    echo "$SSH_PUBLIC_KEY" > /home/liumuser/.ssh/authorized_keys && \
-    chmod 700 /home/liumuser/.ssh && chmod 600 /home/liumuser/.ssh/authorized_keys && \
+    chmod 700 /home/liumuser/.ssh && \
     chown -R liumuser:liumuser /home/liumuser/.ssh
 
 RUN echo 'AcceptEnv CONTAINER_NAME' >>/etc/ssh/sshd_config && \

--- a/neurons/executor/docker_build.sh
+++ b/neurons/executor/docker_build.sh
@@ -69,8 +69,7 @@ echo -e "${DIM}  Date    : $(date -u '+%Y-%m-%d %H:%M:%S UTC')${RESET}"
 log_step "Validating environment variables"
 
 missing=()
-[[ -z "${TAG:-}"            ]] && missing+=("TAG")
-[[ -z "${SSH_PUBLIC_KEY:-}" ]] && missing+=("SSH_PUBLIC_KEY")
+[[ -z "${TAG:-}" ]] && missing+=("TAG")
 
 if [[ ${#missing[@]} -gt 0 ]]; then
   log_error "The following required environment variables are not set:"
@@ -78,13 +77,12 @@ if [[ ${#missing[@]} -gt 0 ]]; then
     echo -e "    ${RED}•  ${var}${RESET}" >&2
   done
   echo -e "\n${YELLOW}  Usage example:${RESET}"
-  echo -e "  ${DIM}TAG=latest SSH_PUBLIC_KEY=<key> [VALIDATOR_HOTKEY_SS58=<hotkey>] bash docker_build.sh${RESET}\n"
+  echo -e "  ${DIM}TAG=latest [VALIDATOR_HOTKEY_SS58=<hotkey>] bash docker_build.sh${RESET}\n"
   exit 1
 fi
 
 log_success "All required environment variables are set"
-log_kv "TAG:"            "${TAG}"
-log_kv "SSH_PUBLIC_KEY:" "${SSH_PUBLIC_KEY:0:40}..."
+log_kv "TAG:" "${TAG}"
 
 IMAGE_NAME="daturaai/compute-subnet-executor:${TAG}"
 
@@ -116,7 +114,6 @@ echo ""
 
 docker build \
   --build-context datura=../../datura \
-  --build-arg SSH_PUBLIC_KEY="${SSH_PUBLIC_KEY}" \
   --tag "${IMAGE_NAME}" \
   "${SCRIPT_DIR}"
 


### PR DESCRIPTION
## Describe your changes

- remove `SSH_PUBLIC_KEY` from the executor Docker build path, including the required environment variable check and `docker build` arguments in `docker_build.sh`
- stop writing `authorized_keys` into the executor image during Docker build while keeping the `.ssh` directory ownership and permissions setup for `liumuser`
- add `neurons/executor/.env.dev.template` to document local executor environment configuration and example renting port settings

## Issue ticket number and link

DAH-1906

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I wrote tests.
- [ ] Need to take care of performance?
