### PR TITLE
Reduce large vloopback volume failures - DAH-2082

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -73,6 +73,10 @@ DOCKER_VOLUME_PLUGINS = {
 _PORT_ALLOCATED_PHRASES = ("port is already allocated", "address already in use", "failed to bind host port")
 _PORT_ALLOCATED_RETRY_BUDGET_SEC = 90
 _PORT_ALLOCATED_RETRY_SLEEP_SEC = 5
+_LOCAL_VOLUME_TIMEOUT_THRESHOLD_GB = 100
+_LOCAL_VOLUME_TIMEOUT_BASE_SEC = 30
+_LOCAL_VOLUME_TIMEOUT_GB_PER_SEC = 10
+_LOCAL_VOLUME_TIMEOUT_MAX_SEC = 180
 
 
 class DockerService:
@@ -350,7 +354,8 @@ class DockerService:
                 log_text,
                 extra=get_extra_info({
                     **log_extra,
-                    "command": command
+                    "command": command,
+                    "timeout_seconds": timeout,
                 }),
             ),
         )
@@ -369,6 +374,17 @@ class DockerService:
             status = False
             error = "Process timed out"
             await self.stream_log(error, "error", log_tag)
+            logger.warning(
+                _m(
+                    "Docker command timed out",
+                    extra=get_extra_info({
+                        **log_extra,
+                        "command": command,
+                        "timeout_seconds": timeout,
+                        "log_text": log_text,
+                    }),
+                )
+            )
 
         if not status and raise_exception:
             raise Exception(f"Failed {log_text}. command: {command} error: {error}")
@@ -1022,13 +1038,26 @@ class DockerService:
             "Connection refused", "Port already in use", "Failed to start"
         ]):
             raise Exception(error)
-    
+
     async def get_docker_root_dir(self, ssh_client: asyncssh.SSHClientConnection):
         """Get Docker storage info using docker info command"""
         command = f"/usr/bin/docker info --format '{{{{.DockerRootDir}}}}'"
         result = await ssh_client.run(command)
         return result.stdout.strip()
-    
+
+    @staticmethod
+    def _get_local_volume_create_timeout(limit: int | None, requested_timeout: int) -> int:
+        if requested_timeout == 0:
+            return requested_timeout
+        if not limit or limit <= _LOCAL_VOLUME_TIMEOUT_THRESHOLD_GB:
+            return requested_timeout
+
+        scaled_timeout = _LOCAL_VOLUME_TIMEOUT_BASE_SEC + (
+            (limit + _LOCAL_VOLUME_TIMEOUT_GB_PER_SEC - 1)
+            // _LOCAL_VOLUME_TIMEOUT_GB_PER_SEC
+        )
+        return max(requested_timeout, min(scaled_timeout, _LOCAL_VOLUME_TIMEOUT_MAX_SEC))
+
     async def create_local_volume(
         self,
         ssh_client: asyncssh.SSHClientConnection,
@@ -1039,26 +1068,44 @@ class DockerService:
         limit: int | None = None,
         timeout: int = 10,
     ):
+        requested_timeout = timeout
         if limit:
             # install loopback plugin
             loopback_plugin_name = "vloopback"
 
             docker_root_dir = await self.get_docker_root_dir(ssh_client)
             logger.info(_m(f"Docker data root: {docker_root_dir}", extra=get_extra_info(log_extra)))
-            
+
             command = f'/usr/bin/docker plugin install ashald/docker-volume-loopback --alias {loopback_plugin_name} --grant-all-permissions DATA_DIR="{docker_root_dir}/loopback"'
             await ssh_client.run(command)
-            
+
             command = f'/usr/bin/docker volume create -d {loopback_plugin_name} {local_volume} -o size={limit}g'
         else:
+            loopback_plugin_name = None
             command = f"/usr/bin/docker volume create {local_volume}"
 
+        timeout = self._get_local_volume_create_timeout(limit, timeout)
+        volume_log_extra = {
+            **log_extra,
+            "local_volume": local_volume,
+            "volume_limit_gb": limit,
+            "requested_timeout_seconds": requested_timeout,
+            "effective_timeout_seconds": timeout,
+            "timeout_scaled": timeout != requested_timeout,
+            "loopback_plugin": loopback_plugin_name,
+        }
+        logger.info(
+            _m(
+                "Preparing local Docker volume creation",
+                extra=get_extra_info(volume_log_extra),
+            )
+        )
         await self.execute_and_stream_logs(
             ssh_client=ssh_client,
             command=command,
             log_tag=log_tag,
             log_text=log_text,
-            log_extra=log_extra,
+            log_extra=volume_log_extra,
             timeout=timeout,
         )
 

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -1099,8 +1099,8 @@ async def test_create_container_cleans_stale_vloopback_when_active_volumes_missi
         gpu_uuids=["GPU-test"],
         cpu_count=1,
         memory_gb=1,
-        volume_limit_gb=1024,
-        storage_limit_gb=3985,
+        volume_limit_gb=2,
+        storage_limit_gb=1,
         available_ports=[PayloadPortMapping(internal_port=20001, external_port=20001)],
         pod_mapping=[],
         active_container_names=[],
@@ -1130,12 +1130,6 @@ async def test_create_container_cleans_stale_vloopback_when_active_volumes_missi
     assert docker_service.clean_stale_vloopback_volumes.await_args.kwargs[
         "skip_volume_names"
     ] == set()
-    # DAH-2082: backend overflow goes into Docker overlay quota, not the mounted path.
-    docker_service.create_local_volume.assert_awaited_once()
-    assert docker_service.create_local_volume.await_args.kwargs["limit"] == 1024
-    docker_run_command = docker_service._run_docker_create_with_port_retry.await_args.kwargs["command"]
-    assert f"-v volume_{payload.pod_id}:/root" in docker_run_command
-    assert "--storage-opt size=3985g" in docker_run_command
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -1099,8 +1099,8 @@ async def test_create_container_cleans_stale_vloopback_when_active_volumes_missi
         gpu_uuids=["GPU-test"],
         cpu_count=1,
         memory_gb=1,
-        volume_limit_gb=2,
-        storage_limit_gb=1,
+        volume_limit_gb=1024,
+        storage_limit_gb=3985,
         available_ports=[PayloadPortMapping(internal_port=20001, external_port=20001)],
         pod_mapping=[],
         active_container_names=[],
@@ -1130,6 +1130,12 @@ async def test_create_container_cleans_stale_vloopback_when_active_volumes_missi
     assert docker_service.clean_stale_vloopback_volumes.await_args.kwargs[
         "skip_volume_names"
     ] == set()
+    # DAH-2082: backend overflow goes into Docker overlay quota, not the mounted path.
+    docker_service.create_local_volume.assert_awaited_once()
+    assert docker_service.create_local_volume.await_args.kwargs["limit"] == 1024
+    docker_run_command = docker_service._run_docker_create_with_port_retry.await_args.kwargs["command"]
+    assert f"-v volume_{payload.pod_id}:/root" in docker_run_command
+    assert "--storage-opt size=3985g" in docker_run_command
 
 
 @pytest.mark.asyncio
@@ -1209,6 +1215,53 @@ def test_build_docker_login_command_quotes_username_too():
 
     # Assert — the entire username appears as one token after --username.
     assert tokens[6] == malicious_username
+
+
+def test_local_volume_timeout_stays_default_for_small_or_unlimited_volumes():
+    assert DockerService._get_local_volume_create_timeout(None, 10) == 10
+    assert DockerService._get_local_volume_create_timeout(100, 10) == 10
+
+
+def test_local_volume_timeout_scales_for_large_limited_volumes():
+    assert DockerService._get_local_volume_create_timeout(1024, 10) == 133
+    assert DockerService._get_local_volume_create_timeout(5064, 10) == 180
+
+
+def test_local_volume_timeout_preserves_larger_explicit_timeout():
+    assert DockerService._get_local_volume_create_timeout(1024, 160) == 160
+    assert DockerService._get_local_volume_create_timeout(1024, 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_create_local_volume_uses_scaled_timeout_for_large_limited_volume(
+    docker_service,
+    monkeypatch,
+):
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=Mock(stdout="/var/lib/docker\n"))
+    execute = AsyncMock()
+    monkeypatch.setattr(docker_service, "execute_and_stream_logs", execute)
+
+    await docker_service.create_local_volume(
+        ssh_client=ssh_client,
+        local_volume="volume_test",
+        log_tag="tag",
+        log_text="Creating docker volume volume_test",
+        log_extra={},
+        limit=1024,
+        timeout=10,
+    )
+
+    execute.assert_awaited_once()
+    assert execute.await_args.kwargs["timeout"] == 133
+    assert execute.await_args.kwargs["log_extra"] == {
+        "local_volume": "volume_test",
+        "volume_limit_gb": 1024,
+        "requested_timeout_seconds": 10,
+        "effective_timeout_seconds": 133,
+        "timeout_scaled": True,
+        "loopback_plugin": "vloopback",
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Describe your changes

- Scale validator local vloopback volume creation timeout for large requested limits.
- Add structured subnet logs for local volume name, requested limit, effective timeout, command, and timeout failures.
- Cover the capped-volume/overlay-quota command shape and timeout scaling in validator tests.
- Backend companion PR: https://github.com/Datura-ai/lium-io-backend/pull/608

## Issue ticket number and link

[DAH-2082](https://www.notion.so/DAH-2082)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?