### PR TITLE
DAH-1932, Add SSH keepalive and SFTP retry for transient connection failures

### DIFF
--- a/neurons/validators/src/services/interactive_shell_service.py
+++ b/neurons/validators/src/services/interactive_shell_service.py
@@ -93,6 +93,8 @@ class InteractiveShellService:
             username=self.username,
             client_keys=[pkey],
             known_hosts=self.known_hosts,
+            keepalive_interval=15,
+            keepalive_count_max=3,
         )
 
     async def __aenter__(self):

--- a/neurons/validators/src/services/task/checks/upload_files.py
+++ b/neurons/validators/src/services/task/checks/upload_files.py
@@ -38,40 +38,48 @@ class UploadFilesCheck:
         random_name = uuid.uuid4().hex
         remote_dir = f"{executor_root.rstrip('/')}/{random_name}"
 
-        try:
-            async with asyncio.timeout(DEFAULT_TIMEOUT):
-                async with ctx.ssh.start_sftp_client() as sftp:
-                    await sftp.put(local_dir, remote_dir, recurse=True)
+        MAX_RETRIES = 2
+        last_exc: Exception | None = None
 
-            event = render_message(
-                Msg.UPLOAD_OK,
-                ctx=ctx,
-                check_id=self.check_id,
-                what={"remote_dir": remote_dir, "local_dir": local_dir},
-            )
-            updated_state = replace(
-                ctx.state,
-                upload_remote_dir=remote_dir,
-                remote_dir=remote_dir,
-            )
-            return CheckResult(
-                passed=True,
-                event=event,
-                updates={"state": updated_state},
-            )
-        except asyncio.TimeoutError:
-            event = render_message(
-                Msg.UPLOAD_FAILED,
-                ctx=ctx,
-                check_id=self.check_id,
-                what={"error": f"Upload timed out after {DEFAULT_TIMEOUT} seconds"},
-            )
-            return CheckResult(passed=False, event=event)
-        except Exception as exc:
-            event = render_message(
-                Msg.UPLOAD_FAILED,
-                ctx=ctx,
-                check_id=self.check_id,
-                what={"error": str(exc)[:200]},
-            )
-            return CheckResult(passed=False, event=event)
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                async with asyncio.timeout(DEFAULT_TIMEOUT):
+                    async with ctx.ssh.start_sftp_client() as sftp:
+                        await sftp.put(local_dir, remote_dir, recurse=True)
+
+                event = render_message(
+                    Msg.UPLOAD_OK,
+                    ctx=ctx,
+                    check_id=self.check_id,
+                    what={"remote_dir": remote_dir, "local_dir": local_dir},
+                )
+                updated_state = replace(
+                    ctx.state,
+                    upload_remote_dir=remote_dir,
+                    remote_dir=remote_dir,
+                )
+                return CheckResult(
+                    passed=True,
+                    event=event,
+                    updates={"state": updated_state},
+                )
+            except asyncio.TimeoutError:
+                event = render_message(
+                    Msg.UPLOAD_FAILED,
+                    ctx=ctx,
+                    check_id=self.check_id,
+                    what={"error": f"Upload timed out after {DEFAULT_TIMEOUT} seconds"},
+                )
+                return CheckResult(passed=False, event=event)
+            except Exception as exc:
+                last_exc = exc
+                if attempt < MAX_RETRIES:
+                    await asyncio.sleep(1.0 * attempt)
+
+        event = render_message(
+            Msg.UPLOAD_FAILED,
+            ctx=ctx,
+            check_id=self.check_id,
+            what={"error": str(last_exc)[:200]},
+        )
+        return CheckResult(passed=False, event=event)

--- a/neurons/validators/src/services/verifyx_validation_service.py
+++ b/neurons/validators/src/services/verifyx_validation_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import ctypes
 import hashlib
 import json
@@ -87,13 +88,17 @@ class VerifyXValidationService:
 
     async def _get_executor_checksum(self, shell) -> str:
         """Get the VerifyX library checksum from executor using SCP."""
-        try:
-            checksums = await shell.get_checksums_over_scp(self.lib_name)
-            # Format is "md5:sha256", we need sha256
-            sha256_checksum = checksums.split(":")[1]
-            return sha256_checksum
-        except Exception:
-            return ""
+        max_retries = 2
+        for attempt in range(1, max_retries + 1):
+            try:
+                checksums = await shell.get_checksums_over_scp(self.lib_name)
+                # Format is "md5:sha256", we need sha256
+                sha256_checksum = checksums.split(":")[1]
+                return sha256_checksum
+            except Exception:
+                if attempt < max_retries:
+                    await asyncio.sleep(1.0)
+        return ""
 
     async def validate_verifyx_and_process_job(
         self,


### PR DESCRIPTION
## Summary

### Task Link

[DAH-1932](https://www.notion.so/Subnet-Backend-Rental-stability-prevent-executor-re-registration-from-killing-rented-pods-341b8bfdbde9819aa39fccb3798d18e3) — sibling reliability fix (transient SSH/SFTP failures contribute to validation flakiness on the same executors that hit the re-registration race)

---

## Problem

Validators intermittently fail validation for healthy executors due to transient SSH/SFTP connection resets (`[Errno 104] Connection reset by peer`). This causes two symptoms:
- **UploadFilesCheck** fails on SFTP upload → entire validation halted, score drops to 0
- **VerifyX checksum mismatch** — SCP read fails silently, returns empty string, misinterpreted as "outdated library"

Both observed on the same executor (`44.249.109.8`) which passes all other checks successfully.

## Solution

1. **SSH keepalive** — added `keepalive_interval=15, keepalive_count_max=3` to `asyncssh.connect()` to prevent idle connection drops
2. **SFTP upload retry** — `UploadFilesCheck` now retries once (2 attempts total) on transient errors, with 1s backoff. Timeouts are not retried.
3. **SCP checksum retry** — `VerifyXValidationService._get_executor_checksum()` retries once on SCP failure, preventing false "outdated library" errors

## Changes

- `interactive_shell_service.py` — add keepalive params to `asyncssh.connect()`
- `upload_files.py` — wrap SFTP upload in retry loop (max 2 attempts)
- `verifyx_validation_service.py` — add retry for SCP checksum read, add `asyncio` import

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Risks

- Keepalive adds minimal network overhead (1 packet every 15s per SSH session)
- Retry adds at most 1s delay on transient failures — negligible vs 300s upload timeout

## Test Cases

### Test Case 1 — Upload retry
**Actions**: Existing `test_upload_files_check.py` tests pass (4/4)
**Expected Output**: All pass

### Test Case 2 — Production validation
**Actions**: Deploy and monitor executor `3adbb63a` / `44.249.109.8` validation logs
**Expected Output**: No more intermittent UPLOAD_FAILED or false VERIFYX_FAILED for healthy executors

## Checklist

- [ ] Proper labels added
- [ ] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
