### PR TITLE
DAH-1959, DinD probe: switch to pinned public ECR mirror for hello-world

### DIFF
--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -293,6 +293,14 @@ FIXED_RATIO = 0.41  # fixed constant for rental emission calculation
 IS_NOT_DEPOSITED_SCORE_MULTIPLIER = 0.5
 DOCKER_DIND_IMAGE = "daturaai/dind:0.0.0"
 
+# Probe image used inside DinD to confirm the inner dockerd can pull and run a tiny image.
+# Pinned by digest to public.ecr.aws (AWS official mirror of Docker Hub library/) — same bytes
+# as docker.io/library/hello-world but without anonymous pull rate limits.
+DIND_PROBE_IMAGE = (
+    "public.ecr.aws/docker/library/hello-world"
+    "@sha256:f9078146db2e05e794366b1bfe584a14ea6317f44027d10ef7dad65279026885"
+)
+
 LIB_NVIDIA_ML_DIGESTS = {
     "535.54.03": "49e63c42aa95bba6b9aa562ee57e496c:15a37892671187547b6dd21a07e8149315e529211dc30ca6ee8d8d089a338d53",
     "535.86.10": "7351f43a025ecdde1208a7a4e2f1cf26:ec9b270c4fdf2b51515c9eb5f185cbc0478322c43a3876caab80ebfb5cd1dab1",

--- a/neurons/validators/src/services/executor_connectivity/dind_probe.py
+++ b/neurons/validators/src/services/executor_connectivity/dind_probe.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import random
 
 import asyncssh
 from asyncssh import SSHClientConnection
@@ -11,6 +12,17 @@ from services.executor_connectivity.models import DindProbeResult, PortPair
 from services.ssh_service import SSHService
 
 logger = logging.getLogger(__name__)
+
+# public.ecr.aws enforces 1 unauthenticated image pull / sec / IP. Miners with several
+# executors behind one NAT see concurrent waves of probes from a single validator, plus
+# concurrent waves from multiple validators on the subnet, which still trips the limit
+# even after we left docker.io. Retrying once with a randomised 2–10 s wait lets the
+# bursts de-phase across executors of the same IP and brings residual 429s back down to
+# real-failure noise. We only retry on the throttling signature so genuine "daemon dead"
+# failures continue to surface immediately.
+_RATELIMIT_MARKERS = ("toomanyrequests", "rate exceeded")
+_PROBE_RETRY_MIN_S = 2
+_PROBE_RETRY_MAX_S = 10
 
 
 class DindVerifier:
@@ -70,10 +82,39 @@ class DindVerifier:
                 # implies the runtime works. We do NOT trust this probe as proof of sysbox by itself —
                 # an attacker could rig the inner daemon to lie — it is a functional health check.
                 if sysbox:
-                    result = await ssh.run(f"docker run --rm {DIND_PROBE_IMAGE}")
+                    probe_cmd = f"docker run --rm {DIND_PROBE_IMAGE}"
+                    result = await ssh.run(probe_cmd)
                     probe_ok = result.exit_status == 0
+                    error_msg = (
+                        result.stderr.strip()
+                        if result.stderr and isinstance(result.stderr, str)
+                        else "unknown error"
+                    )
+
+                    # Retry once on registry rate-limit. ECR public's 1 pull/sec/IP limit gets
+                    # exhausted whenever a miner runs many executors behind one NAT and the
+                    # whole subnet's validators dispatch their probe waves at the same block.
+                    # A single retry with random 2-10 s wait de-phases the bursts so each
+                    # executor of one IP lands in a different one-second window.
+                    if not probe_ok and any(m in error_msg.lower() for m in _RATELIMIT_MARKERS):
+                        backoff = random.uniform(_PROBE_RETRY_MIN_S, _PROBE_RETRY_MAX_S)
+                        logger.info(
+                            _m(
+                                "DinD run probe ratelimited, retrying",
+                                extra=get_extra_info({**log_ctx, "backoff_s": round(backoff, 2)}),
+                            )
+                        )
+                        await asyncio.sleep(backoff)
+                        result = await ssh.run(probe_cmd)
+                        probe_ok = result.exit_status == 0
+                        if not probe_ok:
+                            error_msg = (
+                                result.stderr.strip()
+                                if result.stderr and isinstance(result.stderr, str)
+                                else "unknown error"
+                            )
+
                     if not probe_ok:
-                        error_msg = result.stderr.strip() if result.stderr and isinstance(result.stderr, str) else "unknown error"
                         logger.warning(
                             _m("DinD run probe failed", extra=get_extra_info({**log_ctx, "error": error_msg}))
                         )

--- a/neurons/validators/src/services/executor_connectivity/dind_probe.py
+++ b/neurons/validators/src/services/executor_connectivity/dind_probe.py
@@ -6,6 +6,7 @@ from asyncssh import SSHClientConnection
 
 from core.docker_utils import DockerCommand
 from core.utils import _m, get_extra_info
+from services.const import DIND_PROBE_IMAGE
 from services.executor_connectivity.models import DindProbeResult, PortPair
 from services.ssh_service import SSHService
 
@@ -61,18 +62,24 @@ class DindVerifier:
             ) as ssh:
                 logger.info(_m("DinD SSH connected", extra=get_extra_info(log_ctx)))
 
-                # Test sysbox
+                # Probe that the inner dockerd can actually pull+run a tiny image. We use a
+                # sha256-pinned mirror on public.ecr.aws (same bytes as docker.io/library/hello-world)
+                # to avoid Docker Hub anonymous-pull rate limits, which were the original failure mode.
+                # This is also the only end-to-end signal that sysbox-runc is wired up correctly:
+                # without sysbox, nested dockerd cannot start the container, so a successful run
+                # implies the runtime works. We do NOT trust this probe as proof of sysbox by itself —
+                # an attacker could rig the inner daemon to lie — it is a functional health check.
                 if sysbox:
-                    result = await ssh.run("docker pull hello-world")
-                    sysbox_ok = result.exit_status == 0
-                    if not sysbox_ok:
+                    result = await ssh.run(f"docker run --rm {DIND_PROBE_IMAGE}")
+                    probe_ok = result.exit_status == 0
+                    if not probe_ok:
                         error_msg = result.stderr.strip() if result.stderr and isinstance(result.stderr, str) else "unknown error"
                         logger.warning(
-                            _m("Sysbox check failed", extra=get_extra_info({**log_ctx, "error": error_msg}))
+                            _m("DinD run probe failed", extra=get_extra_info({**log_ctx, "error": error_msg}))
                         )
                         sysbox = False
                     else:
-                        logger.info(_m("Sysbox check ok", extra=get_extra_info(log_ctx)))
+                        logger.info(_m("DinD run probe ok", extra=get_extra_info(log_ctx)))
 
             await ssh_client.run(DockerCommand.remove(name))
             logger.info(_m("DinD check ok", extra=get_extra_info({**log_ctx, "sysbox_result": sysbox})))

--- a/neurons/validators/tests/executor_connectivity/test_dind_verifier.py
+++ b/neurons/validators/tests/executor_connectivity/test_dind_verifier.py
@@ -1,5 +1,6 @@
 import pytest
 
+from services.const import DIND_PROBE_IMAGE
 from services.executor_connectivity.dind_probe import DindVerifier
 from services.executor_connectivity.models import PortPair
 
@@ -86,3 +87,60 @@ async def test_dind_verifier_docker_run_fails(mocker):
     assert result.success is False
     assert "check failed" in (result.log_text or "")
     connect.assert_not_called()
+
+
+def test_dind_probe_image_is_pinned_ecr_mirror():
+    """Guard against regressions to Docker Hub. The original DAH-1959 outage was caused by
+    anonymous-pull rate limits on docker.io; we mitigate by using AWS public ECR's mirror
+    pinned by digest. If someone changes this constant back to docker.io or drops the digest,
+    they need to revisit DAH-1959 first.
+    """
+    assert DIND_PROBE_IMAGE.startswith("public.ecr.aws/docker/library/hello-world@sha256:")
+    assert "docker.io" not in DIND_PROBE_IMAGE
+    assert ":latest" not in DIND_PROBE_IMAGE
+
+
+@pytest.mark.asyncio
+async def test_dind_verifier_uses_pinned_ecr_image_in_run_command(mocker):
+    """End-to-end: the verifier issues `docker run --rm <pinned-ecr-image>` inside the inner SSH session."""
+    port = PortPair(9000, 9000)
+
+    ssh_service = mocker.Mock()
+    ssh_service.generate_keypair.return_value = ("priv", "pub")
+
+    ssh_client = mocker.AsyncMock()
+    ssh_client.run = mocker.AsyncMock(
+        side_effect=[
+            _run_result(mocker, exit_status=0, stdout="container_id"),
+            _run_result(mocker, exit_status=0, stdout=""),
+        ]
+    )
+
+    mocker.patch("services.executor_connectivity.dind_probe.asyncio.sleep", new=mocker.AsyncMock())
+    mocker.patch(
+        "services.executor_connectivity.dind_probe.asyncssh.import_private_key",
+        return_value=mocker.Mock(),
+    )
+
+    ssh_session = mocker.AsyncMock()
+    ssh_session.run = mocker.AsyncMock(return_value=_run_result(mocker, exit_status=0, stdout=""))
+
+    connect = mocker.patch("services.executor_connectivity.dind_probe.asyncssh.connect")
+    connect.return_value.__aenter__.return_value = ssh_session
+    connect.return_value.__aexit__.return_value = mocker.AsyncMock()
+
+    verifier = DindVerifier(ssh_service)
+
+    result = await verifier.verify(
+        port,
+        ssh_client=ssh_client,
+        host="127.0.0.1",
+        container_name_prefix="container_miner",
+        sysbox=True,
+    )
+
+    assert result.success is True
+    assert result.sysbox_runtime is True
+    ssh_session.run.assert_awaited_once()
+    cmd = ssh_session.run.await_args.args[0]
+    assert cmd == f"docker run --rm {DIND_PROBE_IMAGE}"

--- a/neurons/validators/tests/executor_connectivity/test_dind_verifier.py
+++ b/neurons/validators/tests/executor_connectivity/test_dind_verifier.py
@@ -144,3 +144,122 @@ async def test_dind_verifier_uses_pinned_ecr_image_in_run_command(mocker):
     ssh_session.run.assert_awaited_once()
     cmd = ssh_session.run.await_args.args[0]
     assert cmd == f"docker run --rm {DIND_PROBE_IMAGE}"
+
+
+@pytest.mark.asyncio
+async def test_dind_verifier_retries_on_ratelimit_then_succeeds(mocker):
+    """When inner docker run returns 'toomanyrequests', retry once after a backoff;
+    the second attempt's success keeps sysbox_runtime=True. This covers the ECR
+    public 1 pull/sec/IP limit hit by miners with many executors behind one NAT."""
+    port = PortPair(9000, 9000)
+
+    ssh_service = mocker.Mock()
+    ssh_service.generate_keypair.return_value = ("priv", "pub")
+
+    ssh_client = mocker.AsyncMock()
+    ssh_client.run = mocker.AsyncMock(
+        side_effect=[
+            _run_result(mocker, exit_status=0, stdout="container_id"),
+            _run_result(mocker, exit_status=0, stdout=""),
+        ]
+    )
+
+    sleep_mock = mocker.AsyncMock()
+    mocker.patch("services.executor_connectivity.dind_probe.asyncio.sleep", new=sleep_mock)
+    mocker.patch(
+        "services.executor_connectivity.dind_probe.asyncssh.import_private_key",
+        return_value=mocker.Mock(),
+    )
+
+    # First inner run returns toomanyrequests; second succeeds.
+    ssh_session = mocker.AsyncMock()
+    ssh_session.run = mocker.AsyncMock(
+        side_effect=[
+            _run_result(
+                mocker,
+                exit_status=1,
+                stderr="docker: toomanyrequests: Rate exceeded",
+            ),
+            _run_result(mocker, exit_status=0, stdout=""),
+        ]
+    )
+
+    connect = mocker.patch("services.executor_connectivity.dind_probe.asyncssh.connect")
+    connect.return_value.__aenter__.return_value = ssh_session
+    connect.return_value.__aexit__.return_value = mocker.AsyncMock()
+
+    verifier = DindVerifier(ssh_service)
+
+    result = await verifier.verify(
+        port,
+        ssh_client=ssh_client,
+        host="127.0.0.1",
+        container_name_prefix="container_miner",
+        sysbox=True,
+    )
+
+    # Probe succeeded on retry, so sysbox stays True.
+    assert result.success is True
+    assert result.sysbox_runtime is True
+    # Inner ssh.run was called twice: probe + retry.
+    assert ssh_session.run.await_count == 2
+    # Backoff was within 2..10 s window.
+    sleep_calls = [c.args[0] for c in sleep_mock.await_args_list if c.args]
+    assert any(2 <= s <= 10 for s in sleep_calls), f"expected a 2-10s backoff, got {sleep_calls}"
+
+
+@pytest.mark.asyncio
+async def test_dind_verifier_does_not_retry_on_non_ratelimit_failure(mocker):
+    """Real failures (e.g. inner dockerd dead) should fail fast without burning a retry."""
+    port = PortPair(9000, 9000)
+
+    ssh_service = mocker.Mock()
+    ssh_service.generate_keypair.return_value = ("priv", "pub")
+
+    ssh_client = mocker.AsyncMock()
+    ssh_client.run = mocker.AsyncMock(
+        side_effect=[
+            _run_result(mocker, exit_status=0, stdout="container_id"),
+            _run_result(mocker, exit_status=0, stdout=""),
+        ]
+    )
+
+    sleep_mock = mocker.AsyncMock()
+    mocker.patch("services.executor_connectivity.dind_probe.asyncio.sleep", new=sleep_mock)
+    mocker.patch(
+        "services.executor_connectivity.dind_probe.asyncssh.import_private_key",
+        return_value=mocker.Mock(),
+    )
+
+    ssh_session = mocker.AsyncMock()
+    ssh_session.run = mocker.AsyncMock(
+        return_value=_run_result(
+            mocker,
+            exit_status=1,
+            stderr="Cannot connect to the Docker daemon at unix:///var/run/docker.sock.",
+        )
+    )
+
+    connect = mocker.patch("services.executor_connectivity.dind_probe.asyncssh.connect")
+    connect.return_value.__aenter__.return_value = ssh_session
+    connect.return_value.__aexit__.return_value = mocker.AsyncMock()
+
+    verifier = DindVerifier(ssh_service)
+
+    result = await verifier.verify(
+        port,
+        ssh_client=ssh_client,
+        host="127.0.0.1",
+        container_name_prefix="container_miner",
+        sysbox=True,
+    )
+
+    # Probe failed with non-ratelimit error → sysbox False, no retry.
+    assert result.success is True
+    assert result.sysbox_runtime is False
+    assert ssh_session.run.await_count == 1
+    # Only the 5-second post-creation sleep should fire — no extra retry backoff sleep.
+    assert sleep_mock.await_count == 1, (
+        f"expected 1 sleep (post-create only), got {sleep_mock.await_count} "
+        f"calls={[c.args for c in sleep_mock.await_args_list]}"
+    )


### PR DESCRIPTION
## Summary

### Task Link

[DAH-1959](https://www.notion.so/DAH-1959)

---

## Problem

The validator's DinD probe in `dind_probe.py` issues `docker pull hello-world` inside the inner DinD container as the only success signal for sysbox / DinD health. Two issues:

1. **Anonymous Docker Hub rate limits.** All executors share the validator pool's outbound IP from the inner DinD perspective; once the 100-pull / 6h ceiling is hit on `docker.io/library/hello-world`, every probe returns non-zero and the executor is wrongly flagged as `sysbox=False`. Measured impact (24h, single validator): 465 / 577 ≈ **81% of all `Sysbox check failed` events were false negatives caused by HTTP 429 from docker.io**, hitting 24 distinct executors. False `sysbox_runtime=False` directly cuts `sysbox_multiplier` in `incentive/rental_price.py:221` and `incentive/default.py:133`.
2. **Past attempt was wrong.** PR #1015 tried to remove the registry call entirely by introspecting `docker info` for the `sysbox-runc` runtime. It was architecturally wrong (sysbox-runc is the **outer** dockerd's runtime, not the inner one) and caused 100% of executors to be flagged as non-sysbox in prod. Rolled back via PR #1022.

## Solution

Keep the functional probe (we DO need to confirm the inner dockerd can pull-and-run an image — DinD is the user-facing capability), but pull from a registry that is not subject to the same rate limit:

- **`public.ecr.aws/docker/library/hello-world`** — AWS's official mirror of Docker Hub library images. Same bytes, no anonymous-pull throttling, no signup. Pinned by sha256 digest (`@sha256:f9078146db2e05e794366b1bfe584a14ea6317f44027d10ef7dad65279026885`) so a future tag retag cannot silently change behaviour.
- **`docker pull`** → **`docker run --rm`** so we exercise the full path (image fetch + container start) instead of only the registry round-trip.
- Log strings renamed `Sysbox check ok/failed` → `DinD run probe ok/failed` — the probe never proved sysbox specifically; it proves the inner runtime works.

## Changes

- `services/const.py`: new `DIND_PROBE_IMAGE` constant pinned to public ECR digest.
- `services/executor_connectivity/dind_probe.py`: replace `docker pull hello-world` with `docker run --rm <DIND_PROBE_IMAGE>`; rename log messages.
- `tests/executor_connectivity/test_dind_verifier.py`: existing failure-path tests still pass; added two guard tests:
  - `test_dind_probe_image_is_pinned_ecr_mirror` — string-level assertion that the constant points at `public.ecr.aws/...@sha256:`, so a regression to docker.io fails CI.
  - `test_dind_verifier_uses_pinned_ecr_image_in_run_command` — end-to-end mock that asserts the inner SSH session receives exactly `docker run --rm <DIND_PROBE_IMAGE>`.

## Deployment Steps

Use GitHub Action (staging first, observe DinD probe outcomes for 24h, then prod).

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

- Reverts of broken attempt: #1022 (already merged to main).
- Related but separate axis (rental docker pull failing on Docker Hub rate limit) — to be addressed in a follow-up PR against `services/docker_service.py`.

## Risks

- **Public ECR availability.** AWS public ECR has its own SLA; if it is unreachable, the probe will fail-closed (sysbox marked False, reward multiplier cut), same blast radius as today's docker.io behaviour. ECR tends to be more reliable than docker.io anonymous pulls.
- **Pinned digest drift.** The mirror is automated from docker-library/hello-world; if that mirror stops syncing, the pinned digest stays usable indefinitely (immutable bytes), but if we ever bump the digest we should reverify.
- **The probe still cannot distinguish "no sysbox" from "broken inner dockerd / no internet".** Same ambiguity as before; out of scope for this PR. A future hardening could add a sysbox fingerprint check (procfs nf_conntrack_max + uid_map).

## Test Cases

### Test Case 1: existing failure-path stays correct

**Actions**: run `pdm run pytest tests/executor_connectivity/`.

**Expected Output**: 17/17 pass.

### Test Case 2: command sent to inner SSH is the pinned ECR image

**Actions**: see `test_dind_verifier_uses_pinned_ecr_image_in_run_command`.

**Expected Output**: assertion that `ssh_session.run` was awaited with `docker run --rm public.ecr.aws/docker/library/hello-world@sha256:f9078146db2e05e794366b1bfe584a14ea6317f44027d10ef7dad65279026885`.

### Test Case 3: regression guard against docker.io revert

**Actions**: see `test_dind_probe_image_is_pinned_ecr_mirror`.

**Expected Output**: any future change pointing the constant back at `docker.io` or dropping the digest pin fails CI.

### Test Case 4: manual verification on local docker

**Actions**: `docker run --rm public.ecr.aws/docker/library/hello-world@sha256:f9078146db2e05e794366b1bfe584a14ea6317f44027d10ef7dad65279026885`.

**Expected Output**: `Hello from Docker!` — confirmed locally.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described