### PR TITLE
skip registration check for central miner

### DIFF
--- a/neurons/miners/src/core/miner.py
+++ b/neurons/miners/src/core/miner.py
@@ -122,6 +122,15 @@ class Miner:
         await self.initialize_subtensor()
 
     async def check_registered(self):
+        if settings.CENTRAL_MODE:
+            logger.info(
+                _m(
+                    "[check_registered] Skipping registration check (CENTRAL_MODE)",
+                    extra=get_extra_info(self.default_extra),
+                ),
+            )
+            return
+
         try:
             logger.info(
                 _m(


### PR DESCRIPTION
## Summary
- Skip `check_registered()` in `core/miner.py` when `CENTRAL_MODE=true` so the central miner does not exit on start if the wallet hotkey is not registered on the subnet.

## Why
- Central miner only coordinates executors via Miner Portal and does not need its own netuid registration. Prod central-miner pod currently `CrashLoopBackOff` because the hotkey is not registered on netuid 51.

## Test plan
- [ ] Deploy to staging central-miner, confirm pod starts and log shows `[check_registered] Skipping registration check (CENTRAL_MODE)`.
- [ ] Standard miner (CENTRAL_MODE=false) still fails fast when wallet not registered.