### PR TITLE
DAH-1932, enable stale container cleanup with CONTAINER_CLEANUP_DRY_RUN setting

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -142,6 +142,7 @@ class Settings(BaseSettings):
     ENABLE_VERIFYX: bool = True
     SKIP_RENTAL_VERIFICATION: bool = Field(env="SKIP_RENTAL_VERIFICATION", default=False)
     DRY_RUN: bool = Field(env="DRY_RUN", default=False, description="Run validation without publishing scores/weights")
+    CONTAINER_CLEANUP_DRY_RUN: bool = Field(env="CONTAINER_CLEANUP_DRY_RUN", default=False, description="Dry run mode for stale container cleanup")
 
     COLLATERAL_CONTRACT_ADDRESS: str = Field(
         env='COLLATERAL_CONTRACT_ADDRESS', default='0x8A4023FdD1eaA7b242F3723a7d096B6CC693c7C6'

--- a/neurons/validators/src/services/container_cleanup.py
+++ b/neurons/validators/src/services/container_cleanup.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class ContainerCleanup:
     """Service for cleaning up stale containers on executor machines."""
 
-    def __init__(self, stale_threshold_minutes: int = 15, dry_run: bool = True):
+    def __init__(self, stale_threshold_minutes: int = 15, dry_run: bool = False):
         self.stale_threshold_minutes = stale_threshold_minutes
         self.dry_run = dry_run
 

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -97,6 +97,10 @@ class PipelineFactory:
         self.executor_connectivity_service = executor_connectivity_service
         self.backend_client = backend_client
 
+        dry_run = settings.DRY_RUN or settings.CONTAINER_CLEANUP_DRY_RUN
+        logger.info(f"ContainerCleanup dry_run={dry_run}")
+        self.container_cleanup = ContainerCleanup(dry_run=dry_run)
+
     async def build_context(
         self,
         shell: InteractiveShellService,
@@ -170,7 +174,7 @@ class PipelineFactory:
                 shell=shell,
                 score_calculator=calculate_scores,
                 backend=self.backend_client,
-                container_cleanup=ContainerCleanup(),
+                container_cleanup=self.container_cleanup,
             ),
             config=ContextConfig(
                 executor_root=executor_info.root_dir,


### PR DESCRIPTION
## Summary

### Task Link

[DAH-1932](https://www.notion.so/Subnet-Backend-Rental-stability-prevent-executor-re-registration-from-killing-rented-pods-341b8bfdbde9819aa39fccb3798d18e3)

---

## Problem

After PR #987 stale container cleanup was put into permanent `dry_run=True` mode as a hotfix to stop killing live customer pods on miner re-registration. We need a way to re-enable cleanup safely once the underlying race (DAH-1932) is mitigated, without another code change + redeploy cycle.

Additionally, `ContainerCleanup` was being instantiated once per validation context (i.e. per executor per cycle), and a `dry_run` log line was firing on every build — pure noise in production logs.

## Solution

- Add `CONTAINER_CLEANUP_DRY_RUN` env setting; effective `dry_run` is `DRY_RUN OR CONTAINER_CLEANUP_DRY_RUN`. Operator can flip cleanup on/off via env without code change.
- Restore `ContainerCleanup` constructor default to `dry_run=False` (production-default behavior — opt-in for safety mode).
- Instantiate `ContainerCleanup` once in `PipelineFactory.__init__` and reuse across all `build_context` calls. The service is stateless (only immutable config), so sharing is safe.

## Changes

- `core/config.py`: add `CONTAINER_CLEANUP_DRY_RUN` setting (default `False`).
- `services/container_cleanup.py`: change default `dry_run=True → False`.
- `services/task/pipeline_factory.py`: build `ContainerCleanup` once in `__init__`, log `dry_run` flag once at startup, drop per-context construction.

## Deployment Steps

Use GitHub Action.

For initial rollout set `CONTAINER_CLEANUP_DRY_RUN=true` in validator env to keep current behavior (no actual removal). Flip to `false` (or unset) once the executor re-registration race fix lands.

## Review Request

- [x] Just code review

## Other PRs

None for this PR. Sibling work for DAH-1932 (validator rebind on re-registration, backend stable identity) lands separately.

## Risks

- If deployed with `CONTAINER_CLEANUP_DRY_RUN` unset/false **before** the executor re-registration race is fixed, validator may again kill live customer pods on miner re-register — same incident class as #987 mitigated. Mitigation: deploy with env `CONTAINER_CLEANUP_DRY_RUN=true` until DAH-1932 fix lands.
- `ContainerCleanup` singleton change: shared across concurrent validations. Safe today (only immutable config), but if state is added later this needs re-evaluation.

## Test Cases

### Test Case 1 — dry_run log fires once

**Actions**: start validator with `CONTAINER_CLEANUP_DRY_RUN=true`.

**Expected Output**: exactly one `ContainerCleanup dry_run=True` log line at startup; no per-validation duplication.

### Test Case 2 — env override works

**Actions**: start validator with `CONTAINER_CLEANUP_DRY_RUN=false` (or unset). Have a stale (>15min, non-rented) container on an executor.

**Expected Output**: container is removed; `Removed stale container ...` log line emitted.

### Test Case 3 — DRY_RUN global wins

**Actions**: start validator with `DRY_RUN=true` and `CONTAINER_CLEANUP_DRY_RUN=false`.

**Expected Output**: cleanup runs in dry_run mode (no actual removal).

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described