### PR TITLE
DAH-1981: Enforce verifyx EMA network threshold in check; decay EMA on null network measurement

### DIFF
--- a/neurons/validators/src/services/task/checks/verifyx.py
+++ b/neurons/validators/src/services/task/checks/verifyx.py
@@ -53,6 +53,11 @@ class VerifyXCheck:
         # Extract errors with clear priority: data.errors > result.error
         errors = self._extract_errors(result)
 
+        prev_ema = (
+            ctx.state.rented_data.network_ema.get(ctx.executor.uuid)
+            if ctx.state.rented_data else None
+        )
+
         if result.data and result.data.get("success"):
             base_specs = ctx.state.specs
             sanitized = _to_iso(result.data)
@@ -66,10 +71,6 @@ class VerifyXCheck:
             )
 
             # Store verifyx network measurements under their own keys (additive — does not overwrite speedtest values)
-            prev_ema = (
-                ctx.state.rented_data.network_ema.get(ctx.executor.uuid)
-                if ctx.state.rented_data else None
-            )
             if verifyx_network.get("download_speed") is not None:
                 if "network" not in updated_specs:
                     updated_specs["network"] = {}
@@ -131,6 +132,20 @@ class VerifyXCheck:
             check_id=self.check_id,
             what=what,
         )
+
+        if prev_ema and (
+            prev_ema.ema_verifyx_download_speed is not None
+            or prev_ema.ema_verifyx_upload_speed is not None
+        ):
+            specs = ctx.state.specs or {}
+            net = dict(specs.get("network") or {})
+            if prev_ema.ema_verifyx_download_speed is not None:
+                net["ema_verifyx_download_speed"] = prev_ema.ema_verifyx_download_speed
+            if prev_ema.ema_verifyx_upload_speed is not None:
+                net["ema_verifyx_upload_speed"] = prev_ema.ema_verifyx_upload_speed
+            updated_state = replace(ctx.state, specs={**specs, "network": net})
+            return CheckResult(passed=False, event=event, updates={"state": updated_state})
+
         return CheckResult(passed=False, event=event)
 
 

--- a/neurons/validators/src/services/task/checks/verifyx.py
+++ b/neurons/validators/src/services/task/checks/verifyx.py
@@ -140,9 +140,9 @@ class VerifyXCheck:
             specs = ctx.state.specs or {}
             net = dict(specs.get("network") or {})
             if prev_ema.ema_verifyx_download_speed is not None:
-                net["ema_verifyx_download_speed"] = prev_ema.ema_verifyx_download_speed
+                net["ema_verifyx_download_speed"] = compute_ema(prev_ema.ema_verifyx_download_speed, 0.0)
             if prev_ema.ema_verifyx_upload_speed is not None:
-                net["ema_verifyx_upload_speed"] = prev_ema.ema_verifyx_upload_speed
+                net["ema_verifyx_upload_speed"] = compute_ema(prev_ema.ema_verifyx_upload_speed, 0.0)
             updated_state = replace(ctx.state, specs={**specs, "network": net})
             return CheckResult(passed=False, event=event, updates={"state": updated_state})
 

--- a/neurons/validators/src/services/task/checks/verifyx.py
+++ b/neurons/validators/src/services/task/checks/verifyx.py
@@ -8,6 +8,8 @@ from ..messages import VerifyXMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
 from .network_ema import compute_ema
 
+MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS = 100.0
+
 
 class VerifyXCheck:
     """Run the optional VerifyX hardware probe and update specs with its findings.
@@ -70,23 +72,24 @@ class VerifyXCheck:
                 }
             )
 
-            # Store verifyx network measurements under their own keys (additive — does not overwrite speedtest values)
-            if verifyx_network.get("download_speed") is not None:
-                if "network" not in updated_specs:
-                    updated_specs["network"] = {}
-                updated_specs["network"]["verifyx_download_speed"] = verifyx_network.get("download_speed")
-                updated_specs["network"]["ema_verifyx_download_speed"] = compute_ema(
-                    prev_ema.ema_verifyx_download_speed if prev_ema else None,
-                    verifyx_network.get("download_speed"),
-                )
-            if verifyx_network.get("upload_speed") is not None:
-                if "network" not in updated_specs:
-                    updated_specs["network"] = {}
-                updated_specs["network"]["verifyx_upload_speed"] = verifyx_network.get("upload_speed")
-                updated_specs["network"]["ema_verifyx_upload_speed"] = compute_ema(
-                    prev_ema.ema_verifyx_upload_speed if prev_ema else None,
-                    verifyx_network.get("upload_speed"),
-                )
+            # Always compute verifyx network EMA — use 0.0 when network measurement failed
+            # so EMA decays toward 0 on repeated failures, eventually triggering exclusion
+            if "network" not in updated_specs:
+                updated_specs["network"] = {}
+            download_speed = verifyx_network.get("download_speed")
+            if download_speed is not None:
+                updated_specs["network"]["verifyx_download_speed"] = download_speed
+            updated_specs["network"]["ema_verifyx_download_speed"] = compute_ema(
+                prev_ema.ema_verifyx_download_speed if prev_ema else None,
+                download_speed if download_speed is not None else 0.0,
+            )
+            upload_speed = verifyx_network.get("upload_speed")
+            if upload_speed is not None:
+                updated_specs["network"]["verifyx_upload_speed"] = upload_speed
+            updated_specs["network"]["ema_verifyx_upload_speed"] = compute_ema(
+                prev_ema.ema_verifyx_upload_speed if prev_ema else None,
+                upload_speed if upload_speed is not None else 0.0,
+            )
 
             # Update storage specs if storage is present
             if "hard_disk" in sanitized:
@@ -108,6 +111,19 @@ class VerifyXCheck:
                 event.what_we_saw["errors"] = errors
 
             updated_state = replace(ctx.state, specs=updated_specs)
+
+            ema_download = updated_specs["network"]["ema_verifyx_download_speed"]
+            if ema_download < MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS:
+                slow_event = render_message(
+                    Msg.VERIFY_FAILED_NETWORK_SPEED_TOO_SLOW,
+                    ctx=ctx,
+                    check_id=self.check_id,
+                    what={
+                        "ema_verifyx_download_speed": ema_download,
+                        "min_download_speed_mbps": MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS,
+                    },
+                )
+                return CheckResult(passed=False, event=slow_event, updates={"state": updated_state})
 
             return CheckResult(
                 passed=True,
@@ -132,19 +148,6 @@ class VerifyXCheck:
             check_id=self.check_id,
             what=what,
         )
-
-        if prev_ema and (
-            prev_ema.ema_verifyx_download_speed is not None
-            or prev_ema.ema_verifyx_upload_speed is not None
-        ):
-            specs = ctx.state.specs or {}
-            net = dict(specs.get("network") or {})
-            if prev_ema.ema_verifyx_download_speed is not None:
-                net["ema_verifyx_download_speed"] = compute_ema(prev_ema.ema_verifyx_download_speed, 0.0)
-            if prev_ema.ema_verifyx_upload_speed is not None:
-                net["ema_verifyx_upload_speed"] = compute_ema(prev_ema.ema_verifyx_upload_speed, 0.0)
-            updated_state = replace(ctx.state, specs={**specs, "network": net})
-            return CheckResult(passed=False, event=event, updates={"state": updated_state})
 
         return CheckResult(passed=False, event=event)
 

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -554,6 +554,15 @@ class VerifyXMessages:
             "the executor container (docker compose restart) if it does not."
         ),
     )
+    VERIFY_FAILED_NETWORK_SPEED_TOO_SLOW = _verify_failed(
+        label="network speed too slow",
+        reason_suffix="NETWORK_SPEED_TOO_SLOW",
+        remediation=(
+            "EMA download speed is below the minimum threshold. "
+            "Improve the executor's network connection or wait for the EMA to recover "
+            "once speeds improve."
+        ),
+    )
 
 
 class TdxHostMessages:

--- a/neurons/validators/src/services/task/score_calculator.py
+++ b/neurons/validators/src/services/task/score_calculator.py
@@ -12,7 +12,6 @@ from services.task.pipeline import Context
 
 
 SCORE_PORTION_FOR_OLD_CONTRACT = 0
-MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS = 100.0
 
 
 def calculate_scores(
@@ -53,7 +52,7 @@ def calculate_scores(
             f"GPU price exceeds the limit. limit: {base_price * settings.MACHINE_MAX_PRICE_RATE}, actual: {price_per_gpu}"
         )
 
-    # EMA verifyx download speed check
+    # EMA verifyx download speed check — threshold enforced upstream in VerifyXCheck
     ema_verifyx_download = ((ctx.state.specs or {}).get("network") or {}).get(
         "ema_verifyx_download_speed"
     )
@@ -62,13 +61,6 @@ def calculate_scores(
         job_score = 0.0
         warning_messages.append(
             "EMA verifyx download speed unavailable (probe failed or never measured)"
-        )
-    elif ema_verifyx_download is not None and ema_verifyx_download < MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS:
-        actual_score = 0.0
-        job_score = 0.0
-        warning_messages.append(
-            f"EMA verifyx download speed too slow: {ema_verifyx_download:.1f} Mbps "
-            f"(minimum: {MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS:.0f} Mbps)"
         )
 
     # Early return for collateral-excluded GPU types

--- a/neurons/validators/src/services/task/score_calculator.py
+++ b/neurons/validators/src/services/task/score_calculator.py
@@ -57,7 +57,13 @@ def calculate_scores(
     ema_verifyx_download = ((ctx.state.specs or {}).get("network") or {}).get(
         "ema_verifyx_download_speed"
     )
-    if ema_verifyx_download is not None and ema_verifyx_download < MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS:
+    if not rented and ema_verifyx_download is None:
+        actual_score = 0.0
+        job_score = 0.0
+        warning_messages.append(
+            "EMA verifyx download speed unavailable (probe failed or never measured)"
+        )
+    elif ema_verifyx_download is not None and ema_verifyx_download < MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS:
         actual_score = 0.0
         job_score = 0.0
         warning_messages.append(

--- a/neurons/validators/tests/test_score_calculator.py
+++ b/neurons/validators/tests/test_score_calculator.py
@@ -11,14 +11,10 @@ from neurons.validators.src.services.task.score_calculator import (
 from helpers import build_context_config, build_services, build_state, default_executor, make_context
 
 
-def _ctx(ema_verifyx_download_speed, price_per_gpu=None):
-    """Build a minimal context with the given EMA verifyx download speed."""
+def _ctx_without_specs(specs, price_per_gpu=None):
     executor = default_executor()
-    # Override price_per_gpu to None so the price check is not triggered
     executor = executor.model_copy(update={"price_per_gpu": price_per_gpu})
-    state = build_state(
-        specs={"network": {"ema_verifyx_download_speed": ema_verifyx_download_speed}}
-    )
+    state = build_state(specs=specs)
     return make_context(
         executor=executor,
         state=state,
@@ -29,11 +25,18 @@ def _ctx(ema_verifyx_download_speed, price_per_gpu=None):
     )
 
 
+def _ctx(ema_verifyx_download_speed, price_per_gpu=None):
+    return _ctx_without_specs(
+        {"network": {"ema_verifyx_download_speed": ema_verifyx_download_speed}},
+        price_per_gpu=price_per_gpu,
+    )
+
+
 @pytest.mark.parametrize(
     "ema_speed, scores_zeroed, warning_fragment",
     [
-        # No EMA available (VerifyX disabled or no measurement) — no penalty
-        (None, False, None),
+        # No EMA available for a non-rented executor — zero (regression guard for DAH verifyx null fix)
+        (None, True, "unavailable"),
         # Above threshold — no penalty
         (MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS, False, None),
         (120.0, False, None),
@@ -45,7 +48,7 @@ def _ctx(ema_verifyx_download_speed, price_per_gpu=None):
         (0.0, True, "0.0 Mbps"),
     ],
 )
-def test_ema_verifyx_download_speed_scoring(ema_speed, scores_zeroed, warning_fragment):
+def test_ema_verifyx_download_speed_scoring_unrented(ema_speed, scores_zeroed, warning_fragment):
     ctx = _ctx(ema_speed)
     actual_score, job_score, warning = calculate_scores(ctx, rented=False)
 
@@ -59,37 +62,56 @@ def test_ema_verifyx_download_speed_scoring(ema_speed, scores_zeroed, warning_fr
         assert warning == ""
 
 
-def test_no_network_specs_does_not_penalise():
-    """ctx.state.specs has no 'network' key at all — should not raise or penalise."""
-    executor = default_executor()
-    executor = executor.model_copy(update={"price_per_gpu": None})
-    state = build_state(specs={})
-    ctx = make_context(
-        executor=executor,
-        state=state,
-        services=build_services(),
-        config=build_context_config(),
-        collateral_deposited=True,
-        is_rental_succeed=True,
-    )
-    actual_score, _job_score, warning = calculate_scores(ctx, rented=False)
+def test_ema_download_missing_rented_does_not_zero():
+    """Rented executor with missing EMA must not be zeroed — avoids killing emission on active rentals."""
+    ctx = _ctx(None)
+    actual_score, job_score, warning = calculate_scores(ctx, rented=True)
     assert actual_score == 1.0
+    assert job_score == 1.0
+    assert "unavailable" not in warning
+
+
+def test_ema_download_below_threshold_rented_still_zeros_actual_score():
+    """Rented executor below threshold: actual_score zeroed, final job_score forced to 1.0 by _format_return."""
+    ctx = _ctx(50.0)
+    actual_score, job_score, warning = calculate_scores(ctx, rented=True)
+    assert actual_score == 0.0
+    # job_score is forced to 1.0 for rented in _format_return
+    assert job_score == 1.0
+    assert "too slow" in warning
+
+
+def test_no_network_specs_unrented_zeros():
+    """ctx.state.specs has no 'network' key at all — non-rented should zero."""
+    ctx = _ctx_without_specs({})
+    actual_score, job_score, warning = calculate_scores(ctx, rented=False)
+    assert actual_score == 0.0
+    assert job_score == 0.0
+    assert "unavailable" in warning
+
+
+def test_no_network_specs_rented_does_not_penalise():
+    """ctx.state.specs has no 'network' key — rented should not zero."""
+    ctx = _ctx_without_specs({})
+    actual_score, job_score, warning = calculate_scores(ctx, rented=True)
+    assert actual_score == 1.0
+    assert job_score == 1.0
     assert warning == ""
 
 
-def test_none_specs_does_not_penalise():
-    """ctx.state.specs is None — should not raise or penalise."""
-    executor = default_executor()
-    executor = executor.model_copy(update={"price_per_gpu": None})
-    state = build_state(specs=None)
-    ctx = make_context(
-        executor=executor,
-        state=state,
-        services=build_services(),
-        config=build_context_config(),
-        collateral_deposited=True,
-        is_rental_succeed=True,
-    )
-    actual_score, _job_score, warning = calculate_scores(ctx, rented=False)
+def test_none_specs_unrented_zeros():
+    """ctx.state.specs is None — non-rented should zero."""
+    ctx = _ctx_without_specs(None)
+    actual_score, job_score, warning = calculate_scores(ctx, rented=False)
+    assert actual_score == 0.0
+    assert job_score == 0.0
+    assert "unavailable" in warning
+
+
+def test_none_specs_rented_does_not_penalise():
+    """ctx.state.specs is None — rented should not zero."""
+    ctx = _ctx_without_specs(None)
+    actual_score, job_score, warning = calculate_scores(ctx, rented=True)
     assert actual_score == 1.0
+    assert job_score == 1.0
     assert warning == ""

--- a/neurons/validators/tests/test_score_calculator.py
+++ b/neurons/validators/tests/test_score_calculator.py
@@ -4,10 +4,8 @@ via integration in test_score_check.py and test_pipeline_default_scenarios.py.
 """
 import pytest
 
-from neurons.validators.src.services.task.score_calculator import (
-    MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS,
-    calculate_scores,
-)
+from neurons.validators.src.services.task.score_calculator import calculate_scores
+from neurons.validators.src.services.task.checks.verifyx import MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS
 from helpers import build_context_config, build_services, build_state, default_executor, make_context
 
 
@@ -35,17 +33,12 @@ def _ctx(ema_verifyx_download_speed, price_per_gpu=None):
 @pytest.mark.parametrize(
     "ema_speed, scores_zeroed, warning_fragment",
     [
-        # No EMA available for a non-rented executor — zero (regression guard for DAH verifyx null fix)
+        # No EMA available for a non-rented executor — zero (verifyx disabled or first-run edge case)
         (None, True, "unavailable"),
-        # Above threshold — no penalty
+        # At or above threshold — no penalty (threshold enforcement is in VerifyXCheck, not here)
         (MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS, False, None),
         (120.0, False, None),
         (500.0, False, None),
-        # Just below threshold — both scores zeroed with warning
-        (MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS - 0.1, True, "EMA verifyx download speed too slow"),
-        (99.9, True, "99.9 Mbps"),
-        (50.0, True, "50.0 Mbps"),
-        (0.0, True, "0.0 Mbps"),
     ],
 )
 def test_ema_verifyx_download_speed_scoring_unrented(ema_speed, scores_zeroed, warning_fragment):
@@ -69,16 +62,6 @@ def test_ema_download_missing_rented_does_not_zero():
     assert actual_score == 1.0
     assert job_score == 1.0
     assert "unavailable" not in warning
-
-
-def test_ema_download_below_threshold_rented_still_zeros_actual_score():
-    """Rented executor below threshold: actual_score zeroed, final job_score forced to 1.0 by _format_return."""
-    ctx = _ctx(50.0)
-    actual_score, job_score, warning = calculate_scores(ctx, rented=True)
-    assert actual_score == 0.0
-    # job_score is forced to 1.0 for rented in _format_return
-    assert job_score == 1.0
-    assert "too slow" in warning
 
 
 def test_no_network_specs_unrented_zeros():

--- a/neurons/validators/tests/test_verifyx_check.py
+++ b/neurons/validators/tests/test_verifyx_check.py
@@ -89,8 +89,8 @@ class DummyVerifyXService:
             True,
             Msg.VERIFY_SUCCESS.reason,
         ),
-        # VerifyX succeeds without additional specs
-        (True, True, True, "", {}, True, Msg.VERIFY_SUCCESS.reason),
+        # VerifyX succeeds without network data → EMA=0 < threshold → fails
+        (True, True, True, "", {}, False, Msg.VERIFY_FAILED_NETWORK_SPEED_TOO_SLOW.reason),
         # VerifyX fails with error message
         (True, True, False, "Checksum mismatch", {}, False, Msg.VERIFY_FAILED.reason),
         # VerifyX fails with data errors
@@ -254,66 +254,6 @@ def _rented_data_with_ema(executor_uuid: str, *, download: float | None = None, 
 
 
 @pytest.mark.asyncio
-async def test_verifyx_failure_decays_prev_ema_download(context_factory):
-    """On probe failure, download EMA decays by one step toward 0 (0.7 × prev)."""
-    verifyx_service = _VerifyXServiceReturning(MockVerifyXResponse(error="failure"))
-    services = build_services(verifyx=verifyx_service)
-    config = build_context_config(verifyx_enabled=True)
-    state = build_state(
-        specs={"gpu": {"count": 1}},
-        rented_data=_rented_data_with_ema("executor-123", download=250.0),
-    )
-    ctx = context_factory(services=services, config=config, state=state)
-
-    result = await VerifyXCheck().run(ctx)
-
-    assert result.passed is False
-    assert "state" in result.updates
-    # compute_ema(250.0, 0.0) = 0.3*0 + 0.7*250 = 175.0
-    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(175.0)
-
-
-@pytest.mark.asyncio
-async def test_verifyx_failure_decays_prev_ema_upload(context_factory):
-    """On probe failure, upload EMA also decays by one step toward 0 (0.7 × prev)."""
-    verifyx_service = _VerifyXServiceReturning(MockVerifyXResponse(error="failure"))
-    services = build_services(verifyx=verifyx_service)
-    config = build_context_config(verifyx_enabled=True)
-    state = build_state(
-        specs={"gpu": {"count": 1}},
-        rented_data=_rented_data_with_ema("executor-123", upload=40.0),
-    )
-    ctx = context_factory(services=services, config=config, state=state)
-
-    result = await VerifyXCheck().run(ctx)
-
-    assert result.passed is False
-    assert "state" in result.updates
-    # compute_ema(40.0, 0.0) = 0.3*0 + 0.7*40 = 28.0
-    assert result.updates["state"].specs["network"]["ema_verifyx_upload_speed"] == pytest.approx(28.0)
-
-
-@pytest.mark.asyncio
-async def test_verifyx_failure_repeated_decays_below_threshold(context_factory):
-    """After 5 consecutive failures starting from 500 Mbps, EMA drops below 100 Mbps threshold."""
-    # 500 * 0.7^5 ≈ 84.0 < 100 Mbps
-    ema = 500.0
-    for _ in range(5):
-        verifyx_service = _VerifyXServiceReturning(MockVerifyXResponse(error="failure"))
-        services = build_services(verifyx=verifyx_service)
-        config = build_context_config(verifyx_enabled=True)
-        state = build_state(
-            specs={"gpu": {"count": 1}},
-            rented_data=_rented_data_with_ema("executor-123", download=ema),
-        )
-        ctx = context_factory(services=services, config=config, state=state)
-        result = await VerifyXCheck().run(ctx)
-        ema = result.updates["state"].specs["network"]["ema_verifyx_download_speed"]
-
-    assert ema < 100.0
-
-
-@pytest.mark.asyncio
 async def test_verifyx_failure_without_prev_ema_leaves_specs_empty(context_factory):
     """No prior EMA anywhere — failure branch must not fabricate a state update."""
     verifyx_service = _VerifyXServiceReturning(MockVerifyXResponse(error="failure"))
@@ -347,11 +287,111 @@ async def test_verifyx_failure_without_rented_data_does_not_update_state(context
 
 
 @pytest.mark.asyncio
+async def test_verifyx_success_ema_below_threshold_fails_check(context_factory):
+    """Verifyx passes but EMA drops below 100 Mbps threshold → check fails with specific reason."""
+    # prev_ema=110, current=0 → new EMA = 0.7*110 = 77 < 100
+    verifyx_service = DummyVerifyXService(success=True, updated_specs={"network": {}})
+    services = build_services(verifyx=verifyx_service)
+    config = build_context_config(verifyx_enabled=True)
+    state = build_state(
+        specs={"gpu": {"count": 1}},
+        rented_data=_rented_data_with_ema("executor-123", download=110.0),
+    )
+    ctx = context_factory(services=services, config=config, state=state)
+
+    result = await VerifyXCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.VERIFY_FAILED_NETWORK_SPEED_TOO_SLOW.reason
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(77.0)
+
+
+@pytest.mark.asyncio
+async def test_verifyx_success_ema_at_threshold_passes(context_factory):
+    """EMA exactly at 100 Mbps passes (threshold is strictly less-than)."""
+    # prev_ema=None, current=100 → EMA = 100.0 (bootstrap)
+    verifyx_service = DummyVerifyXService(
+        success=True,
+        updated_specs={"network": {"download_speed": 100.0, "upload_speed": 50.0}},
+    )
+    services = build_services(verifyx=verifyx_service)
+    config = build_context_config(verifyx_enabled=True)
+    state = build_state(specs={"gpu": {"count": 1}}, rented_data=None)
+    ctx = context_factory(services=services, config=config, state=state)
+
+    result = await VerifyXCheck().run(ctx)
+
+    assert result.passed is True
+
+
+@pytest.mark.asyncio
+async def test_verifyx_success_null_network_bootstraps_ema_to_zero_and_fails(context_factory):
+    """First run: verifyx passes but network failed → EMA=0.0 < threshold → check fails."""
+    verifyx_service = DummyVerifyXService(success=True, updated_specs={"network": {}})
+    services = build_services(verifyx=verifyx_service)
+    config = build_context_config(verifyx_enabled=True)
+    state = build_state(specs={"gpu": {"count": 1}}, rented_data=None)
+    ctx = context_factory(services=services, config=config, state=state)
+
+    result = await VerifyXCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.VERIFY_FAILED_NETWORK_SPEED_TOO_SLOW.reason
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(0.0)
+    assert result.updates["state"].specs["network"]["ema_verifyx_upload_speed"] == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_verifyx_success_null_network_decays_prev_ema(context_factory):
+    """Verifyx passes but network failed → EMA decays: compute_ema(prev, 0.0) = 0.7 × prev."""
+    verifyx_service = DummyVerifyXService(success=True, updated_specs={"network": {}})
+    services = build_services(verifyx=verifyx_service)
+    config = build_context_config(verifyx_enabled=True)
+    state = build_state(
+        specs={"gpu": {"count": 1}},
+        rented_data=_rented_data_with_ema("executor-123", download=500.0, upload=100.0),
+    )
+    ctx = context_factory(services=services, config=config, state=state)
+
+    result = await VerifyXCheck().run(ctx)
+
+    assert result.passed is True
+    net = result.updates["state"].specs["network"]
+    # compute_ema(500.0, 0.0) = 0.7 * 500 = 350.0
+    assert net["ema_verifyx_download_speed"] == pytest.approx(350.0)
+    # compute_ema(100.0, 0.0) = 0.7 * 100 = 70.0
+    assert net["ema_verifyx_upload_speed"] == pytest.approx(70.0)
+    # raw speed keys must NOT be set when there was no measurement
+    assert "verifyx_download_speed" not in net
+    assert "verifyx_upload_speed" not in net
+
+
+@pytest.mark.asyncio
+async def test_verifyx_success_null_network_repeated_decays_below_threshold(context_factory):
+    """5 consecutive verifyx-pass / network-fail cycles from 500 Mbps → EMA below 100 Mbps."""
+    # 500 * 0.7^5 ≈ 84.0 < 100 Mbps
+    ema = 500.0
+    for _ in range(5):
+        verifyx_service = DummyVerifyXService(success=True, updated_specs={"network": {}})
+        services = build_services(verifyx=verifyx_service)
+        config = build_context_config(verifyx_enabled=True)
+        state = build_state(
+            specs={"gpu": {"count": 1}},
+            rented_data=_rented_data_with_ema("executor-123", download=ema),
+        )
+        ctx = context_factory(services=services, config=config, state=state)
+        result = await VerifyXCheck().run(ctx)
+        ema = result.updates["state"].specs["network"]["ema_verifyx_download_speed"]
+
+    assert ema < 100.0
+
+
+@pytest.mark.asyncio
 async def test_verifyx_success_path_emits_no_verifyx_failed_log(
     context_factory, caplog
 ):
     """Regression: success path MUST NOT emit the new VerifyX failure log line."""
-    updated_specs = {"ram": {"total": "64GB"}, "hard_disk": {"total": "1TB"}}
+    updated_specs = {"ram": {"total": "64GB"}, "hard_disk": {"total": "1TB"}, "network": {"download_speed": 500.0, "upload_speed": 100.0}}
     verifyx_service = DummyVerifyXService(success=True, updated_specs=updated_specs)
     services = build_services(verifyx=verifyx_service)
     config = build_context_config(verifyx_enabled=True)

--- a/neurons/validators/tests/test_verifyx_check.py
+++ b/neurons/validators/tests/test_verifyx_check.py
@@ -7,6 +7,7 @@ from neurons.validators.src.services.task.messages import (
     VERIFYX_DEBUG_DOC_URL,
     VerifyXMessages as Msg,
 )
+from protocol.vc_protocol.compute_requests import NetworkEMA, RentedExecutorsResponse
 
 from tests.helpers import build_context_config, build_services, build_state
 
@@ -237,6 +238,108 @@ async def test_verifyx_failure_without_diagnostics_falls_back_to_generic_templat
     # No diagnostic keys when no diagnostics available
     assert "failure_class" not in result.event.what_we_saw
     assert result.event.help_uri == VERIFYX_DEBUG_DOC_URL
+
+
+def _rented_data_with_ema(executor_uuid: str, *, download: float | None = None, upload: float | None = None) -> RentedExecutorsResponse:
+    return RentedExecutorsResponse(
+        executors={},
+        banned_guids=[],
+        network_ema={
+            executor_uuid: NetworkEMA(
+                ema_verifyx_download_speed=download,
+                ema_verifyx_upload_speed=upload,
+            )
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_verifyx_failure_propagates_prev_ema_when_present(context_factory):
+    """On probe failure, prior EMA (download) should be carried forward into specs."""
+    verifyx_service = _VerifyXServiceReturning(MockVerifyXResponse(error="failure"))
+    services = build_services(verifyx=verifyx_service)
+    config = build_context_config(verifyx_enabled=True)
+    state = build_state(
+        specs={"gpu": {"count": 1}},
+        rented_data=_rented_data_with_ema("executor-123", download=250.0),
+    )
+    ctx = context_factory(services=services, config=config, state=state)
+
+    result = await VerifyXCheck().run(ctx)
+
+    assert result.passed is False
+    assert "state" in result.updates
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == 250.0
+
+
+@pytest.mark.asyncio
+async def test_verifyx_failure_propagates_upload_ema_when_present(context_factory):
+    """On probe failure, prior EMA (upload) should also be carried forward."""
+    verifyx_service = _VerifyXServiceReturning(MockVerifyXResponse(error="failure"))
+    services = build_services(verifyx=verifyx_service)
+    config = build_context_config(verifyx_enabled=True)
+    state = build_state(
+        specs={"gpu": {"count": 1}},
+        rented_data=_rented_data_with_ema("executor-123", upload=40.0),
+    )
+    ctx = context_factory(services=services, config=config, state=state)
+
+    result = await VerifyXCheck().run(ctx)
+
+    assert result.passed is False
+    assert "state" in result.updates
+    assert result.updates["state"].specs["network"]["ema_verifyx_upload_speed"] == 40.0
+
+
+@pytest.mark.asyncio
+async def test_verifyx_failure_does_not_decay_prev_ema(context_factory):
+    """Carried-forward value must equal prev_ema exactly — no decay, no 0-sample EMA update."""
+    verifyx_service = _VerifyXServiceReturning(MockVerifyXResponse(error="failure"))
+    services = build_services(verifyx=verifyx_service)
+    config = build_context_config(verifyx_enabled=True)
+    state = build_state(
+        specs={"gpu": {"count": 1}},
+        rented_data=_rented_data_with_ema("executor-123", download=250.0, upload=40.0),
+    )
+    ctx = context_factory(services=services, config=config, state=state)
+
+    result = await VerifyXCheck().run(ctx)
+
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == 250.0
+    assert result.updates["state"].specs["network"]["ema_verifyx_upload_speed"] == 40.0
+
+
+@pytest.mark.asyncio
+async def test_verifyx_failure_without_prev_ema_leaves_specs_empty(context_factory):
+    """No prior EMA anywhere — failure branch must not fabricate a state update."""
+    verifyx_service = _VerifyXServiceReturning(MockVerifyXResponse(error="failure"))
+    services = build_services(verifyx=verifyx_service)
+    config = build_context_config(verifyx_enabled=True)
+    state = build_state(
+        specs={"gpu": {"count": 1}},
+        rented_data=RentedExecutorsResponse(executors={}, banned_guids=[], network_ema={}),
+    )
+    ctx = context_factory(services=services, config=config, state=state)
+
+    result = await VerifyXCheck().run(ctx)
+
+    assert result.passed is False
+    assert "state" not in result.updates
+
+
+@pytest.mark.asyncio
+async def test_verifyx_failure_without_rented_data_does_not_update_state(context_factory):
+    """rented_data is None — failure branch must not attempt to read from it."""
+    verifyx_service = _VerifyXServiceReturning(MockVerifyXResponse(error="failure"))
+    services = build_services(verifyx=verifyx_service)
+    config = build_context_config(verifyx_enabled=True)
+    state = build_state(specs={"gpu": {"count": 1}}, rented_data=None)
+    ctx = context_factory(services=services, config=config, state=state)
+
+    result = await VerifyXCheck().run(ctx)
+
+    assert result.passed is False
+    assert "state" not in result.updates
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_verifyx_check.py
+++ b/neurons/validators/tests/test_verifyx_check.py
@@ -254,8 +254,8 @@ def _rented_data_with_ema(executor_uuid: str, *, download: float | None = None, 
 
 
 @pytest.mark.asyncio
-async def test_verifyx_failure_propagates_prev_ema_when_present(context_factory):
-    """On probe failure, prior EMA (download) should be carried forward into specs."""
+async def test_verifyx_failure_decays_prev_ema_download(context_factory):
+    """On probe failure, download EMA decays by one step toward 0 (0.7 × prev)."""
     verifyx_service = _VerifyXServiceReturning(MockVerifyXResponse(error="failure"))
     services = build_services(verifyx=verifyx_service)
     config = build_context_config(verifyx_enabled=True)
@@ -269,12 +269,13 @@ async def test_verifyx_failure_propagates_prev_ema_when_present(context_factory)
 
     assert result.passed is False
     assert "state" in result.updates
-    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == 250.0
+    # compute_ema(250.0, 0.0) = 0.3*0 + 0.7*250 = 175.0
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(175.0)
 
 
 @pytest.mark.asyncio
-async def test_verifyx_failure_propagates_upload_ema_when_present(context_factory):
-    """On probe failure, prior EMA (upload) should also be carried forward."""
+async def test_verifyx_failure_decays_prev_ema_upload(context_factory):
+    """On probe failure, upload EMA also decays by one step toward 0 (0.7 × prev)."""
     verifyx_service = _VerifyXServiceReturning(MockVerifyXResponse(error="failure"))
     services = build_services(verifyx=verifyx_service)
     config = build_context_config(verifyx_enabled=True)
@@ -288,25 +289,28 @@ async def test_verifyx_failure_propagates_upload_ema_when_present(context_factor
 
     assert result.passed is False
     assert "state" in result.updates
-    assert result.updates["state"].specs["network"]["ema_verifyx_upload_speed"] == 40.0
+    # compute_ema(40.0, 0.0) = 0.3*0 + 0.7*40 = 28.0
+    assert result.updates["state"].specs["network"]["ema_verifyx_upload_speed"] == pytest.approx(28.0)
 
 
 @pytest.mark.asyncio
-async def test_verifyx_failure_does_not_decay_prev_ema(context_factory):
-    """Carried-forward value must equal prev_ema exactly — no decay, no 0-sample EMA update."""
-    verifyx_service = _VerifyXServiceReturning(MockVerifyXResponse(error="failure"))
-    services = build_services(verifyx=verifyx_service)
-    config = build_context_config(verifyx_enabled=True)
-    state = build_state(
-        specs={"gpu": {"count": 1}},
-        rented_data=_rented_data_with_ema("executor-123", download=250.0, upload=40.0),
-    )
-    ctx = context_factory(services=services, config=config, state=state)
+async def test_verifyx_failure_repeated_decays_below_threshold(context_factory):
+    """After 5 consecutive failures starting from 500 Mbps, EMA drops below 100 Mbps threshold."""
+    # 500 * 0.7^5 ≈ 84.0 < 100 Mbps
+    ema = 500.0
+    for _ in range(5):
+        verifyx_service = _VerifyXServiceReturning(MockVerifyXResponse(error="failure"))
+        services = build_services(verifyx=verifyx_service)
+        config = build_context_config(verifyx_enabled=True)
+        state = build_state(
+            specs={"gpu": {"count": 1}},
+            rented_data=_rented_data_with_ema("executor-123", download=ema),
+        )
+        ctx = context_factory(services=services, config=config, state=state)
+        result = await VerifyXCheck().run(ctx)
+        ema = result.updates["state"].specs["network"]["ema_verifyx_download_speed"]
 
-    result = await VerifyXCheck().run(ctx)
-
-    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == 250.0
-    assert result.updates["state"].specs["network"]["ema_verifyx_upload_speed"] == 40.0
+    assert ema < 100.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Describe your changes

**Problem:** Three related bugs in the VerifyX/scoring pipeline:

1. When an unrented executor had no EMA verifyx download speed, \`calculate_scores\` treated \`None\` as \"no penalty\" — an executor that had never been network-verified could receive a full score.
2. When a VerifyX probe succeeded overall but the network measurement failed (\`VERIFYX_NETWORK_VALIDATION=false\`, the default), the EMA was simply left null rather than decayed — so repeated network failures did not progressively lower the score.
3. The EMA download speed threshold (100 Mbps) lived in \`score_calculator.py\`, which only runs when the pipeline succeeds. This meant the threshold was misplaced — it should gate the check itself, not a downstream scorer.

**Fix:**

- \`verifyx.py\` — **Always compute verifyx network EMA** in the success path. When network measurement failed (\`download_speed\` is \`None\`), feed \`0.0\` into \`compute_ema\` so the EMA decays by 30% each cycle (\`0.7 × prev\`). After ~5 consecutive failures from 500 Mbps the EMA drops below the 100 Mbps threshold.
- \`verifyx.py\` — **Threshold check moved here**: after computing the EMA, if \`ema_verifyx_download_speed < 100 Mbps\`, return \`passed=False\` with the new \`VERIFYX_FAILED_NETWORK_SPEED_TOO_SLOW\` event. Pipeline short-circuits → both \`actual_score\` and \`job_score\` are 0.
- \`verifyx.py\` — **Remove dead failure-path EMA block**: when VerifyXCheck fails (fatal), the pipeline already gives score=0 from Context defaults. Writing a decayed EMA into state on failure was dead code.
- \`messages.py\` — Added \`VERIFY_FAILED_NETWORK_SPEED_TOO_SLOW\` message template (\`VERIFYX_FAILED_NETWORK_SPEED_TOO_SLOW\`).
- \`score_calculator.py\` — Removed the below-threshold check and the \`MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS\` constant. Retains only the null-EMA guard for the edge case where verifyx is disabled.

## Issue ticket number and link

No ticket.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?