### PR TITLE
DAH-2050, fix Jupyter Lab startup regression in run_jupyter.sh

### DIFF
--- a/neurons/executor/run_jupyter.sh
+++ b/neurons/executor/run_jupyter.sh
@@ -139,12 +139,15 @@ install_python_packages() {
     pip install --upgrade pip
     
     # Install Jupyter and common packages
+    # Jupyter stack is pinned: an unpinned upstream release on 2026-05-04 added
+    # strict preferred_dir/root_dir validation that broke pod startup (DAH-2050).
     echo "Installing Jupyter and Python packages..."
     pip install \
         jupyter \
-        jupyterlab \
-        notebook \
-        ipykernel \
+        jupyterlab==4.5.7 \
+        jupyter-server==2.18.0 \
+        notebook==7.5.6 \
+        ipykernel==7.2.0 \
         matplotlib \
         numpy \
         pandas \
@@ -198,7 +201,7 @@ start_jupyter() {
         --ServerApp.terminado_settings="{\"shell_command\":[\"$shell_cmd\"]}" \
         --IdentityProvider.token=$JUPYTER_PASSWORD \
         --ServerApp.allow_origin=* \
-        --FileContentsManager.preferred_dir=/root \
+        --ServerApp.root_dir=/root \
         --ServerApp.disable_check_xsrf=True \
         --ServerApp.tornado_settings="{\"max_body_size\": 536870912}" \
         --ServerApp.log_level=ERROR \


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2050](https://www.notion.so/Fix-Jupyter-Lab-startup-regression-in-run_jupyter-sh-root-is-outside-root-contents-directory-357b8bfdbde98153bfd6c53cef30f3a2)

---

## Problem

Pod creation with `enable_jupyter=true` started failing on `2026-05-04 13:51 UTC` for any rental on the affected pytorch image. Stderr captured by the validator:

```
[C 2026-05-05 01:28:20.435 ServerApp] Bad config encountered during initialization: root is outside root contents directory
Error: Failed to start Jupyter Lab
```

Reference incident: pod_id `5dfd6d8f-b887-4016-883f-df679efe1881`, executor `7cd3a7f3-8ac4-4d35-af72-0710c865f099` at `64.247.196.52:2200`, image `daturaai/pytorch:2.7.0-py3.12-cuda12.8.0-devel-ubuntu24.04`. 24 events across 9 distinct pods within 24h, multiple miners and IPs — a fleet-wide regression, not a single bad host.

## Solution

`start_jupyter` in `run_jupyter.sh` passed `--FileContentsManager.preferred_dir=/root` with no `--ServerApp.root_dir`. The pytorch image has `WORKDIR=/`, so Jupyter's `root_dir` defaulted to `/`. The freshly installed (unpinned) `jupyter-server 2.18.0` validates `preferred_dir` strictly against `root_dir` and rejects `/root` as outside `/`.

Fix:
- Drop the conflicting `--FileContentsManager.preferred_dir=/root` and add `--ServerApp.root_dir=/root` (the flag we actually want — strict superset of the previous UX).
- Pin the Jupyter stack so a future PyPI release cannot turn into another cliff-edge regression.

## Changes

- `neurons/executor/run_jupyter.sh`:
  - `start_jupyter`: replace `--FileContentsManager.preferred_dir=/root` with `--ServerApp.root_dir=/root`.
  - `install_python_packages`: pin `jupyterlab==4.5.7`, `jupyter-server==2.18.0`, `notebook==7.5.6`, `ipykernel==7.2.0`. Keep `jupyter`, `matplotlib`, `numpy`, `pandas`, `requests` unpinned (unrelated to the regression).

## Deployment Steps

After merge: trigger `executor_cd_prod` (or whichever workflow rebuilds `daturaai/compute-subnet-executor:latest`) — the validator hardcodes `:latest` at [`docker_service.py:809`](https://github.com/Datura-ai/lium-io/blob/main/neurons/validators/src/services/docker_service.py#L809) for the local_volume Jupyter path. Miner executor hosts (digest-pinned in `docker-compose.app.yml`) pick up the new image on their normal update cycle, which then refreshes `/root/app/run_jupyter.sh` for the no-volume path.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

None.

## Risks

- Behavior of `--ServerApp.root_dir=/root` is a strict superset of `--FileContentsManager.preferred_dir=/root` for users (file browser still lands at `/root`), and additionally constrains Jupyter to never serve files outside `/root` — that's a security-positive, not a regression.
- Pinning Jupyter stack means we no longer auto-pick up upstream Jupyter security/bugfix releases. Acceptable trade-off given the regression we just hit; revisit pins explicitly when refreshing the executor image.
- Fix only lands when the executor image is rebuilt and miners re-deploy. Until `:latest` is republished and the fleet pulls it, the bug persists for new rentals.

## Test Cases

### Test Case 1 — image carries the fix

**Actions**

```bash
docker pull daturaai/compute-subnet-executor:dev   # built from this PR
docker run --rm daturaai/compute-subnet-executor:dev \
  cat /root/app/run_jupyter.sh \
  | grep -E 'preferred_dir|root_dir|jupyter-server=='
```

**Expected Output**

`--ServerApp.root_dir=/root \` and `jupyter-server==2.18.0 \` present; no `--FileContentsManager.preferred_dir=/root`. Verified ✅.

### Test Case 2 — end-to-end Jupyter startup (validator local_volume path)

**Actions**

On a fresh Linux x86_64 host, emulate the validator's `run_jupyter` `local_volume` branch (`docker_service.py:803-854`):

```bash
mkdir -p /tmp/jupyter-test
docker run --rm -v /tmp/jupyter-test:/mnt --entrypoint sh \
  daturaai/compute-subnet-executor:dev -c 'cp /root/app/run_jupyter.sh /mnt/'
docker run -d --name jupyter-test -v /tmp/jupyter-test:/scripts \
  daturaai/pytorch:2.7.0-py3.12-cuda12.8.0-devel-ubuntu24.04 sleep infinity
docker exec jupyter-test sh -c 'chmod +x /scripts/run_jupyter.sh && /scripts/run_jupyter.sh --password=test --port=8888'
docker exec jupyter-test cat /jupyter.log
docker exec jupyter-test sh -c 'apt-get install -y -qq curl && curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:8888/api/status?token=test'
```

**Expected Output**

- `Jupyter Lab started successfully on port 8888`. ✅
- `/jupyter.log` empty — no `Bad config / outside root contents directory / Failed to start`. ✅
- `HTTP 200` from `/api/status`. ✅

Reproduced on `shadeform@149.36.1.151` 2026-05-05 03:43 UTC — all green.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described