### PR TITLE
Clean stale vloopback volumes safely - DAH-2044

### DIFF
--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -242,6 +242,7 @@ class ContainerCreateRequest(ContainerBaseRequest):
     available_ports: list[PayloadPortMapping] | None = None
     pod_mapping: list[PayloadPortMapping] | None = None
     active_container_names: list[str] | None = None
+    active_volume_names: list[str] | None = None
 
 
 class ExecutorRentFinishedRequest(ContainerBaseRequest):

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -639,7 +639,7 @@ class DockerService:
         skip_volume_names: list[str] | set[str] | None = None,
     ) -> None:
         skip_set = {name for name in (skip_volume_names or []) if name}
-        list_volumes_cmd = '/usr/bin/docker volume ls --filter driver=vloopback --format "{{.Name}}"'
+        list_volumes_cmd = '/usr/bin/docker volume ls --format "{{.Name}} {{.Driver}}"'
         mounted_volumes_cmd = (
             "/usr/bin/docker ps -a -q | xargs -r /usr/bin/docker inspect --format "
             "'{{range .Mounts}}{{if eq .Type \"volume\"}}{{.Name}}{{\"\\n\"}}{{end}}{{end}}'"
@@ -659,11 +659,18 @@ class DockerService:
                 )
                 return
 
-            vloopback_volumes = {
-                name.strip()
-                for name in (volume_result.stdout or "").splitlines()
-                if name.strip().startswith("volume_")
-            }
+            vloopback_volumes = set()
+            for line in (volume_result.stdout or "").splitlines():
+                parts = line.strip().split(maxsplit=1)
+                if len(parts) != 2:
+                    continue
+                name, driver = parts
+                if not (
+                    name.startswith("volume_")
+                    and (driver == "vloopback" or driver.startswith("vloopback:"))
+                ):
+                    continue
+                vloopback_volumes.add(name)
             if not vloopback_volumes:
                 return
 

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -588,6 +588,7 @@ class DockerService:
         sleep: int = 0,
         clear_volume: bool = True,
         active_container_names: list[str] | None = None,
+        active_volume_names: list[str] | None = None,
     ):
         command = f'/usr/bin/docker ps -a --format "{{{{.Names}}}}"'
         result = await ssh_client.run(command)
@@ -596,12 +597,13 @@ class DockerService:
             await asyncio.sleep(sleep)
 
             active_set = set(active_container_names) if active_container_names else set()
+            active_volume_set = set(active_volume_names) if active_volume_names else set()
             pod_containers = [
                 name for name in result.stdout.strip().split("\n")
                 if name == pod_name or name.startswith(POD_CONTAINER_PREFIX)
             ]
             stale_containers = [name for name in pod_containers if name not in active_set]
-            container_names = " ".join(stale_containers)
+            container_names = " ".join(shlex.quote(name) for name in stale_containers)
             if not container_names:
                 return
 
@@ -620,12 +622,137 @@ class DockerService:
             await retry_ssh_command(ssh_client, command, 'clean_existing_containers')
 
             if clear_volume:
-                if active_set:
-                    volumes = " ".join(f"volume_{name.removeprefix(POD_CONTAINER_PREFIX)}" for name in stale_containers)
+                volumes_to_remove = [
+                    f"volume_{name.removeprefix(POD_CONTAINER_PREFIX)}"
+                    for name in stale_containers
+                    if f"volume_{name.removeprefix(POD_CONTAINER_PREFIX)}" not in active_volume_set
+                ]
+                if volumes_to_remove:
+                    volumes = " ".join(shlex.quote(volume) for volume in volumes_to_remove)
                     command = f'/usr/bin/docker volume rm {volumes} 2>/dev/null || true'
-                else:
-                    command = '/usr/bin/docker volume prune -af'
-                await retry_ssh_command(ssh_client, command, 'clean_existing_containers')
+                    await retry_ssh_command(ssh_client, command, 'clean_existing_containers')
+
+    async def clean_stale_vloopback_volumes(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        default_extra: dict,
+        skip_volume_names: list[str] | set[str] | None = None,
+    ) -> None:
+        skip_set = {name for name in (skip_volume_names or []) if name}
+        list_volumes_cmd = '/usr/bin/docker volume ls --filter driver=vloopback --format "{{.Name}}"'
+        mounted_volumes_cmd = (
+            "/usr/bin/docker ps -a -q | xargs -r /usr/bin/docker inspect --format "
+            "'{{range .Mounts}}{{if eq .Type \"volume\"}}{{.Name}}{{\"\\n\"}}{{end}}{{end}}'"
+        )
+
+        try:
+            volume_result = await ssh_client.run(list_volumes_cmd)
+            if getattr(volume_result, "exit_status", 0) != 0:
+                logger.warning(
+                    _m(
+                        "Unable to list vloopback volumes",
+                        extra=get_extra_info({
+                            **default_extra,
+                            "stderr": getattr(volume_result, "stderr", ""),
+                        }),
+                    )
+                )
+                return
+
+            vloopback_volumes = {
+                name.strip()
+                for name in (volume_result.stdout or "").splitlines()
+                if name.strip().startswith("volume_")
+            }
+            if not vloopback_volumes:
+                return
+
+            mounted_result = await ssh_client.run(mounted_volumes_cmd)
+            if getattr(mounted_result, "exit_status", 0) != 0:
+                logger.warning(
+                    _m(
+                        "Unable to inspect mounted Docker volumes",
+                        extra=get_extra_info({
+                            **default_extra,
+                            "stderr": getattr(mounted_result, "stderr", ""),
+                        }),
+                    )
+                )
+                return
+
+            mounted_volumes = {
+                name.strip() for name in (mounted_result.stdout or "").splitlines() if name.strip()
+            }
+            stale_volumes = sorted(vloopback_volumes - mounted_volumes - skip_set)
+            if not stale_volumes:
+                return
+
+            logger.info(
+                _m(
+                    "Cleaning stale vloopback Docker volumes",
+                    extra=get_extra_info({
+                        **default_extra,
+                        "stale_volumes": stale_volumes,
+                        "skipped_volumes": sorted(skip_set),
+                    }),
+                )
+            )
+            volumes = " ".join(shlex.quote(volume) for volume in stale_volumes)
+            await retry_ssh_command(
+                ssh_client,
+                f"/usr/bin/docker volume rm {volumes} 2>/dev/null || true",
+                "clean_stale_vloopback_volumes",
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                _m(
+                    "Failed to clean stale vloopback volumes",
+                    extra=get_extra_info({**default_extra, "error": str(exc)}),
+                ),
+                exc_info=True,
+            )
+
+    async def cleanup_failed_container_creation(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        default_extra: dict,
+        container_name: str,
+        volume_name: str | None = None,
+        remove_volume: bool = False,
+    ) -> None:
+        try:
+            container = shlex.quote(container_name)
+            await retry_ssh_command(
+                ssh_client,
+                f"/usr/bin/docker rm -f {container} 2>/dev/null || true",
+                "cleanup_failed_container_creation",
+            )
+
+            if remove_volume and volume_name:
+                volume = shlex.quote(volume_name)
+                await retry_ssh_command(
+                    ssh_client,
+                    f"/usr/bin/docker volume rm {volume} 2>/dev/null || true",
+                    "cleanup_failed_container_creation",
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                _m(
+                    "Failed to clean up failed container creation artifacts",
+                    extra=get_extra_info({
+                        **default_extra,
+                        "container_name": container_name,
+                        "volume_name": volume_name,
+                        "remove_volume": remove_volume,
+                        "error": str(exc),
+                    }),
+                ),
+                exc_info=True,
+            )
 
     async def install_open_ssh_server_and_start_ssh_service(
         self,
@@ -1168,6 +1295,10 @@ class DockerService:
                 )
 
                 container_name = f"{POD_CONTAINER_PREFIX}{payload.pod_id}"
+                created_local_volume = False
+                protected_volume_names = set(payload.active_volume_names or [])
+                if local_volume:
+                    protected_volume_names.add(local_volume)
 
                 await self.clean_existing_containers(
                     ssh_client=ssh_client,
@@ -1176,7 +1307,15 @@ class DockerService:
                     sleep=10,
                     clear_volume=False if local_volume else True,
                     active_container_names=payload.active_container_names,
+                    active_volume_names=payload.active_volume_names,
                 )
+
+                if payload.active_volume_names is not None:
+                    await self.clean_stale_vloopback_volumes(
+                        ssh_client=ssh_client,
+                        default_extra=default_extra,
+                        skip_volume_names=protected_volume_names,
+                    )
 
                 # Add profiler for docker volume creation
                 profilers.append({"name": "Container cleaning step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
@@ -1193,6 +1332,7 @@ class DockerService:
                         log_extra=default_extra,
                         limit=payload.volume_limit_gb,
                     )
+                    created_local_volume = True
 
                 volume_flag = f"-v {local_volume}:{local_volume_path}"
 
@@ -1289,55 +1429,64 @@ class DockerService:
                     )
                 )
 
-                await self._run_docker_create_with_port_retry(
-                    ssh_client=ssh_client,
-                    command=command,
-                    container_name=container_name,
-                    log_tag=log_tag,
-                    default_extra=default_extra,
-                    timeout=timeout,
-                )
-
-                logger.info(f"Container creation step finished")
-
-                # check if the container is running correctly
-                if not await self.check_container_running(ssh_client, container_name):
-                    # Capture the failure reason and check whether it points to our
-                    # --device flags (DAH-1987). State.Error covers cgroup / device
-                    # failures; logs --tail covers entrypoint failures.
-                    failure_reason = ""
-                    try:
-                        inspect = await ssh_client.run(
-                            f"/usr/bin/docker inspect -f '{{{{.State.Error}}}}' {container_name}"
-                        )
-                        logs_tail = await ssh_client.run(
-                            f"/usr/bin/docker logs --tail 50 {container_name} 2>&1 || true"
-                        )
-                        failure_reason = (inspect.stdout or "") + "\n" + (logs_tail.stdout or "")
-                    except Exception:
-                        failure_reason = "(failure_reason capture failed)"
-
-                    nvidia_signal = any(
-                        marker in failure_reason.lower()
-                        for marker in ("/dev/nvidia", "device cgroup", "no such device", "operation not permitted")
+                try:
+                    await self._run_docker_create_with_port_retry(
+                        ssh_client=ssh_client,
+                        command=command,
+                        container_name=container_name,
+                        log_tag=log_tag,
+                        default_extra=default_extra,
+                        timeout=timeout,
                     )
-                    log_extra = get_extra_info({
-                        **default_extra,
-                        "container_name": container_name,
-                        "gpu_flags": gpu_flags,
-                        "failure_reason": failure_reason[:2000],
-                    })
-                    if nvidia_signal:
-                        logger.error(_m(
-                            "docker run failed with NVIDIA-device-related error — "
-                            "possible regression from build_gpu_flags --device flag set",
-                            extra=log_extra,
-                        ))
-                    else:
-                        logger.error(_m("docker run failed", extra=log_extra))
 
-                    await self.clean_existing_containers(ssh_client=ssh_client, default_extra=default_extra, pod_name=container_name, active_container_names=payload.active_container_names)
-                    raise Exception("Run docker run command but container is not running")
+                    logger.info(f"Container creation step finished")
+
+                    # check if the container is running correctly
+                    if not await self.check_container_running(ssh_client, container_name):
+                        # Capture the failure reason and check whether it points to our
+                        # --device flags (DAH-1987). State.Error covers cgroup / device
+                        # failures; logs --tail covers entrypoint failures.
+                        failure_reason = ""
+                        try:
+                            inspect = await ssh_client.run(
+                                f"/usr/bin/docker inspect -f '{{{{.State.Error}}}}' {container_name}"
+                            )
+                            logs_tail = await ssh_client.run(
+                                f"/usr/bin/docker logs --tail 50 {container_name} 2>&1 || true"
+                            )
+                            failure_reason = (inspect.stdout or "") + "\n" + (logs_tail.stdout or "")
+                        except Exception:
+                            failure_reason = "(failure_reason capture failed)"
+
+                        nvidia_signal = any(
+                            marker in failure_reason.lower()
+                            for marker in ("/dev/nvidia", "device cgroup", "no such device", "operation not permitted")
+                        )
+                        log_extra = get_extra_info({
+                            **default_extra,
+                            "container_name": container_name,
+                            "gpu_flags": gpu_flags,
+                            "failure_reason": failure_reason[:2000],
+                        })
+                        if nvidia_signal:
+                            logger.error(_m(
+                                "docker run failed with NVIDIA-device-related error — "
+                                "possible regression from build_gpu_flags --device flag set",
+                                extra=log_extra,
+                            ))
+                        else:
+                            logger.error(_m("docker run failed", extra=log_extra))
+
+                        raise Exception("Run docker run command but container is not running")
+                except Exception:
+                    await self.cleanup_failed_container_creation(
+                        ssh_client=ssh_client,
+                        default_extra=default_extra,
+                        container_name=container_name,
+                        volume_name=local_volume,
+                        remove_volume=created_local_volume,
+                    )
+                    raise
 
                 # Add profiler for docker container creation
                 profilers.append({"name": "Docker container creation step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
@@ -1361,57 +1510,67 @@ class DockerService:
                 #         ),
                 #     )
                 # else:
-                await self.install_open_ssh_server_and_start_ssh_service(
-                    ssh_client=ssh_client,
-                    container_name=container_name,
-                    log_tag=log_tag,
-                    log_extra=default_extra,
-                )
-
-                jupyter_url = None
-                if payload.enable_jupyter and jupyter_port_map:
-                    jupyter_token = secrets.token_hex(16)
-                    await self.run_jupyter(
+                try:
+                    await self.install_open_ssh_server_and_start_ssh_service(
                         ssh_client=ssh_client,
                         container_name=container_name,
-                        jupyter_token=jupyter_token,
-                        jupyter_port=jupyter_port_map[0],
                         log_tag=log_tag,
                         log_extra=default_extra,
-                        local_volume=local_volume,
-                        local_volume_path=local_volume_path,
                     )
-                    jupyter_url = f"http://{executor_info.address}:{jupyter_port_map[1]}/lab?token={jupyter_token}"
 
-                # Add profiler for ssh service installation
-                profilers.append({"name": "SSH service installation step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
-                prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
+                    jupyter_url = None
+                    if payload.enable_jupyter and jupyter_port_map:
+                        jupyter_token = secrets.token_hex(16)
+                        await self.run_jupyter(
+                            ssh_client=ssh_client,
+                            container_name=container_name,
+                            jupyter_token=jupyter_token,
+                            jupyter_port=jupyter_port_map[0],
+                            log_tag=log_tag,
+                            log_extra=default_extra,
+                            local_volume=local_volume,
+                            local_volume_path=local_volume_path,
+                        )
+                        jupyter_url = f"http://{executor_info.address}:{jupyter_port_map[1]}/lab?token={jupyter_token}"
 
-                # add rest of public keys
-                for public_key in payload.user_public_keys:
-                    command = f"/usr/bin/docker exec {container_name} sh -c 'echo \"{public_key}\" >> ~/.ssh/authorized_keys'"
-                    await ssh_client.run(command)
+                    # Add profiler for ssh service installation
+                    profilers.append({"name": "SSH service installation step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
+                    prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
 
-                # add environment variables
-                if custom_options and custom_options.environment:
-                    for k, v in custom_options.environment.items():
-                        if k and v and k.strip() and str(v).strip():
-                            env_line = f"{k}={v}"
-                            # Execute each variable addition separately for better error handling
-                            script = f'printf "%s\\n" {shlex.quote(env_line)} >> /etc/environment'
-                            command = f"/usr/bin/docker exec {container_name} sh -c {shlex.quote(script)}"
-                            try:
-                                await ssh_client.run(command)
-                            except Exception as e:
-                                print(f"Failed to set environment variable {k}: {e}")
+                    # add rest of public keys
+                    for public_key in payload.user_public_keys:
+                        command = f"/usr/bin/docker exec {container_name} sh -c 'echo \"{public_key}\" >> ~/.ssh/authorized_keys'"
+                        await ssh_client.run(command)
 
-                # Add profiler for adding public keys
-                profilers.append({"name": "Adding public keys step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
-                prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
+                    # add environment variables
+                    if custom_options and custom_options.environment:
+                        for k, v in custom_options.environment.items():
+                            if k and v and k.strip() and str(v).strip():
+                                env_line = f"{k}={v}"
+                                # Execute each variable addition separately for better error handling
+                                script = f'printf "%s\\n" {shlex.quote(env_line)} >> /etc/environment'
+                                command = f"/usr/bin/docker exec {container_name} sh -c {shlex.quote(script)}"
+                                try:
+                                    await ssh_client.run(command)
+                                except Exception as e:
+                                    print(f"Failed to set environment variable {k}: {e}")
 
-                await self.finish_stream_logs()
+                    # Add profiler for adding public keys
+                    profilers.append({"name": "Adding public keys step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
+                    prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
 
-                await self.redis_service.add_rented_pod(executor_info, payload.pod_id, container_name)
+                    await self.finish_stream_logs()
+
+                    await self.redis_service.add_rented_pod(executor_info, payload.pod_id, container_name)
+                except Exception:
+                    await self.cleanup_failed_container_creation(
+                        ssh_client=ssh_client,
+                        default_extra=default_extra,
+                        container_name=container_name,
+                        volume_name=local_volume,
+                        remove_volume=created_local_volume,
+                    )
+                    raise
 
                 # Add profiler for ssh service installation
                 profilers.append({"name": "Finished in subnet.", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1317,12 +1317,11 @@ class DockerService:
                     active_volume_names=payload.active_volume_names,
                 )
 
-                if payload.active_volume_names is not None:
-                    await self.clean_stale_vloopback_volumes(
-                        ssh_client=ssh_client,
-                        default_extra=default_extra,
-                        skip_volume_names=protected_volume_names,
-                    )
+                await self.clean_stale_vloopback_volumes(
+                    ssh_client=ssh_client,
+                    default_extra=default_extra,
+                    skip_volume_names=protected_volume_names,
+                )
 
                 # Add profiler for docker volume creation
                 profilers.append({"name": "Container cleaning step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -939,7 +939,15 @@ async def test_clean_stale_vloopback_volumes_skips_mounted_and_backend_known(
     ssh_client.run = AsyncMock(
         side_effect=[
             _make_ssh_command_result(
-                stdout="volume_orphan\nvolume_mounted\nvolume_backend_known\nhc_probe\ncustom_loopback\n"
+                stdout=(
+                    "volume_orphan vloopback:latest\n"
+                    "volume_mounted vloopback\n"
+                    "volume_backend_known vloopback:latest\n"
+                    "hc_probe vloopback:latest\n"
+                    "custom_loopback vloopback:latest\n"
+                    "volume_local local\n"
+                    "volume_other other:latest\n"
+                )
             ),
             _make_ssh_command_result(stdout="volume_mounted\n"),
         ]
@@ -960,6 +968,34 @@ async def test_clean_stale_vloopback_volumes_skips_mounted_and_backend_known(
     assert "volume_backend_known" not in volume_command
     assert "hc_probe" not in volume_command
     assert "custom_loopback" not in volume_command
+    assert "volume_local" not in volume_command
+    assert "volume_other" not in volume_command
+
+
+@pytest.mark.asyncio
+async def test_clean_stale_vloopback_volumes_accepts_tagged_driver(
+    docker_service,
+    retry_ssh_mock,
+):
+    """Docker reports plugin drivers with tags, for example vloopback:latest."""
+    # Arrange
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(
+        side_effect=[
+            _make_ssh_command_result(stdout="volume_tagged vloopback:latest\n"),
+            _make_ssh_command_result(stdout=""),
+        ]
+    )
+
+    # Act
+    await docker_service.clean_stale_vloopback_volumes(
+        ssh_client=ssh_client,
+        default_extra={},
+    )
+
+    # Assert
+    assert retry_ssh_mock.call_count == 1
+    assert "volume_tagged" in retry_ssh_mock.call_args_list[0][0][1]
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -877,8 +877,8 @@ async def test_clean_containers_targeted_volume_rm(docker_service, retry_ssh_moc
 
 
 @pytest.mark.asyncio
-async def test_clean_containers_empty_active_list_falls_back_to_prune(docker_service, retry_ssh_mock):
-    """When active_container_names is empty list, volume prune -af is used (old behavior)."""
+async def test_clean_containers_empty_active_list_uses_targeted_volume_rm(docker_service, retry_ssh_mock):
+    """Container cleanup never runs global docker volume prune."""
     # Arrange
     ssh_client = AsyncMock()
     ssh_client.run = AsyncMock(return_value=_make_ssh_run_result(
@@ -894,10 +894,72 @@ async def test_clean_containers_empty_active_list_falls_back_to_prune(docker_ser
         active_container_names=[],
     )
 
-    # Assert — falls back to prune, not targeted volume rm
+    # Assert — targeted volume rm, not global prune
     assert retry_ssh_mock.call_count == 2
     volume_command = retry_ssh_mock.call_args_list[1][0][1]
-    assert "volume prune -af" in volume_command
+    assert "volume_target" in volume_command
+    assert "volume_stale" in volume_command
+    assert "volume prune" not in volume_command
+
+
+@pytest.mark.asyncio
+async def test_clean_containers_respects_active_volume_names(docker_service, retry_ssh_mock):
+    """Backend-known pod volumes are skipped even if the pod container is removed."""
+    # Arrange
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_run_result(
+        "pod_target\npod_rebooting\n"
+    ))
+
+    # Act
+    await docker_service.clean_existing_containers(
+        ssh_client=ssh_client,
+        default_extra={},
+        pod_name="pod_target",
+        clear_volume=True,
+        active_container_names=[],
+        active_volume_names=["volume_rebooting"],
+    )
+
+    # Assert
+    volume_command = retry_ssh_mock.call_args_list[1][0][1]
+    assert "volume_target" in volume_command
+    assert "volume_rebooting" not in volume_command
+    assert "volume prune" not in volume_command
+
+
+@pytest.mark.asyncio
+async def test_clean_stale_vloopback_volumes_skips_mounted_and_backend_known(
+    docker_service,
+    retry_ssh_mock,
+):
+    """Only unmounted vloopback volumes absent from backend's skip list are removed."""
+    # Arrange
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(
+        side_effect=[
+            _make_ssh_command_result(
+                stdout="volume_orphan\nvolume_mounted\nvolume_backend_known\nhc_probe\ncustom_loopback\n"
+            ),
+            _make_ssh_command_result(stdout="volume_mounted\n"),
+        ]
+    )
+
+    # Act
+    await docker_service.clean_stale_vloopback_volumes(
+        ssh_client=ssh_client,
+        default_extra={},
+        skip_volume_names={"volume_backend_known"},
+    )
+
+    # Assert
+    assert retry_ssh_mock.call_count == 1
+    volume_command = retry_ssh_mock.call_args_list[0][0][1]
+    assert "volume_orphan" in volume_command
+    assert "volume_mounted" not in volume_command
+    assert "volume_backend_known" not in volume_command
+    assert "hc_probe" not in volume_command
+    assert "custom_loopback" not in volume_command
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -7,9 +7,12 @@ import pytest
 import pytest_asyncio
 
 from services.docker_service import DockerService
-from payload_models.payloads import PayloadPortMapping
+from payload_models.payloads import (
+    ContainerCreateRequest,
+    ContainerStartRequest,
+    PayloadPortMapping,
+)
 from datura.requests.miner_requests import ExecutorSSHInfo
-from payload_models.payloads import ContainerStartRequest
 
 
 def create_mock_port_dict(
@@ -996,6 +999,90 @@ async def test_clean_stale_vloopback_volumes_accepts_tagged_driver(
     # Assert
     assert retry_ssh_mock.call_count == 1
     assert "volume_tagged" in retry_ssh_mock.call_args_list[0][0][1]
+
+
+@pytest.mark.asyncio
+async def test_create_container_cleans_stale_vloopback_when_active_volumes_missing(
+    docker_service,
+    monkeypatch,
+):
+    """Connector requests may omit active_volume_names; cleanup should still run."""
+    # Arrange
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr("services.docker_service.build_gpu_flags", AsyncMock(return_value=""))
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.add_pending_pod = AsyncMock()
+    docker_service.redis_service.remove_pending_pod = AsyncMock()
+    docker_service.redis_service.add_rented_pod = AsyncMock()
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        docker_service,
+        "generate_portMappings",
+        AsyncMock(return_value=([(22, 20001, 20001)], None)),
+    )
+    monkeypatch.setattr(docker_service, "execute_and_stream_logs", AsyncMock())
+    monkeypatch.setattr(docker_service, "clean_existing_containers", AsyncMock())
+    monkeypatch.setattr(docker_service, "clean_stale_vloopback_volumes", AsyncMock())
+    monkeypatch.setattr(docker_service, "create_local_volume", AsyncMock())
+    monkeypatch.setattr(
+        docker_service,
+        "wait_for_port_check_containers",
+        AsyncMock(return_value=(True, "ok")),
+    )
+    monkeypatch.setattr(docker_service, "_run_docker_create_with_port_retry", AsyncMock())
+    monkeypatch.setattr(docker_service, "check_container_running", AsyncMock(return_value=True))
+    monkeypatch.setattr(docker_service, "install_open_ssh_server_and_start_ssh_service", AsyncMock())
+    monkeypatch.setattr(docker_service, "stream_log", AsyncMock())
+    monkeypatch.setattr(docker_service, "finish_stream_logs", AsyncMock())
+    monkeypatch.setattr(docker_service, "handle_stream_logs", AsyncMock())
+
+    payload = ContainerCreateRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        docker_image="daturaai/pytorch:test",
+        user_public_keys=["ssh-ed25519 test-key"],
+        gpu_uuids=["GPU-test"],
+        cpu_count=1,
+        memory_gb=1,
+        volume_limit_gb=2,
+        storage_limit_gb=1,
+        available_ports=[PayloadPortMapping(internal_port=20001, external_port=20001)],
+        pod_mapping=[],
+        active_container_names=[],
+        active_volume_names=None,
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+    )
+    keypair = Mock(ss58_address="validator-hotkey")
+
+    # Act
+    await docker_service.create_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=keypair,
+        private_key="encrypted",
+    )
+
+    # Assert
+    docker_service.clean_stale_vloopback_volumes.assert_awaited_once()
+    assert docker_service.clean_stale_vloopback_volumes.await_args.kwargs[
+        "skip_volume_names"
+    ] == set()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Describe your changes

- Add `active_volume_names` to the validator container-create payload.
- Clean stale pod-owned `vloopback` volumes before rental container creation when backend volume context is available.
- Keep cleanup scoped to `volume_*` pod volumes and skip mounted volumes, backend-known sibling volumes, health-check `hc_*` volumes, and unrelated loopback volumes.
- Clean partial rental container artifacts when container creation/setup fails.
- Update Docker service tests for targeted volume cleanup, stale vloopback cleanup, and skip-list behavior.
- Related backend PR: https://github.com/Datura-ai/lium-io-backend/pull/598

## Issue ticket number and link

[DAH-2044](https://www.notion.so/DAH-2044)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?
