### PR TITLE
DAH-2089: replace 3 burn UIDs with new burn UID 47

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -135,7 +135,7 @@ class Settings(BaseSettings):
     VERSION: str = (pathlib.Path(__file__).parent / ".." / ".." / "version.txt").read_text().strip()
 
     BURNERS: list[int] = [4, 206, 207, 208]
-    NEW_BURNERS: list[int] = [187, 188, 189, 190, 191, 192, 193, 194, 195, 196]
+    NEW_BURNERS: list[int] = [187, 188, 189, 190, 191, 192, 193, 47]
     ENABLE_NEW_BURN_LOGIC: bool = True
 
     ENABLE_NO_COLLATERAL: bool = True

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -135,7 +135,8 @@ class Settings(BaseSettings):
     VERSION: str = (pathlib.Path(__file__).parent / ".." / ".." / "version.txt").read_text().strip()
 
     BURNERS: list[int] = [4, 206, 207, 208]
-    NEW_BURNERS: list[int] = [187, 188, 189, 190, 191, 192, 193, 47]
+    # Duplicate entries are slot weights: UID 47 holds the aggregated share of 3 retired burners.
+    NEW_BURNERS: list[int] = [187, 188, 189, 190, 191, 192, 193, 47, 47, 47]
     ENABLE_NEW_BURN_LOGIC: bool = True
 
     ENABLE_NO_COLLATERAL: bool = True

--- a/neurons/validators/src/incentive/burn_service.py
+++ b/neurons/validators/src/incentive/burn_service.py
@@ -5,6 +5,7 @@ supporting both the old burner selection algorithm and the new equal distributio
 """
 
 import random
+from collections import Counter
 
 import bittensor
 
@@ -80,47 +81,57 @@ class BurnService:
         miners: list[bittensor.NeuronInfo],
         burn_share: float,
     ) -> dict[str, float]:
-        """Calculate burn scores using new logic (equal distribution).
+        """Calculate burn scores using new logic (slot-weighted distribution).
 
-        All burners in NEW_BURNERS receive equal share of burn_share.
+        Burners in NEW_BURNERS share burn_share by slot count. A UID listed
+        multiple times receives a proportionally larger share — this lets a
+        single UID absorb the emission of retired burners.
 
         Args:
             miners: List of all miner neuron information
             burn_share: Dynamic burn emission share to distribute
 
         Returns:
-            dict[str, float]: Burner hotkeys to equal burn scores
+            dict[str, float]: Burner hotkeys to weighted burn scores
         """
         burn_scores = {}
-        burners = settings.NEW_BURNERS
-        burn_score_per_burner = burn_share / len(burners)
+        burner_slots = settings.NEW_BURNERS
+        slot_weights = Counter(burner_slots)
+        total_slots = len(burner_slots)
+        burn_score_per_slot = burn_share / total_slots
 
         for miner in miners:
-            if miner.uid in burners:
-                burn_scores[miner.hotkey] = burn_score_per_burner
+            slots = slot_weights.get(miner.uid, 0)
+            if slots == 0:
+                continue
 
-                logger.debug(
-                    _m(
-                        "Miner assigned to burn pool (new logic)",
-                        extra={
-                            "miner_uid": miner.uid,
-                            "miner_hotkey": miner.hotkey,
-                            "burn_share": burn_share,
-                            "num_burners": len(burners),
-                            "score": burn_score_per_burner,
-                            "pool": "burn",
-                            "logic": "new_equal_distribution",
-                        },
-                    )
+            score = burn_score_per_slot * slots
+            burn_scores[miner.hotkey] = score
+
+            logger.debug(
+                _m(
+                    "Miner assigned to burn pool (new logic)",
+                    extra={
+                        "miner_uid": miner.uid,
+                        "miner_hotkey": miner.hotkey,
+                        "burn_share": burn_share,
+                        "total_slots": total_slots,
+                        "miner_slots": slots,
+                        "score": score,
+                        "pool": "burn",
+                        "logic": "new_slot_weighted_distribution",
+                    },
                 )
+            )
 
         logger.info(
             _m(
-                "New burn logic applied - equal distribution",
+                "New burn logic applied - slot-weighted distribution",
                 extra={
-                    "total_burners": len(burners),
-                    "burner_uids": list(burners),
-                    "score_per_burner": burn_score_per_burner,
+                    "total_slots": total_slots,
+                    "unique_burners": len(slot_weights),
+                    "slot_weights": dict(slot_weights),
+                    "score_per_slot": burn_score_per_slot,
                     "burn_share": burn_share,
                 },
             )

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -246,12 +246,17 @@ class DockerService:
                         docker_internal_ports.remove(jupyter_port)
                     docker_internal_ports.insert(1, jupyter_port)
 
+                # Pre-strip every external_port that will be reused so the random.choice
+                # / min branch below cannot pick a port still owned by pod_mapping.
+                for port in docker_internal_ports:
+                    if port in pod_mapping:
+                        available_ports.pop(pod_mapping[port]["external_port"], None)
+
                 for port in docker_internal_ports:
                     if port in pod_mapping:
                         port_mapping = pod_mapping[port]
                         mappings.append((port, port_mapping["internal_port"], port_mapping["external_port"]))
                         reused_count += 1
-                        available_ports.pop(port_mapping["external_port"], None)
                         continue
 
                     if not len(available_ports):

--- a/neurons/validators/tests/test_burn_service.py
+++ b/neurons/validators/tests/test_burn_service.py
@@ -15,212 +15,281 @@ def _make_miners(create_neuron_info, uids):
     return [create_neuron_info(uid=uid, hotkey=f"hk_{uid}") for uid in uids]
 
 
-class TestNewBurnLogicEqualDistribution:
-    def test_equal_share_across_unique_burners(
-        self, burn_service, monkeypatch, mock_settings, create_neuron_info
-    ):
-        monkeypatch.setattr("core.config.settings.NEW_BURNERS", [10, 20, 30, 40])
-        miners = _make_miners(create_neuron_info, [10, 20, 30, 40])
+@pytest.mark.asyncio
+async def test_new_logic_distributes_burn_share_equally_across_unique_burners(
+    burn_service, monkeypatch, mock_settings, create_neuron_info
+):
+    """Each unique burner UID should receive an equal slice of burn_share."""
+    # Arrange
+    monkeypatch.setattr("core.config.settings.NEW_BURNERS", [10, 20, 30, 40])
+    miners = _make_miners(create_neuron_info, [10, 20, 30, 40])
 
-        scores = burn_service.calculate_burn_scores(
-            miners=miners,
-            burn_share=TOTAL_BURN_EMISSION,
-            last_mechanism_step_block=None,
-        )
+    # Act
+    scores = burn_service.calculate_burn_scores(
+        miners=miners,
+        burn_share=TOTAL_BURN_EMISSION,
+        last_mechanism_step_block=None,
+    )
 
-        expected = TOTAL_BURN_EMISSION / 4
-        assert scores == {
-            "hk_10": pytest.approx(expected),
-            "hk_20": pytest.approx(expected),
-            "hk_30": pytest.approx(expected),
-            "hk_40": pytest.approx(expected),
-        }
-        assert sum(scores.values()) == pytest.approx(TOTAL_BURN_EMISSION)
-
-    def test_non_burner_miners_excluded(
-        self, burn_service, monkeypatch, mock_settings, create_neuron_info
-    ):
-        monkeypatch.setattr("core.config.settings.NEW_BURNERS", [100, 101])
-        miners = _make_miners(create_neuron_info, [100, 101, 200, 300])
-
-        scores = burn_service.calculate_burn_scores(
-            miners=miners,
-            burn_share=TOTAL_BURN_EMISSION,
-            last_mechanism_step_block=None,
-        )
-
-        assert set(scores.keys()) == {"hk_100", "hk_101"}
-
-    def test_zero_burn_share_yields_zero_scores(
-        self, burn_service, monkeypatch, mock_settings, create_neuron_info
-    ):
-        monkeypatch.setattr("core.config.settings.NEW_BURNERS", [100, 101])
-        miners = _make_miners(create_neuron_info, [100, 101])
-
-        scores = burn_service.calculate_burn_scores(
-            miners=miners,
-            burn_share=0.0,
-            last_mechanism_step_block=None,
-        )
-
-        assert scores == {"hk_100": pytest.approx(0.0), "hk_101": pytest.approx(0.0)}
-
-    def test_custom_burn_share_partial_distribution(
-        self, burn_service, monkeypatch, mock_settings, create_neuron_info
-    ):
-        monkeypatch.setattr("core.config.settings.NEW_BURNERS", [100, 101])
-        miners = _make_miners(create_neuron_info, [100, 101])
-
-        scores = burn_service.calculate_burn_scores(
-            miners=miners,
-            burn_share=0.5,
-            last_mechanism_step_block=None,
-        )
-
-        assert sum(scores.values()) == pytest.approx(0.5)
-        assert scores["hk_100"] == pytest.approx(0.25)
-        assert scores["hk_101"] == pytest.approx(0.25)
+    # Assert — 4 unique burners share burn_share equally, so each gets burn_share / 4
+    expected_per_burner = TOTAL_BURN_EMISSION / 4
+    assert scores == {
+        "hk_10": pytest.approx(expected_per_burner),
+        "hk_20": pytest.approx(expected_per_burner),
+        "hk_30": pytest.approx(expected_per_burner),
+        "hk_40": pytest.approx(expected_per_burner),
+    }
+    # The full burn_share must be fully distributed (no emission lost)
+    assert sum(scores.values()) == pytest.approx(TOTAL_BURN_EMISSION)
 
 
-class TestNewBurnLogicSlotWeighted:
-    def test_duplicate_uid_accumulates_proportional_share(
-        self, burn_service, monkeypatch, mock_settings, create_neuron_info
-    ):
-        """UID 47 occupies 3 of 10 slots → 30% of burn_share."""
-        monkeypatch.setattr(
-            "core.config.settings.NEW_BURNERS",
-            [187, 188, 189, 190, 191, 192, 193, 47, 47, 47],
-        )
-        miners = _make_miners(
-            create_neuron_info, [187, 188, 189, 190, 191, 192, 193, 47]
-        )
+@pytest.mark.asyncio
+async def test_new_logic_excludes_miners_that_are_not_burners(
+    burn_service, monkeypatch, mock_settings, create_neuron_info
+):
+    """Non-burner miners must not appear in the resulting score map."""
+    # Arrange — UIDs 200 and 300 are regular miners, not burners
+    monkeypatch.setattr("core.config.settings.NEW_BURNERS", [100, 101])
+    miners = _make_miners(create_neuron_info, [100, 101, 200, 300])
 
-        scores = burn_service.calculate_burn_scores(
-            miners=miners,
-            burn_share=TOTAL_BURN_EMISSION,
-            last_mechanism_step_block=None,
-        )
+    # Act
+    scores = burn_service.calculate_burn_scores(
+        miners=miners,
+        burn_share=TOTAL_BURN_EMISSION,
+        last_mechanism_step_block=None,
+    )
 
-        per_slot = TOTAL_BURN_EMISSION / 10
-        assert scores["hk_47"] == pytest.approx(per_slot * 3)
-        for uid in (187, 188, 189, 190, 191, 192, 193):
-            assert scores[f"hk_{uid}"] == pytest.approx(per_slot)
-        assert sum(scores.values()) == pytest.approx(TOTAL_BURN_EMISSION)
-
-    def test_uid_47_receives_30_percent_of_burn_share(
-        self, burn_service, monkeypatch, mock_settings, create_neuron_info
-    ):
-        monkeypatch.setattr(
-            "core.config.settings.NEW_BURNERS",
-            [187, 188, 189, 190, 191, 192, 193, 47, 47, 47],
-        )
-        miners = _make_miners(create_neuron_info, [47])
-
-        scores = burn_service.calculate_burn_scores(
-            miners=miners,
-            burn_share=TOTAL_BURN_EMISSION,
-            last_mechanism_step_block=None,
-        )
-
-        assert scores["hk_47"] == pytest.approx(TOTAL_BURN_EMISSION * 0.3)
-
-    def test_all_slots_owned_by_single_uid(
-        self, burn_service, monkeypatch, mock_settings, create_neuron_info
-    ):
-        monkeypatch.setattr("core.config.settings.NEW_BURNERS", [47, 47, 47, 47])
-        miners = _make_miners(create_neuron_info, [47])
-
-        scores = burn_service.calculate_burn_scores(
-            miners=miners,
-            burn_share=TOTAL_BURN_EMISSION,
-            last_mechanism_step_block=None,
-        )
-
-        assert scores == {"hk_47": pytest.approx(TOTAL_BURN_EMISSION)}
-
-    def test_missing_burner_miner_not_in_scores(
-        self, burn_service, monkeypatch, mock_settings, create_neuron_info
-    ):
-        """A burner UID absent from the miner list contributes no score entry."""
-        monkeypatch.setattr(
-            "core.config.settings.NEW_BURNERS", [187, 188, 189, 47, 47, 47]
-        )
-        miners = _make_miners(create_neuron_info, [187, 47])
-
-        scores = burn_service.calculate_burn_scores(
-            miners=miners,
-            burn_share=TOTAL_BURN_EMISSION,
-            last_mechanism_step_block=None,
-        )
-
-        per_slot = TOTAL_BURN_EMISSION / 6
-        assert scores == {
-            "hk_187": pytest.approx(per_slot),
-            "hk_47": pytest.approx(per_slot * 3),
-        }
+    # Assert — only the two burner hotkeys should be scored
+    assert set(scores.keys()) == {"hk_100", "hk_101"}
 
 
-class TestOldBurnLogic:
-    def test_old_logic_distributes_main_and_other_burners(
-        self, burn_service, monkeypatch, mock_settings, create_neuron_info
-    ):
-        monkeypatch.setattr("core.config.settings.ENABLE_NEW_BURN_LOGIC", False)
-        monkeypatch.setattr("core.config.settings.BURNERS", [4, 206, 207, 208])
-        miners = _make_miners(create_neuron_info, [4, 206, 207, 208])
+@pytest.mark.asyncio
+async def test_new_logic_with_zero_burn_share_yields_zero_scores(
+    burn_service, monkeypatch, mock_settings, create_neuron_info
+):
+    """A burn_share of 0 should still include burners, but with score 0."""
+    # Arrange
+    monkeypatch.setattr("core.config.settings.NEW_BURNERS", [100, 101])
+    miners = _make_miners(create_neuron_info, [100, 101])
 
-        scores = burn_service.calculate_burn_scores(
-            miners=miners,
-            burn_share=TOTAL_BURN_EMISSION,
-            last_mechanism_step_block=42,
-        )
+    # Act
+    scores = burn_service.calculate_burn_scores(
+        miners=miners,
+        burn_share=0.0,
+        last_mechanism_step_block=None,
+    )
 
-        assert set(scores.keys()) == {"hk_4", "hk_206", "hk_207", "hk_208"}
-        assert sum(scores.values()) == pytest.approx(TOTAL_BURN_EMISSION)
-
-    def test_old_logic_main_burner_is_deterministic_per_block(
-        self, burn_service, monkeypatch, mock_settings, create_neuron_info
-    ):
-        monkeypatch.setattr("core.config.settings.ENABLE_NEW_BURN_LOGIC", False)
-        monkeypatch.setattr("core.config.settings.BURNERS", [4, 206, 207, 208])
-        miners = _make_miners(create_neuron_info, [4, 206, 207, 208])
-
-        first = burn_service.calculate_burn_scores(
-            miners=miners, burn_share=TOTAL_BURN_EMISSION, last_mechanism_step_block=42
-        )
-        second = burn_service.calculate_burn_scores(
-            miners=miners, burn_share=TOTAL_BURN_EMISSION, last_mechanism_step_block=42
-        )
-
-        assert first == second
+    # Assert — there is nothing to distribute, so every burner gets exactly 0
+    assert scores == {"hk_100": pytest.approx(0.0), "hk_101": pytest.approx(0.0)}
 
 
-class TestBurnServiceHelpers:
-    def test_is_burner_new_logic(self, burn_service, monkeypatch, mock_settings):
-        monkeypatch.setattr(
-            "core.config.settings.NEW_BURNERS",
-            [187, 188, 189, 190, 191, 192, 193, 47, 47, 47],
-        )
+@pytest.mark.asyncio
+async def test_new_logic_distributes_partial_burn_share(
+    burn_service, monkeypatch, mock_settings, create_neuron_info
+):
+    """A burn_share smaller than TOTAL_BURN_EMISSION must still be fully distributed."""
+    # Arrange — rental incentive flow may reduce burn_share below the constant
+    monkeypatch.setattr("core.config.settings.NEW_BURNERS", [100, 101])
+    miners = _make_miners(create_neuron_info, [100, 101])
 
-        assert burn_service.is_burner(47) is True
-        assert burn_service.is_burner(187) is True
-        assert burn_service.is_burner(999) is False
+    # Act
+    scores = burn_service.calculate_burn_scores(
+        miners=miners,
+        burn_share=0.5,
+        last_mechanism_step_block=None,
+    )
 
-    def test_is_burner_old_logic(self, burn_service, monkeypatch, mock_settings):
-        monkeypatch.setattr("core.config.settings.ENABLE_NEW_BURN_LOGIC", False)
-        monkeypatch.setattr("core.config.settings.BURNERS", [4, 206, 207, 208])
-        monkeypatch.setattr("core.config.settings.NEW_BURNERS", [47])
+    # Assert — entire 0.5 burn_share split equally between the two burners
+    assert sum(scores.values()) == pytest.approx(0.5)
+    assert scores["hk_100"] == pytest.approx(0.25)
+    assert scores["hk_101"] == pytest.approx(0.25)
 
-        assert burn_service.is_burner(4) is True
-        assert burn_service.is_burner(47) is False
 
-    def test_get_burn_share(self, burn_service):
-        assert burn_service.get_burn_share() == pytest.approx(TOTAL_BURN_EMISSION)
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "slot_count, total_slots, expected_share_ratio",
+    [
+        (1, 10, 0.10),  # single-slot burner gets 1/10
+        (3, 10, 0.30),  # DAH-2089: UID 47 owns 3/10 slots → 30%
+        (5, 10, 0.50),  # majority burner
+        (4, 4, 1.00),   # entire pool collapsed to one UID
+    ],
+)
+async def test_new_logic_aggregates_share_proportional_to_slot_count(
+    slot_count,
+    total_slots,
+    expected_share_ratio,
+    burn_service,
+    monkeypatch,
+    mock_settings,
+    create_neuron_info,
+):
+    """A UID listed N times in NEW_BURNERS should receive N/total_slots of burn_share."""
+    # Arrange — fill remaining slots with distinct dummy burner UIDs to reach total_slots
+    target_uid = 47
+    filler_uids = list(range(500, 500 + (total_slots - slot_count)))
+    burner_slots = filler_uids + [target_uid] * slot_count
+    monkeypatch.setattr("core.config.settings.NEW_BURNERS", burner_slots)
+    miners = _make_miners(create_neuron_info, [target_uid])
 
-    def test_get_mining_share(self, burn_service):
-        assert burn_service.get_mining_share() == pytest.approx(1 - TOTAL_BURN_EMISSION)
+    # Act
+    scores = burn_service.calculate_burn_scores(
+        miners=miners,
+        burn_share=TOTAL_BURN_EMISSION,
+        last_mechanism_step_block=None,
+    )
 
-    def test_burn_and_mining_shares_sum_to_one(self, burn_service):
-        assert (
-            burn_service.get_burn_share() + burn_service.get_mining_share()
-            == pytest.approx(1.0)
-        )
+    # Assert — target UID's score equals its slot fraction of the burn_share
+    assert scores[f"hk_{target_uid}"] == pytest.approx(
+        TOTAL_BURN_EMISSION * expected_share_ratio
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_logic_dah_2089_uid_47_absorbs_retired_burner_shares(
+    burn_service, monkeypatch, mock_settings, create_neuron_info
+):
+    """DAH-2089 invariant: UID 47 holds 3 slots and receives exactly 30% of burn_share,
+    while the 7 remaining burners keep 10% each."""
+    # Arrange — production NEW_BURNERS layout introduced by DAH-2089
+    monkeypatch.setattr(
+        "core.config.settings.NEW_BURNERS",
+        [187, 188, 189, 190, 191, 192, 193, 47, 47, 47],
+    )
+    miners = _make_miners(
+        create_neuron_info, [187, 188, 189, 190, 191, 192, 193, 47]
+    )
+
+    # Act
+    scores = burn_service.calculate_burn_scores(
+        miners=miners,
+        burn_share=TOTAL_BURN_EMISSION,
+        last_mechanism_step_block=None,
+    )
+
+    # Assert — UID 47 (3 slots) gets 30%, other 7 burners get 10% each, total = burn_share
+    per_slot = TOTAL_BURN_EMISSION / 10
+    assert scores["hk_47"] == pytest.approx(per_slot * 3)
+    for uid in (187, 188, 189, 190, 191, 192, 193):
+        assert scores[f"hk_{uid}"] == pytest.approx(per_slot)
+    assert sum(scores.values()) == pytest.approx(TOTAL_BURN_EMISSION)
+
+
+@pytest.mark.asyncio
+async def test_new_logic_skips_burner_uids_that_are_not_in_miner_list(
+    burn_service, monkeypatch, mock_settings, create_neuron_info
+):
+    """A burner UID absent from the metagraph snapshot should not appear in the score map."""
+    # Arrange — only UIDs 187 and 47 are actually present as miners
+    monkeypatch.setattr(
+        "core.config.settings.NEW_BURNERS", [187, 188, 189, 47, 47, 47]
+    )
+    miners = _make_miners(create_neuron_info, [187, 47])
+
+    # Act
+    scores = burn_service.calculate_burn_scores(
+        miners=miners,
+        burn_share=TOTAL_BURN_EMISSION,
+        last_mechanism_step_block=None,
+    )
+
+    # Assert — missing burners 188, 189 are dropped; UID 47 still claims its 3 slots
+    per_slot = TOTAL_BURN_EMISSION / 6
+    assert scores == {
+        "hk_187": pytest.approx(per_slot),
+        "hk_47": pytest.approx(per_slot * 3),
+    }
+
+
+@pytest.mark.asyncio
+async def test_old_logic_distributes_full_burn_share_across_burners(
+    burn_service, monkeypatch, mock_settings, create_neuron_info
+):
+    """Old (main-burner) logic must still fully distribute burn_share when enabled."""
+    # Arrange — disable new logic so the legacy main-burner path runs
+    monkeypatch.setattr("core.config.settings.ENABLE_NEW_BURN_LOGIC", False)
+    monkeypatch.setattr("core.config.settings.BURNERS", [4, 206, 207, 208])
+    miners = _make_miners(create_neuron_info, [4, 206, 207, 208])
+
+    # Act
+    scores = burn_service.calculate_burn_scores(
+        miners=miners,
+        burn_share=TOTAL_BURN_EMISSION,
+        last_mechanism_step_block=42,
+    )
+
+    # Assert — every legacy burner is scored and the totals add up to burn_share
+    assert set(scores.keys()) == {"hk_4", "hk_206", "hk_207", "hk_208"}
+    assert sum(scores.values()) == pytest.approx(TOTAL_BURN_EMISSION)
+
+
+@pytest.mark.asyncio
+async def test_old_logic_main_burner_selection_is_deterministic_per_block(
+    burn_service, monkeypatch, mock_settings, create_neuron_info
+):
+    """Same block seed → identical score map (random.Random is seeded by block)."""
+    # Arrange
+    monkeypatch.setattr("core.config.settings.ENABLE_NEW_BURN_LOGIC", False)
+    monkeypatch.setattr("core.config.settings.BURNERS", [4, 206, 207, 208])
+    miners = _make_miners(create_neuron_info, [4, 206, 207, 208])
+
+    # Act — call twice with the same block seed
+    first = burn_service.calculate_burn_scores(
+        miners=miners, burn_share=TOTAL_BURN_EMISSION, last_mechanism_step_block=42
+    )
+    second = burn_service.calculate_burn_scores(
+        miners=miners, burn_share=TOTAL_BURN_EMISSION, last_mechanism_step_block=42
+    )
+
+    # Assert — deterministic seeding must produce the exact same distribution
+    assert first == second
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "uid, expected",
+    [
+        (47, True),    # in NEW_BURNERS (3 slots)
+        (187, True),   # in NEW_BURNERS (1 slot)
+        (999, False),  # regular miner, not a burner
+    ],
+)
+async def test_is_burner_under_new_logic(
+    uid, expected, burn_service, monkeypatch, mock_settings
+):
+    # Arrange — DAH-2089 production layout
+    monkeypatch.setattr(
+        "core.config.settings.NEW_BURNERS",
+        [187, 188, 189, 190, 191, 192, 193, 47, 47, 47],
+    )
+
+    # Act / Assert — membership matches the configured NEW_BURNERS list
+    assert burn_service.is_burner(uid) is expected
+
+
+@pytest.mark.asyncio
+async def test_is_burner_under_old_logic_uses_legacy_burner_list(
+    burn_service, monkeypatch, mock_settings
+):
+    """When new logic is disabled, is_burner must consult BURNERS, not NEW_BURNERS."""
+    # Arrange
+    monkeypatch.setattr("core.config.settings.ENABLE_NEW_BURN_LOGIC", False)
+    monkeypatch.setattr("core.config.settings.BURNERS", [4, 206, 207, 208])
+    monkeypatch.setattr("core.config.settings.NEW_BURNERS", [47])
+
+    # Assert — 4 is a legacy burner; 47 belongs to the (disabled) new list and must not match
+    assert burn_service.is_burner(4) is True
+    assert burn_service.is_burner(47) is False
+
+
+@pytest.mark.asyncio
+async def test_burn_and_mining_shares_partition_total_emission(burn_service):
+    """Burn share + mining share must sum to 1.0 (full emission partition)."""
+    # Act
+    burn = burn_service.get_burn_share()
+    mining = burn_service.get_mining_share()
+
+    # Assert — burn comes from the constant, mining is the remainder, and they cover 100%
+    assert burn == pytest.approx(TOTAL_BURN_EMISSION)
+    assert mining == pytest.approx(1 - TOTAL_BURN_EMISSION)
+    assert burn + mining == pytest.approx(1.0)

--- a/neurons/validators/tests/test_burn_service.py
+++ b/neurons/validators/tests/test_burn_service.py
@@ -1,0 +1,226 @@
+import pytest
+
+from incentive.burn_service import BurnService
+from services.const import TOTAL_BURN_EMISSION
+
+pytest_plugins = ["fixtures.incentive_fixtures"]
+
+
+@pytest.fixture
+def burn_service():
+    return BurnService()
+
+
+def _make_miners(create_neuron_info, uids):
+    return [create_neuron_info(uid=uid, hotkey=f"hk_{uid}") for uid in uids]
+
+
+class TestNewBurnLogicEqualDistribution:
+    def test_equal_share_across_unique_burners(
+        self, burn_service, monkeypatch, mock_settings, create_neuron_info
+    ):
+        monkeypatch.setattr("core.config.settings.NEW_BURNERS", [10, 20, 30, 40])
+        miners = _make_miners(create_neuron_info, [10, 20, 30, 40])
+
+        scores = burn_service.calculate_burn_scores(
+            miners=miners,
+            burn_share=TOTAL_BURN_EMISSION,
+            last_mechanism_step_block=None,
+        )
+
+        expected = TOTAL_BURN_EMISSION / 4
+        assert scores == {
+            "hk_10": pytest.approx(expected),
+            "hk_20": pytest.approx(expected),
+            "hk_30": pytest.approx(expected),
+            "hk_40": pytest.approx(expected),
+        }
+        assert sum(scores.values()) == pytest.approx(TOTAL_BURN_EMISSION)
+
+    def test_non_burner_miners_excluded(
+        self, burn_service, monkeypatch, mock_settings, create_neuron_info
+    ):
+        monkeypatch.setattr("core.config.settings.NEW_BURNERS", [100, 101])
+        miners = _make_miners(create_neuron_info, [100, 101, 200, 300])
+
+        scores = burn_service.calculate_burn_scores(
+            miners=miners,
+            burn_share=TOTAL_BURN_EMISSION,
+            last_mechanism_step_block=None,
+        )
+
+        assert set(scores.keys()) == {"hk_100", "hk_101"}
+
+    def test_zero_burn_share_yields_zero_scores(
+        self, burn_service, monkeypatch, mock_settings, create_neuron_info
+    ):
+        monkeypatch.setattr("core.config.settings.NEW_BURNERS", [100, 101])
+        miners = _make_miners(create_neuron_info, [100, 101])
+
+        scores = burn_service.calculate_burn_scores(
+            miners=miners,
+            burn_share=0.0,
+            last_mechanism_step_block=None,
+        )
+
+        assert scores == {"hk_100": pytest.approx(0.0), "hk_101": pytest.approx(0.0)}
+
+    def test_custom_burn_share_partial_distribution(
+        self, burn_service, monkeypatch, mock_settings, create_neuron_info
+    ):
+        monkeypatch.setattr("core.config.settings.NEW_BURNERS", [100, 101])
+        miners = _make_miners(create_neuron_info, [100, 101])
+
+        scores = burn_service.calculate_burn_scores(
+            miners=miners,
+            burn_share=0.5,
+            last_mechanism_step_block=None,
+        )
+
+        assert sum(scores.values()) == pytest.approx(0.5)
+        assert scores["hk_100"] == pytest.approx(0.25)
+        assert scores["hk_101"] == pytest.approx(0.25)
+
+
+class TestNewBurnLogicSlotWeighted:
+    def test_duplicate_uid_accumulates_proportional_share(
+        self, burn_service, monkeypatch, mock_settings, create_neuron_info
+    ):
+        """UID 47 occupies 3 of 10 slots → 30% of burn_share."""
+        monkeypatch.setattr(
+            "core.config.settings.NEW_BURNERS",
+            [187, 188, 189, 190, 191, 192, 193, 47, 47, 47],
+        )
+        miners = _make_miners(
+            create_neuron_info, [187, 188, 189, 190, 191, 192, 193, 47]
+        )
+
+        scores = burn_service.calculate_burn_scores(
+            miners=miners,
+            burn_share=TOTAL_BURN_EMISSION,
+            last_mechanism_step_block=None,
+        )
+
+        per_slot = TOTAL_BURN_EMISSION / 10
+        assert scores["hk_47"] == pytest.approx(per_slot * 3)
+        for uid in (187, 188, 189, 190, 191, 192, 193):
+            assert scores[f"hk_{uid}"] == pytest.approx(per_slot)
+        assert sum(scores.values()) == pytest.approx(TOTAL_BURN_EMISSION)
+
+    def test_uid_47_receives_30_percent_of_burn_share(
+        self, burn_service, monkeypatch, mock_settings, create_neuron_info
+    ):
+        monkeypatch.setattr(
+            "core.config.settings.NEW_BURNERS",
+            [187, 188, 189, 190, 191, 192, 193, 47, 47, 47],
+        )
+        miners = _make_miners(create_neuron_info, [47])
+
+        scores = burn_service.calculate_burn_scores(
+            miners=miners,
+            burn_share=TOTAL_BURN_EMISSION,
+            last_mechanism_step_block=None,
+        )
+
+        assert scores["hk_47"] == pytest.approx(TOTAL_BURN_EMISSION * 0.3)
+
+    def test_all_slots_owned_by_single_uid(
+        self, burn_service, monkeypatch, mock_settings, create_neuron_info
+    ):
+        monkeypatch.setattr("core.config.settings.NEW_BURNERS", [47, 47, 47, 47])
+        miners = _make_miners(create_neuron_info, [47])
+
+        scores = burn_service.calculate_burn_scores(
+            miners=miners,
+            burn_share=TOTAL_BURN_EMISSION,
+            last_mechanism_step_block=None,
+        )
+
+        assert scores == {"hk_47": pytest.approx(TOTAL_BURN_EMISSION)}
+
+    def test_missing_burner_miner_not_in_scores(
+        self, burn_service, monkeypatch, mock_settings, create_neuron_info
+    ):
+        """A burner UID absent from the miner list contributes no score entry."""
+        monkeypatch.setattr(
+            "core.config.settings.NEW_BURNERS", [187, 188, 189, 47, 47, 47]
+        )
+        miners = _make_miners(create_neuron_info, [187, 47])
+
+        scores = burn_service.calculate_burn_scores(
+            miners=miners,
+            burn_share=TOTAL_BURN_EMISSION,
+            last_mechanism_step_block=None,
+        )
+
+        per_slot = TOTAL_BURN_EMISSION / 6
+        assert scores == {
+            "hk_187": pytest.approx(per_slot),
+            "hk_47": pytest.approx(per_slot * 3),
+        }
+
+
+class TestOldBurnLogic:
+    def test_old_logic_distributes_main_and_other_burners(
+        self, burn_service, monkeypatch, mock_settings, create_neuron_info
+    ):
+        monkeypatch.setattr("core.config.settings.ENABLE_NEW_BURN_LOGIC", False)
+        monkeypatch.setattr("core.config.settings.BURNERS", [4, 206, 207, 208])
+        miners = _make_miners(create_neuron_info, [4, 206, 207, 208])
+
+        scores = burn_service.calculate_burn_scores(
+            miners=miners,
+            burn_share=TOTAL_BURN_EMISSION,
+            last_mechanism_step_block=42,
+        )
+
+        assert set(scores.keys()) == {"hk_4", "hk_206", "hk_207", "hk_208"}
+        assert sum(scores.values()) == pytest.approx(TOTAL_BURN_EMISSION)
+
+    def test_old_logic_main_burner_is_deterministic_per_block(
+        self, burn_service, monkeypatch, mock_settings, create_neuron_info
+    ):
+        monkeypatch.setattr("core.config.settings.ENABLE_NEW_BURN_LOGIC", False)
+        monkeypatch.setattr("core.config.settings.BURNERS", [4, 206, 207, 208])
+        miners = _make_miners(create_neuron_info, [4, 206, 207, 208])
+
+        first = burn_service.calculate_burn_scores(
+            miners=miners, burn_share=TOTAL_BURN_EMISSION, last_mechanism_step_block=42
+        )
+        second = burn_service.calculate_burn_scores(
+            miners=miners, burn_share=TOTAL_BURN_EMISSION, last_mechanism_step_block=42
+        )
+
+        assert first == second
+
+
+class TestBurnServiceHelpers:
+    def test_is_burner_new_logic(self, burn_service, monkeypatch, mock_settings):
+        monkeypatch.setattr(
+            "core.config.settings.NEW_BURNERS",
+            [187, 188, 189, 190, 191, 192, 193, 47, 47, 47],
+        )
+
+        assert burn_service.is_burner(47) is True
+        assert burn_service.is_burner(187) is True
+        assert burn_service.is_burner(999) is False
+
+    def test_is_burner_old_logic(self, burn_service, monkeypatch, mock_settings):
+        monkeypatch.setattr("core.config.settings.ENABLE_NEW_BURN_LOGIC", False)
+        monkeypatch.setattr("core.config.settings.BURNERS", [4, 206, 207, 208])
+        monkeypatch.setattr("core.config.settings.NEW_BURNERS", [47])
+
+        assert burn_service.is_burner(4) is True
+        assert burn_service.is_burner(47) is False
+
+    def test_get_burn_share(self, burn_service):
+        assert burn_service.get_burn_share() == pytest.approx(TOTAL_BURN_EMISSION)
+
+    def test_get_mining_share(self, burn_service):
+        assert burn_service.get_mining_share() == pytest.approx(1 - TOTAL_BURN_EMISSION)
+
+    def test_burn_and_mining_shares_sum_to_one(self, burn_service):
+        assert (
+            burn_service.get_burn_share() + burn_service.get_mining_share()
+            == pytest.approx(1.0)
+        )


### PR DESCRIPTION
## Describe your changes

Reallocate burn emission so the new burn UID **47** receives the aggregated **30%** share that 3 retired burners previously held.

**Mechanism**
- `NEW_BURNERS` is now a slot-weighted list. Each entry represents one equal slot of the burn share.
- Retired UIDs `194, 195, 196` are removed; UID `47` occupies their 3 slots.
- `BurnService._calculate_new_burn_logic` now distributes `burn_share` per slot (via `Counter`), so a UID with 3 slots gets 3× the per-slot emission.

**Result**
- Total burn slots remain `10` → per-slot share unchanged at `burn_share / 10`.
- UIDs 187–193 each keep their 10% slot → 70% total.
- UID 47 receives 30% (the aggregated share of the 3 removed UIDs).

**Files**
- `neurons/validators/src/core/config.py` — `NEW_BURNERS = [187, 188, 189, 190, 191, 192, 193, 47, 47, 47]`
- `neurons/validators/src/incentive/burn_service.py` — slot-weighted distribution in `_calculate_new_burn_logic`.

## Issue ticket number and link

DAH-2089

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I wrote tests.
- [ ] Need to take care of performance?