### PR TITLE
DAH-2044, clean up orphan vloopback volumes on create_container failure

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -928,6 +928,61 @@ class DockerService:
             timeout=timeout,
         )
 
+    async def _cleanup_orphan_local_volume(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        local_volume: str,
+        default_extra: dict,
+    ) -> str:
+        """Best-effort removal of a leaked vloopback volume after a failed create_container.
+
+        Vloopback reserves disk via fallocate(2) at volume create time, so a leaked
+        volume holds `volume_limit_gb` of executor disk until the periodic GC runs.
+        This helper is invoked from the create_container failure paths to release
+        that disk immediately. It must never raise — failure to clean up the orphan
+        must not mask the original create_container exception.
+
+        Returns one of: "removed", "not_present", "rm_failed".
+        """
+        quoted = shlex.quote(local_volume)
+        status = "rm_failed"
+        try:
+            inspect = await ssh_client.run(
+                f"/usr/bin/docker volume inspect {quoted} >/dev/null 2>&1"
+            )
+            if inspect.exit_status != 0:
+                status = "not_present"
+            else:
+                rm = await ssh_client.run(f"/usr/bin/docker volume rm -f {quoted}")
+                status = "removed" if rm.exit_status == 0 else "rm_failed"
+        except Exception as e:
+            logger.warning(
+                _m(
+                    "Orphan local volume cleanup raised",
+                    extra=get_extra_info(
+                        {
+                            **default_extra,
+                            "local_volume": local_volume,
+                            "error": str(e),
+                        }
+                    ),
+                )
+            )
+
+        logger.info(
+            _m(
+                "Orphan local volume cleanup attempted",
+                extra=get_extra_info(
+                    {
+                        **default_extra,
+                        "local_volume": local_volume,
+                        "orphan_volume_cleanup_status": status,
+                    }
+                ),
+            )
+        )
+        return status
+
     async def create_container(
         self,
         payload: ContainerCreateRequest,
@@ -938,6 +993,10 @@ class DockerService:
         warnings = []
         local_volume = payload.local_volume
         external_volume_info = payload.external_volume_info
+        # Tracks whether create_local_volume actually allocated a vloopback volume in
+        # this call (DAH-2044). Only set when we created it ourselves; pre-existing
+        # volumes from edit-pod / restart flows belong to the caller.
+        local_volume_created = False
 
         default_extra = {
             "miner_hotkey": payload.miner_hotkey,
@@ -1076,364 +1135,379 @@ class DockerService:
                 client_keys=[pkey],
                 known_hosts=known_hosts_policy,
             ) as ssh_client:
-                # Add profiler for ssh connection
-                profilers.append({"name": "SSH connection established", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
-                prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
+                try:
+                    # Add profiler for ssh connection
+                    profilers.append({"name": "SSH connection established", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
+                    prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
 
-                # set real-time logging
-                self.log_task = asyncio.create_task(
-                    self.handle_stream_logs(
-                        miner_hotkey=payload.miner_hotkey,
-                        executor_id=payload.executor_id,
-                        pod_id=payload.pod_id,
+                    # set real-time logging
+                    self.log_task = asyncio.create_task(
+                        self.handle_stream_logs(
+                            miner_hotkey=payload.miner_hotkey,
+                            executor_id=payload.executor_id,
+                            pod_id=payload.pod_id,
+                        )
                     )
-                )
-                # command = f"/usr/bin/docker logout"
-                # await self.execute_and_stream_logs(
-                #     ssh_client=ssh_client,
-                #     command=command,
-                #     log_tag=log_tag,
-                #     log_text=f"Logging out of Docker registry",
-                #     log_extra=default_extra,
-                # )
-                if payload.docker_username and payload.docker_password:
-                    command = self._build_docker_login_command(
-                        payload.docker_username, payload.docker_password
-                    )
+                    # command = f"/usr/bin/docker logout"
+                    # await self.execute_and_stream_logs(
+                    #     ssh_client=ssh_client,
+                    #     command=command,
+                    #     log_tag=log_tag,
+                    #     log_text=f"Logging out of Docker registry",
+                    #     log_extra=default_extra,
+                    # )
+                    if payload.docker_username and payload.docker_password:
+                        command = self._build_docker_login_command(
+                            payload.docker_username, payload.docker_password
+                        )
+                        await self.execute_and_stream_logs(
+                            ssh_client=ssh_client,
+                            command=command,
+                            log_tag=log_tag,
+                            log_text=f"Logging in to Docker registry as {payload.docker_image}",
+                            log_extra=default_extra,
+                            raise_exception=False
+                        )
+
+                    # Add profiler for docker login
+                    profilers.append({"name": "Docker login step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
+                    prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
+
+                    command = f"/usr/bin/docker pull {payload.docker_image}"
                     await self.execute_and_stream_logs(
                         ssh_client=ssh_client,
                         command=command,
                         log_tag=log_tag,
-                        log_text=f"Logging in to Docker registry as {payload.docker_image}",
+                        log_text=f"Pulling docker image {payload.docker_image}",
                         log_extra=default_extra,
-                        raise_exception=False
                     )
 
-                # Add profiler for docker login
-                profilers.append({"name": "Docker login step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
-                prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
+                    # Add profiler for docker pull
+                    profilers.append({"name": "Docker pull step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
+                    prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
 
-                command = f"/usr/bin/docker pull {payload.docker_image}"
-                await self.execute_and_stream_logs(
-                    ssh_client=ssh_client,
-                    command=command,
-                    log_tag=log_tag,
-                    log_text=f"Pulling docker image {payload.docker_image}",
-                    log_extra=default_extra,
-                )
-
-                # Add profiler for docker pull
-                profilers.append({"name": "Docker pull step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
-                prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
-
-                port_flags = " ".join(
-                    [
-                        f"-p {internal_port}:{docker_port}"
-                        for docker_port, internal_port, _ in port_maps
-                    ]
-                )
-
-                # Get the container path from the first volume
-                local_volume_path = custom_options.volumes[0].split(':')[-1] if custom_options.volumes else '/root'
-                entrypoint_flag = (
-                    f"--entrypoint {custom_options.entrypoint}"
-                    if custom_options
-                    and custom_options.entrypoint
-                    and custom_options.entrypoint.strip()
-                    else ""
-                )
-                shm_size_flag = (
-                    f"--shm-size {custom_options.shm_size}"
-                    if custom_options and custom_options.shm_size
-                    else ""
-                )
-                env_flags = (
-                    " ".join(
+                    port_flags = " ".join(
                         [
-                            f"-e '{key}={value}'"
-                            for key, value in custom_options.environment.items()
-                            if key and value and key.strip() and value.strip()
+                            f"-p {internal_port}:{docker_port}"
+                            for docker_port, internal_port, _ in port_maps
                         ]
-                        + ["-e NVIDIA_DRIVER_CAPABILITIES=all"]
                     )
-                    if custom_options and custom_options.environment
-                    else "-e NVIDIA_DRIVER_CAPABILITIES=all"
-                )
-                startup_commands = (
-                    f"{custom_options.startup_commands}"
-                    if custom_options
-                    and custom_options.startup_commands
-                    and custom_options.startup_commands.strip()
-                    else ""
-                )
 
-                container_name = f"{POD_CONTAINER_PREFIX}{payload.pod_id}"
+                    # Get the container path from the first volume
+                    local_volume_path = custom_options.volumes[0].split(':')[-1] if custom_options.volumes else '/root'
+                    entrypoint_flag = (
+                        f"--entrypoint {custom_options.entrypoint}"
+                        if custom_options
+                        and custom_options.entrypoint
+                        and custom_options.entrypoint.strip()
+                        else ""
+                    )
+                    shm_size_flag = (
+                        f"--shm-size {custom_options.shm_size}"
+                        if custom_options and custom_options.shm_size
+                        else ""
+                    )
+                    env_flags = (
+                        " ".join(
+                            [
+                                f"-e '{key}={value}'"
+                                for key, value in custom_options.environment.items()
+                                if key and value and key.strip() and value.strip()
+                            ]
+                            + ["-e NVIDIA_DRIVER_CAPABILITIES=all"]
+                        )
+                        if custom_options and custom_options.environment
+                        else "-e NVIDIA_DRIVER_CAPABILITIES=all"
+                    )
+                    startup_commands = (
+                        f"{custom_options.startup_commands}"
+                        if custom_options
+                        and custom_options.startup_commands
+                        and custom_options.startup_commands.strip()
+                        else ""
+                    )
 
-                await self.clean_existing_containers(
-                    ssh_client=ssh_client,
-                    default_extra=default_extra,
-                    pod_name=container_name,
-                    sleep=10,
-                    clear_volume=False if local_volume else True,
-                    active_container_names=payload.active_container_names,
-                )
+                    container_name = f"{POD_CONTAINER_PREFIX}{payload.pod_id}"
 
-                # Add profiler for docker volume creation
-                profilers.append({"name": "Container cleaning step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
-                prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
-
-                if not local_volume:
-                    # create docker volume
-                    local_volume = f"volume_{payload.pod_id}"
-                    await self.create_local_volume(
+                    await self.clean_existing_containers(
                         ssh_client=ssh_client,
-                        local_volume=local_volume,
-                        log_tag=log_tag,
-                        log_text=f"Creating docker volume {local_volume}",
-                        log_extra=default_extra,
-                        limit=payload.volume_limit_gb,
+                        default_extra=default_extra,
+                        pod_name=container_name,
+                        sleep=10,
+                        clear_volume=False if local_volume else True,
+                        active_container_names=payload.active_container_names,
                     )
 
-                volume_flag = f"-v {local_volume}:{local_volume_path}"
+                    # Add profiler for docker volume creation
+                    profilers.append({"name": "Container cleaning step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
+                    prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
 
-                if external_volume_info:
-                    success, msg = await self.create_s3fs_volume(
-                        ssh_client=ssh_client,
-                        log_extra=default_extra,
-                        volume_info=external_volume_info,
-                        log_tag=log_tag,
+                    if not local_volume:
+                        # create docker volume
+                        local_volume = f"volume_{payload.pod_id}"
+                        await self.create_local_volume(
+                            ssh_client=ssh_client,
+                            local_volume=local_volume,
+                            log_tag=log_tag,
+                            log_text=f"Creating docker volume {local_volume}",
+                            log_extra=default_extra,
+                            limit=payload.volume_limit_gb,
+                        )
+                        local_volume_created = True
+
+                    volume_flag = f"-v {local_volume}:{local_volume_path}"
+
+                    if external_volume_info:
+                        success, msg = await self.create_s3fs_volume(
+                            ssh_client=ssh_client,
+                            log_extra=default_extra,
+                            volume_info=external_volume_info,
+                            log_tag=log_tag,
+                        )
+                        if success:
+                            # Add profiler for docker volume creation
+                            profilers.append({"name": "Docker volume creation step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
+                            prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
+                            # Important: disable sysbox when using s3fs volume because s3fs volume is not supported by sysbox
+                            payload.is_sysbox = False
+
+                            volume_flag += f" -v {external_volume_info.name}:/mnt"
+                        else:
+                            warnings.append(ContainerWarningCode.ExternalVolumeFailed)
+                            profilers.append({"name": "Docker volume creation step failed", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
+                            await self.stream_log("S3 volume setup failed", "error", log_tag)
+
+                    # Network permission flags (permission to create a network interface inside the container)
+                    net_perm_flags = (
+                        "--cap-add=NET_ADMIN "
+                        "--sysctl net.ipv4.conf.all.src_valid_mark=1 "
+                        "--device /dev/net/tun "
                     )
-                    if success:
-                        # Add profiler for docker volume creation
-                        profilers.append({"name": "Docker volume creation step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
-                        prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
-                        # Important: disable sysbox when using s3fs volume because s3fs volume is not supported by sysbox
-                        payload.is_sysbox = False
 
-                        volume_flag += f" -v {external_volume_info.name}:/mnt"
+                    # GPU flags. --gpus injects userspace libs (libnvidia-ml.so, nvidia-smi);
+                    # explicit --device entries persist the device cgroup across systemd
+                    # daemon-reload (cgroup v2 + systemd cgroup driver wipe the transient
+                    # nvidia hook program; HostConfig.Devices is reapplied by Docker).
+                    gpu_flags = await build_gpu_flags(ssh_client, payload.gpu_uuids) + " "
+
+                    # CPU and memory restriction flags
+                    # --cpus flag isn't working inside cvm. skip to use it when tdx_quote is present
+                    # TODO: remove this when cvm is fixed
+                    if executor_info.tdx_quote: 
+                        cpu_flag = ""
                     else:
-                        warnings.append(ContainerWarningCode.ExternalVolumeFailed)
-                        profilers.append({"name": "Docker volume creation step failed", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
-                        await self.stream_log("S3 volume setup failed", "error", log_tag)
-
-                # Network permission flags (permission to create a network interface inside the container)
-                net_perm_flags = (
-                    "--cap-add=NET_ADMIN "
-                    "--sysctl net.ipv4.conf.all.src_valid_mark=1 "
-                    "--device /dev/net/tun "
-                )
-
-                # GPU flags. --gpus injects userspace libs (libnvidia-ml.so, nvidia-smi);
-                # explicit --device entries persist the device cgroup across systemd
-                # daemon-reload (cgroup v2 + systemd cgroup driver wipe the transient
-                # nvidia hook program; HostConfig.Devices is reapplied by Docker).
-                gpu_flags = await build_gpu_flags(ssh_client, payload.gpu_uuids) + " "
-
-                # CPU and memory restriction flags
-                # --cpus flag isn't working inside cvm. skip to use it when tdx_quote is present
-                # TODO: remove this when cvm is fixed
-                if executor_info.tdx_quote: 
-                    cpu_flag = ""
-                else:
-                    cpu_flag = f"--cpus {payload.cpu_count} " if payload.cpu_count else ""
-                memory_flag = f"--memory {payload.memory_gb}g " if payload.memory_gb else ""
+                        cpu_flag = f"--cpus {payload.cpu_count} " if payload.cpu_count else ""
+                    memory_flag = f"--memory {payload.memory_gb}g " if payload.memory_gb else ""
                 
-                storage_flag = f"--storage-opt size={payload.storage_limit_gb}g " if payload.storage_limit_gb else ""
+                    storage_flag = f"--storage-opt size={payload.storage_limit_gb}g " if payload.storage_limit_gb else ""
 
-                command = (
-                    f'/usr/bin/docker run -d '
-                    f'{"--runtime=sysbox-runc " if payload.is_sysbox else ""}'
-                    f'{net_perm_flags} '  # Network permission flags
-                    f'{port_flags} '
-                    f'{volume_flag} '
-                    f'{entrypoint_flag} '
-                    f'{env_flags} '
-                    f'{shm_size_flag} '
-                    f'{gpu_flags} '  # GPU restriction flags
-                    f'{cpu_flag} '  # CPU restriction flags
-                    f'{memory_flag} '  # Memory restriction flags
-                    f'{storage_flag} '  # Storage restriction flags
-                    f'--restart unless-stopped '
-                    f'--name {container_name} '
-                    f'{payload.docker_image} '
-                    f'{startup_commands}'
-                )
-
-                timeout = 120
-                logger.info(f"Running command: {command} with timeout={timeout}")
-
-                # DAH-2018: re-check for backend health_check_* / validator
-                # port-test containers immediately before `docker run`. The
-                # early check in miner_service runs before the image pull, but
-                # the backend's RentalVerificationCheck can spin up a
-                # health_check container during the pull window and grab a
-                # host port from the same verified-port pool the rental
-                # allocated. Reuse the open ssh_client so we don't pay the
-                # cost of a second connect (and don't widen the TOCTOU gap).
-                # Tighter budget than the early call: by this point HC should
-                # be near completion, and the port-allocated retry loop +
-                # `docker rm -f` are the backstop for any residual race.
-                wait_ok, wait_msg = await self.wait_for_port_check_containers(
-                    executor_info=executor_info,
-                    miner_hotkey=payload.miner_hotkey,
-                    keypair=keypair,
-                    private_key=private_key,
-                    max_retries=1,
-                    retry_delay=30,
-                    ssh_client=ssh_client,
-                )
-                logger.info(
-                    _m(
-                        f"Port check container pre-run wait result: {wait_msg}",
-                        extra=get_extra_info({**default_extra, "ok": wait_ok}),
+                    command = (
+                        f'/usr/bin/docker run -d '
+                        f'{"--runtime=sysbox-runc " if payload.is_sysbox else ""}'
+                        f'{net_perm_flags} '  # Network permission flags
+                        f'{port_flags} '
+                        f'{volume_flag} '
+                        f'{entrypoint_flag} '
+                        f'{env_flags} '
+                        f'{shm_size_flag} '
+                        f'{gpu_flags} '  # GPU restriction flags
+                        f'{cpu_flag} '  # CPU restriction flags
+                        f'{memory_flag} '  # Memory restriction flags
+                        f'{storage_flag} '  # Storage restriction flags
+                        f'--restart unless-stopped '
+                        f'--name {container_name} '
+                        f'{payload.docker_image} '
+                        f'{startup_commands}'
                     )
-                )
 
-                await self._run_docker_create_with_port_retry(
-                    ssh_client=ssh_client,
-                    command=command,
-                    container_name=container_name,
-                    log_tag=log_tag,
-                    default_extra=default_extra,
-                    timeout=timeout,
-                )
+                    timeout = 120
+                    logger.info(f"Running command: {command} with timeout={timeout}")
 
-                logger.info(f"Container creation step finished")
-
-                # check if the container is running correctly
-                if not await self.check_container_running(ssh_client, container_name):
-                    # Capture the failure reason and check whether it points to our
-                    # --device flags (DAH-1987). State.Error covers cgroup / device
-                    # failures; logs --tail covers entrypoint failures.
-                    failure_reason = ""
-                    try:
-                        inspect = await ssh_client.run(
-                            f"/usr/bin/docker inspect -f '{{{{.State.Error}}}}' {container_name}"
-                        )
-                        logs_tail = await ssh_client.run(
-                            f"/usr/bin/docker logs --tail 50 {container_name} 2>&1 || true"
-                        )
-                        failure_reason = (inspect.stdout or "") + "\n" + (logs_tail.stdout or "")
-                    except Exception:
-                        failure_reason = "(failure_reason capture failed)"
-
-                    nvidia_signal = any(
-                        marker in failure_reason.lower()
-                        for marker in ("/dev/nvidia", "device cgroup", "no such device", "operation not permitted")
+                    # DAH-2018: re-check for backend health_check_* / validator
+                    # port-test containers immediately before `docker run`. The
+                    # early check in miner_service runs before the image pull, but
+                    # the backend's RentalVerificationCheck can spin up a
+                    # health_check container during the pull window and grab a
+                    # host port from the same verified-port pool the rental
+                    # allocated. Reuse the open ssh_client so we don't pay the
+                    # cost of a second connect (and don't widen the TOCTOU gap).
+                    # Tighter budget than the early call: by this point HC should
+                    # be near completion, and the port-allocated retry loop +
+                    # `docker rm -f` are the backstop for any residual race.
+                    wait_ok, wait_msg = await self.wait_for_port_check_containers(
+                        executor_info=executor_info,
+                        miner_hotkey=payload.miner_hotkey,
+                        keypair=keypair,
+                        private_key=private_key,
+                        max_retries=1,
+                        retry_delay=30,
+                        ssh_client=ssh_client,
                     )
-                    log_extra = get_extra_info({
-                        **default_extra,
-                        "container_name": container_name,
-                        "gpu_flags": gpu_flags,
-                        "failure_reason": failure_reason[:2000],
-                    })
-                    if nvidia_signal:
-                        logger.error(_m(
-                            "docker run failed with NVIDIA-device-related error — "
-                            "possible regression from build_gpu_flags --device flag set",
-                            extra=log_extra,
-                        ))
-                    else:
-                        logger.error(_m("docker run failed", extra=log_extra))
+                    logger.info(
+                        _m(
+                            f"Port check container pre-run wait result: {wait_msg}",
+                            extra=get_extra_info({**default_extra, "ok": wait_ok}),
+                        )
+                    )
 
-                    await self.clean_existing_containers(ssh_client=ssh_client, default_extra=default_extra, pod_name=container_name, active_container_names=payload.active_container_names)
-                    raise Exception("Run docker run command but container is not running")
+                    await self._run_docker_create_with_port_retry(
+                        ssh_client=ssh_client,
+                        command=command,
+                        container_name=container_name,
+                        log_tag=log_tag,
+                        default_extra=default_extra,
+                        timeout=timeout,
+                    )
 
-                # Add profiler for docker container creation
-                profilers.append({"name": "Docker container creation step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
-                prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
+                    logger.info(f"Container creation step finished")
 
-                logger.info(
-                    _m(
-                        "Created Docker Container",
-                        extra=get_extra_info({**default_extra, "container_name": container_name}),
-                    ),
-                )
+                    # check if the container is running correctly
+                    if not await self.check_container_running(ssh_client, container_name):
+                        # Capture the failure reason and check whether it points to our
+                        # --device flags (DAH-1987). State.Error covers cgroup / device
+                        # failures; logs --tail covers entrypoint failures.
+                        failure_reason = ""
+                        try:
+                            inspect = await ssh_client.run(
+                                f"/usr/bin/docker inspect -f '{{{{.State.Error}}}}' {container_name}"
+                            )
+                            logs_tail = await ssh_client.run(
+                                f"/usr/bin/docker logs --tail 50 {container_name} 2>&1 || true"
+                            )
+                            failure_reason = (inspect.stdout or "") + "\n" + (logs_tail.stdout or "")
+                        except Exception:
+                            failure_reason = "(failure_reason capture failed)"
 
-                await self.stream_log("Created Docker Container", "success", log_tag)
+                        nvidia_signal = any(
+                            marker in failure_reason.lower()
+                            for marker in ("/dev/nvidia", "device cgroup", "no such device", "operation not permitted")
+                        )
+                        log_extra = get_extra_info({
+                            **default_extra,
+                            "container_name": container_name,
+                            "gpu_flags": gpu_flags,
+                            "failure_reason": failure_reason[:2000],
+                        })
+                        if nvidia_signal:
+                            logger.error(_m(
+                                "docker run failed with NVIDIA-device-related error — "
+                                "possible regression from build_gpu_flags --device flag set",
+                                extra=log_extra,
+                            ))
+                        else:
+                            logger.error(_m("docker run failed", extra=log_extra))
 
-                # skip installing ssh service for daturaai images
-                # if payload.docker_image.startswith("daturaai/"):
-                #     logger.info(
-                #         _m(
-                #             "Skipping checking install and start ssh service for daturaai images",
-                #             extra=get_extra_info({**default_extra, "container_name": container_name}),
-                #         ),
-                #     )
-                # else:
-                await self.install_open_ssh_server_and_start_ssh_service(
-                    ssh_client=ssh_client,
-                    container_name=container_name,
-                    log_tag=log_tag,
-                    log_extra=default_extra,
-                )
+                        await self.clean_existing_containers(ssh_client=ssh_client, default_extra=default_extra, pod_name=container_name, active_container_names=payload.active_container_names)
+                        raise Exception("Run docker run command but container is not running")
 
-                jupyter_url = None
-                if payload.enable_jupyter and jupyter_port_map:
-                    jupyter_token = secrets.token_hex(16)
-                    await self.run_jupyter(
+                    # Add profiler for docker container creation
+                    profilers.append({"name": "Docker container creation step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
+                    prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
+
+                    logger.info(
+                        _m(
+                            "Created Docker Container",
+                            extra=get_extra_info({**default_extra, "container_name": container_name}),
+                        ),
+                    )
+
+                    await self.stream_log("Created Docker Container", "success", log_tag)
+
+                    # skip installing ssh service for daturaai images
+                    # if payload.docker_image.startswith("daturaai/"):
+                    #     logger.info(
+                    #         _m(
+                    #             "Skipping checking install and start ssh service for daturaai images",
+                    #             extra=get_extra_info({**default_extra, "container_name": container_name}),
+                    #         ),
+                    #     )
+                    # else:
+                    await self.install_open_ssh_server_and_start_ssh_service(
                         ssh_client=ssh_client,
                         container_name=container_name,
-                        jupyter_token=jupyter_token,
-                        jupyter_port=jupyter_port_map[0],
                         log_tag=log_tag,
                         log_extra=default_extra,
-                        local_volume=local_volume,
+                    )
+
+                    jupyter_url = None
+                    if payload.enable_jupyter and jupyter_port_map:
+                        jupyter_token = secrets.token_hex(16)
+                        await self.run_jupyter(
+                            ssh_client=ssh_client,
+                            container_name=container_name,
+                            jupyter_token=jupyter_token,
+                            jupyter_port=jupyter_port_map[0],
+                            log_tag=log_tag,
+                            log_extra=default_extra,
+                            local_volume=local_volume,
+                            local_volume_path=local_volume_path,
+                        )
+                        jupyter_url = f"http://{executor_info.address}:{jupyter_port_map[1]}/lab?token={jupyter_token}"
+
+                    # Add profiler for ssh service installation
+                    profilers.append({"name": "SSH service installation step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
+                    prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
+
+                    # add rest of public keys
+                    for public_key in payload.user_public_keys:
+                        command = f"/usr/bin/docker exec {container_name} sh -c 'echo \"{public_key}\" >> ~/.ssh/authorized_keys'"
+                        await ssh_client.run(command)
+
+                    # add environment variables
+                    if custom_options and custom_options.environment:
+                        for k, v in custom_options.environment.items():
+                            if k and v and k.strip() and str(v).strip():
+                                env_line = f"{k}={v}"
+                                # Execute each variable addition separately for better error handling
+                                script = f'printf "%s\\n" {shlex.quote(env_line)} >> /etc/environment'
+                                command = f"/usr/bin/docker exec {container_name} sh -c {shlex.quote(script)}"
+                                try:
+                                    await ssh_client.run(command)
+                                except Exception as e:
+                                    print(f"Failed to set environment variable {k}: {e}")
+
+                    # Add profiler for adding public keys
+                    profilers.append({"name": "Adding public keys step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
+                    prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
+
+                    await self.finish_stream_logs()
+
+                    await self.redis_service.add_rented_pod(executor_info, payload.pod_id, container_name)
+
+                    # Add profiler for ssh service installation
+                    profilers.append({"name": "Finished in subnet.", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
+
+                    return ContainerCreated(
+                        miner_hotkey=payload.miner_hotkey,
+                        executor_id=payload.executor_id,
+                        pod_id=payload.pod_id,
+                        container_name=container_name,
+                        volume_name=local_volume,
+                        port_maps=[
+                            (docker_port, external_port) for docker_port, _, external_port in port_maps
+                        ],
+                        profilers=profilers,
+                        backup_log_id=payload.backup_log_id,
+                        restore_path=payload.restore_path,
+                        jupyter_url=jupyter_url,
+                        warnings=warnings,
+                        storage_limit_gb=payload.storage_limit_gb,
+                        volume_limit_gb=payload.volume_limit_gb,
                         local_volume_path=local_volume_path,
                     )
-                    jupyter_url = f"http://{executor_info.address}:{jupyter_port_map[1]}/lab?token={jupyter_token}"
-
-                # Add profiler for ssh service installation
-                profilers.append({"name": "SSH service installation step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
-                prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
-
-                # add rest of public keys
-                for public_key in payload.user_public_keys:
-                    command = f"/usr/bin/docker exec {container_name} sh -c 'echo \"{public_key}\" >> ~/.ssh/authorized_keys'"
-                    await ssh_client.run(command)
-
-                # add environment variables
-                if custom_options and custom_options.environment:
-                    for k, v in custom_options.environment.items():
-                        if k and v and k.strip() and str(v).strip():
-                            env_line = f"{k}={v}"
-                            # Execute each variable addition separately for better error handling
-                            script = f'printf "%s\\n" {shlex.quote(env_line)} >> /etc/environment'
-                            command = f"/usr/bin/docker exec {container_name} sh -c {shlex.quote(script)}"
-                            try:
-                                await ssh_client.run(command)
-                            except Exception as e:
-                                print(f"Failed to set environment variable {k}: {e}")
-
-                # Add profiler for adding public keys
-                profilers.append({"name": "Adding public keys step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
-                prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
-
-                await self.finish_stream_logs()
-
-                await self.redis_service.add_rented_pod(executor_info, payload.pod_id, container_name)
-
-                # Add profiler for ssh service installation
-                profilers.append({"name": "Finished in subnet.", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
-
-                return ContainerCreated(
-                    miner_hotkey=payload.miner_hotkey,
-                    executor_id=payload.executor_id,
-                    pod_id=payload.pod_id,
-                    container_name=container_name,
-                    volume_name=local_volume,
-                    port_maps=[
-                        (docker_port, external_port) for docker_port, _, external_port in port_maps
-                    ],
-                    profilers=profilers,
-                    backup_log_id=payload.backup_log_id,
-                    restore_path=payload.restore_path,
-                    jupyter_url=jupyter_url,
-                    warnings=warnings,
-                    storage_limit_gb=payload.storage_limit_gb,
-                    volume_limit_gb=payload.volume_limit_gb,
-                    local_volume_path=local_volume_path,
-                )
+                except Exception:
+                    # DAH-2044: vloopback volumes are fallocated on create, so any
+                    # failure between create_local_volume and the successful return
+                    # leaks `volume_limit_gb` of executor disk until the periodic
+                    # GC runs. Best-effort cleanup here while the SSH session is
+                    # still open. Status is logged via orphan_volume_cleanup_status
+                    # for measurability. Cleanup never raises — original exception
+                    # always propagates.
+                    if local_volume_created:
+                        await self._cleanup_orphan_local_volume(
+                            ssh_client, local_volume, default_extra
+                        )
+                    raise
         except Exception as e:
             log_text = _m(
                 "Failed create_container",

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -1486,3 +1486,109 @@ async def test_wait_for_port_check_late_call_force_cleans_stale_health_check(
         "docker rm -f" in c and "health_check_" in c and "container_5TestMiner_" in c
         for c in FakeSSHClient.seen
     ), f"force-rm xargs missing. Seen: {FakeSSHClient.seen}"
+
+
+# =====================================================================
+# DAH-2044: orphan vloopback volume cleanup on create_container failure.
+# =====================================================================
+
+
+class _FakeRunResult:
+    def __init__(self, exit_status=0, stdout="", stderr=""):
+        self.exit_status = exit_status
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class _FakeSSHClient:
+    """Minimal asyncssh-style stub. queue is a list of either _FakeRunResult or
+    Exception instances; each ssh_client.run() pops one from the head."""
+
+    def __init__(self, queue):
+        self.queue = list(queue)
+        self.seen: list[str] = []
+
+    async def run(self, command):
+        self.seen.append(command)
+        item = self.queue.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+@pytest.mark.asyncio
+async def test_cleanup_orphan_local_volume_removes_existing(docker_service):
+    ssh = _FakeSSHClient([
+        _FakeRunResult(exit_status=0),  # docker volume inspect -> exists
+        _FakeRunResult(exit_status=0),  # docker volume rm -f -> ok
+    ])
+
+    status = await docker_service._cleanup_orphan_local_volume(
+        ssh, "volume_e7e5b2f8-2ffe-45d4-acef-4949e3cda820", {"pod_id": "p"}
+    )
+
+    assert status == "removed"
+    assert any("docker volume inspect" in c for c in ssh.seen)
+    assert any("docker volume rm -f" in c for c in ssh.seen)
+    # shlex.quote'd volume name must appear in the rm command.
+    assert any("volume_e7e5b2f8-2ffe-45d4-acef-4949e3cda820" in c for c in ssh.seen)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_orphan_local_volume_not_present(docker_service):
+    ssh = _FakeSSHClient([
+        _FakeRunResult(exit_status=1),  # docker volume inspect -> missing
+    ])
+
+    status = await docker_service._cleanup_orphan_local_volume(
+        ssh, "volume_missing", {}
+    )
+
+    assert status == "not_present"
+    # rm must NOT be called when inspect reports missing — saves an SSH round-trip.
+    assert not any("docker volume rm" in c for c in ssh.seen)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_orphan_local_volume_rm_failed(docker_service):
+    ssh = _FakeSSHClient([
+        _FakeRunResult(exit_status=0),  # inspect -> exists
+        _FakeRunResult(exit_status=1, stderr="volume is in use"),  # rm fails
+    ])
+
+    status = await docker_service._cleanup_orphan_local_volume(
+        ssh, "volume_in_use", {}
+    )
+
+    assert status == "rm_failed"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_orphan_local_volume_swallows_ssh_exception(docker_service):
+    """Cleanup must never raise — that would mask the original create_container error."""
+    ssh = _FakeSSHClient([
+        ConnectionError("ssh broke mid-cleanup"),
+    ])
+
+    status = await docker_service._cleanup_orphan_local_volume(
+        ssh, "volume_x", {}
+    )
+
+    assert status == "rm_failed"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_orphan_local_volume_quotes_volume_name(docker_service):
+    """Defense-in-depth: untrusted-looking volume names get shell-quoted before SSH."""
+    ssh = _FakeSSHClient([
+        _FakeRunResult(exit_status=1),  # inspect -> not present
+    ])
+
+    weird_name = "volume_x; rm -rf /"
+    await docker_service._cleanup_orphan_local_volume(ssh, weird_name, {})
+
+    inspect_cmd = ssh.seen[0]
+    # The dangerous payload must be enclosed in single quotes by shlex.quote and
+    # must not appear unquoted (that would be `; rm -rf /`).
+    assert shlex.quote(weird_name) in inspect_cmd
+    assert "; rm -rf /" not in inspect_cmd.replace(shlex.quote(weird_name), "")


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2044](https://www.notion.so/Cleanup-orphan-vloopback-volumes-on-create_container-failure-validator-docker_service-356b8bfdbde981ae8ec5f6c56a3f5623)

---

## Problem

Failed pod rentals leak full-size vloopback volumes on executors. The validator runs `docker volume create -d vloopback ... -o size=Xg` on the executor before `docker run`. The vloopback plugin reserves space via `fallocate(2)`, so `volume_limit_gb` of disk is physically consumed at volume create time.

If anything between `create_local_volume` success and `return ContainerCreated(...)` raises (NVIDIA hook, sysbox config, port-retry exhaustion, ssh disconnect, `_run_docker_create_with_port_retry` failure, `wait_for_port_check_containers` failure, `build_gpu_flags` failure, `check_container_running` returning false), the volume is never cleaned and sits on disk until the periodic GC runs hours later. Stacked failures saturate the executor: subsequent rentals fail with `fallocate: No space left on device`.

Reference incident: pod_id `e7e5b2f8-2ffe-45d4-acef-4949e3cda820` on executor `a41c2902-727c-4fd7-9841-b33704a0bd1d` at 2026-05-04 12:18 UTC. NVIDIA-hook failure during `docker run`. Across 16 fallocate / NVIDIA-hook failures observed 2026-04-27 to 2026-05-04 on 5 executors, `executor_disk_history` snapshots show clean per-failure drops equal to `volume_limit_gb`. On executor `35a239c4-186f-4396-aa23-0ab6ad29a9af` (H100x8, 12 TB): `free_gb` went 11999 → 4798 → 1822 → 704 across 4 sequential `rent_failed` attempts before recovering.

The validator has two failure paths in `create_container`, both leak:
- **Inner branch** (`check_container_running` false at `docker_service.py:1304`) — calls `clean_existing_containers`, but volume cleanup is keyed off `docker ps -a` output. If `docker run` fails before the container registers, the orphan volume isn't in the cleanup list.
- **Outer branch** (`except Exception` at `docker_service.py:1437` in pre-fix code) — no volume cleanup at all.

## Solution

Track whether `create_local_volume` actually allocated a vloopback volume in this call (vs. pre-existing volume from edit-pod / restart flows) via a `local_volume_created` flag. Wrap the body of the `async with asyncssh.connect(...) as ssh_client:` in an inner `try / except Exception` that calls a new best-effort cleanup helper while the SSH session is still open, then re-raises so the existing outer `except Exception as e:` keeps logging, removing the pending pod, and returning `FailedContainerRequest` unchanged.

The new `_cleanup_orphan_local_volume` helper uses `docker volume inspect` first to disambiguate `not_present` from `rm_failed`, then `docker volume rm -f` if the volume exists. It never raises — failure to clean must never mask the original `create_container` exception. Volume name is `shlex.quote`'d defense-in-depth.

## Changes

- `services/docker_service.py`:
  - New `_cleanup_orphan_local_volume(ssh_client, local_volume, default_extra) -> str` returning `removed` / `not_present` / `rm_failed`.
  - New `local_volume_created` flag in `create_container`, set to `True` only after `create_local_volume(...)` succeeds inside the `if not local_volume:` branch.
  - New `try / except Exception: ...; raise` wrapping the entire `async with ssh_client:` body (most of the file diff is the resulting +4-space reindent — `git diff -w` shows ~74 semantic insertions).
  - Structured `orphan_volume_cleanup_status` log key on every cleanup attempt for measurability.
- `tests/test_docker_service.py`: 5 new unit tests for `_cleanup_orphan_local_volume` (existing volume removed, missing volume, rm fails, ssh exception swallowed, weird volume name shell-quoted).

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

None.

## Risks

- The new `try/except Exception` inside `async with` re-raises every exception, so the outer `except Exception as e:` keeps its existing behavior. `CancelledError` derives from `BaseException` and is intentionally not swallowed (task cancellation propagates cleanly).
- `_cleanup_orphan_local_volume` performs two extra SSH round-trips (`inspect` + `rm -f`) on every failure path. Failure paths are rare; round-trips happen on the already-open SSH session.
- The `local_volume_created` flag is set after `create_local_volume` returns success. If `execute_and_stream_logs` raises mid-volume-create due to ssh disconnect after dispatch but before stdout/stderr are read, vloopback may have committed the volume on disk while the flag stays `False`. This is the same TOCTOU window all SSH-over-fire-and-forget calls in the file have today; vloopback's atomicity contract (fallocate-then-register) is the load-bearing assumption — accepted residual risk per spec.
- Most of the diff is whitespace from reindenting the `async with` body. `git diff -w` shows the actual semantic delta.

## Test Cases

### Test Case 1: pre-deploy baseline on staging executor 149.36.1.151

**Actions**
1. Capture baseline `df -h` and `docker volume ls` on 149.36.1.151.
2. Trigger a rental that succeeds volume create but fails `docker run` (simplest: invalid GPU UUID in payload).
3. Without the patch, confirm `docker volume ls` keeps `volume_<pod_id>` and `df` shows the volume reserved.

**Expected Output (pre-patch)**
- Orphan `volume_<pod_id>` persists in `docker volume ls`.
- `df -h` reports `volume_limit_gb` consumed.

### Test Case 2: post-deploy on staging executor 149.36.1.151

**Actions**
1. Apply the patch (deploy validator to staging).
2. Repeat the failure trigger from Test Case 1.
3. Within a few seconds: `docker volume ls | grep volume_<pod_id>` and `df -h` on the executor.
4. Inspect validator logs for the `orphan_volume_cleanup_status` key.

**Expected Output (post-patch)**
- `docker volume ls` no longer contains `volume_<pod_id>`.
- `df -h` returns to baseline.
- Validator log line carries `orphan_volume_cleanup_status: removed`.

### Test Case 3: happy-path regression check

**Actions**
1. Run one happy-path rental to completion on staging.
2. Run normal `stop_container` afterward.

**Expected Output**
- Container created and rented as before. No `orphan_volume_cleanup_status` log line on success path. `stop_container` still removes the volume cleanly.

### Test Case 4: post-deploy +1 day metric

**Actions**
- After +1 day on staging/prod: query `executor_rent_errors_hourly` for disk / fallocate / no-space categories.

**Expected Output**
- Counts drop measurably vs the same window in the prior week.

### Test Case 5: post-deploy +7 day metric

**Actions**
- Across executors with at least one `rent_failed` in the previous 24 h: check `executor_disk_history.free_gb` recovery time.

**Expected Output**
- `free_gb` returns to within 5% of pre-failure baseline by the next 15-min snapshot, not hours later.
- Random sample of 5 `rent_failed` validator log entries: each carries `orphan_volume_cleanup_status` with `removed` or `not_present`.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described