### PR TITLE
DAH-1998, precompute 8x unrented estimates for bucket capacity

### DIFF
--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -627,7 +627,11 @@ async def precompute_all_estimates(
 ) -> dict[str, dict]:
     """Precompute rented and unrented estimates for every GPU model in BASE_GPU_MAP.
 
-    Returns a dict keyed by full GPU model name with "rented" and "unrented" estimates.
+    Returns a dict keyed by full GPU model name with "rented", "unrented" (gpu_count=1)
+    and "unrented_8x" (gpu_count=8) estimates. The 8x variant exposes per-bucket capacity
+    (max_cap, total_unrented_by_gpu_type, hourly_rate) for the 8-GPU rig bucket so that
+    downstream consumers can render network-wide bucket fill state without an extra
+    on-demand request to the validator.
     """
     gpu_models = list(BASE_GPU_MAP.keys())
     estimates: dict[str, dict] = {}
@@ -644,6 +648,12 @@ async def precompute_all_estimates(
                 redis_service,
                 snapshot,
                 ExecutorEstimateParams(gpu_model=gpu_model, is_rented=True),
+            ),
+            "unrented_8x": await estimate_executor(
+                config,
+                redis_service,
+                snapshot,
+                ExecutorEstimateParams(gpu_model=gpu_model, gpu_count=8, is_rented=False),
             ),
         }
 

--- a/neurons/validators/tests/test_rental_price_estimate.py
+++ b/neurons/validators/tests/test_rental_price_estimate.py
@@ -405,80 +405,19 @@ async def test_precompute_all_estimates_returns_both_rented_and_unrented_without
             },
         },
     )
-    estimates_by_key = {
-        ("H100", False): RentalPriceEstimate(
-            gpu_model="H100",
-            base_model="H100",
-            gpu_count=1,
-            is_rented=False,
+    def _make_estimate(gpu_model: str, gpu_count: int, is_rented: bool) -> RentalPriceEstimate:
+        return RentalPriceEstimate(
+            gpu_model=gpu_model,
+            base_model=gpu_model,
+            gpu_count=gpu_count,
+            is_rented=is_rented,
             usd_per_epoch=1.0,
-        ),
-        ("H100", True): RentalPriceEstimate(
-            gpu_model="H100",
-            base_model="H100",
-            gpu_count=1,
-            is_rented=True,
-            usd_per_epoch=2.0,
-        ),
-        ("H100 NVL", False): RentalPriceEstimate(
-            gpu_model="H100 NVL",
-            base_model="H100",
-            gpu_count=1,
-            is_rented=False,
-            usd_per_epoch=3.0,
-        ),
-        ("H100 NVL", True): RentalPriceEstimate(
-            gpu_model="H100 NVL",
-            base_model="H100",
-            gpu_count=1,
-            is_rented=True,
-            usd_per_epoch=4.0,
-        ),
-        ("H200", False): RentalPriceEstimate(
-            gpu_model="H200",
-            base_model="H200",
-            gpu_count=1,
-            is_rented=False,
-            usd_per_epoch=5.0,
-        ),
-        ("H200", True): RentalPriceEstimate(
-            gpu_model="H200",
-            base_model="H200",
-            gpu_count=1,
-            is_rented=True,
-            usd_per_epoch=6.0,
-        ),
-        ("A100", False): RentalPriceEstimate(
-            gpu_model="A100",
-            base_model="A100",
-            gpu_count=1,
-            is_rented=False,
-            usd_per_epoch=7.0,
-        ),
-        ("A100", True): RentalPriceEstimate(
-            gpu_model="A100",
-            base_model="A100",
-            gpu_count=1,
-            is_rented=True,
-            usd_per_epoch=8.0,
-        ),
-        ("L4", False): RentalPriceEstimate(
-            gpu_model="L4",
-            base_model="L4",
-            gpu_count=1,
-            is_rented=False,
-            usd_per_epoch=9.0,
-        ),
-        ("L4", True): RentalPriceEstimate(
-            gpu_model="L4",
-            base_model="L4",
-            gpu_count=1,
-            is_rented=True,
-            usd_per_epoch=10.0,
-        ),
-    }
+        )
+
     estimate_executor_mock = AsyncMock(
-        side_effect=lambda _config, _redis, _snapshot, params: estimates_by_key[(params.gpu_model, params.is_rented)]
+        side_effect=lambda _config, _redis, _snapshot, params: _make_estimate(
+            params.gpu_model, params.gpu_count, params.is_rented
+        )
     )
 
     monkeypatch.setattr(rental_price_module, "BASE_GPU_MAP", BASE_GPU_MAP)
@@ -498,11 +437,18 @@ async def test_precompute_all_estimates_returns_both_rented_and_unrented_without
 
     assert set(estimates) == set(BASE_GPU_MAP)
     for gpu_model in BASE_GPU_MAP:
-        assert estimates[gpu_model]["unrented"] == estimates_by_key[(gpu_model, False)]
-        assert estimates[gpu_model]["rented"] == estimates_by_key[(gpu_model, True)]
+        assert estimates[gpu_model]["unrented"].gpu_count == 1
+        assert estimates[gpu_model]["unrented"].is_rented is False
+        assert estimates[gpu_model]["rented"].gpu_count == 1
+        assert estimates[gpu_model]["rented"].is_rented is True
+        assert estimates[gpu_model]["unrented_8x"].gpu_count == 8
+        assert estimates[gpu_model]["unrented_8x"].is_rented is False
 
-    assert estimate_executor_mock.await_count == len(BASE_GPU_MAP) * 2
-    assert estimate_executor_mock.await_args_list[0].args[3].gpu_model == "H100"
-    assert estimate_executor_mock.await_args_list[0].args[3].is_rented is False
-    assert estimate_executor_mock.await_args_list[1].args[3].gpu_model == "H100"
-    assert estimate_executor_mock.await_args_list[1].args[3].is_rented is True
+    # 3 calls per GPU model: unrented(1), rented(1), unrented_8x(8) — sequential, no gather.
+    assert estimate_executor_mock.await_count == len(BASE_GPU_MAP) * 3
+    first_three = estimate_executor_mock.await_args_list[:3]
+    assert [(c.args[3].gpu_count, c.args[3].is_rented) for c in first_three] == [
+        (1, False),
+        (1, True),
+        (8, False),
+    ]


### PR DESCRIPTION
## Summary

### Task Link

[DAH-1998](https://www.notion.so/Public-page-with-unrented-hr-per-GPU-type-for-provider-acquisition-34eb8bfdbde981c39017fb3f778b8adc)

---

## Problem

The miner-portal Rewards Calculator page is getting a new \"Open Earning Capacity\" table that shows, per base GPU model, how many open spots are available in the **single-GPU** (bucket=1) and **8-GPU rig** (bucket=8) capacity buckets the validator pays unrented rewards for.

Today the validator already pre-computes \`unrented\`/\`rented\` estimates per full GPU name with \`gpu_count=1\` (in \`precompute_all_estimates\`) and ships them to compute-app via the existing \`GpuEstimatesRequest\` WS message. That gives consumers per-bucket fields (\`max_cap\`, \`total_unrented_by_gpu_type\`, \`hourly_rate\`) for the **1×** bucket only. The **8×** bucket data is not in the bulk Redis cache; consumers would have to fan out on-demand \`GetEstimateRequest\` calls per base model on every page load.

## Solution

Add one more \`estimate_executor\` call per GPU model with \`gpu_count=8\` and emit it under the new \`unrented_8x\` key, alongside the existing \`unrented\` / \`rented\` entries. Same code path as before — just one extra sequential call per model per epoch. No new protocol messages, no new Redis keys, no schema migrations.

Compute-app reads the new key from the existing \`GPU_ESTIMATES_KEY\` cache; older compute-app versions ignore the unknown key.

## Changes

- \`incentive/rental_price.py\`: add \`unrented_8x\` branch in \`precompute_all_estimates\` (\`gpu_count=8\`, \`is_rented=False\`).
- \`tests/test_rental_price_estimate.py\`: update \`test_precompute_all_estimates_returns_both_rented_and_unrented_without_gather\` to expect 3 sequential calls per GPU model and assert the parameter triple \`(gpu_count, is_rented)\`.

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review

## Other PRs

- compute-app: \`DAH-1998-expected-earnings-bucket-capacity\` — new \`GET /machines/capacity\` endpoint that aggregates this data by \`base_model\`.
- lium-miner-portal-frontend: \`DAH-1998-expected-earnings-bucket-capacity\` — new \"Open Earning Capacity\" table on the Rewards Calculator page consuming the endpoint.

## Risks

- Per-epoch precompute now does 3 sequential \`estimate_executor\` calls per GPU model in \`BASE_GPU_MAP\` instead of 2. Same ballpark wall-clock cost (calls are cheap, no I/O).
- Redis \`gpu_estimates\` payload grows by ~50% per epoch; well under TTL/size limits.
- Backward compatible: \`unrented\` and \`rented\` keys are unchanged. compute-app's existing \`/machines\` route reads only those.

## Test Cases

### Test Case 1 — bulk precompute exposes 8x estimate

**Actions**

\`\`\`
pdm run pytest tests/test_rental_price_estimate.py::test_precompute_all_estimates_returns_both_rented_and_unrented_without_gather -v
\`\`\`

**Expected Output**

For every \`gpu_model\` in \`BASE_GPU_MAP\`, the returned dict contains \`unrented\` (gpu_count=1, is_rented=False), \`rented\` (gpu_count=1, is_rented=True), and \`unrented_8x\` (gpu_count=8, is_rented=False). \`estimate_executor\` is awaited \`len(BASE_GPU_MAP) * 3\` times in the order \`(1, False) → (1, True) → (8, False)\` per model.

### Test Case 2 — full rental flow tests still pass

**Actions**

\`\`\`
pdm run pytest tests/test_rental_price_incentive_flow.py tests/test_rental_price_estimate.py tests/prod_snapshot/ -q
\`\`\`

**Expected Output**

All tests pass.

## Checklist

- [ ] Proper labels added (\`ready-review\`, \`require-qa\`, \`breaking-changes\` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described