### PR TITLE
DAH-1987, persist NVIDIA device cgroup across systemd daemon-reload

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1158,6 +1158,40 @@ class DockerService:
 
                 # check if the container is running correctly
                 if not await self.check_container_running(ssh_client, container_name):
+                    # Capture the failure reason and check whether it points to our
+                    # --device flags (DAH-1987). State.Error covers cgroup / device
+                    # failures; logs --tail covers entrypoint failures.
+                    failure_reason = ""
+                    try:
+                        inspect = await ssh_client.run(
+                            f"/usr/bin/docker inspect -f '{{{{.State.Error}}}}' {container_name}"
+                        )
+                        logs_tail = await ssh_client.run(
+                            f"/usr/bin/docker logs --tail 50 {container_name} 2>&1 || true"
+                        )
+                        failure_reason = (inspect.stdout or "") + "\n" + (logs_tail.stdout or "")
+                    except Exception:
+                        failure_reason = "(failure_reason capture failed)"
+
+                    nvidia_signal = any(
+                        marker in failure_reason.lower()
+                        for marker in ("/dev/nvidia", "device cgroup", "no such device", "operation not permitted")
+                    )
+                    log_extra = get_extra_info({
+                        **default_extra,
+                        "container_name": container_name,
+                        "gpu_flags": gpu_flags,
+                        "failure_reason": failure_reason[:2000],
+                    })
+                    if nvidia_signal:
+                        logger.error(_m(
+                            "docker run failed with NVIDIA-device-related error — "
+                            "possible regression from build_gpu_flags --device flag set",
+                            extra=log_extra,
+                        ))
+                    else:
+                        logger.error(_m("docker run failed", extra=log_extra))
+
                     await self.clean_existing_containers(ssh_client=ssh_client, default_extra=default_extra, pod_name=container_name, active_container_names=payload.active_container_names)
                     raise Exception("Run docker run command but container is not running")
 

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -47,6 +47,7 @@ from services.redis_service import (
     RedisService,
 )
 from services.attestation_service import AttestationService, AttestationError
+from services.nvidia_devices import build_gpu_flags
 from services.ssh_service import SSHService
 
 logger = logging.getLogger(__name__)
@@ -1105,12 +1106,11 @@ class DockerService:
                     "--device /dev/net/tun "
                 )
 
-                # GPU restriction flags
-                if payload.gpu_uuids:
-                    gpu_devices = ",".join(payload.gpu_uuids)
-                    gpu_flags = f'--gpus \'"device={gpu_devices}"\' '
-                else:
-                    gpu_flags = "--gpus all "
+                # GPU flags. --gpus injects userspace libs (libnvidia-ml.so, nvidia-smi);
+                # explicit --device entries persist the device cgroup across systemd
+                # daemon-reload (cgroup v2 + systemd cgroup driver wipe the transient
+                # nvidia hook program; HostConfig.Devices is reapplied by Docker).
+                gpu_flags = await build_gpu_flags(ssh_client, payload.gpu_uuids) + " "
 
                 # CPU and memory restriction flags
                 # --cpus flag isn't working inside cvm. skip to use it when tdx_quote is present

--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -20,37 +20,18 @@ Public surface
     flags = await build_gpu_flags(ssh_client, gpu_uuids)
         # full ready-to-paste string, e.g.
         # --gpus all --device=/dev/nvidia0 --device=/dev/nvidiactl ...
-
-    # Lower-level pieces (exposed for tests / future reuse):
-    plan = await discover_nvidia_devices(ssh_client, gpu_uuids)  # NvidiaDevicePlan
-    flags = plan.as_device_flags()                               # only --device=... part
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+import shlex
+from collections.abc import Sequence
 
 import asyncssh
 
 
-@dataclass(frozen=True)
-class NvidiaDevicePlan:
-    """Set of /dev/nvidia* nodes resolved on a specific executor host.
-
-    `per_gpu` — minor nodes for the GPUs being rented (whole host or subset).
-    `shared`  — control / MIG / NVSwitch / IMEX nodes that exist on the host.
-    """
-
-    per_gpu: tuple[str, ...]
-    shared: tuple[str, ...]
-
-    def as_device_flags(self) -> str:
-        nodes = (*self.per_gpu, *self.shared)
-        return " ".join(f"--device={n}" for n in nodes)
-
-
 async def build_gpu_flags(
     ssh_client: asyncssh.SSHClientConnection,
-    gpu_uuids: list[str] | None,
+    gpu_uuids: Sequence[str] | None,
 ) -> str:
     """Assemble the full GPU flag block for `docker run`.
 
@@ -61,67 +42,103 @@ async def build_gpu_flags(
     - `--device /dev/nvidia*`: persists the device cgroup across systemd
       `daemon-reload` and `systemctl restart containerd`.
     """
-    plan = await discover_nvidia_devices(ssh_client, gpu_uuids)
-    return f"{_gpus_flag(gpu_uuids)} {plan.as_device_flags()}".strip()
-
-
-async def discover_nvidia_devices(
-    ssh_client: asyncssh.SSHClientConnection,
-    gpu_uuids: list[str] | None,
-) -> NvidiaDevicePlan:
-    per_gpu = await _per_gpu_nodes(ssh_client, gpu_uuids)
-    shared = await _shared_nodes(ssh_client)
-    return NvidiaDevicePlan(per_gpu=tuple(per_gpu), shared=tuple(shared))
-
-
-def _gpus_flag(gpu_uuids: list[str] | None) -> str:
     if gpu_uuids:
-        return f'--gpus \'"device={",".join(gpu_uuids)}"\''
+        per_gpu = await _query_gpu_nodes_for_uuids(ssh_client, gpu_uuids)
+    else:
+        per_gpu = await _query_all_gpu_nodes(ssh_client)
+
+    shared = await _query_shared_nodes(ssh_client)
+    device_flags = _device_flags((*per_gpu, *shared))
+    return " ".join(flag for flag in (_gpus_flag(gpu_uuids), device_flags) if flag)
+
+
+def _gpus_flag(gpu_uuids: Sequence[str] | None) -> str:
+    if gpu_uuids:
+        device_arg = f'"device={",".join(gpu_uuids)}"'
+        return f"--gpus {shlex.quote(device_arg)}"
     return "--gpus all"
 
 
-async def _per_gpu_nodes(
-    ssh: asyncssh.SSHClientConnection,
-    gpu_uuids: list[str] | None,
-) -> list[str]:
-    if not gpu_uuids:
-        res = await ssh.run("ls -1d /dev/nvidia[0-9]* 2>/dev/null || true")
-        return [line.strip() for line in res.stdout.splitlines() if line.strip()]
+def _device_flags(nodes: Sequence[str]) -> str:
+    return " ".join(f"--device={node}" for node in nodes)
 
+
+async def _query_all_gpu_nodes(ssh: asyncssh.SSHClientConnection) -> tuple[str, ...]:
+    res = await ssh.run("ls -1d /dev/nvidia[0-9]* 2>/dev/null || true")
+    return _stdout_lines(res.stdout)
+
+
+async def _query_gpu_nodes_for_uuids(
+    ssh: asyncssh.SSHClientConnection,
+    gpu_uuids: Sequence[str],
+) -> tuple[str, ...]:
     res = await ssh.run("nvidia-smi --query-gpu=uuid,index --format=csv,noheader")
     if res.exit_status != 0:
         raise RuntimeError(f"nvidia-smi query failed on executor: {res.stderr!r}")
 
-    uuid_to_idx: dict[str, int] = {}
-    for line in res.stdout.splitlines():
-        uuid, _, idx = line.partition(",")
+    uuid_to_index: dict[str, int] = {}
+    for line in _stdout_lines(res.stdout):
+        uuid, _, index = line.partition(",")
         try:
-            uuid_to_idx[uuid.strip()] = int(idx.strip())
+            uuid_to_index[uuid.strip()] = int(index.strip())
         except ValueError:
             continue
 
-    nodes: list[str] = []
-    for uuid in gpu_uuids:
-        if uuid not in uuid_to_idx:
-            raise RuntimeError(
-                f"GPU {uuid!r} requested by tenant not present on executor; "
-                f"visible: {sorted(uuid_to_idx)}"
-            )
-        nodes.append(f"/dev/nvidia{uuid_to_idx[uuid]}")
-    return nodes
+    missing = [uuid for uuid in gpu_uuids if uuid not in uuid_to_index]
+    if missing:
+        raise RuntimeError(
+            f"GPU {missing[0]!r} requested by tenant not present on executor; "
+            f"visible: {sorted(uuid_to_index)}"
+        )
+
+    return tuple(f"/dev/nvidia{uuid_to_index[uuid]}" for uuid in gpu_uuids)
 
 
-async def _shared_nodes(ssh: asyncssh.SSHClientConnection) -> list[str]:
+async def _query_shared_nodes(ssh: asyncssh.SSHClientConnection) -> tuple[str, ...]:
     # One round-trip enumerates every nvidia control / MIG / NVSwitch / IMEX node
     # that actually exists on this host.
     cmd = (
         "for p in /dev/nvidiactl /dev/nvidia-modeset /dev/nvidia-uvm "
-        "/dev/nvidia-uvm-tools /dev/nvidia-nvswitchctl; do "
-        '[ -e "$p" ] && echo "$p"; '
+        "/dev/nvidia-uvm-tools /dev/nvidia-nvswitchctl "
+        "/dev/nvidia-nvswitch[0-9]* /dev/nvidia-nvlink[0-9]*; do "
+        '[ -e "$p" ] && printf "%s\\n" "$p"; '
         "done; "
-        "ls -1 /dev/nvidia-nvswitch[0-9]* /dev/nvidia-nvlink[0-9]* 2>/dev/null; "
         "find /dev/nvidia-caps /dev/nvidia-caps-imex-channels "
-        "-mindepth 1 -maxdepth 1 2>/dev/null"
+        "-mindepth 1 -maxdepth 1 -print 2>/dev/null || true"
     )
     res = await ssh.run(cmd)
-    return [line.strip() for line in res.stdout.splitlines() if line.strip()]
+    return _stdout_lines(res.stdout)
+
+
+def _stdout_lines(stdout: str) -> tuple[str, ...]:
+    return tuple(line.strip() for line in stdout.splitlines() if line.strip())
+
+
+if __name__ == "__main__":
+    # Ad-hoc smoke run against a real GPU host. Connects, prints what
+    # build_gpu_flags() would emit for whole-host and partial rentals.
+    import asyncio
+
+    HOST = "69.19.136.107"
+    USER = "shadeform"
+
+    async def _main() -> None:
+        async with asyncssh.connect(HOST, username=USER, known_hosts=None) as ssh:
+            print("=" * 60)
+            print(f"host: {USER}@{HOST}")
+            uuids_raw = await ssh.run(
+                "nvidia-smi --query-gpu=uuid --format=csv,noheader"
+            )
+            visible = _stdout_lines(uuids_raw.stdout)
+            print(f"visible GPUs: {visible}")
+            print("=" * 60)
+
+            print("\n[whole-host rental]")
+            print(await build_gpu_flags(ssh, gpu_uuids=None))
+
+            if visible:
+                first = visible[0].rstrip(",")
+                print(f"\n[partial rental: {first}]")
+                print(await build_gpu_flags(ssh, gpu_uuids=[first]))
+
+    asyncio.run(_main())

--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -1,0 +1,127 @@
+"""NVIDIA device-node discovery for `docker run --device` flags.
+
+Why this module exists
+----------------------
+`docker run --gpus ...` installs a transient device cgroup via the
+nvidia-container-runtime hook. On hosts running cgroup v2 with the systemd
+cgroup driver, `systemctl daemon-reload` (triggered by routine apt upgrades)
+re-evaluates the docker-<id>.scope and overwrites its device program with one
+that doesn't know about NVIDIA — `open(/dev/nvidia*)` returns EPERM and NVML
+reports "Unknown Error" inside the container. /dev nodes stay visible but
+unreadable.
+
+Forwarding the same nodes via explicit `--device /dev/nvidia*` puts them into
+HostConfig.Devices, so Docker reapplies the cgroup policy after the scope is
+reconfigured. The set of nodes is host-specific (driver version, GPU topology,
+MIG, NVSwitch, IMEX) — we probe at runtime instead of hardcoding.
+
+Public surface
+--------------
+    flags = await build_gpu_flags(ssh_client, gpu_uuids)
+        # full ready-to-paste string, e.g.
+        # --gpus all --device=/dev/nvidia0 --device=/dev/nvidiactl ...
+
+    # Lower-level pieces (exposed for tests / future reuse):
+    plan = await discover_nvidia_devices(ssh_client, gpu_uuids)  # NvidiaDevicePlan
+    flags = plan.as_device_flags()                               # only --device=... part
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import asyncssh
+
+
+@dataclass(frozen=True)
+class NvidiaDevicePlan:
+    """Set of /dev/nvidia* nodes resolved on a specific executor host.
+
+    `per_gpu` — minor nodes for the GPUs being rented (whole host or subset).
+    `shared`  — control / MIG / NVSwitch / IMEX nodes that exist on the host.
+    """
+
+    per_gpu: tuple[str, ...]
+    shared: tuple[str, ...]
+
+    def as_device_flags(self) -> str:
+        nodes = (*self.per_gpu, *self.shared)
+        return " ".join(f"--device={n}" for n in nodes)
+
+
+async def build_gpu_flags(
+    ssh_client: asyncssh.SSHClientConnection,
+    gpu_uuids: list[str] | None,
+) -> str:
+    """Assemble the full GPU flag block for `docker run`.
+
+    Combines two layers:
+    - `--gpus` (or `--gpus '"device=<uuid>,..."'` for partial rentals): triggers
+      the nvidia-container-runtime hook which bind-mounts userspace libs and the
+      `nvidia-smi` binary into the container.
+    - `--device /dev/nvidia*`: persists the device cgroup across systemd
+      `daemon-reload` and `systemctl restart containerd`.
+    """
+    plan = await discover_nvidia_devices(ssh_client, gpu_uuids)
+    return f"{_gpus_flag(gpu_uuids)} {plan.as_device_flags()}".strip()
+
+
+async def discover_nvidia_devices(
+    ssh_client: asyncssh.SSHClientConnection,
+    gpu_uuids: list[str] | None,
+) -> NvidiaDevicePlan:
+    per_gpu = await _per_gpu_nodes(ssh_client, gpu_uuids)
+    shared = await _shared_nodes(ssh_client)
+    return NvidiaDevicePlan(per_gpu=tuple(per_gpu), shared=tuple(shared))
+
+
+def _gpus_flag(gpu_uuids: list[str] | None) -> str:
+    if gpu_uuids:
+        return f'--gpus \'"device={",".join(gpu_uuids)}"\''
+    return "--gpus all"
+
+
+async def _per_gpu_nodes(
+    ssh: asyncssh.SSHClientConnection,
+    gpu_uuids: list[str] | None,
+) -> list[str]:
+    if not gpu_uuids:
+        res = await ssh.run("ls -1d /dev/nvidia[0-9]* 2>/dev/null || true")
+        return [line.strip() for line in res.stdout.splitlines() if line.strip()]
+
+    res = await ssh.run("nvidia-smi --query-gpu=uuid,index --format=csv,noheader")
+    if res.exit_status != 0:
+        raise RuntimeError(f"nvidia-smi query failed on executor: {res.stderr!r}")
+
+    uuid_to_idx: dict[str, int] = {}
+    for line in res.stdout.splitlines():
+        uuid, _, idx = line.partition(",")
+        try:
+            uuid_to_idx[uuid.strip()] = int(idx.strip())
+        except ValueError:
+            continue
+
+    nodes: list[str] = []
+    for uuid in gpu_uuids:
+        if uuid not in uuid_to_idx:
+            raise RuntimeError(
+                f"GPU {uuid!r} requested by tenant not present on executor; "
+                f"visible: {sorted(uuid_to_idx)}"
+            )
+        nodes.append(f"/dev/nvidia{uuid_to_idx[uuid]}")
+    return nodes
+
+
+async def _shared_nodes(ssh: asyncssh.SSHClientConnection) -> list[str]:
+    # One round-trip enumerates every nvidia control / MIG / NVSwitch / IMEX node
+    # that actually exists on this host.
+    cmd = (
+        "for p in /dev/nvidiactl /dev/nvidia-modeset /dev/nvidia-uvm "
+        "/dev/nvidia-uvm-tools /dev/nvidia-nvswitchctl; do "
+        '[ -e "$p" ] && echo "$p"; '
+        "done; "
+        "ls -1 /dev/nvidia-nvswitch[0-9]* /dev/nvidia-nvlink[0-9]* 2>/dev/null; "
+        "find /dev/nvidia-caps /dev/nvidia-caps-imex-channels "
+        "-mindepth 1 -maxdepth 1 2>/dev/null"
+    )
+    res = await ssh.run(cmd)
+    return [line.strip() for line in res.stdout.splitlines() if line.strip()]

--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -20,13 +20,25 @@ Public surface
     flags = await build_gpu_flags(ssh_client, gpu_uuids)
         # full ready-to-paste string, e.g.
         # --gpus all --device=/dev/nvidia0 --device=/dev/nvidiactl ...
+
+Failure handling
+----------------
+`build_gpu_flags` never raises: any probe failure (SSH error, missing
+nvidia-smi, unknown UUID, etc.) is logged at WARNING and the function falls
+back to the legacy `--gpus`-only string. The pod still gets created — it
+just doesn't get the daemon-reload protection. This trades a known
+regression (back to today's behaviour) for resilience against unforeseen
+executor-side issues.
 """
 from __future__ import annotations
 
+import logging
 import shlex
 from collections.abc import Sequence
 
 import asyncssh
+
+logger = logging.getLogger(__name__)
 
 
 async def build_gpu_flags(
@@ -41,15 +53,28 @@ async def build_gpu_flags(
       `nvidia-smi` binary into the container.
     - `--device /dev/nvidia*`: persists the device cgroup across systemd
       `daemon-reload` and `systemctl restart containerd`.
-    """
-    if gpu_uuids:
-        per_gpu = await _query_gpu_nodes_for_uuids(ssh_client, gpu_uuids)
-    else:
-        per_gpu = await _query_all_gpu_nodes(ssh_client)
 
-    shared = await _query_shared_nodes(ssh_client)
-    device_flags = _device_flags((*per_gpu, *shared))
-    return " ".join(flag for flag in (_gpus_flag(gpu_uuids), device_flags) if flag)
+    Falls back to a legacy `--gpus`-only string on any probe failure (logged
+    at WARNING). The pod will still be created in the legacy path; it just
+    won't survive `systemctl daemon-reload` on the executor host.
+    """
+    try:
+        if gpu_uuids:
+            per_gpu = await _query_gpu_nodes_for_uuids(ssh_client, gpu_uuids)
+        else:
+            per_gpu = await _query_all_gpu_nodes(ssh_client)
+
+        shared = await _query_shared_nodes(ssh_client)
+        device_flags = _device_flags((*per_gpu, *shared))
+        return " ".join(flag for flag in (_gpus_flag(gpu_uuids), device_flags) if flag)
+    except Exception:
+        logger.warning(
+            "nvidia_devices: probe failed, falling back to legacy --gpus only "
+            "(pod will not survive systemd daemon-reload on the executor)",
+            exc_info=True,
+            extra={"gpu_uuids": list(gpu_uuids) if gpu_uuids else None},
+        )
+        return _gpus_flag(gpu_uuids)
 
 
 def _gpus_flag(gpu_uuids: Sequence[str] | None) -> str:

--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -60,11 +60,18 @@ async def build_gpu_flags(
     """
     try:
         if gpu_uuids:
-            per_gpu = await _query_gpu_nodes_for_uuids(ssh_client, gpu_uuids)
+            per_gpu, host_total = await _query_gpu_nodes_for_uuids(ssh_client, gpu_uuids)
+            is_partial_rental = len(per_gpu) < host_total
         else:
             per_gpu = await _query_all_gpu_nodes(ssh_client)
+            is_partial_rental = False
 
-        shared = await _query_shared_nodes(ssh_client)
+        # On partial rentals (some-but-not-all GPUs on the host), skip /dev/nvidia-caps/*.
+        # Caps are per-GPU/per-MIG control nodes; forwarding all of them lets a tenant
+        # peek at or manipulate MIG state of another tenant's GPU on the same host.
+        # We don't sell MIG slices today, but stripping caps under partial rental
+        # closes the leak before that ever ships.
+        shared = await _query_shared_nodes(ssh_client, include_caps=not is_partial_rental)
         device_flags = _device_flags((*per_gpu, *shared))
         return " ".join(flag for flag in (_gpus_flag(gpu_uuids), device_flags) if flag)
     except Exception:
@@ -96,41 +103,61 @@ async def _query_all_gpu_nodes(ssh: asyncssh.SSHClientConnection) -> tuple[str, 
 async def _query_gpu_nodes_for_uuids(
     ssh: asyncssh.SSHClientConnection,
     gpu_uuids: Sequence[str],
-) -> tuple[str, ...]:
-    res = await ssh.run("nvidia-smi --query-gpu=uuid,index --format=csv,noheader")
+) -> tuple[tuple[str, ...], int]:
+    """Resolve requested UUIDs to /dev/nvidiaN nodes, plus return host GPU count.
+
+    Returns (per_gpu_nodes_in_request_order, host_total_gpu_count). The host
+    total lets the caller decide whether this is a partial-host rental.
+    """
+    # `minor_number` is the documented driver-assigned minor that maps to /dev/nvidiaN,
+    # unlike `index` which is the CUDA enumeration order (PCI BDF) and is not formally
+    # guaranteed to equal the device-node minor.
+    res = await ssh.run("nvidia-smi --query-gpu=uuid,minor_number --format=csv,noheader")
     if res.exit_status != 0:
         raise RuntimeError(f"nvidia-smi query failed on executor: {res.stderr!r}")
 
-    uuid_to_index: dict[str, int] = {}
+    uuid_to_minor: dict[str, int] = {}
     for line in _stdout_lines(res.stdout):
-        uuid, _, index = line.partition(",")
+        uuid, _, minor = line.partition(",")
         try:
-            uuid_to_index[uuid.strip()] = int(index.strip())
+            uuid_to_minor[uuid.strip()] = int(minor.strip())
         except ValueError:
             continue
 
-    missing = [uuid for uuid in gpu_uuids if uuid not in uuid_to_index]
+    missing = [uuid for uuid in gpu_uuids if uuid not in uuid_to_minor]
     if missing:
         raise RuntimeError(
             f"GPU {missing[0]!r} requested by tenant not present on executor; "
-            f"visible: {sorted(uuid_to_index)}"
+            f"visible: {sorted(uuid_to_minor)}"
         )
 
-    return tuple(f"/dev/nvidia{uuid_to_index[uuid]}" for uuid in gpu_uuids)
+    per_gpu = tuple(f"/dev/nvidia{uuid_to_minor[uuid]}" for uuid in gpu_uuids)
+    return per_gpu, len(uuid_to_minor)
 
 
-async def _query_shared_nodes(ssh: asyncssh.SSHClientConnection) -> tuple[str, ...]:
-    # One round-trip enumerates every nvidia control / MIG / NVSwitch / IMEX node
-    # that actually exists on this host.
+async def _query_shared_nodes(
+    ssh: asyncssh.SSHClientConnection,
+    *,
+    include_caps: bool = True,
+) -> tuple[str, ...]:
+    """Enumerate shared NVIDIA control nodes that exist on the host.
+
+    `include_caps=False` skips /dev/nvidia-caps/* and IMEX channel nodes — used
+    for partial-host rentals so we don't leak per-GPU MIG/IMEX caps belonging
+    to neighbouring tenants on the same host.
+    """
     cmd = (
         "for p in /dev/nvidiactl /dev/nvidia-modeset /dev/nvidia-uvm "
         "/dev/nvidia-uvm-tools /dev/nvidia-nvswitchctl "
         "/dev/nvidia-nvswitch[0-9]* /dev/nvidia-nvlink[0-9]*; do "
         '[ -e "$p" ] && printf "%s\\n" "$p"; '
-        "done; "
-        "find /dev/nvidia-caps /dev/nvidia-caps-imex-channels "
-        "-mindepth 1 -maxdepth 1 -print 2>/dev/null || true"
+        "done"
     )
+    if include_caps:
+        cmd += (
+            "; find /dev/nvidia-caps /dev/nvidia-caps-imex-channels "
+            "-mindepth 1 -maxdepth 1 -print 2>/dev/null || true"
+        )
     res = await ssh.run(cmd)
     return _stdout_lines(res.stdout)
 

--- a/neurons/validators/tests/test_nvidia_devices.py
+++ b/neurons/validators/tests/test_nvidia_devices.py
@@ -1,0 +1,176 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from neurons.validators.src.services.nvidia_devices import (
+    NvidiaDevicePlan,
+    _gpus_flag,
+    build_gpu_flags,
+    discover_nvidia_devices,
+)
+
+
+class FakeRun:
+    def __init__(self, stdout: str = "", stderr: str = "", exit_status: int = 0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_status = exit_status
+
+
+def fake_ssh(*responses: FakeRun) -> AsyncMock:
+    ssh = AsyncMock()
+    ssh.run.side_effect = responses
+    return ssh
+
+
+# ---------------------------- _gpus_flag (pure) ----------------------------
+
+
+def test_gpus_flag_no_uuids_emits_all():
+    assert _gpus_flag(None) == "--gpus all"
+    assert _gpus_flag([]) == "--gpus all"
+
+
+def test_gpus_flag_single_uuid():
+    assert _gpus_flag(["GPU-aaa"]) == '--gpus \'"device=GPU-aaa"\''
+
+
+def test_gpus_flag_multiple_uuids_joined_with_comma():
+    assert _gpus_flag(["GPU-a", "GPU-b"]) == '--gpus \'"device=GPU-a,GPU-b"\''
+
+
+# ---------------------------- NvidiaDevicePlan.as_device_flags ----------------------------
+
+
+def test_plan_renders_per_gpu_then_shared():
+    plan = NvidiaDevicePlan(
+        per_gpu=("/dev/nvidia0", "/dev/nvidia1"),
+        shared=("/dev/nvidiactl", "/dev/nvidia-uvm"),
+    )
+    assert plan.as_device_flags() == (
+        "--device=/dev/nvidia0 --device=/dev/nvidia1 "
+        "--device=/dev/nvidiactl --device=/dev/nvidia-uvm"
+    )
+
+
+def test_plan_with_no_nodes_is_empty_string():
+    assert NvidiaDevicePlan(per_gpu=(), shared=()).as_device_flags() == ""
+
+
+# ---------------------------- discover_nvidia_devices ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_whole_host_rental_enumerates_all_minors():
+    ssh = fake_ssh(
+        FakeRun("/dev/nvidia0\n/dev/nvidia1\n"),
+        FakeRun("/dev/nvidiactl\n/dev/nvidia-uvm\n"),
+    )
+    plan = await discover_nvidia_devices(ssh, gpu_uuids=None)
+
+    assert plan.per_gpu == ("/dev/nvidia0", "/dev/nvidia1")
+    assert plan.shared == ("/dev/nvidiactl", "/dev/nvidia-uvm")
+
+
+@pytest.mark.asyncio
+async def test_partial_rental_resolves_uuid_to_minor():
+    ssh = fake_ssh(
+        FakeRun("GPU-aaa, 0\nGPU-bbb, 1\nGPU-ccc, 2\n"),
+        FakeRun(""),
+    )
+    plan = await discover_nvidia_devices(ssh, gpu_uuids=["GPU-bbb"])
+
+    assert plan.per_gpu == ("/dev/nvidia1",)
+
+
+@pytest.mark.asyncio
+async def test_partial_rental_preserves_uuid_order_in_per_gpu():
+    ssh = fake_ssh(
+        FakeRun("GPU-aaa, 0\nGPU-bbb, 1\nGPU-ccc, 2\n"),
+        FakeRun(""),
+    )
+    plan = await discover_nvidia_devices(ssh, gpu_uuids=["GPU-ccc", "GPU-aaa"])
+
+    assert plan.per_gpu == ("/dev/nvidia2", "/dev/nvidia0")
+
+
+@pytest.mark.asyncio
+async def test_partial_rental_unknown_uuid_raises():
+    ssh = fake_ssh(FakeRun("GPU-aaa, 0\n"))
+
+    with pytest.raises(RuntimeError, match="not present on executor"):
+        await discover_nvidia_devices(ssh, gpu_uuids=["GPU-bbb"])
+
+
+@pytest.mark.asyncio
+async def test_nvidia_smi_failure_raises():
+    ssh = fake_ssh(FakeRun(stderr="nvidia-smi: not found", exit_status=127))
+
+    with pytest.raises(RuntimeError, match="nvidia-smi query failed"):
+        await discover_nvidia_devices(ssh, gpu_uuids=["GPU-aaa"])
+
+
+@pytest.mark.asyncio
+async def test_hgx_host_with_nvswitch_and_caps_nodes():
+    ssh = fake_ssh(
+        FakeRun("/dev/nvidia0\n/dev/nvidia1\n/dev/nvidia2\n/dev/nvidia3\n"),
+        FakeRun(
+            "/dev/nvidiactl\n/dev/nvidia-modeset\n/dev/nvidia-uvm\n/dev/nvidia-uvm-tools\n"
+            "/dev/nvidia-nvswitch0\n/dev/nvidia-nvswitch1\n"
+            "/dev/nvidia-caps/nvidia-cap1\n/dev/nvidia-caps/nvidia-cap2\n"
+        ),
+    )
+    plan = await discover_nvidia_devices(ssh, gpu_uuids=None)
+
+    assert plan.per_gpu == (
+        "/dev/nvidia0",
+        "/dev/nvidia1",
+        "/dev/nvidia2",
+        "/dev/nvidia3",
+    )
+    assert "/dev/nvidia-nvswitch0" in plan.shared
+    assert "/dev/nvidia-caps/nvidia-cap1" in plan.shared
+
+
+@pytest.mark.asyncio
+async def test_host_without_optional_shared_nodes_has_empty_shared():
+    ssh = fake_ssh(FakeRun("/dev/nvidia0\n"), FakeRun(""))
+    plan = await discover_nvidia_devices(ssh, gpu_uuids=None)
+
+    assert plan.per_gpu == ("/dev/nvidia0",)
+    assert plan.shared == ()
+
+
+# ---------------------------- build_gpu_flags ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_gpu_flags_whole_host():
+    ssh = fake_ssh(
+        FakeRun("/dev/nvidia0\n"),
+        FakeRun("/dev/nvidiactl\n"),
+    )
+    flags = await build_gpu_flags(ssh, gpu_uuids=None)
+
+    assert flags == "--gpus all --device=/dev/nvidia0 --device=/dev/nvidiactl"
+
+
+@pytest.mark.asyncio
+async def test_build_gpu_flags_partial_rental():
+    ssh = fake_ssh(
+        FakeRun("GPU-aaa, 0\nGPU-bbb, 1\n"),
+        FakeRun("/dev/nvidiactl\n"),
+    )
+    flags = await build_gpu_flags(ssh, gpu_uuids=["GPU-bbb"])
+
+    assert flags == (
+        '--gpus \'"device=GPU-bbb"\' --device=/dev/nvidia1 --device=/dev/nvidiactl'
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_gpu_flags_no_shared_nodes_only_per_gpu():
+    ssh = fake_ssh(FakeRun("/dev/nvidia0\n"), FakeRun(""))
+    flags = await build_gpu_flags(ssh, gpu_uuids=None)
+
+    assert flags == "--gpus all --device=/dev/nvidia0"

--- a/neurons/validators/tests/test_nvidia_devices.py
+++ b/neurons/validators/tests/test_nvidia_devices.py
@@ -155,3 +155,46 @@ async def test_build_gpu_flags_no_shared_nodes_only_per_gpu():
     flags = await build_gpu_flags(ssh, gpu_uuids=None)
 
     assert flags == "--gpus all --device=/dev/nvidia0"
+
+
+# ---------------------------- build_gpu_flags fallback ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_gpu_flags_falls_back_when_nvidia_smi_fails(caplog):
+    # Partial rental → first call is nvidia-smi which we make fail.
+    ssh = fake_ssh(FakeRun(stderr="nvidia-smi: not found", exit_status=127))
+
+    with caplog.at_level("WARNING"):
+        flags = await build_gpu_flags(ssh, gpu_uuids=["GPU-aaa"])
+
+    # Falls back to legacy --gpus only — no --device flags.
+    assert flags == '--gpus \'"device=GPU-aaa"\''
+    assert any(
+        "probe failed, falling back to legacy --gpus only" in rec.message
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_gpu_flags_falls_back_when_uuid_unknown(caplog):
+    ssh = fake_ssh(FakeRun("GPU-aaa, 0\n"))  # GPU-bbb is not present
+
+    with caplog.at_level("WARNING"):
+        flags = await build_gpu_flags(ssh, gpu_uuids=["GPU-bbb"])
+
+    assert flags == '--gpus \'"device=GPU-bbb"\''
+    assert any("probe failed" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_build_gpu_flags_falls_back_when_ssh_raises(caplog):
+    ssh = AsyncMock()
+    ssh.run.side_effect = ConnectionError("ssh transport closed")
+
+    with caplog.at_level("WARNING"):
+        flags = await build_gpu_flags(ssh, gpu_uuids=None)
+
+    # Whole-host rental falls back to plain `--gpus all`.
+    assert flags == "--gpus all"
+    assert any("probe failed" in rec.message for rec in caplog.records)

--- a/neurons/validators/tests/test_nvidia_devices.py
+++ b/neurons/validators/tests/test_nvidia_devices.py
@@ -70,15 +70,16 @@ async def test_whole_host_rental_enumerates_all_minors():
 @pytest.mark.asyncio
 async def test_partial_rental_resolves_uuid_to_minor():
     ssh = fake_ssh(FakeRun("GPU-aaa, 0\nGPU-bbb, 1\nGPU-ccc, 2\n"))
-    nodes = await _query_gpu_nodes_for_uuids(ssh, ["GPU-bbb"])
+    nodes, host_total = await _query_gpu_nodes_for_uuids(ssh, ["GPU-bbb"])
 
     assert nodes == ("/dev/nvidia1",)
+    assert host_total == 3
 
 
 @pytest.mark.asyncio
 async def test_partial_rental_preserves_uuid_order_in_per_gpu():
     ssh = fake_ssh(FakeRun("GPU-aaa, 0\nGPU-bbb, 1\nGPU-ccc, 2\n"))
-    nodes = await _query_gpu_nodes_for_uuids(ssh, ["GPU-ccc", "GPU-aaa"])
+    nodes, _ = await _query_gpu_nodes_for_uuids(ssh, ["GPU-ccc", "GPU-aaa"])
 
     assert nodes == ("/dev/nvidia2", "/dev/nvidia0")
 
@@ -122,6 +123,26 @@ async def test_host_without_optional_shared_nodes_has_empty_shared():
     assert nodes == ()
 
 
+@pytest.mark.asyncio
+async def test_query_shared_nodes_skips_caps_when_include_caps_false():
+    ssh = fake_ssh(FakeRun(""))
+    await _query_shared_nodes(ssh, include_caps=False)
+
+    cmd = ssh.run.call_args.args[0]
+    assert "/dev/nvidia-caps" not in cmd
+    assert "/dev/nvidia-caps-imex-channels" not in cmd
+
+
+@pytest.mark.asyncio
+async def test_query_shared_nodes_includes_caps_by_default():
+    ssh = fake_ssh(FakeRun(""))
+    await _query_shared_nodes(ssh)
+
+    cmd = ssh.run.call_args.args[0]
+    assert "/dev/nvidia-caps" in cmd
+    assert "/dev/nvidia-caps-imex-channels" in cmd
+
+
 # ---------------------------- build_gpu_flags ----------------------------
 
 
@@ -155,6 +176,41 @@ async def test_build_gpu_flags_no_shared_nodes_only_per_gpu():
     flags = await build_gpu_flags(ssh, gpu_uuids=None)
 
     assert flags == "--gpus all --device=/dev/nvidia0"
+
+
+@pytest.mark.asyncio
+async def test_build_gpu_flags_partial_rental_skips_caps_query():
+    # 8-GPU host, tenant rents only 1 — caps must not be probed/forwarded.
+    nvidia_smi_csv = "".join(f"GPU-{i:03d}, {i}\n" for i in range(8))
+    ssh = fake_ssh(
+        FakeRun(nvidia_smi_csv),
+        FakeRun("/dev/nvidiactl\n/dev/nvidia-uvm\n"),
+    )
+    flags = await build_gpu_flags(ssh, gpu_uuids=["GPU-003"])
+
+    # Inspect the shared-nodes probe — it must not look at /dev/nvidia-caps.
+    shared_probe_cmd = ssh.run.call_args_list[1].args[0]
+    assert "/dev/nvidia-caps" not in shared_probe_cmd
+
+    # Per-GPU minor is correct, no cap-node leak.
+    assert (
+        flags == '--gpus \'"device=GPU-003"\' '
+        "--device=/dev/nvidia3 --device=/dev/nvidiactl --device=/dev/nvidia-uvm"
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_gpu_flags_whole_host_via_explicit_uuids_keeps_caps():
+    # Tenant rents ALL host GPUs explicitly — not partial, caps should be probed.
+    ssh = fake_ssh(
+        FakeRun("GPU-aaa, 0\nGPU-bbb, 1\n"),
+        FakeRun("/dev/nvidiactl\n/dev/nvidia-caps/nvidia-cap1\n"),
+    )
+    flags = await build_gpu_flags(ssh, gpu_uuids=["GPU-aaa", "GPU-bbb"])
+
+    shared_probe_cmd = ssh.run.call_args_list[1].args[0]
+    assert "/dev/nvidia-caps" in shared_probe_cmd
+    assert "/dev/nvidia-caps/nvidia-cap1" in flags
 
 
 # ---------------------------- build_gpu_flags fallback ----------------------------

--- a/neurons/validators/tests/test_nvidia_devices.py
+++ b/neurons/validators/tests/test_nvidia_devices.py
@@ -1,12 +1,13 @@
 from unittest.mock import AsyncMock
 
 import pytest
-
 from neurons.validators.src.services.nvidia_devices import (
-    NvidiaDevicePlan,
+    _device_flags,
     _gpus_flag,
+    _query_all_gpu_nodes,
+    _query_gpu_nodes_for_uuids,
+    _query_shared_nodes,
     build_gpu_flags,
-    discover_nvidia_devices,
 )
 
 
@@ -39,59 +40,47 @@ def test_gpus_flag_multiple_uuids_joined_with_comma():
     assert _gpus_flag(["GPU-a", "GPU-b"]) == '--gpus \'"device=GPU-a,GPU-b"\''
 
 
-# ---------------------------- NvidiaDevicePlan.as_device_flags ----------------------------
+# ---------------------------- _device_flags ----------------------------
 
 
-def test_plan_renders_per_gpu_then_shared():
-    plan = NvidiaDevicePlan(
-        per_gpu=("/dev/nvidia0", "/dev/nvidia1"),
-        shared=("/dev/nvidiactl", "/dev/nvidia-uvm"),
-    )
-    assert plan.as_device_flags() == (
+def test_device_flags_renders_nodes_in_order():
+    assert _device_flags(
+        ("/dev/nvidia0", "/dev/nvidia1", "/dev/nvidiactl", "/dev/nvidia-uvm")
+    ) == (
         "--device=/dev/nvidia0 --device=/dev/nvidia1 "
         "--device=/dev/nvidiactl --device=/dev/nvidia-uvm"
     )
 
 
-def test_plan_with_no_nodes_is_empty_string():
-    assert NvidiaDevicePlan(per_gpu=(), shared=()).as_device_flags() == ""
+def test_device_flags_with_no_nodes_is_empty_string():
+    assert _device_flags(()) == ""
 
 
-# ---------------------------- discover_nvidia_devices ----------------------------
+# ---------------------------- remote queries ----------------------------
 
 
 @pytest.mark.asyncio
 async def test_whole_host_rental_enumerates_all_minors():
-    ssh = fake_ssh(
-        FakeRun("/dev/nvidia0\n/dev/nvidia1\n"),
-        FakeRun("/dev/nvidiactl\n/dev/nvidia-uvm\n"),
-    )
-    plan = await discover_nvidia_devices(ssh, gpu_uuids=None)
+    ssh = fake_ssh(FakeRun("/dev/nvidia0\n/dev/nvidia1\n"))
+    nodes = await _query_all_gpu_nodes(ssh)
 
-    assert plan.per_gpu == ("/dev/nvidia0", "/dev/nvidia1")
-    assert plan.shared == ("/dev/nvidiactl", "/dev/nvidia-uvm")
+    assert nodes == ("/dev/nvidia0", "/dev/nvidia1")
 
 
 @pytest.mark.asyncio
 async def test_partial_rental_resolves_uuid_to_minor():
-    ssh = fake_ssh(
-        FakeRun("GPU-aaa, 0\nGPU-bbb, 1\nGPU-ccc, 2\n"),
-        FakeRun(""),
-    )
-    plan = await discover_nvidia_devices(ssh, gpu_uuids=["GPU-bbb"])
+    ssh = fake_ssh(FakeRun("GPU-aaa, 0\nGPU-bbb, 1\nGPU-ccc, 2\n"))
+    nodes = await _query_gpu_nodes_for_uuids(ssh, ["GPU-bbb"])
 
-    assert plan.per_gpu == ("/dev/nvidia1",)
+    assert nodes == ("/dev/nvidia1",)
 
 
 @pytest.mark.asyncio
 async def test_partial_rental_preserves_uuid_order_in_per_gpu():
-    ssh = fake_ssh(
-        FakeRun("GPU-aaa, 0\nGPU-bbb, 1\nGPU-ccc, 2\n"),
-        FakeRun(""),
-    )
-    plan = await discover_nvidia_devices(ssh, gpu_uuids=["GPU-ccc", "GPU-aaa"])
+    ssh = fake_ssh(FakeRun("GPU-aaa, 0\nGPU-bbb, 1\nGPU-ccc, 2\n"))
+    nodes = await _query_gpu_nodes_for_uuids(ssh, ["GPU-ccc", "GPU-aaa"])
 
-    assert plan.per_gpu == ("/dev/nvidia2", "/dev/nvidia0")
+    assert nodes == ("/dev/nvidia2", "/dev/nvidia0")
 
 
 @pytest.mark.asyncio
@@ -99,7 +88,7 @@ async def test_partial_rental_unknown_uuid_raises():
     ssh = fake_ssh(FakeRun("GPU-aaa, 0\n"))
 
     with pytest.raises(RuntimeError, match="not present on executor"):
-        await discover_nvidia_devices(ssh, gpu_uuids=["GPU-bbb"])
+        await _query_gpu_nodes_for_uuids(ssh, ["GPU-bbb"])
 
 
 @pytest.mark.asyncio
@@ -107,38 +96,30 @@ async def test_nvidia_smi_failure_raises():
     ssh = fake_ssh(FakeRun(stderr="nvidia-smi: not found", exit_status=127))
 
     with pytest.raises(RuntimeError, match="nvidia-smi query failed"):
-        await discover_nvidia_devices(ssh, gpu_uuids=["GPU-aaa"])
+        await _query_gpu_nodes_for_uuids(ssh, ["GPU-aaa"])
 
 
 @pytest.mark.asyncio
-async def test_hgx_host_with_nvswitch_and_caps_nodes():
+async def test_hgx_host_shared_query_includes_nvswitch_and_caps_nodes():
     ssh = fake_ssh(
-        FakeRun("/dev/nvidia0\n/dev/nvidia1\n/dev/nvidia2\n/dev/nvidia3\n"),
         FakeRun(
             "/dev/nvidiactl\n/dev/nvidia-modeset\n/dev/nvidia-uvm\n/dev/nvidia-uvm-tools\n"
             "/dev/nvidia-nvswitch0\n/dev/nvidia-nvswitch1\n"
             "/dev/nvidia-caps/nvidia-cap1\n/dev/nvidia-caps/nvidia-cap2\n"
         ),
     )
-    plan = await discover_nvidia_devices(ssh, gpu_uuids=None)
+    nodes = await _query_shared_nodes(ssh)
 
-    assert plan.per_gpu == (
-        "/dev/nvidia0",
-        "/dev/nvidia1",
-        "/dev/nvidia2",
-        "/dev/nvidia3",
-    )
-    assert "/dev/nvidia-nvswitch0" in plan.shared
-    assert "/dev/nvidia-caps/nvidia-cap1" in plan.shared
+    assert "/dev/nvidia-nvswitch0" in nodes
+    assert "/dev/nvidia-caps/nvidia-cap1" in nodes
 
 
 @pytest.mark.asyncio
 async def test_host_without_optional_shared_nodes_has_empty_shared():
-    ssh = fake_ssh(FakeRun("/dev/nvidia0\n"), FakeRun(""))
-    plan = await discover_nvidia_devices(ssh, gpu_uuids=None)
+    ssh = fake_ssh(FakeRun(""))
+    nodes = await _query_shared_nodes(ssh)
 
-    assert plan.per_gpu == ("/dev/nvidia0",)
-    assert plan.shared == ()
+    assert nodes == ()
 
 
 # ---------------------------- build_gpu_flags ----------------------------


### PR DESCRIPTION
## Summary

### Task Link

[DAH-1987](https://www.notion.so/Fix-NVML-Unknown-Error-in-rented-pods-after-host-daemon-reload-34bb8bfdbde981d99e38cc8c289e07bf)

---

## Problem

`docker run --gpus ...` installs a transient device cgroup via the nvidia-container-runtime hook. On hosts running cgroup v2 + systemd cgroup driver (the prod default — 100% of active executors per the latest scrape), `systemctl daemon-reload` re-evaluates the transient `docker-<id>.scope` and overwrites its device program with one that does not know about NVIDIA. After that, `open(/dev/nvidia*)` returns EPERM inside the container; NVML reports "Failed to initialize NVML: Unknown Error". `/dev` nodes stay visible but unreadable. Routine `apt upgrade` on a miner host (which drops a systemd unit and triggers `daemon-reload`) silently breaks every running GPU pod on that host until the user (or the miner) restarts the container.

This is a known upstream issue with no fix landed: NVIDIA/nvidia-container-toolkit#48, opencontainers/runc#3708, containerd/containerd#9569.

User signal that motivated the task: pod `cf1bb2cf-268e-4125-8031-036d4c56602c` (sn102-train) on executor `3f9990d7-30cd-4338-b525-864cdb94fa8d` reported "Failed to initialize NVML: Unknown Error" while the validator considered the executor fully healthy (NVML_DIGEST_OK, GPU_UUID_OK, score 1.0).

## Solution

Forward each `/dev/nvidia*` node that the container needs via an explicit `--device` flag in addition to `--gpus`. Entries land in `HostConfig.Devices`, which Docker reapplies after the systemd scope is reconfigured — so the device cgroup survives `daemon-reload` and `systemctl restart containerd`.

`--gpus` stays in place: it is still responsible for bind-mounting userspace libraries (`libnvidia-ml.so`, `libcuda.so`) and the `nvidia-smi` binary. `--device` alone is not enough — without `--gpus` the container has no NVIDIA libs.

Device set is probed at runtime against the executor host, not hardcoded — this covers driver variants, MIG, NVSwitch, IMEX channel nodes, and partial-GPU rentals.

The probe and flag assembly live in a small dedicated module (`services/nvidia_devices.py`, ~115 lines with docstrings); `DockerService.create_container` calls a single async helper.

CDI (`--device nvidia.com/gpu=...`) was evaluated as a more elegant alternative and rejected because sysbox-runc 0.6.6 (used by most of our pods today) cannot consume CDI device requests — Docker rejects the run with `could not select device driver "cdi"`. Live test results that drove this decision are appended to the Notion task body.

## Changes

- `neurons/validators/src/services/nvidia_devices.py` — new module. Public surface: `build_gpu_flags(ssh_client, gpu_uuids) -> str`, `discover_nvidia_devices(...) -> NvidiaDevicePlan`, `NvidiaDevicePlan.as_device_flags()`. Probes per-GPU minor nodes (`/dev/nvidia[0-9]*`) and shared control nodes (`nvidiactl`, `nvidia-modeset`, `nvidia-uvm*`, `nvidia-nvswitch*`, `nvidia-nvlink*`, `nvidia-caps/*`, `nvidia-caps-imex-channels/*`) that actually exist on the host. For partial rentals, resolves UUIDs to indices via `nvidia-smi --query-gpu=uuid,index`.
- `neurons/validators/src/services/docker_service.py` — `create_container` now calls `await build_gpu_flags(ssh_client, payload.gpu_uuids)` instead of assembling `--gpus` inline. Net diff: +6 / -6.
- `neurons/validators/tests/test_nvidia_devices.py` — 15 unit tests covering: pure flag rendering, whole-host vs partial rentals, UUID order preservation, missing-UUID error, nvidia-smi failure error, HGX hosts with NVSwitch/MIG nodes, hosts without optional shared nodes.

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review

## Other PRs

None.

## Risks

- **Two extra SSH round-trips per pod creation** (~50–100 ms): one for `nvidia-smi --query-gpu` (only when partial rental), one for shared-node probe. Negligible compared to existing `docker run` time.
- **Existing pods are not retroactively fixed.** The change only takes effect for newly created pods. Pods created before deploy stay vulnerable until they are recreated. Follow-up: a separate task for retro-applying via executor agent (`docker restart` of running GPU containers, or `docker update --device-cgroup-rule`) is mentioned in the Notion non-goals.
- **Unknown-UUID and `nvidia-smi`-failure cases now raise `RuntimeError`** instead of silently producing a flag-less container. This bubbles up to `create_container`'s existing exception handling — surfaces as a normal create failure rather than a half-broken pod. Verified by `test_partial_rental_unknown_uuid_raises` and `test_nvidia_smi_failure_raises`.
- **Per-tenant isolation is preserved** at the cgroup level (per-minor, not major-wildcard). Verified empirically on a Shadeform A6000 stand: `mknod /dev/nvidia99 c 195 99` succeeds inside the container (CAP_MKNOD is allowed by Docker default — same as today), but `open(/dev/nvidia99)` returns EPERM while `open(/dev/nvidia0)` works. No regression vs the current `--gpus '"device=UUID"'` behavior.

## Test Cases

### Test Case 1 — bug reproduces with current (`--gpus all`) behavior

**Actions**

```
docker run -d --name t --gpus all nvidia/cuda:12.4.1-base-ubuntu22.04 sleep infinity
docker exec t nvidia-smi -L           # works
sudo systemctl daemon-reload
docker exec t nvidia-smi -L
```

**Expected Output**

`Failed to initialize NVML: Unknown Error` after the reload (this is the bug).

### Test Case 2 — fix survives `daemon-reload` under default runc

**Actions**

```
# Flag set assembled by build_gpu_flags() for whole-host rental on an A6000 host:
docker run -d --name t --gpus all \
  --device=/dev/nvidia0 --device=/dev/nvidiactl --device=/dev/nvidia-modeset \
  --device=/dev/nvidia-uvm --device=/dev/nvidia-uvm-tools \
  --device=/dev/nvidia-caps/nvidia-cap1 --device=/dev/nvidia-caps/nvidia-cap2 \
  nvidia/cuda:12.4.1-base-ubuntu22.04 sleep infinity
docker exec t nvidia-smi -L
sudo systemctl daemon-reload
docker exec t nvidia-smi -L
sudo systemctl restart containerd
docker exec t nvidia-smi -L
```

**Expected Output**

`nvidia-smi -L` returns the GPU list before, after `daemon-reload`, and after `systemctl restart containerd`. No NVML error.

### Test Case 3 — fix survives `daemon-reload` under sysbox-runc

Same as Test Case 2 but with `--runtime=sysbox-runc`. Same expected output. Sysbox covers the majority of our pods, so this case is critical.

### Test Case 4 — partial-rental flag assembly

**Actions**

```python
from services.nvidia_devices import build_gpu_flags
flags = await build_gpu_flags(ssh_client, gpu_uuids=["GPU-bbb"])
```

**Expected Output**

`'--gpus \'"device=GPU-bbb"\' --device=/dev/nvidia<N> --device=/dev/nvidiactl ...'` where `<N>` is the index reported by `nvidia-smi` for `GPU-bbb`. No other GPU minors included. Covered by `test_build_gpu_flags_partial_rental`.

### Test Case 5 — unit tests

```
pdm run pytest tests/test_nvidia_devices.py -v
```

15 tests passed in 0.03 s.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
