### PR TITLE
DAH-2017: Persist validator miner_scores per cycle and gate first post-restart set_weights

### DIFF
--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -47,6 +47,10 @@ class Validator:
         self.default_extra = {}
 
         self.miner_scores = {}
+        # Number of fully-completed sync cycles since this process started.
+        # Used to skip the first post-restart set_weights when the in-memory
+        # accumulator may have been re-built from a partial cycle.
+        self.completed_cycles_since_start = 0
 
         # set incentive algorithm from setting
         self.incentive = settings.incentive
@@ -105,22 +109,20 @@ class Validator:
             attestation_service=self.attestation_service,
         )
 
-        # init miner_scores
+        # init miner_scores: always load from Redis if present so accumulated
+        # scores survive an unclean restart (SIGKILL / OOM / liveness preempt).
         try:
-            if await self.subtensor_client.should_set_weights():
+            miner_scores_json = await self.redis_service.get(MINER_SCORES_KEY)
+            if miner_scores_json is None:
+                logger.info(
+                    _m(
+                        "[initiate_services] No data found in Redis for MINER_SCORES_KEY, initializing empty miner_scores.",
+                        extra=get_extra_info(self.default_extra),
+                    ),
+                )
                 self.miner_scores = {}
             else:
-                miner_scores_json = await self.redis_service.get(MINER_SCORES_KEY)
-                if miner_scores_json is None:
-                    logger.info(
-                        _m(
-                            "[initiate_services] No data found in Redis for MINER_SCORES_KEY, initializing empty miner_scores.",
-                            extra=get_extra_info(self.default_extra),
-                        ),
-                    )
-                    self.miner_scores = {}
-                else:
-                    self.miner_scores = json.loads(miner_scores_json)
+                self.miner_scores = json.loads(miner_scores_json)
 
             # remove pod renting-in-progress status
             await self.redis_service.delete(PENDING_PODS_PREFIX)
@@ -159,16 +161,30 @@ class Validator:
 
             try:
                 if await self.subtensor_client.should_set_weights():
-                    if settings.DRY_RUN:
-                        logger.info(
+                    if self.completed_cycles_since_start < 1:
+                        logger.warning(
                             _m(
-                                "[sync] DRY_RUN: Skipping set_weights to Bittensor",
-                                extra=get_extra_info({**self.default_extra, "miner_scores": self.miner_scores}),
-                            )
+                                "[set_weights] post-restart warm-up: skipping until first cycle completes",
+                                extra=get_extra_info(
+                                    {
+                                        **self.default_extra,
+                                        "completed_cycles_since_start": self.completed_cycles_since_start,
+                                        "miner_scores_size": len(self.miner_scores),
+                                    }
+                                ),
+                            ),
                         )
                     else:
-                        await self.subtensor_client.set_weights(miner_scores=self.miner_scores)
-                    self.miner_scores = {}
+                        if settings.DRY_RUN:
+                            logger.info(
+                                _m(
+                                    "[sync] DRY_RUN: Skipping set_weights to Bittensor",
+                                    extra=get_extra_info({**self.default_extra, "miner_scores": self.miner_scores}),
+                                )
+                            )
+                        else:
+                            await self.subtensor_client.set_weights(miner_scores=self.miner_scores)
+                        self.miner_scores = {}
             except Exception as e:
                 logger.error(
                     _m(
@@ -427,6 +443,8 @@ class Validator:
                         if miner_coldkey:
                             await self.miner_service.publish_machine_specs(results, miner_hotkey, miner_coldkey)
 
+                    self.completed_cycles_since_start += 1
+
                     logger.info(
                         _m(
                             "[sync] All Jobs finished",
@@ -440,6 +458,7 @@ class Validator:
                                     "total_executors": incentive.total_executors,
                                     "successful_executors": incentive.successful_executors,
                                     "failed_executors": incentive.failed_executors,
+                                    "completed_cycles_since_start": self.completed_cycles_since_start,
                                 }
                             ),
                         ),
@@ -490,6 +509,23 @@ class Validator:
                 ),
                 exc_info=True,
             )
+        finally:
+            # Persist the current accumulator on every cycle so an unclean
+            # restart (SIGKILL / OOM / liveness preempt) does not lose the
+            # in-memory state — graceful stop() alone is not enough.
+            try:
+                await self.redis_service.set(
+                    MINER_SCORES_KEY, json.dumps(self.miner_scores)
+                )
+            except Exception as e:
+                logger.warning(
+                    _m(
+                        "[sync] Failed to persist miner_scores",
+                        extra=get_extra_info(
+                            {**self.default_extra, "error": str(e)}
+                        ),
+                    ),
+                )
 
     async def start(self):
         logger.info(


### PR DESCRIPTION
## Summary

Notion: [DAH-2017 — Validator loses miner_scores accumulator on restart](https://www.notion.so/datura/Validator-loses-miner_scores-accumulator-on-restart-351b8bfdbde981378123d72f86a1de4d)

After an unclean validator restart (SIGKILL / OOM / liveness preempt) the next `set_weights` cycle published a near-empty weights vector — burner UIDs survived (BurnService floor) but multi-cycle-accumulation miners read as 0. Reference incident 2026-04-28 UTC: miner UID 234 (5HbCth…SFf2) submitted at weight 0.0 after a validator restart, deregistered shortly after.

Two pre-existing flaws in the persistence layer:

1. **Save runs only in `Validator.stop()`** — graceful shutdown only. SIGKILL/OOM/liveness never fire it.
2. **Load in `initiate_services()` had a guard**: `if should_set_weights(): miner_scores = {}` regardless of Redis. After restart `should_set_weights()` is always true (chain is overdue) → the guard always fires → load is bypassed.

Result: first post-restart cycle accumulates from `{}` for ~5 min and submits a degraded vector.

## What changed (`neurons/validators/src/core/validator.py`)

- **Always load** from Redis in `initiate_services()` — removed the `should_set_weights()` guard.
- **Persist after every cycle** — added `try/finally` around `sync()` that writes the current accumulator to Redis after every iteration. Save errors are logged at WARNING and don't break sync.
- **Warm-up guard** — added `self.completed_cycles_since_start: int = 0`, incremented after `[sync] All Jobs finished`. The `set_weights` branch in `sync()` now skips submission until at least one cycle fully completes after process start (logs a warning so we can track frequency). This is defense-in-depth: catches cases where Redis was unavailable or returned empty (first deploy, Redis flush) and a half-empty submission would otherwise still happen.

## Out of scope

- An orthogonal pre-existing bug exists: if `set_weights()` raises, the `miner_scores = {}` reset is skipped, causing double-counting on the next submission. Filed mentally as follow-up — not addressed here to keep this change surgical.
- The upstream cause of the unclean restarts (OOM vs liveness probe vs deploy churn) is a separate investigation per the spec's Plan section.

## Test plan

### Pre-deploy verification (from spec)

- [ ] Rent two executors against the staging validator, let scores accumulate for ≥2 cycles
- [ ] `kubectl delete pod validator-... -n staging-subnet --grace-period=0 --force` (simulate unclean kill)
- [ ] After restart, confirm Redis `miner_scores` key still contains the pre-kill dict (`redis-cli get miner_scores` via port-forward)
- [ ] Verify the next `set_weights` log shows weights consistent with the pre-restart snapshot, not a single-batch undercount
- [ ] Verify `[set_weights] post-restart warm-up` warning fires exactly once after the kill

### Post-deploy verification (from spec)

- [ ] +1 d: query Loki for `[set_weights] No miner scores available, skipping set_weights.` events — count drops to ~0
- [ ] +7 d: cross-reference validator pod restart events (`kubectl get events -n subnet`) with `set_weights` distributions ±2 cycles around each restart — verify low-band miner weights do not drop to 0 in the first post-restart cycle