### PR TITLE
DAH-2027: remove legacy 'pending rental' score zeroing

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -140,7 +140,7 @@ class Settings(BaseSettings):
 
     ENABLE_NO_COLLATERAL: bool = True
     ENABLE_VERIFYX: bool = True
-    SKIP_RENTAL_VERIFICATION: bool = Field(env="SKIP_RENTAL_VERIFICATION", default=True)
+    SKIP_RENTAL_VERIFICATION: bool = Field(env="SKIP_RENTAL_VERIFICATION", default=False)
     SKIP_COLLATERAL_PENALTY: bool = Field(env="SKIP_COLLATERAL_PENALTY", default=True)
     DRY_RUN: bool = Field(env="DRY_RUN", default=False, description="Run validation without publishing scores/weights")
     CONTAINER_CLEANUP_DRY_RUN: bool = Field(env="CONTAINER_CLEANUP_DRY_RUN", default=False, description="Dry run mode for stale container cleanup")

--- a/neurons/validators/src/services/task/score_calculator.py
+++ b/neurons/validators/src/services/task/score_calculator.py
@@ -32,17 +32,12 @@ def calculate_scores(
     """
     gpu_model = ctx.state.gpu_model or ""
     collateral_deposited = ctx.collateral_deposited
-    is_rental_succeed = ctx.is_rental_succeed
     contract_version = ctx.contract_version or ""
     price_per_gpu = ctx.executor.price_per_gpu
 
     warning_messages = []
     job_score = 1.0
     actual_score = 1.0
-
-    if not is_rental_succeed and not settings.SKIP_RENTAL_VERIFICATION:
-        actual_score = 0.0
-        warning_messages.append("Score set to 0 pending rental verification")
 
     # Machine price check
     base_price = MACHINE_PRICES.get(gpu_model, 0)

--- a/neurons/validators/tests/test_score_check.py
+++ b/neurons/validators/tests/test_score_check.py
@@ -39,8 +39,8 @@ class DummyScoreCalculator:
     [
         # Normal success case: full scores, no warnings
         ("NVIDIA RTX 4090", True, True, "v1.0.0", False, 10, 1.0, 1.0, "", True),
-        # Success with warning
-        ("NVIDIA RTX 3090", True, False, "v1.0.0", False, 10, 0.0, 1.0, " WARNING: Score set to 0 pending rental verification", True),
+        # Success with warning (e.g. price exceeds limit — exact text is not asserted, only propagation)
+        ("NVIDIA RTX 3090", True, False, "v1.0.0", False, 10, 0.0, 1.0, " WARNING: GPU price exceeds the limit", True),
         # Low collateral warning
         ("NVIDIA RTX 3080", False, True, "v1.0.0", False, 10, 1.0, 1.0, " WARNING: No collateral deposited", True),
         # Rented machine


### PR DESCRIPTION
## Summary

Two-line fix on the validator side:

- Delete legacy `Score set to 0 pending rental verification` zeroing in `score_calculator.py` — pre-DAH-1815 semantics, no longer useful since slashing isn't live and the warning produced no actionable signal.
- Restore `SKIP_RENTAL_VERIFICATION` default to `False`. DAH-2016 (commit `ba2e4d59`) flipped it to `True` to disable the legacy zeroing above, but the same flag also short-circuits the active `RentalVerificationCheck` probe — so DAH-2026's loopback verification ([PR #591](https://github.com/Datura-ai/lium-io-backend/pull/591)) was sitting in dead code.

The flag itself stays in place as a kill switch for `RentalVerificationCheck`. `fatal=True` semantics on the check are unchanged — failures still halt validation.

Soft-launch of the new vloopback probe added in DAH-2026 will be handled separately on the backend side (`compute-app/orchestrator/executor_health_check.py`) so that **only** the new loopback step is observe-only, not the rest of `verify_executor`.

Notion: [DAH-2027](https://www.notion.so/datura/352b8bfdbde981c6946ffe48a87a8a07)
Related: [DAH-2026 / PR #591](https://github.com/Datura-ai/lium-io-backend/pull/591)

## Test plan

### Pre-deploy

```
cd neurons/validators
pdm run pytest tests/test_rental_verification_check.py tests/test_score_check.py tests/test_score_calculator.py
```

Expect 28 passed.

### Post-deploy (staging)

- [ ] Tail validator logs: `reason=RENTAL_CHECK_DISABLED` events disappear (since flag default is now False on fresh deploys without env override).
- [ ] `reason=RENTAL_VERIFIED` and `reason=RENTAL_NOT_VERIFIED` events appear on every cycle for every executor.
- [ ] No new `Score set to 0 pending rental verification` warnings in `SCORE_COMPUTED` events.