### PR TITLE
DAH-2013: floor positive weights so they never collapse to u16=0 on emit

### DIFF
--- a/neurons/validators/src/clients/subtensor_client.py
+++ b/neurons/validators/src/clients/subtensor_client.py
@@ -52,24 +52,24 @@ def _log_sync_block(name: str, *, extra: dict | None = None):
 def _convert_weights_with_positive_floor(
     uids,
     weights,
-) -> tuple[list[int], list[int], int]:
+) -> tuple[list[int], list[int], list[int]]:
     """Max-upscale floats to u16 like bittensor's `convert_weights_and_uids_for_emit`,
     but bump u16=0 → u16=1 whenever the source float was strictly positive. SDK-zeroed
     entries (quantile/permit/max-limit exclusions) stay dropped.
 
-    Returns (uids, weights, floored_count) where floored_count is the number of
-    entries that would have rounded to 0 but were lifted to 1.
+    Returns (uids, weights, floored_uids) where floored_uids is the list of uids
+    whose float weight was positive but rounded to 0 and were lifted to 1.
     """
     uids_l = uids.tolist() if hasattr(uids, "tolist") else list(uids)
     weights_l = weights.tolist() if hasattr(weights, "tolist") else list(weights)
     if not weights_l:
-        return [], [], 0
+        return [], [], []
     max_w = float(max(weights_l))
     if max_w <= 0:
-        return [], [], 0
+        return [], [], []
     out_uids: list[int] = []
     out_vals: list[int] = []
-    floored_count = 0
+    floored_uids: list[int] = []
     for u, w in zip(uids_l, weights_l):
         wf = float(w)
         if wf <= 0:
@@ -77,10 +77,10 @@ def _convert_weights_with_positive_floor(
         v = round(wf / max_w * 65535)
         if v == 0:
             v = 1
-            floored_count += 1
+            floored_uids.append(int(u))
         out_uids.append(int(u))
         out_vals.append(int(v))
-    return out_uids, out_vals, floored_count
+    return out_uids, out_vals, floored_uids
 
 
 class SubtensorClient:
@@ -420,9 +420,13 @@ class SubtensorClient:
             ),
         )
 
-        uint_uids, uint_weights, floored_count = _convert_weights_with_positive_floor(
+        uint_uids, uint_weights, floored_uids = _convert_weights_with_positive_floor(
             processed_uids, processed_weights
         )
+
+        # Resolve floored uids back to hotkeys so the log row is human-debuggable.
+        uid_to_hotkey = dict(zip([int(u) for u in uids], miner_hotkeys))
+        floored_hotkeys = [uid_to_hotkey.get(u) for u in floored_uids]
 
         logger.info(
             _m(
@@ -430,7 +434,9 @@ class SubtensorClient:
                 extra=get_extra_info({
                     **self.default_extra,
                     "version_key": self.version_key,
-                    "floored_from_zero_count": floored_count,
+                    "floored_from_zero_count": len(floored_uids),
+                    "floored_from_zero_uids": floored_uids,
+                    "floored_from_zero_hotkeys": floored_hotkeys,
                 }),
             ),
         )

--- a/neurons/validators/src/clients/subtensor_client.py
+++ b/neurons/validators/src/clients/subtensor_client.py
@@ -4,10 +4,7 @@ import contextlib
 import numpy as np
 import time
 from typing import Self, TYPE_CHECKING
-from bittensor.utils.weight_utils import (
-    convert_weights_and_uids_for_emit,
-    process_weights_for_netuid,
-)
+from bittensor.utils.weight_utils import process_weights_for_netuid
 from websockets.protocol import State as WebSocketClientState
 from datetime import datetime
 import json
@@ -50,6 +47,40 @@ def _log_sync_block(name: str, *, extra: dict | None = None):
                 }),
             )
         )
+
+
+def _convert_weights_with_positive_floor(
+    uids,
+    weights,
+) -> tuple[list[int], list[int], int]:
+    """Max-upscale floats to u16 like bittensor's `convert_weights_and_uids_for_emit`,
+    but bump u16=0 → u16=1 whenever the source float was strictly positive. SDK-zeroed
+    entries (quantile/permit/max-limit exclusions) stay dropped.
+
+    Returns (uids, weights, floored_count) where floored_count is the number of
+    entries that would have rounded to 0 but were lifted to 1.
+    """
+    uids_l = uids.tolist() if hasattr(uids, "tolist") else list(uids)
+    weights_l = weights.tolist() if hasattr(weights, "tolist") else list(weights)
+    if not weights_l:
+        return [], [], 0
+    max_w = float(max(weights_l))
+    if max_w <= 0:
+        return [], [], 0
+    out_uids: list[int] = []
+    out_vals: list[int] = []
+    floored_count = 0
+    for u, w in zip(uids_l, weights_l):
+        wf = float(w)
+        if wf <= 0:
+            continue
+        v = round(wf / max_w * 65535)
+        if v == 0:
+            v = 1
+            floored_count += 1
+        out_uids.append(int(u))
+        out_vals.append(int(v))
+    return out_uids, out_vals, floored_count
 
 
 class SubtensorClient:
@@ -389,8 +420,8 @@ class SubtensorClient:
             ),
         )
 
-        uint_uids, uint_weights = convert_weights_and_uids_for_emit(
-            uids=processed_uids, weights=processed_weights
+        uint_uids, uint_weights, floored_count = _convert_weights_with_positive_floor(
+            processed_uids, processed_weights
         )
 
         logger.info(
@@ -399,6 +430,7 @@ class SubtensorClient:
                 extra=get_extra_info({
                     **self.default_extra,
                     "version_key": self.version_key,
+                    "floored_from_zero_count": floored_count,
                 }),
             ),
         )

--- a/neurons/validators/src/clients/subtensor_client.py
+++ b/neurons/validators/src/clients/subtensor_client.py
@@ -52,13 +52,13 @@ def _log_sync_block(name: str, *, extra: dict | None = None):
 def _convert_weights_with_positive_floor(
     uids,
     weights,
-) -> tuple[list[int], list[int], list[int]]:
+) -> tuple[list[int], list[int], list[tuple[int, float]]]:
     """Max-upscale floats to u16 like bittensor's `convert_weights_and_uids_for_emit`,
     but bump u16=0 → u16=1 whenever the source float was strictly positive. SDK-zeroed
     entries (quantile/permit/max-limit exclusions) stay dropped.
 
-    Returns (uids, weights, floored_uids) where floored_uids is the list of uids
-    whose float weight was positive but rounded to 0 and were lifted to 1.
+    Returns (uids, weights, floored) where `floored` is a list of `(uid, original_weight)`
+    tuples for entries whose float weight was positive but rounded to 0 and were lifted to 1.
     """
     uids_l = uids.tolist() if hasattr(uids, "tolist") else list(uids)
     weights_l = weights.tolist() if hasattr(weights, "tolist") else list(weights)
@@ -69,7 +69,7 @@ def _convert_weights_with_positive_floor(
         return [], [], []
     out_uids: list[int] = []
     out_vals: list[int] = []
-    floored_uids: list[int] = []
+    floored: list[tuple[int, float]] = []
     for u, w in zip(uids_l, weights_l):
         wf = float(w)
         if wf <= 0:
@@ -77,10 +77,10 @@ def _convert_weights_with_positive_floor(
         v = round(wf / max_w * 65535)
         if v == 0:
             v = 1
-            floored_uids.append(int(u))
+            floored.append((int(u), wf))
         out_uids.append(int(u))
         out_vals.append(int(v))
-    return out_uids, out_vals, floored_uids
+    return out_uids, out_vals, floored
 
 
 class SubtensorClient:
@@ -420,13 +420,16 @@ class SubtensorClient:
             ),
         )
 
-        uint_uids, uint_weights, floored_uids = _convert_weights_with_positive_floor(
+        uint_uids, uint_weights, floored = _convert_weights_with_positive_floor(
             processed_uids, processed_weights
         )
 
         # Resolve floored uids back to hotkeys so the log row is human-debuggable.
         uid_to_hotkey = dict(zip([int(u) for u in uids], miner_hotkeys))
-        floored_hotkeys = [uid_to_hotkey.get(u) for u in floored_uids]
+        floored_entries = [
+            {"uid": uid, "hotkey": uid_to_hotkey.get(uid), "original_score": original_score}
+            for uid, original_score in floored
+        ]
 
         logger.info(
             _m(
@@ -434,9 +437,8 @@ class SubtensorClient:
                 extra=get_extra_info({
                     **self.default_extra,
                     "version_key": self.version_key,
-                    "floored_from_zero_count": len(floored_uids),
-                    "floored_from_zero_uids": floored_uids,
-                    "floored_from_zero_hotkeys": floored_hotkeys,
+                    "floored_from_zero_count": len(floored),
+                    "floored_from_zero": floored_entries,
                 }),
             ),
         )

--- a/neurons/validators/tests/test_incentive_flow.py
+++ b/neurons/validators/tests/test_incentive_flow.py
@@ -1193,3 +1193,83 @@ async def test_scenario_zero_gpu_count_edge_case(
     assert weights_by_uid[100] == pytest.approx(TOTAL_BURN_EMISSION / BURNER_COUNT)
     assert weights_by_uid[101] == pytest.approx(TOTAL_BURN_EMISSION / BURNER_COUNT)
     assert weights_by_uid[2] == 0
+
+
+# ---------------------------------------------------------------------------
+# Quantization floor: positive scores must never silently collapse to u16=0
+# ---------------------------------------------------------------------------
+
+
+def test_convert_weights_with_positive_floor_lifts_tiny_positive():
+    import numpy as _np
+    from clients.subtensor_client import _convert_weights_with_positive_floor
+
+    uids = _np.array([1, 2, 3], dtype=_np.int64)
+    # uid 1: cap, uid 2: tiny positive that rounds to 0, uid 3: SDK-zeroed
+    weights = _np.array([1.0, 1e-9, 0.0], dtype=_np.float32)
+
+    out_uids, out_vals, floored = _convert_weights_with_positive_floor(uids, weights)
+
+    assert out_uids == [1, 2]
+    assert out_vals == [65535, 1]
+    assert floored == 1
+
+
+def test_convert_weights_with_positive_floor_passes_through_normal_weights():
+    import numpy as _np
+    from clients.subtensor_client import _convert_weights_with_positive_floor
+
+    uids = _np.array([10, 20], dtype=_np.int64)
+    weights = _np.array([1.0, 0.5], dtype=_np.float32)
+
+    out_uids, out_vals, floored = _convert_weights_with_positive_floor(uids, weights)
+
+    assert out_uids == [10, 20]
+    assert out_vals == [65535, round(0.5 * 65535)]
+    assert floored == 0
+
+
+def test_convert_weights_with_positive_floor_handles_empty_and_all_zero():
+    import numpy as _np
+    from clients.subtensor_client import _convert_weights_with_positive_floor
+
+    empty = _convert_weights_with_positive_floor(
+        _np.array([], dtype=_np.int64), _np.array([], dtype=_np.float32)
+    )
+    assert empty == ([], [], 0)
+
+    all_zero = _convert_weights_with_positive_floor(
+        _np.array([7, 8], dtype=_np.int64), _np.array([0.0, 0.0], dtype=_np.float32)
+    )
+    assert all_zero == ([], [], 0)
+
+
+@pytest.mark.asyncio
+async def test_set_weights_floors_positive_scores_to_min_one(
+    mock_subtensor_client,
+    create_neuron_info,
+):
+    """A miner with a tiny but positive score must be submitted with weight >= 1,
+    while a miner with score 0 (absent from miner_scores) must be excluded.
+    """
+    miners = [
+        create_neuron_info(uid=100, hotkey="burner"),
+        create_neuron_info(uid=2, hotkey="tiny"),
+        create_neuron_info(uid=3, hotkey="zero"),
+    ]
+    miner_scores = {"burner": 1.0, "tiny": 1e-9}  # "zero" deliberately absent
+
+    # normalize=True → captured floats sum to ~1, mirroring the SDK's real output
+    await _run_set_weights_and_capture(
+        mock_subtensor_client, miners, miner_scores, normalize=True
+    )
+
+    call = mock_subtensor_client.subtensor.set_weights.call_args
+    submitted_uids = list(call.kwargs["uids"])
+    submitted_weights = list(call.kwargs["weights"])
+    by_uid = dict(zip(submitted_uids, submitted_weights))
+
+    assert 2 in by_uid, f"tiny-positive uid was dropped: {by_uid}"
+    assert by_uid[2] >= 1
+    assert by_uid[100] == 65535
+    assert 3 not in by_uid

--- a/neurons/validators/tests/test_incentive_flow.py
+++ b/neurons/validators/tests/test_incentive_flow.py
@@ -1212,7 +1212,9 @@ def test_convert_weights_with_positive_floor_lifts_tiny_positive():
 
     assert out_uids == [1, 2]
     assert out_vals == [65535, 1]
-    assert floored == [2]
+    assert len(floored) == 1
+    assert floored[0][0] == 2
+    assert floored[0][1] == pytest.approx(1e-9, rel=1e-3)
 
 
 def test_convert_weights_with_positive_floor_passes_through_normal_weights():

--- a/neurons/validators/tests/test_incentive_flow.py
+++ b/neurons/validators/tests/test_incentive_flow.py
@@ -1212,7 +1212,7 @@ def test_convert_weights_with_positive_floor_lifts_tiny_positive():
 
     assert out_uids == [1, 2]
     assert out_vals == [65535, 1]
-    assert floored == 1
+    assert floored == [2]
 
 
 def test_convert_weights_with_positive_floor_passes_through_normal_weights():
@@ -1226,7 +1226,7 @@ def test_convert_weights_with_positive_floor_passes_through_normal_weights():
 
     assert out_uids == [10, 20]
     assert out_vals == [65535, round(0.5 * 65535)]
-    assert floored == 0
+    assert floored == []
 
 
 def test_convert_weights_with_positive_floor_handles_empty_and_all_zero():
@@ -1236,12 +1236,12 @@ def test_convert_weights_with_positive_floor_handles_empty_and_all_zero():
     empty = _convert_weights_with_positive_floor(
         _np.array([], dtype=_np.int64), _np.array([], dtype=_np.float32)
     )
-    assert empty == ([], [], 0)
+    assert empty == ([], [], [])
 
     all_zero = _convert_weights_with_positive_floor(
         _np.array([7, 8], dtype=_np.int64), _np.array([0.0, 0.0], dtype=_np.float32)
     )
-    assert all_zero == ([], [], 0)
+    assert all_zero == ([], [], [])
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_rental_price_incentive_flow.py
+++ b/neurons/validators/tests/test_rental_price_incentive_flow.py
@@ -1404,13 +1404,13 @@ async def test_rental_price_integration_chain_submission(
     mock_subtensor_client.get_miners = AsyncMock(return_value=miners)
 
     with patch("clients.subtensor_client.process_weights_for_netuid") as process_mock, patch(
-        "clients.subtensor_client.convert_weights_and_uids_for_emit"
+        "clients.subtensor_client._convert_weights_with_positive_floor"
     ) as convert_mock:
         def process_side_effect(uids, weights, netuid, subtensor, metagraph):
             return uids, weights
 
         process_mock.side_effect = process_side_effect
-        convert_mock.return_value = (list(range(len(miners))), [10000] * len(miners))
+        convert_mock.return_value = (list(range(len(miners))), [10000] * len(miners), 0)
 
         await mock_subtensor_client.set_weights(miner_scores=validator.miner_scores)
 

--- a/neurons/validators/tests/test_rental_price_incentive_flow.py
+++ b/neurons/validators/tests/test_rental_price_incentive_flow.py
@@ -1410,7 +1410,7 @@ async def test_rental_price_integration_chain_submission(
             return uids, weights
 
         process_mock.side_effect = process_side_effect
-        convert_mock.return_value = (list(range(len(miners))), [10000] * len(miners), 0)
+        convert_mock.return_value = (list(range(len(miners))), [10000] * len(miners), [])
 
         await mock_subtensor_client.set_weights(miner_scores=validator.miner_scores)
 


### PR DESCRIPTION
## Summary
- bittensor's `convert_weights_and_uids_for_emit` max-upscales floats to u16 via `round(w / max(w) * 65535)` and **silently drops** any uid that rounds to 0. With our burn-heavy weighting (10 uids at the cap), any organic miner with score below ~7.6e-6 of the burn target disappears from chain — indistinguishable from miners that earned nothing.
- Replace the SDK call in `SubtensorClient.set_weights` with a tiny local helper that does the same max-upscale but lifts `u16=0 → 1` whenever the input float was strictly positive. SDK-zeroed entries (quantile / permit / max-limit exclusions) remain dropped.
- Add `floored_from_zero_count` to the structured log payload so we can track how often this fires in production.

## Test plan
- [ ] `pdm run pytest neurons/validators/tests/test_incentive_flow.py -v -k "convert_weights_with_positive_floor or set_weights_floors"` — four new unit/flow tests pass
- [ ] `pdm run pytest neurons/validators/tests/test_incentive_flow.py -v` — existing scenarios still pass
- [ ] `pdm run ruff check neurons/validators/src/clients/subtensor_client.py neurons/validators/tests/test_incentive_flow.py`
- [ ] After deploy: grep validator logs for `floored_from_zero_count` to confirm the floor fires on every cycle with a long tail (cross-check against `latestsetweights` row size in the DB).

## Notes / out of scope
- Burn-allocation cap (currently u16::MAX, compresses dynamic range available to the tail) is **not** changed — separate conversation.
- Rank-stable tie-break nudge to differentiate miners with near-equal scores is **not** added — separate change.
- Chain side: `vec_u16_max_upscale_to_u16` (`pallets/subtensor/src/subnets/weights.rs:833`) is an identity for inputs already at u16-cap, so a `1` we send survives the chain's defensive re-upscale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)