### PR TITLE
DAH-1932, collect docker diagnostics on POD_NOT_RUNNING

### DIFF
--- a/neurons/validators/src/clients/subtensor_client.py
+++ b/neurons/validators/src/clients/subtensor_client.py
@@ -23,6 +23,8 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 SYNC_CYCLE = 12
+SUBTENSOR_BACKOFF_INITIAL = 12
+SUBTENSOR_BACKOFF_MAX = 300
 
 
 class SubtensorClient:
@@ -99,7 +101,7 @@ class SubtensorClient:
 
             SubtensorClient._subtensor = subtensor
         except Exception as e:
-            logger.info(
+            logger.error(
                 _m(
                     "[Error] failed initializing subtensor",
                     extra=get_extra_info(
@@ -520,9 +522,13 @@ class SubtensorClient:
 
     async def _warm_up_subtensor(self):
         count = 0
+        backoff = SUBTENSOR_BACKOFF_INITIAL
         while True:
             try:
                 self.set_subtensor()
+
+                if SubtensorClient._subtensor is None:
+                    raise RuntimeError("subtensor is not initialized")
 
                 if count == 0:
                     await self.fetch_miners()
@@ -534,18 +540,22 @@ class SubtensorClient:
                     self.sync_evm_address_maps()
                     count = 1
 
-                # sync every 12 seconds
+                backoff = SUBTENSOR_BACKOFF_INITIAL
                 await asyncio.sleep(SYNC_CYCLE)
             except Exception as e:
                 logger.error(
                     _m(
                         "[_warm_up_subtensor] Failed to connect into subtensor",
-                        extra=get_extra_info({**self.default_extra, "error": str(e)}),
+                        extra=get_extra_info({
+                            **self.default_extra,
+                            "error": str(e),
+                            "backoff": backoff,
+                        }),
                     ),
                     exc_info=True,
                 )
-                self.initialize_subtensor()
-                await asyncio.sleep(SYNC_CYCLE)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, SUBTENSOR_BACKOFF_MAX)
 
     @classmethod
     async def initialize(cls) -> Self:

--- a/neurons/validators/src/clients/subtensor_client.py
+++ b/neurons/validators/src/clients/subtensor_client.py
@@ -1,6 +1,8 @@
 import asyncio
 import bittensor
+import contextlib
 import numpy as np
+import time
 from typing import Self, TYPE_CHECKING
 from bittensor.utils.weight_utils import (
     convert_weights_and_uids_for_emit,
@@ -25,6 +27,36 @@ logger = get_logger(__name__)
 SYNC_CYCLE = 12
 SUBTENSOR_BACKOFF_INITIAL = 12
 SUBTENSOR_BACKOFF_MAX = 300
+
+
+@contextlib.contextmanager
+def _log_sync_block(name: str, *, extra: dict | None = None):
+    """Bracket a synchronous call that runs inside the asyncio event loop with entry/exit
+    logs. These helpers double as a breadcrumb trail when async HTTP clients report
+    timeouts that were actually caused by the loop being frozen here.
+    """
+    start = time.perf_counter()
+    logger.info(
+        _m(
+            f"[sync-block][start] {name}",
+            extra=get_extra_info({**(extra or {}), "sync_block": name, "phase": "start"}),
+        )
+    )
+    try:
+        yield
+    finally:
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+        logger.info(
+            _m(
+                f"[sync-block][end] {name} ({elapsed_ms}ms)",
+                extra=get_extra_info({
+                    **(extra or {}),
+                    "sync_block": name,
+                    "phase": "end",
+                    "elapsed_ms": elapsed_ms,
+                }),
+            )
+        )
 
 
 class SubtensorClient:
@@ -123,7 +155,8 @@ class SubtensorClient:
         ):
             return
 
-        self.initialize_subtensor()
+        with _log_sync_block("set_subtensor.initialize", extra=self.default_extra):
+            self.initialize_subtensor()
 
     def check_registered(self, subtensor: bittensor.subtensor):
         try:
@@ -153,23 +186,27 @@ class SubtensorClient:
             )
 
     def get_metagraph(self):
-        return self.subtensor.metagraph(netuid=self.netuid)
+        with _log_sync_block("get_metagraph", extra=self.default_extra):
+            return self.subtensor.metagraph(netuid=self.netuid)
 
     def get_node(self):
         # return SubstrateInterface(url=self.config.subtensor.chain_endpoint)
         return self.subtensor.substrate
 
     def get_current_block(self):
-        node = self.get_node()
-        return node.query("System", "Number", []).value
+        with _log_sync_block("get_current_block"):
+            node = self.get_node()
+            return node.query("System", "Number", []).value
 
     def get_weights_rate_limit(self):
-        node = self.get_node()
-        return node.query("SubtensorModule", "WeightsSetRateLimit", [self.netuid]).value
+        with _log_sync_block("get_weights_rate_limit"):
+            node = self.get_node()
+            return node.query("SubtensorModule", "WeightsSetRateLimit", [self.netuid]).value
 
     def get_last_mechansim_step_block(self):
-        node = self.get_node()
-        return node.query("SubtensorModule", "LastMechansimStepBlock", [self.netuid]).value
+        with _log_sync_block("get_last_mechansim_step_block"):
+            node = self.get_node()
+            return node.query("SubtensorModule", "LastMechansimStepBlock", [self.netuid]).value
 
     def get_uid_for_hotkey(self, hotkey):
         metagraph = self.get_metagraph()
@@ -179,16 +216,17 @@ class SubtensorClient:
         return self.hotkey_to_evm_address.get(hotkey, None)
 
     def sync_evm_address_maps(self):
-        node = self.get_node()
-        associated_evms = node.query_map(module="SubtensorModule", storage_function="AssociatedEvmAddress", params=[self.netuid])
-        for uid, evm_address in associated_evms:
-            address_bytes = evm_address.value[0][0]
-            evm_address_hex = "0x" + bytes(address_bytes).hex()
-            self.uid_to_evm_address[uid] = evm_address_hex
+        with _log_sync_block("sync_evm_address_maps", extra=self.default_extra):
+            node = self.get_node()
+            associated_evms = node.query_map(module="SubtensorModule", storage_function="AssociatedEvmAddress", params=[self.netuid])
+            for uid, evm_address in associated_evms:
+                address_bytes = evm_address.value[0][0]
+                evm_address_hex = "0x" + bytes(address_bytes).hex()
+                self.uid_to_evm_address[uid] = evm_address_hex
 
-        """Update the map of miner_hotkey -> evm_address for all miners."""
-        for miner in self.miners:
-            self.hotkey_to_evm_address[miner.hotkey] = self.uid_to_evm_address.get(miner.uid, None)
+            """Update the map of miner_hotkey -> evm_address for all miners."""
+            for miner in self.miners:
+                self.hotkey_to_evm_address[miner.hotkey] = self.uid_to_evm_address.get(miner.uid, None)
 
         logger.info(
             _m(

--- a/neurons/validators/src/clients/subtensor_client.py
+++ b/neurons/validators/src/clients/subtensor_client.py
@@ -31,28 +31,21 @@ SUBTENSOR_BACKOFF_MAX = 300
 
 @contextlib.contextmanager
 def _log_sync_block(name: str, *, extra: dict | None = None):
-    """Bracket a synchronous call that runs inside the asyncio event loop with entry/exit
-    logs. These helpers double as a breadcrumb trail when async HTTP clients report
-    timeouts that were actually caused by the loop being frozen here.
+    """Time a synchronous call that runs inside the asyncio event loop. Emits a single
+    log on exit with elapsed ms — doubles as a breadcrumb trail when async HTTP clients
+    report timeouts that were actually caused by the loop being frozen here.
     """
     start = time.perf_counter()
-    logger.info(
-        _m(
-            f"[sync-block][start] {name}",
-            extra=get_extra_info({**(extra or {}), "sync_block": name, "phase": "start"}),
-        )
-    )
     try:
         yield
     finally:
         elapsed_ms = int((time.perf_counter() - start) * 1000)
         logger.info(
             _m(
-                f"[sync-block][end] {name} ({elapsed_ms}ms)",
+                f"[sync-block] {name} ({elapsed_ms}ms)",
                 extra=get_extra_info({
                     **(extra or {}),
                     "sync_block": name,
-                    "phase": "end",
                     "elapsed_ms": elapsed_ms,
                 }),
             )

--- a/neurons/validators/src/clients/validator_portal_api.py
+++ b/neurons/validators/src/clients/validator_portal_api.py
@@ -49,7 +49,10 @@ class ValidatorPortalAPI:
                 "signature": signature,
             }
 
-            timeout = aiohttp.ClientTimeout(total=10)
+            # Generous total timeout so we survive short event-loop stalls from concurrent
+            # sync bittensor/subtensor calls in this process. aiohttp's timer is driven by
+            # the event loop, so a 10s cap fires spuriously whenever the loop stays blocked.
+            timeout = aiohttp.ClientTimeout(total=60)
             async with aiohttp.ClientSession(timeout=timeout) as session:
                 try:
                     async with session.get(url, headers=headers) as resp:

--- a/neurons/validators/src/services/task/checks/rented_machine.py
+++ b/neurons/validators/src/services/task/checks/rented_machine.py
@@ -1,3 +1,5 @@
+import json
+import shlex
 from typing import Iterable
 from dataclasses import replace
 from protocol.vc_protocol.validator_requests import ResetVerifiedJobReason
@@ -130,6 +132,7 @@ class TenantEnforcementCheck:
             pod_id = pod.pod_id
             pod_running, ssh_pub_keys = await _check_pod_running(ctx.ssh, pod_container_name)
             if not pod_running:
+                diagnostics = await _collect_pod_diagnostics(ctx.ssh, pod_container_name)
                 event = render_message(
                     Msg.POD_NOT_RUNNING,
                     ctx=ctx,
@@ -139,6 +142,7 @@ class TenantEnforcementCheck:
                         "pod_id": pod_id,
                         "container_name": pod_container_name,
                         "executor_uuid": ctx.executor.uuid,
+                        "diagnostics": diagnostics,
                     },
                     extra=extra,
                 )
@@ -231,4 +235,54 @@ async def _check_pod_running(ssh_client, container_name: str) -> tuple[bool, lis
         ssh_keys = []
 
     return pod_running, ssh_keys
+
+
+_POD_LOG_TAIL_LINES = 50
+_POD_LOG_TAIL_CHAR_LIMIT = 4000
+
+
+async def _collect_pod_diagnostics(ssh_client, container_name: str) -> dict:
+    """Collect raw Docker diagnostics for a pod that the ps-running check reported as down.
+
+    Uses the already-open SSH session to query the executor's local Docker daemon. Returns
+    whatever it can: container state (ExitCode, OOMKilled, Error, FinishedAt, ...) and a
+    tail of stdout/stderr logs. When the container has been removed both calls fail and we
+    surface the errors so the operator can distinguish "exited in place" from "rm'd".
+    """
+    quoted_name = shlex.quote(container_name)
+    result: dict = {}
+
+    try:
+        state_cmd = f"/usr/bin/docker inspect --format '{{{{json .State}}}}' {quoted_name}"
+        inspect_result = await ssh_client.run(state_cmd)
+        raw_state = (inspect_result.stdout or "").strip()
+        if raw_state:
+            state = json.loads(raw_state)
+            result["state"] = {
+                "Status": state.get("Status"),
+                "ExitCode": state.get("ExitCode"),
+                "OOMKilled": state.get("OOMKilled"),
+                "Error": state.get("Error"),
+                "StartedAt": state.get("StartedAt"),
+                "FinishedAt": state.get("FinishedAt"),
+            }
+        else:
+            stderr = getattr(inspect_result, "stderr", "")
+            stderr = stderr.strip() if isinstance(stderr, str) else ""
+            result["inspect_error"] = stderr or "empty stdout"
+    except Exception as exc:
+        result["inspect_error"] = str(exc)
+
+    try:
+        logs_cmd = (
+            f"/usr/bin/docker logs --tail {_POD_LOG_TAIL_LINES} {quoted_name} 2>&1"
+        )
+        logs_result = await ssh_client.run(logs_cmd)
+        tail = (logs_result.stdout or "")[-_POD_LOG_TAIL_CHAR_LIMIT:]
+        if tail:
+            result["logs_tail"] = tail
+    except Exception as exc:
+        result["logs_error"] = str(exc)
+
+    return result
 

--- a/neurons/validators/src/services/task/checks/rented_machine.py
+++ b/neurons/validators/src/services/task/checks/rented_machine.py
@@ -284,5 +284,59 @@ async def _collect_pod_diagnostics(ssh_client, container_name: str) -> dict:
     except Exception as exc:
         result["logs_error"] = str(exc)
 
+    host_context = await _collect_host_context(ssh_client)
+    if host_context:
+        result["host_context"] = host_context
+
+    return result
+
+
+async def _collect_host_context(ssh_client) -> dict:
+    """Collect executor-host context that helps distinguish real pod failure from host reboot
+    or executor-container restart.
+
+    Two independent signals:
+      - `host_boot_time` from `uptime -s` — if it is close to the pod's FinishedAt, the host
+        likely rebooted and the pod did not come back up on its own.
+      - `executor_container_started_at` — if far newer than `host_boot_time`, the executor
+        container itself restarted (watchtower, compose restart, autoheal) without a full
+        host reboot. The executor container is located via the compose service label so
+        that the lookup survives renames.
+
+    All failures are swallowed into `*_error` fields — this runs on the already-open SSH
+    session, so we prefer empty signal over raising and losing the rest of the event.
+    """
+    result: dict = {}
+
+    try:
+        uptime_result = await ssh_client.run("uptime -s")
+        boot_time = (uptime_result.stdout or "").strip()
+        if boot_time:
+            result["host_boot_time"] = boot_time
+    except Exception as exc:
+        result["host_boot_error"] = str(exc)
+
+    try:
+        name_cmd = (
+            "/usr/bin/docker ps -a "
+            "--filter label=com.docker.compose.service=executor "
+            "--format '{{.Names}}' | head -n 1"
+        )
+        name_result = await ssh_client.run(name_cmd)
+        executor_name = (name_result.stdout or "").strip().splitlines()[0:1]
+        executor_name = executor_name[0] if executor_name else ""
+        if executor_name:
+            quoted_executor = shlex.quote(executor_name)
+            start_cmd = (
+                f"/usr/bin/docker inspect --format '{{{{.State.StartedAt}}}}' {quoted_executor}"
+            )
+            start_result = await ssh_client.run(start_cmd)
+            started_at = (start_result.stdout or "").strip()
+            if started_at:
+                result["executor_container_name"] = executor_name
+                result["executor_container_started_at"] = started_at
+    except Exception as exc:
+        result["executor_container_error"] = str(exc)
+
     return result
 

--- a/neurons/validators/tests/test_rented_machine_check.py
+++ b/neurons/validators/tests/test_rented_machine_check.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 
 from neurons.validators.src.services.task.checks.rented_machine import (
     TenantEnforcementCheck,
+    _collect_host_context,
     _collect_pod_diagnostics,
 )
 from neurons.validators.src.services.task.messages import TenantEnforcementMessages as Msg
@@ -352,13 +353,25 @@ async def test_tenant_enforcement_check(
 
 
 class DiagnosticsSSHClient:
-    """SSH mock returning scripted stdout per docker subcommand for diagnostics tests."""
+    """SSH mock returning scripted stdout per docker/shell subcommand for diagnostics tests."""
 
-    def __init__(self, *, inspect_stdout: str = "", inspect_stderr: str = "",
-                 logs_stdout: str = "", raise_on: str | None = None):
+    def __init__(
+        self,
+        *,
+        inspect_stdout: str = "",
+        inspect_stderr: str = "",
+        logs_stdout: str = "",
+        uptime_stdout: str = "",
+        ps_executor_stdout: str = "",
+        executor_inspect_stdout: str = "",
+        raise_on: str | None = None,
+    ):
         self.inspect_stdout = inspect_stdout
         self.inspect_stderr = inspect_stderr
         self.logs_stdout = logs_stdout
+        self.uptime_stdout = uptime_stdout
+        self.ps_executor_stdout = ps_executor_stdout
+        self.executor_inspect_stdout = executor_inspect_stdout
         self.raise_on = raise_on
         self.commands_called: list[str] = []
 
@@ -367,7 +380,17 @@ class DiagnosticsSSHClient:
         if self.raise_on and self.raise_on in command:
             raise RuntimeError(f"ssh failed on {self.raise_on}")
         result = Mock()
-        if "docker inspect" in command:
+        # Order matters — more specific matches first.
+        if command.startswith("uptime"):
+            result.stdout = self.uptime_stdout
+            result.stderr = ""
+        elif "--filter label=com.docker.compose.service=executor" in command:
+            result.stdout = self.ps_executor_stdout
+            result.stderr = ""
+        elif "{{.State.StartedAt}}" in command:
+            result.stdout = self.executor_inspect_stdout
+            result.stderr = ""
+        elif "docker inspect" in command:
             result.stdout = self.inspect_stdout
             result.stderr = self.inspect_stderr
         elif "docker logs" in command:
@@ -400,7 +423,14 @@ async def test_collect_pod_diagnostics_reports_exited_container():
     assert diagnostics["logs_tail"].endswith("traceback line 2\n")
     assert any("docker inspect" in cmd for cmd in ssh.commands_called)
     assert any("docker logs" in cmd for cmd in ssh.commands_called)
-    assert all("pod_abc" in cmd for cmd in ssh.commands_called)
+    # Pod-scoped commands all carry the pod name; host-context probes do not.
+    pod_scoped = [
+        cmd for cmd in ssh.commands_called
+        if ("docker inspect" in cmd or "docker logs" in cmd)
+        and "{{.State.StartedAt}}" not in cmd
+    ]
+    assert pod_scoped
+    assert all("pod_abc" in cmd for cmd in pod_scoped)
 
 
 @pytest.mark.asyncio
@@ -426,3 +456,60 @@ async def test_collect_pod_diagnostics_never_raises_on_ssh_failure():
 
     assert "inspect_error" in diagnostics
     assert "ssh failed" in diagnostics["inspect_error"]
+
+
+@pytest.mark.asyncio
+async def test_collect_pod_diagnostics_includes_host_context_when_available():
+    state = {
+        "Status": "exited",
+        "ExitCode": 137,
+        "OOMKilled": True,
+        "Error": "",
+        "StartedAt": "2026-04-20T00:00:00Z",
+        "FinishedAt": "2026-04-20T00:05:00Z",
+    }
+    ssh = DiagnosticsSSHClient(
+        inspect_stdout=json.dumps(state),
+        logs_stdout="oom line\n",
+        uptime_stdout="2026-04-03 10:07:20\n",
+        ps_executor_stdout="executor-executor-1\n",
+        executor_inspect_stdout="2026-04-20T03:23:42.619916501Z\n",
+    )
+
+    diagnostics = await _collect_pod_diagnostics(ssh, "pod_abc")
+
+    assert diagnostics["state"]["OOMKilled"] is True
+    assert diagnostics["host_context"] == {
+        "host_boot_time": "2026-04-03 10:07:20",
+        "executor_container_name": "executor-executor-1",
+        "executor_container_started_at": "2026-04-20T03:23:42.619916501Z",
+    }
+    # executor lookup uses the compose label filter — not a hardcoded container name
+    assert any(
+        "--filter label=com.docker.compose.service=executor" in cmd
+        for cmd in ssh.commands_called
+    )
+
+
+@pytest.mark.asyncio
+async def test_collect_host_context_handles_missing_executor_container():
+    ssh = DiagnosticsSSHClient(
+        uptime_stdout="2026-04-03 10:07:20\n",
+        ps_executor_stdout="",  # no container matching the compose label
+    )
+
+    host_context = await _collect_host_context(ssh)
+
+    assert host_context == {"host_boot_time": "2026-04-03 10:07:20"}
+    assert "executor_container_name" not in host_context
+    assert "executor_container_started_at" not in host_context
+
+
+@pytest.mark.asyncio
+async def test_collect_host_context_never_raises_on_ssh_failure():
+    ssh = DiagnosticsSSHClient(raise_on="uptime")
+
+    host_context = await _collect_host_context(ssh)
+
+    assert "host_boot_error" in host_context
+    assert "ssh failed" in host_context["host_boot_error"]

--- a/neurons/validators/tests/test_rented_machine_check.py
+++ b/neurons/validators/tests/test_rented_machine_check.py
@@ -1,7 +1,12 @@
+import json
+
 import pytest
 from unittest.mock import Mock
 
-from neurons.validators.src.services.task.checks.rented_machine import TenantEnforcementCheck
+from neurons.validators.src.services.task.checks.rented_machine import (
+    TenantEnforcementCheck,
+    _collect_pod_diagnostics,
+)
 from neurons.validators.src.services.task.messages import TenantEnforcementMessages as Msg
 from protocol.vc_protocol.validator_requests import ResetVerifiedJobReason
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse, RentedExecutor, RentedPod
@@ -344,3 +349,80 @@ async def test_tenant_enforcement_check(
             assert "gpu_utilization" in result.event.what_we_saw
             assert "vram_utilization" in result.event.what_we_saw
             assert "process_count" in result.event.what_we_saw
+
+
+class DiagnosticsSSHClient:
+    """SSH mock returning scripted stdout per docker subcommand for diagnostics tests."""
+
+    def __init__(self, *, inspect_stdout: str = "", inspect_stderr: str = "",
+                 logs_stdout: str = "", raise_on: str | None = None):
+        self.inspect_stdout = inspect_stdout
+        self.inspect_stderr = inspect_stderr
+        self.logs_stdout = logs_stdout
+        self.raise_on = raise_on
+        self.commands_called: list[str] = []
+
+    async def run(self, command: str):
+        self.commands_called.append(command)
+        if self.raise_on and self.raise_on in command:
+            raise RuntimeError(f"ssh failed on {self.raise_on}")
+        result = Mock()
+        if "docker inspect" in command:
+            result.stdout = self.inspect_stdout
+            result.stderr = self.inspect_stderr
+        elif "docker logs" in command:
+            result.stdout = self.logs_stdout
+            result.stderr = ""
+        else:
+            result.stdout = ""
+            result.stderr = ""
+        return result
+
+
+@pytest.mark.asyncio
+async def test_collect_pod_diagnostics_reports_exited_container():
+    state = {
+        "Status": "exited",
+        "ExitCode": 137,
+        "OOMKilled": False,
+        "Error": "",
+        "StartedAt": "2026-04-20T00:00:00Z",
+        "FinishedAt": "2026-04-20T00:05:00Z",
+    }
+    ssh = DiagnosticsSSHClient(
+        inspect_stdout=json.dumps(state),
+        logs_stdout="traceback line 1\ntraceback line 2\n",
+    )
+
+    diagnostics = await _collect_pod_diagnostics(ssh, "pod_abc")
+
+    assert diagnostics["state"] == state
+    assert diagnostics["logs_tail"].endswith("traceback line 2\n")
+    assert any("docker inspect" in cmd for cmd in ssh.commands_called)
+    assert any("docker logs" in cmd for cmd in ssh.commands_called)
+    assert all("pod_abc" in cmd for cmd in ssh.commands_called)
+
+
+@pytest.mark.asyncio
+async def test_collect_pod_diagnostics_handles_removed_container():
+    ssh = DiagnosticsSSHClient(
+        inspect_stdout="",
+        inspect_stderr="Error: No such object: pod_abc",
+        logs_stdout="",
+    )
+
+    diagnostics = await _collect_pod_diagnostics(ssh, "pod_abc")
+
+    assert "state" not in diagnostics
+    assert diagnostics["inspect_error"] == "Error: No such object: pod_abc"
+    assert "logs_tail" not in diagnostics
+
+
+@pytest.mark.asyncio
+async def test_collect_pod_diagnostics_never_raises_on_ssh_failure():
+    ssh = DiagnosticsSSHClient(raise_on="docker inspect")
+
+    diagnostics = await _collect_pod_diagnostics(ssh, "pod_abc")
+
+    assert "inspect_error" in diagnostics
+    assert "ssh failed" in diagnostics["inspect_error"]


### PR DESCRIPTION
## Summary

### Task Link

[DAH-1932](https://www.notion.so/341b8bfdbde9819aa39fccb3798d18e3)

---

## Problem

When `TenantEnforcementCheck` (`executor.validate.rented_state`) finds that a rented pod is no longer running, it logs a bare `POD_NOT_RUNNING` event with just `pod_id`, `container_name`, and `executor_uuid`. From the validator log alone we cannot tell **why** the container is gone — OOM, CUDA crash, manual `docker stop`, or validator-driven stale-container cleanup (the exact P0 failure mode described in DAH-1932).

Recent production incident: executor was scraped with 8× B200 @ 99% GPU util and the pod container in `docker ps`, yet ~seconds later the rented-state check reported `POD_NOT_RUNNING`. We had no way to distinguish "renter's job finished cleanly" from "validator race killed a live container".

## Solution

On the `POD_NOT_RUNNING` branch, before emitting the event, use the already-open `ctx.ssh` session to run two read-only `docker` queries and attach raw results to the event's `what_we_saw.diagnostics`:

- `docker inspect --format '{{json .State}}' <container>` → `Status`, `ExitCode`, `OOMKilled`, `Error`, `StartedAt`, `FinishedAt`
- `docker logs --tail 50 <container>` → last 4 KB of stdout/stderr

If the container has been removed entirely, both calls fail in distinguishable ways (`inspect_error`) — itself a useful signal separating "exited in place" from "rm'd by something external".

No changes to control flow, scoring, or `clear_verified_job_reason`. Same `CheckResult.passed=False`, same reason code. Pure observability.

## Changes

- `rented_machine.py`: added `_collect_pod_diagnostics(ssh_client, container_name)` helper and call it right before `render_message(Msg.POD_NOT_RUNNING, ...)`; include result under `what["diagnostics"]`.
- `test_rented_machine_check.py`: three new async tests — exited-container path (happy path), removed-container path (inspect_error), and ssh-raise path (never raises).

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review

## Other PRs

N/A

## Risks

- Two extra SSH calls on every `POD_NOT_RUNNING` path. Already inside an open `asyncssh` session, both are read-only and bounded (`--tail 50`, `--format json`). Each call is wrapped in `try/except` and cannot fail the check.
- `container_name` is passed through `shlex.quote()` even though it comes from internal rental state (`rented_executor.pods`), as hygiene for the SSH `/bin/sh -c` surface called out in the repo-level shell-injection doc.
- `docker logs` may contain sensitive output from the renter's workload. Tail is capped to 4 KB and goes into the same structured event we already ship for this check — no new sink, no new retention.
- No changes to pipeline control flow; `passed`, `clear_verified_job_info`, `clear_verified_job_reason` are untouched.

## Test Cases

### Test Case 1 — exited container
`docker inspect` returns JSON state with `ExitCode=137`, `OOMKilled=false`. Verifies `diagnostics.state` round-trips all 6 fields and `logs_tail` contains the last tail line.

### Test Case 2 — removed container
`docker inspect` returns empty stdout + `Error: No such object: pod_abc` on stderr. Verifies `diagnostics.inspect_error` carries the docker error and `state`/`logs_tail` are absent.

### Test Case 3 — SSH failure
`ctx.ssh.run` raises on `docker inspect`. Verifies `_collect_pod_diagnostics` swallows the exception and returns `inspect_error` with the message, so the check still emits the event.

### Test Case 4 — existing suite
Ran `pdm run pytest --ignore=tests/test_attestation_service.py --ignore=tests/test_port_mapping_dao.py` (both excluded files fail pre-existing on `main`, unrelated): **391 passed, 4 skipped**. Targeted `tests/test_rented_machine_check.py`: **11 passed**.
### Test Case 9 — end-to-end staging run (2026-04-20)

Staging validator redeployed with this branch (image
`lium-staging-validator:5a4e72b@sha256:bc6e9f086f7dec71...`). Live pod rented
on a real staging executor (`149.36.1.151`, NVIDIA RTX A4000 × 1,
`daturaai/verify-gpu:0.0.0`), then the container was wiped from the host
(`ssh shadeform@149.36.1.151 'docker rm -f pod_280579e8-b8a9-4918-ab8c-acb21774960a'`).
The very next `executor.validate.rented_state` round captured the following event
(verbatim from `validator-bb4ff96b7-sg984` logs at `2026-04-20 09:42:00 UTC`):

```json
{
  "event": "Pod not running",
  "reason_code": "POD_NOT_RUNNING",
  "severity": "error",
  "category": "runtime",
  "impact": "Score set to 0; verification cleared",
  "what_we_saw": {
    "pod_id": "280579e8-b8a9-4918-ab8c-acb21774960a",
    "container_name": "pod_280579e8-b8a9-4918-ab8c-acb21774960a",
    "executor_uuid": "2439b3f0-3b40-49f8-a8d0-4ec030c95905",
    "diagnostics": {
      "inspect_error": "error: no such object: pod_280579e8-b8a9-4918-ab8c-acb21774960a",
      "logs_tail": "Error response from daemon: No such container: pod_280579e8-b8a9-4918-ab8c-acb21774960a\n",
      "host_context": {
        "host_boot_time": "2026-04-03 10:07:19",
        "executor_container_name": "executor-executor-1",
        "executor_container_started_at": "2026-04-20T06:41:48.714739808Z"
      }
    }
  },
  "check_id": "executor.validate.rented_state",
  "context": { "...": "...", "execution_time_ms": 1874 }
}
```

All five new fields are populated as designed:
- `diagnostics.inspect_error` — verbatim docker error (container removed case).
- `diagnostics.logs_tail` — verbatim `docker logs` stderr forwarded via `2>&1`.
- `host_context.host_boot_time` — **2026-04-03** (17-day-old host).
- `host_context.executor_container_name` — discovered via compose label, not hardcoded.
- `host_context.executor_container_started_at` — **2026-04-20T06:41:48Z** (~3 h
  before the event). Combined with `host_boot_time`, this surfaces the
  "executor container restarted without a host reboot" case that a pure boot-time
  probe would miss — exactly the motivation in the description's diagnostic table.

`execution_time_ms=1874` confirms the four extra SSH probes stay well under
budget on the cold path. No change to `passed`, scoring, or control flow.

Full evidence (timeline, docker inspect output, sync-block telemetry for the
companion aiohttp-timeout fix) lives in
`untracked/staging-test-pod-not-running/report.md` — not checked in.

### Test Case 10 — exited-from-OOM pod on staging (2026-04-20)

Also on staging, a fresh pod was rented against the same executor
(`daturaai/verify-gpu:0.0.0`, image cached). Before touching it, we verified
end-to-end that the pipeline does propagate memory limits:

```
$ docker inspect --format '{{.HostConfig.Memory}}' pod_280579e8-…
19327352832                          # 18 GB, = memory_gb=18 from ContainerCreateRequest
$ docker exec pod_… cat /sys/fs/cgroup/memory.max
19327352832                          # same limit at cgroup v2 layer
$ docker exec pod_… cat /sys/fs/cgroup/memory.oom.group
0                                    # default - OOM-killer reaps only the heaviest process
$ docker exec pod_… sh -c 'cat /proc/1/cmdline | tr \\0 \\ '
tail -f /dev/null                    # PID 1 in the default template is idle
```

A RAM-eater (`python3 -c "bufs=[]; [bufs.append(bytearray(500*1024*1024)) ...]"`) ramped
to 18 GB and got SIGKILL'd — but the container stayed `Running=true` with a sticky
`OOMKilled=true` flag, because `oom.group=0` + PID 1 is idle. This is the "silent
in-pod OOM" case and is intentionally **outside** the scope of POD_NOT_RUNNING.

To exercise the code path this PR targets (PID 1 gone → pod exited), we sent
`docker kill --signal=KILL` at 09:59:59 UTC. The next `executor.validate.rented_state`
round at `job_batch_id=2026-04-20 10:00:24` (emit 10:09:15 UTC) captured the event
with the full expected shape:

```json
{
  "what_we_saw": {
    "pod_id": "280579e8-b8a9-4918-ab8c-acb21774960a",
    "container_name": "pod_280579e8-b8a9-4918-ab8c-acb21774960a",
    "executor_uuid": "2439b3f0-3b40-49f8-a8d0-4ec030c95905",
    "diagnostics": {
      "state": {
        "Status": "exited",
        "ExitCode": 137,
        "OOMKilled": true,
        "Error": "",
        "StartedAt": "2026-04-20T09:57:39.339286006Z",
        "FinishedAt": "2026-04-20T09:59:59.102116241Z"
      },
      "logs_tail": "\n==========\n== CUDA ==\n==========\n\nCUDA Version 12.6.0\n\n...",
      "host_context": {
        "host_boot_time": "2026-04-03 10:07:19",
        "executor_container_name": "executor-executor-1",
        "executor_container_started_at": "2026-04-20T06:41:48.714739808Z"
      }
    }
  },
  "context": { "...": "...", "execution_time_ms": 1838 }
}
```

All six docker `State` fields round-trip cleanly. `OOMKilled=true` is exactly the
disambiguator the diagnostic table in the Solution section relies on — without it,
a plain `ExitCode=137` could be either a cgroup OOM or an external `docker stop` that
timed out into SIGKILL; the boolean makes them distinguishable.

### Two clarifications worth baking back into the deployment doc

1. **The pipeline does propagate `memory_gb`.** `docker inspect` on a live staging
   pod shows the cgroup memory limit matches `ContainerCreateRequest.memory_gb`
   at the kernel layer. No code change needed here; this just removes a previous
   "unknown" from the risk table.
2. **Default Lium pods run with `oom.group=0` + `tail -f /dev/null` as PID 1.**
   A cgroup OOM on a subprocess leaves PID 1 alive and the pod `Running`, so
   POD_NOT_RUNNING (and therefore these diagnostics) will not fire on the common
   "renter's workload OOM'd" case. That case shows up as
   `State.OOMKilled=true && Running=true` and would need a separate signal to
   surface. Out of scope for DAH-1932 — worth a follow-up ticket if we want to
   catch it. This is separate from the exited-from-OOM case above, which this
   PR *does* diagnose.
