### PR TITLE
DAH-2055, do not classify SSH transport errors as POD_NOT_RUNNING

### DIFF
--- a/neurons/validators/src/services/task/checks/rented_machine.py
+++ b/neurons/validators/src/services/task/checks/rented_machine.py
@@ -1,17 +1,18 @@
 import json
 import shlex
-from typing import Iterable
-from dataclasses import replace
+from collections.abc import Iterable
+
+import asyncssh
+from core.docker_utils import DockerCommand
 from protocol.vc_protocol.validator_requests import ResetVerifiedJobReason
 
-from core.docker_utils import DockerCommand
-from ..messages import TenantEnforcementMessages as Msg, render_message
-from ..pipeline import CheckResult, Context
 from ...const import (
     GPU_MEMORY_UTILIZATION_LIMIT,
     GPU_UTILIZATION_LIMIT,
-    MIN_PORT_COUNT,
 )
+from ..messages import TenantEnforcementMessages as Msg
+from ..messages import render_message
+from ..pipeline import CheckResult, Context
 
 
 def _has_gpu_process_outside_container(rented_pods: list[str], processes: Iterable[dict]) -> bool:
@@ -130,7 +131,30 @@ class TenantEnforcementCheck:
         for pod in rented_pods:
             pod_container_name = pod.container_name
             pod_id = pod.pod_id
-            pod_running, ssh_pub_keys = await _check_pod_running(ctx.ssh, pod_container_name)
+            try:
+                pod_running, ssh_pub_keys = await _check_pod_running(ctx.ssh, pod_container_name)
+            except (asyncssh.Error, OSError) as exc:
+                # SSH transport died mid-cycle. Pod state is unknown; do NOT set
+                # clear_verified_job_*: that path triggers immediate executor flip
+                # in compute-app and would punish honest miners for a network blip.
+                # Persistent unreachability is handled by the stale-executor sweep.
+                event = render_message(
+                    Msg.EXECUTOR_TRANSPORT_UNREACHABLE,
+                    ctx=ctx,
+                    check_id=self.check_id,
+                    what={
+                        "pod_id": pod_id,
+                        "container_name": pod_container_name,
+                        "executor_uuid": ctx.executor.uuid,
+                        "transport_error": repr(exc),
+                    },
+                    extra=extra,
+                )
+                return CheckResult(
+                    passed=False,
+                    event=event,
+                    updates={"default_extra": extra},
+                )
             if not pod_running:
                 diagnostics = await _collect_pod_diagnostics(ctx.ssh, pod_container_name)
                 event = render_message(
@@ -220,9 +244,14 @@ class TenantEnforcementCheck:
 
 
 async def _check_pod_running(ssh_client, container_name: str) -> tuple[bool, list[str]]:
+    # asyncssh.Error / OSError mean the SSH session itself is dead -> caller must
+    # treat this as "pod state unknown", not "pod down". Other exceptions are
+    # genuine docker / business failures and keep the legacy fall-through.
     try:
         ps_result = await ssh_client.run(DockerCommand.ps_running(container_name))
         pod_running = bool(ps_result.stdout.strip())
+    except (asyncssh.Error, OSError):
+        raise
     except Exception:
         pod_running = False
 
@@ -231,6 +260,8 @@ async def _check_pod_running(ssh_client, container_name: str) -> tuple[bool, lis
             DockerCommand.exec_command(container_name, 'cat ~/.ssh/authorized_keys')
         )
         ssh_keys = keys_result.stdout.strip().split("\n") if keys_result.stdout else []
+    except (asyncssh.Error, OSError):
+        raise
     except Exception:
         ssh_keys = []
 

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -23,7 +23,7 @@ class MessageTemplate:
 def render_message(
     template: MessageTemplate,
     *,
-    ctx: "Context",
+    ctx: Context,
     check_id: str,
     what: dict[str, Any] | None = None,
     severity: str | None = None,
@@ -367,6 +367,17 @@ class TenantEnforcementMessages:
         category="runtime",
         impact="Score set to 0; verification cleared",
         remediation="Start container and ensure it stays healthy.",
+    )
+    EXECUTOR_TRANSPORT_UNREACHABLE = MessageTemplate(
+        event="Executor unreachable over SSH",
+        reason="EXECUTOR_TRANSPORT_UNREACHABLE",
+        severity="warning",
+        category="transport",
+        impact="No verdict for this cycle - pod state unknown",
+        remediation=(
+            "Transient SSH transport failure (network blip, conntrack flush). "
+            "Persistent unreachability is handled by the stale-executor sweep."
+        ),
     )
     GPU_OUTSIDE_TENANT = MessageTemplate(
         event="Tenant container does not own GPU",

--- a/neurons/validators/tests/test_rented_machine_check.py
+++ b/neurons/validators/tests/test_rented_machine_check.py
@@ -1,18 +1,17 @@
 import json
-
-import pytest
 from unittest.mock import Mock
 
+import asyncssh
+import pytest
+from helpers import build_context_config, build_services, build_state
 from neurons.validators.src.services.task.checks.rented_machine import (
     TenantEnforcementCheck,
     _collect_host_context,
     _collect_pod_diagnostics,
 )
 from neurons.validators.src.services.task.messages import TenantEnforcementMessages as Msg
+from protocol.vc_protocol.compute_requests import RentedExecutor, RentedExecutorsResponse, RentedPod
 from protocol.vc_protocol.validator_requests import ResetVerifiedJobReason
-from protocol.vc_protocol.compute_requests import RentedExecutorsResponse, RentedExecutor, RentedPod
-
-from helpers import build_context_config, build_services, build_state
 
 
 class MockContainerCleanup:
@@ -98,21 +97,33 @@ def build_rented_data(
 class DummySSHClient:
     """Mock SSH client for pod health and SSH keys checks."""
 
-    def __init__(self, *, pod_running: bool = True, ssh_keys: list[str] | None = None, should_raise: bool = False):
+    def __init__(
+        self,
+        *,
+        pod_running: bool = True,
+        ssh_keys: list[str] | None = None,
+        should_raise: bool = False,
+        raise_on_run: BaseException | None = None,
+    ):
         """
         Args:
             pod_running: Whether the container is running
             ssh_keys: SSH keys to return from authorized_keys
-            should_raise: Whether to raise an exception
+            should_raise: Whether to raise a generic RuntimeError
+            raise_on_run: Specific exception to raise on every .run() call
         """
         self.pod_running = pod_running
         self.ssh_keys = ssh_keys or []
         self.should_raise = should_raise
+        self.raise_on_run = raise_on_run
         self.commands_called: list[str] = []
 
     async def run(self, command: str):
         """Mock SSH run command."""
         self.commands_called.append(command)
+
+        if self.raise_on_run is not None:
+            raise self.raise_on_run
 
         if self.should_raise:
             raise RuntimeError("SSH command failed")
@@ -513,3 +524,95 @@ async def test_collect_host_context_never_raises_on_ssh_failure():
 
     assert "host_boot_error" in host_context
     assert "ssh failed" in host_context["host_boot_error"]
+
+
+@pytest.mark.parametrize(
+    "transport_exc",
+    [
+        pytest.param(asyncssh.ConnectionLost("conntrack flush"), id="connection_lost"),
+        pytest.param(asyncssh.DisconnectError(11, "network", "en"), id="disconnect_error"),
+        pytest.param(OSError("socket closed"), id="os_error"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_tenant_enforcement_emits_transport_unreachable_on_ssh_failure(
+    transport_exc, context_factory
+):
+    """DAH-2055: SSH transport failure mid-cycle must NOT trigger immediate
+    executor flip. Validator emits EXECUTOR_TRANSPORT_UNREACHABLE without any
+    clear_verified_job_* in updates so compute-app's reset_verified_job is bypassed."""
+    executor_uuid = "executor-123"
+    rented_machine = {
+        "containers": [{"name": "tenant-123", "pod_id": "pod-1"}],
+        "owner_flag": False,
+    }
+    rented_data = build_rented_data(executor_uuid, rented_machine)
+
+    ssh_client = DummySSHClient(raise_on_run=transport_exc)
+    services = build_services(
+        score_calculator=DummyScoreCalculator(actual_score=1.0, job_score=1.0, warning=""),
+        container_cleanup=MockContainerCleanup(),
+    )
+    state = build_state(
+        gpu_processes=[],
+        gpu_details=[],
+        gpu_model="NVIDIA RTX 4090",
+        rented_data=rented_data,
+    )
+    ctx = context_factory(
+        services=services,
+        config=build_context_config(),
+        state=state,
+        ssh=ssh_client,
+        collateral_deposited=True,
+        is_rental_succeed=True,
+        contract_version="v1.0.0",
+    )
+
+    result = await TenantEnforcementCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.EXECUTOR_TRANSPORT_UNREACHABLE.reason
+    assert "clear_verified_job_info" not in result.updates
+    assert "clear_verified_job_reason" not in result.updates
+
+
+@pytest.mark.asyncio
+async def test_tenant_enforcement_keeps_pod_not_running_for_non_transport_errors(context_factory):
+    """Regression guard: a non-transport exception (e.g. RuntimeError from a
+    misbehaving docker daemon) must keep its legacy POD_NOT_RUNNING classification
+    and continue to set clear_verified_job_reason."""
+    executor_uuid = "executor-123"
+    rented_machine = {
+        "containers": [{"name": "tenant-123", "pod_id": "pod-1"}],
+        "owner_flag": False,
+    }
+    rented_data = build_rented_data(executor_uuid, rented_machine)
+
+    ssh_client = DummySSHClient(should_raise=True)  # raises RuntimeError
+    services = build_services(
+        score_calculator=DummyScoreCalculator(actual_score=1.0, job_score=1.0, warning=""),
+        container_cleanup=MockContainerCleanup(),
+    )
+    state = build_state(
+        gpu_processes=[],
+        gpu_details=[],
+        gpu_model="NVIDIA RTX 4090",
+        rented_data=rented_data,
+    )
+    ctx = context_factory(
+        services=services,
+        config=build_context_config(),
+        state=state,
+        ssh=ssh_client,
+        collateral_deposited=True,
+        is_rental_succeed=True,
+        contract_version="v1.0.0",
+    )
+
+    result = await TenantEnforcementCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.POD_NOT_RUNNING.reason
+    assert result.updates.get("clear_verified_job_info") is True
+    assert result.updates.get("clear_verified_job_reason") == ResetVerifiedJobReason.POD_NOT_RUNNING.value


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2055](https://www.notion.so/Don-t-classify-SSH-transport-errors-as-POD_NOT_RUNNING-358b8bfdbde98167af6fe6fc98c0fca2)

---

## Problem

When the validator's SSH session to an executor dies mid-pipeline (network blip, transit flap, conntrack flush), `_check_pod_running` was misclassifying the failure as `POD_NOT_RUNNING`. Compute-app received `POD_NOT_RUNNING`, immediately called `reset_verified_job`, flipped the executor to `active=false`, and fired `EXECUTOR_INACTIVE_MID_RENTAL` penalty after a single failed cycle — bypassing both the existing 1-hour stale-executor sweep and the `ssh_connection_consecutive_failures` Redis counter.

Reference incident 2026-05-05 15:13:20–15:14:19 UTC: a ~60 s outbound network event from validator pod `subnet/validator-8785f8c95-hs5wj` dropped 15 already-established SSH sessions. 14 honest miners were penalized for $2,366.41 total, manually reverted via `admin-penalty revert`.

The bug sat in three lines of `_check_pod_running`: a broad `except Exception` that swallowed `asyncssh.ConnectionLost`, `asyncssh.DisconnectError`, `asyncssh.ChannelOpenError`, and `OSError` and returned `pod_running=False`, conflating "executor unreachable, state unknown" with "executor responded, container is dead".

## Solution

Distinguish transport-level failures from genuine docker / business failures and emit a new `EXECUTOR_TRANSPORT_UNREACHABLE` event that is observable in Grafana / Loki but does **not** carry `clear_verified_job_*` keys — so compute-app's `reset_verified_job` is bypassed entirely. Persistent unreachability remains covered by the existing 1-hour stale-executor sweep.

Caught exception class is `asyncssh.Error` (the base class — covers `ConnectionLost`, `DisconnectError`, `ChannelOpenError`, `ProtocolError`, `asyncssh.TimeoutError`) plus `OSError` as a low-level safety net. Non-transport exceptions still produce `pod_running=False` and trigger `POD_NOT_RUNNING` as before.

## Changes

- `messages.py` — new `TenantEnforcementMessages.EXECUTOR_TRANSPORT_UNREACHABLE` template (`severity=warning`, `category=transport`).
- `rented_machine.py::_check_pod_running` — broad `except Exception` split into `except (asyncssh.Error, OSError): raise` (re-raised to caller) and `except Exception: pod_running=False` (legacy fall-through).
- `rented_machine.py::TenantEnforcementCheck.run` — wraps `_check_pod_running` in `try/except (asyncssh.Error, OSError)`, emits `EXECUTOR_TRANSPORT_UNREACHABLE` with `passed=False` and `updates={"default_extra": extra}` (no `clear_verified_job_*`).
- `tests/test_rented_machine_check.py` — extended `DummySSHClient` with `raise_on_run` parameter; added 3 parametrized tests (ConnectionLost / DisconnectError / OSError) and 1 regression test confirming non-transport `RuntimeError` still triggers `POD_NOT_RUNNING`.

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review

## Other PRs

None — fix is fully contained in `lium-io`. The defensive allowlist assertion in `compute-app/src/services/executor.py::reset_verified_job` mentioned in the original spec was deliberately scoped out: the validator simply stops sending `clear_verified_job_*` keys on transport errors, which closes the bug without a cross-repo change. Hardening `reset_verified_job` itself can be a separate ticket.

## Risks

- **Severity downgrade**: the new event is `severity=warning, category=transport`, while `POD_NOT_RUNNING` is `severity=error, category=runtime`. Any Grafana/Loki alert that pages on `severity=error` will no longer fire on transient SSH blips — this is intentional. Alerts that filter by `category` are unaffected.
- **Broader catch than the spec**: we catch `asyncssh.Error` (base class) instead of the three explicitly named subclasses. This also covers `ProtocolError` and `asyncssh.TimeoutError` — semantically these are also "session unusable" cases, so classifying them as `EXECUTOR_TRANSPORT_UNREACHABLE` is correct.
- **Auth keys probe**: in `_check_pod_running`, if `ps_running` succeeds but the second SSH call (`cat ~/.ssh/authorized_keys`) hits transport failure, we now propagate instead of silently returning empty keys. Result: that cycle emits `EXECUTOR_TRANSPORT_UNREACHABLE` rather than continuing with stale data — conservative and safe.
- **No effect on pipeline halt semantics**: `TenantEnforcementCheck.fatal=True`, so `passed=False` still stops the pipeline as before; no stale-state propagation downstream.
- **Compute-app side intentionally untouched**: validator no longer publishes `clear_verified_job_info=True` on transport errors → `result_handler._persist_verification_data` skips the `RESET_VERIFIED_JOB` channel → compute-app never receives the immediate-flip signal. Verified by reading `result_handler.py:170`.

## Test Cases

### Test Case 1 — SSH transport error must NOT trigger immediate flip

**Actions**
Run `pdm run pytest tests/test_rented_machine_check.py::test_tenant_enforcement_emits_transport_unreachable_on_ssh_failure -v`. Parametrized over `asyncssh.ConnectionLost`, `asyncssh.DisconnectError`, `OSError`.

**Expected Output**
All three pass. `result.event.reason_code == "EXECUTOR_TRANSPORT_UNREACHABLE"`. `clear_verified_job_info` and `clear_verified_job_reason` keys absent from `result.updates`.

### Test Case 2 — non-transport exception still classified as POD_NOT_RUNNING

**Actions**
Run `pdm run pytest tests/test_rented_machine_check.py::test_tenant_enforcement_keeps_pod_not_running_for_non_transport_errors -v` (DummySSHClient raises `RuntimeError`).

**Expected Output**
`result.event.reason_code == "POD_NOT_RUNNING"`, `result.updates["clear_verified_job_info"] is True`, `result.updates["clear_verified_job_reason"] == ResetVerifiedJobReason.POD_NOT_RUNNING.value`.

### Test Case 3 — full validator suite

**Actions**
Run `pdm run pytest` from `neurons/validators/`.

**Expected Output**
461 passed, 4 skipped (the 9 errors in `test_port_mapping_dao.py` are pre-existing — missing `greenlet` in local env, present on `main` baseline as well; not introduced by this PR).

### Test Case 4 — staging verification (deferred)

**Actions** (deferred, will run post-deploy)
Rent a pod on a staging executor, then block validator → executor SSH at iptables level for ~60 s mid-cycle: `iptables -A OUTPUT -p tcp --dport 2200 -j DROP`. Unblock after 60 s.

**Expected Output**
Validator logs `EXECUTOR_TRANSPORT_UNREACHABLE` (not `POD_NOT_RUNNING`); `executor.active` stays `true` in `staging-backend` DB; no `penalty_events` row written; no `EXECUTOR_INACTIVE_MID_RENTAL` log in compute-app workers for that executor; next cycle passes normally.

## Checklist

- [x] Tests added (3 transport-failure parametrized + 1 regression)
- [x] PR description is clear and complete
- [x] Risks are documented