### PR TITLE
DAH-1959: use bundled hello-world from daturaai/dind:0.0.1 for sysbox probe

### DIFF
--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -291,7 +291,7 @@ SECONDS_PER_BLOCK = 12  # seconds per block
 FIXED_RATIO = 0.41  # fixed constant for rental emission calculation
 
 IS_NOT_DEPOSITED_SCORE_MULTIPLIER = 0.5
-DOCKER_DIND_IMAGE = "daturaai/dind:0.0.0"
+DOCKER_DIND_IMAGE = "daturaai/dind:0.0.1"
 
 LIB_NVIDIA_ML_DIGESTS = {
     "535.54.03": "49e63c42aa95bba6b9aa562ee57e496c:15a37892671187547b6dd21a07e8149315e529211dc30ca6ee8d8d089a338d53",

--- a/neurons/validators/src/services/executor_connectivity/dind_probe.py
+++ b/neurons/validators/src/services/executor_connectivity/dind_probe.py
@@ -63,7 +63,12 @@ class DindVerifier:
 
                 # Test sysbox
                 if sysbox:
-                    result = await ssh.run("docker pull hello-world")
+                    # daturaai/dind:0.0.1 bundles the hello-world image into the inner dockerd
+                    # at container start (DAH-1959), so `docker run` resolves it locally with no
+                    # registry round-trip. If the bundled load failed for any reason the local
+                    # image is absent and docker falls back to a Docker Hub pull, matching the
+                    # previous behaviour.
+                    result = await ssh.run("docker run --rm hello-world")
                     sysbox_ok = result.exit_status == 0
                     if not sysbox_ok:
                         error_msg = result.stderr.strip() if result.stderr and isinstance(result.stderr, str) else "unknown error"


### PR DESCRIPTION
## Summary
- Bump validator's DinD base image from `daturaai/dind:0.0.0` to `daturaai/dind:0.0.1`, which bundles the official `hello-world` image into the inner dockerd at start (DAH-1959 fix).
- Replace `docker pull hello-world` with `docker run --rm hello-world` in the sysbox probe so it consumes the bundled local image with no Docker Hub round-trip — eliminates per-IP rate-limit false-`sysbox=False` flagging on miners with several executors behind one NAT.

## Why a draft
Depends on `daturaai/dind:0.0.1` being published to Docker Hub first. Source PR: [computenet-docker-images#11](https://github.com/Datura-ai/computenet-docker-images/pull/11). Once that image is live, this PR is ready to merge — Daisy or whoever runs `docker buildx bake --push` from `templates/docker-dind/` flips the dependency.

## Why this approach
Two earlier attempts on `main` were reverted (commits `ec947b34`, `3aa39086`, `d791615d`):
- ECR mirror — public.ecr.aws has its own 1 pull/sec/IP anonymous limit; parallel probe waves still saturated it.
- Treating ratelimit responses as `sysbox=ok` — too lenient, masked real failures.

Bundling the image into the dind base eliminates the registry round-trip entirely. The bundled load is best-effort (script in image runs in background, exits cleanly on any failure), so if for any reason the load fails, `docker run` falls back to a Docker Hub pull — same behaviour as today, no regression risk.

## Changes
- `neurons/validators/src/services/const.py` — `DOCKER_DIND_IMAGE = "daturaai/dind:0.0.1"`.
- `neurons/validators/src/services/executor_connectivity/dind_probe.py` — `docker pull hello-world` → `docker run --rm hello-world` with explanatory comment about the bundled-image fallback.

## Test plan
- [x] Existing `tests/executor_connectivity/test_dind_verifier.py` passes (2/2).
- [ ] Staging deploy after merge: tail validator logs for `DinD run probe ok` / no `toomanyrequests` markers across full sync cycle.
- [ ] Confirm at least one executor has `sysbox_runtime=True` post-deploy where it was flapping pre-deploy.