### PR TITLE
DAH-2016: disable collateral penalty and rental-verification gate via defaults

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -140,8 +140,8 @@ class Settings(BaseSettings):
 
     ENABLE_NO_COLLATERAL: bool = True
     ENABLE_VERIFYX: bool = True
-    SKIP_RENTAL_VERIFICATION: bool = Field(env="SKIP_RENTAL_VERIFICATION", default=False)
-    SKIP_COLLATERAL_PENALTY: bool = Field(env="SKIP_COLLATERAL_PENALTY", default=False)
+    SKIP_RENTAL_VERIFICATION: bool = Field(env="SKIP_RENTAL_VERIFICATION", default=True)
+    SKIP_COLLATERAL_PENALTY: bool = Field(env="SKIP_COLLATERAL_PENALTY", default=True)
     DRY_RUN: bool = Field(env="DRY_RUN", default=False, description="Run validation without publishing scores/weights")
     CONTAINER_CLEANUP_DRY_RUN: bool = Field(env="CONTAINER_CLEANUP_DRY_RUN", default=False, description="Dry run mode for stale container cleanup")
 

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -141,6 +141,7 @@ class Settings(BaseSettings):
     ENABLE_NO_COLLATERAL: bool = True
     ENABLE_VERIFYX: bool = True
     SKIP_RENTAL_VERIFICATION: bool = Field(env="SKIP_RENTAL_VERIFICATION", default=False)
+    SKIP_COLLATERAL_PENALTY: bool = Field(env="SKIP_COLLATERAL_PENALTY", default=False)
     DRY_RUN: bool = Field(env="DRY_RUN", default=False, description="Run validation without publishing scores/weights")
     CONTAINER_CLEANUP_DRY_RUN: bool = Field(env="CONTAINER_CLEANUP_DRY_RUN", default=False, description="Dry run mode for stale container cleanup")
 

--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -138,7 +138,7 @@ class DefaultIncentive(BaseIncentive):
             job_result.sysbox_multiplier = 1 - portion
 
         # Uptime multiplier
-        if settings.ENABLE_NO_COLLATERAL or job_result.collateral_deposited:
+        if settings.SKIP_COLLATERAL_PENALTY or job_result.collateral_deposited:
             job_result.uptime_multiplier = 1
         else:
             uptime_in_minutes = await self.redis_service.get_executor_uptime(job_result.executor_info)

--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -138,7 +138,9 @@ class DefaultIncentive(BaseIncentive):
             job_result.sysbox_multiplier = 1 - portion
 
         # Uptime multiplier
-        if not job_result.collateral_deposited:
+        if settings.ENABLE_NO_COLLATERAL or job_result.collateral_deposited:
+            job_result.uptime_multiplier = 1
+        else:
             uptime_in_minutes = await self.redis_service.get_executor_uptime(job_result.executor_info)
             job_result.uptime_multiplier = (
                 1
@@ -146,8 +148,6 @@ class DefaultIncentive(BaseIncentive):
                 + settings.PORTION_FOR_UPTIME
                 * min(1, uptime_in_minutes / settings.UPTIME_REQUIRED_MINUTES)
             )
-        else:
-            job_result.uptime_multiplier = 1
 
         # Apply multiplier
         job_result.mining_score *= job_result.sysbox_multiplier * job_result.uptime_multiplier


### PR DESCRIPTION
## Summary
Part of [DAH-2016](https://app.notion.com/p/Disable-collateral-and-rental-verification-requirements-now-until-slashing-is-live-351b8bfdbde9819cbbb0e3c53ecc9422) — disable provider collateral soft penalty and the rental-verification gate while slashing isn't shipping. Self-contained change in this repo only — no deploy-side env flips required.

## What changed

`core/config.py`:
- New flag `SKIP_COLLATERAL_PENALTY: bool` with default `True`.
- `SKIP_RENTAL_VERIFICATION` default flipped from `False` to `True`.
- `ENABLE_NO_COLLATERAL` semantics untouched — it still gates network access for non-deposited providers.

`incentive/default.py:140`:
- Uptime branch now guarded by `SKIP_COLLATERAL_PENALTY`. When `True` (default), `uptime_multiplier=1` regardless of `collateral_deposited`. When `False`, the original fractional penalty is restored.

The two existing rental-verification call sites (`score_calculator.py:43-45`, `services/task/checks/rental_verification.py:29`) already read `SKIP_RENTAL_VERIFICATION`; flipping its default short-circuits both without any code change.

## Why a new flag instead of reusing `ENABLE_NO_COLLATERAL`

`ENABLE_NO_COLLATERAL=True` historically means "accept providers in the network without collateral" (network access). The uptime penalty is a separate concept — providers without collateral were already accepted, just penalised. Mixing those two into one flag would break the meaning of `ENABLE_NO_COLLATERAL`. Pattern matches the existing `SKIP_RENTAL_VERIFICATION` for symmetry.

## Reversibility
- Re-enable penalty fast: set env `SKIP_COLLATERAL_PENALTY=false` on the validator pod.
- Re-enable rental verification: `SKIP_RENTAL_VERIFICATION=false`.
- Long-term revert: flip the defaults back in `core/config.py`.

## Coordinated PRs
- `lium-miner-portal-frontend`#116: disable Deposit button with tooltip
- `lium-docs`#43: "currently optional" banner on collateral pages

## Test plan
- [ ] Validator log "Mining score is calculated successfully" reports `uptime_multiplier=1.0` for both deposited and non-deposited executors.
- [ ] Validator log "Score set to 0 pending rental verification" no longer appears.
- [ ] With `SKIP_COLLATERAL_PENALTY=false` set in env, the original fractional penalty re-applies for non-deposited executors (backward-compat verification).
- [ ] +1 d on prod after deploy: Loki — every `uptime_multiplier` entry equals `1.0`; count of "Score set to 0 pending rental verification" drops to 0.
