### PR TITLE
DAH-1953, harden pod sshd config (disable password auth)

### DIFF
--- a/neurons/validators/src/services/assets/sshd_bootstrap.sh
+++ b/neurons/validators/src/services/assets/sshd_bootstrap.sh
@@ -92,7 +92,11 @@ harden_sshd_config() {
     if grep -q '^# lium-hardened$' "$sshd_config" 2>/dev/null; then
         return 0
     fi
-    printf '\n# lium-hardened\nPasswordAuthentication no\nChallengeResponseAuthentication no\n' >> "$sshd_config"
+    # sshd honors the first matching directive — comment out any existing
+    # occurrences before appending, otherwise our values would be ignored on
+    # base images that ship explicit settings.
+    sed -i -E 's/^[[:space:]]*(PasswordAuthentication|ChallengeResponseAuthentication|KbdInteractiveAuthentication)[[:space:]]+.*/# lium-disabled &/I' "$sshd_config"
+    printf '\n# lium-hardened\nPasswordAuthentication no\nKbdInteractiveAuthentication no\nChallengeResponseAuthentication no\n' >> "$sshd_config"
 }
 
 prepare_sshd_runtime() {

--- a/neurons/validators/src/services/assets/sshd_bootstrap.sh
+++ b/neurons/validators/src/services/assets/sshd_bootstrap.sh
@@ -86,11 +86,21 @@ ensure_sshd_installed() {
     return 1
 }
 
+harden_sshd_config() {
+    sshd_config="/etc/ssh/sshd_config"
+    [ -f "$sshd_config" ] || return 0
+    if grep -q '^# lium-hardened$' "$sshd_config" 2>/dev/null; then
+        return 0
+    fi
+    printf '\n# lium-hardened\nPasswordAuthentication no\nChallengeResponseAuthentication no\n' >> "$sshd_config"
+}
+
 prepare_sshd_runtime() {
     mkdir -p /run/sshd
     mkdir -p /root/.ssh
     chmod 700 /root/.ssh
     ssh-keygen -A
+    harden_sshd_config
 }
 
 start_sshd_if_needed() {


### PR DESCRIPTION
## Summary

### Task Link

[DAH-1953](https://www.notion.so/Security-Harden-pod-sshd-config-SEC-B6-343b8bfdbde98189a58ac4d079f84ead)

---

## Problem

`prepare_sshd_runtime()` in the pod sshd bootstrap script only creates runtime dirs and regenerates host keys; it never edits `sshd_config`. The daemon therefore starts with whatever policy the base image ships, which typically leaves `PasswordAuthentication yes` on. Renters can weaken their own pod by setting a root password via `startup_commands`, making the pod brute-forceable from outside. Task SEC-B6 asks for explicit key-only login.

## Solution

Append two directives to `/etc/ssh/sshd_config` before starting the daemon:
- `PasswordAuthentication no`
- `ChallengeResponseAuthentication no`

Done via a new `harden_sshd_config()` helper called from `prepare_sshd_runtime()`. Writes are guarded by a `# lium-hardened` marker so repeated bootstrap runs (e.g. from the watchdog) do not duplicate lines.

## Changes

- `neurons/validators/src/services/assets/sshd_bootstrap.sh`:
  - New idempotent `harden_sshd_config()` appending `PasswordAuthentication no` and `ChallengeResponseAuthentication no` with a marker line.
  - `prepare_sshd_runtime()` now calls `harden_sshd_config` after `ssh-keygen -A`.

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review

## Other PRs

None.

## Risks

- Strictly stricter policy — existing rentals continue to work (pubkey auth is unchanged). No impact on Jupyter (token auth).
- Only base images that ship with an `/etc/ssh/sshd_config` are affected. If the file is absent, `harden_sshd_config` is a no-op.
- The marker-based guard prevents duplicated directives across watchdog reruns, but will not detect pre-existing `PasswordAuthentication yes` lines earlier in the file — the appended `no` wins because sshd honors the first occurrence... actually sshd honors the first occurrence, not the last. This is fine for fresh pod bootstrap (appending after defaults) because the default file has `PasswordAuthentication` commented out; if a base image ever pre-sets it to `yes`, hardening would silently fail. Worth a follow-up if we see such an image in production.

## Test Cases

### Test Case 1: fresh pod

**Actions**
1. Start a pod on an Ubuntu base image.
2. Exec into the container and `grep -E 'PasswordAuthentication|ChallengeResponseAuthentication' /etc/ssh/sshd_config`.

**Expected Output**
Both directives present with value `no`, preceded by the `# lium-hardened` marker.

### Test Case 2: watchdog reruns

**Actions**
1. In the running pod, kill `sshd` and wait for the watchdog to restart it.
2. Inspect `/etc/ssh/sshd_config`.

**Expected Output**
Only one `# lium-hardened` block in the file — no duplicated directives.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described