### PR TITLE
DAH-2090, add forced executor validation endpoint

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -102,6 +102,9 @@ class Settings(BaseSettings):
     INTERNAL_PORT: int = Field(env="INTERNAL_PORT", default=8000)
     BLOCKS_FOR_JOB: int = 75  # 15 minutes
     JOB_TIME_OUT: int = 60 * 15  # 15 minutes
+    FORCED_VALIDATION_INTERNAL_TOKEN: str | None = Field(
+        env="FORCED_VALIDATION_INTERNAL_TOKEN", default=None
+    )
 
     REDIS_HOST: str = Field(env="REDIS_HOST", default="localhost")
     REDIS_PORT: int = Field(env="REDIS_PORT", default=6379)

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -3,34 +3,34 @@ import json
 import os
 import time
 
-from payload_models.payloads import MinerJobRequestPayload
-from clients.backend_client import BackendClient
-
-from core.config import settings
 from incentive.factory import IncentiveFactory
 from incentive.rental_price import precompute_all_estimates
-from core.utils import _m, get_extra_info, get_logger
+from payload_models.payloads import MinerJobRequestPayload
+
+from clients.backend_client import BackendClient
 from clients.subtensor_client import SubtensorClient
+from core.config import settings
+from core.utils import _m, get_extra_info, get_logger
+from services.attestation_service import AttestationService
+from services.collateral_contract_service import CollateralContractService
+from services.const import IS_NOT_DEPOSITED_SCORE_MULTIPLIER
 from services.docker_service import DockerService
 from services.executor_connectivity.container_runner import ContainerRunner
 from services.executor_connectivity.dind_probe import DindProbe, DindVerifier
+from services.executor_connectivity.orchestrator import ConnectivityOrchestrator
 from services.executor_connectivity.port_probe import PortProbe
 from services.executor_connectivity.port_selector import PortSelector
 from services.executor_connectivity.port_tester import PortTester
 from services.executor_connectivity.port_verifiers import BatchVerifier, FallbackVerifier
-from services.executor_connectivity.orchestrator import ConnectivityOrchestrator
 from services.executor_connectivity_service import ExecutorConnectivityService
 from services.file_encrypt_service import FileEncryptService
+from services.forced_validation import ForceValidationRequestStore, ForceValidationService
+from services.matrix_validation_service import ValidationService
 from services.miner_service import MinerService
 from services.redis_service import GPU_ESTIMATES_CHANNEL, PENDING_PODS_PREFIX, RedisService
 from services.ssh_service import SSHService
-from services.task_service import TaskService, JobResult
-from services.matrix_validation_service import ValidationService
+from services.task_service import JobResult, TaskService
 from services.verifyx_validation_service import VerifyXValidationService
-from services.collateral_contract_service import CollateralContractService
-from services.attestation_service import AttestationService
-from services.const import IS_NOT_DEPOSITED_SCORE_MULTIPLIER
-
 
 logger = get_logger(__name__)
 
@@ -107,6 +107,13 @@ class Validator:
             task_service=task_service,
             redis_service=self.redis_service,
             attestation_service=self.attestation_service,
+        )
+        self.force_validation_service = ForceValidationService(
+            store=ForceValidationRequestStore(self.redis_service),
+            miner_service=self.miner_service,
+            subtensor_client=self.subtensor_client,
+            backend_client=self.backend_client,
+            file_encrypt_service=self.file_encrypt_service,
         )
 
         # init miner_scores: always load from Redis if present so accumulated

--- a/neurons/validators/src/payload_models/forced_validation.py
+++ b/neurons/validators/src/payload_models/forced_validation.py
@@ -1,0 +1,36 @@
+from datetime import UTC, datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+ForceValidationStatus = Literal["queued", "running", "succeeded", "failed"]
+
+
+class ForceValidationCreateRequest(BaseModel):
+    executor_id: str
+    miner_hotkey: str
+
+
+class ForceValidationResult(BaseModel):
+    success: bool
+    message: str | None = None
+    score: float | None = None
+    job_score: float | None = None
+    gpu_model: str | None = None
+    gpu_count: int | None = None
+
+
+class ForceValidationError(BaseModel):
+    message: str
+
+
+class ForceValidationRequestRecord(BaseModel):
+    request_id: str
+    executor_id: str
+    miner_hotkey: str
+    status: ForceValidationStatus
+    stage: str
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    result: ForceValidationResult | None = None
+    error: ForceValidationError | None = None

--- a/neurons/validators/src/services/forced_validation.py
+++ b/neurons/validators/src/services/forced_validation.py
@@ -1,0 +1,242 @@
+import asyncio
+import logging
+from collections.abc import Callable, Coroutine
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from payload_models.forced_validation import (
+    ForceValidationError,
+    ForceValidationRequestRecord,
+    ForceValidationResult,
+)
+from payload_models.payloads import MinerJobRequestPayload
+
+from clients.backend_client import BackendClient
+from clients.subtensor_client import SubtensorClient
+from core.config import settings
+from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
+from services.file_encrypt_service import FileEncryptService
+from services.miner_service import MinerService
+from services.redis_service import RedisService
+from services.task_service import JobResult
+
+logger = logging.getLogger(__name__)
+
+FORCED_VALIDATION_REQUEST_PREFIX = "forced_validation:request"
+FORCED_VALIDATION_ACTIVE_PREFIX = "forced_validation:active_executor"
+DEFAULT_REQUEST_TTL_SECONDS = 24 * 60 * 60
+
+
+class ForceValidationConflict(Exception):
+    pass
+
+
+class ForceValidationNotFound(Exception):
+    pass
+
+
+class ForceValidationRequestStore:
+    def __init__(
+        self,
+        redis_service: RedisService,
+        *,
+        request_ttl_seconds: int = DEFAULT_REQUEST_TTL_SECONDS,
+        active_ttl_seconds: int | None = None,
+    ):
+        self.redis_service = redis_service
+        self.request_ttl_seconds = request_ttl_seconds
+        self.active_ttl_seconds = active_ttl_seconds or settings.JOB_TIME_OUT + 600
+
+    def _request_key(self, request_id: str) -> str:
+        return f"{FORCED_VALIDATION_REQUEST_PREFIX}:{request_id}"
+
+    def _active_key(self, executor_id: str) -> str:
+        return f"{FORCED_VALIDATION_ACTIVE_PREFIX}:{executor_id}"
+
+    async def create_request(
+        self, *, executor_id: str, miner_hotkey: str
+    ) -> ForceValidationRequestRecord:
+        request_id = str(uuid4())
+        active_created = await self.redis_service.redis.set(
+            self._active_key(executor_id),
+            request_id,
+            nx=True,
+            ex=self.active_ttl_seconds,
+        )
+        if not active_created:
+            raise ForceValidationConflict()
+
+        record = ForceValidationRequestRecord(
+            request_id=request_id,
+            executor_id=executor_id,
+            miner_hotkey=miner_hotkey,
+            status="queued",
+            stage="queued",
+        )
+        await self._save(record)
+        return record
+
+    async def get_request(self, request_id: str) -> ForceValidationRequestRecord:
+        raw = await self.redis_service.redis.get(self._request_key(request_id))
+        if raw is None:
+            raise ForceValidationNotFound()
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        return ForceValidationRequestRecord.model_validate_json(raw)
+
+    async def update(
+        self,
+        request_id: str,
+        *,
+        status: str | None = None,
+        stage: str | None = None,
+        result: ForceValidationResult | None = None,
+        error: ForceValidationError | None = None,
+    ) -> ForceValidationRequestRecord:
+        record = await self.get_request(request_id)
+        update_data = {}
+        if status is not None:
+            update_data["status"] = status
+        if stage is not None:
+            update_data["stage"] = stage
+        if result is not None:
+            update_data["result"] = result
+            update_data["error"] = None
+        if error is not None:
+            update_data["error"] = error
+            update_data["result"] = None
+        updated = record.model_copy(
+            update={**update_data, "updated_at": datetime.now(UTC)}
+        )
+        await self._save(updated)
+        return updated
+
+    async def release_active_executor(self, executor_id: str, request_id: str) -> None:
+        active_key = self._active_key(executor_id)
+        active_request_id = await self.redis_service.redis.get(active_key)
+        if isinstance(active_request_id, bytes):
+            active_request_id = active_request_id.decode("utf-8")
+        if active_request_id == request_id:
+            await self.redis_service.redis.delete(active_key)
+
+    async def _save(self, record: ForceValidationRequestRecord) -> None:
+        await self.redis_service.redis.set(
+            self._request_key(record.request_id),
+            record.model_dump_json(),
+            ex=self.request_ttl_seconds,
+        )
+
+
+class ForceValidationService:
+    def __init__(
+        self,
+        *,
+        store: ForceValidationRequestStore,
+        miner_service: MinerService,
+        subtensor_client: SubtensorClient,
+        backend_client: BackendClient,
+        file_encrypt_service: FileEncryptService,
+        task_factory: Callable[[Coroutine], asyncio.Task] = asyncio.create_task,
+    ):
+        self.store = store
+        self.miner_service = miner_service
+        self.subtensor_client = subtensor_client
+        self.backend_client = backend_client
+        self.file_encrypt_service = file_encrypt_service
+        self.task_factory = task_factory
+
+    async def create_request(
+        self, executor_id: str, miner_hotkey: str
+    ) -> ForceValidationRequestRecord:
+        record = await self.store.create_request(
+            executor_id=executor_id,
+            miner_hotkey=miner_hotkey,
+        )
+        self.task_factory(self.validate(record.request_id))
+        return record
+
+    async def get_request(self, request_id: str) -> ForceValidationRequestRecord:
+        return await self.store.get_request(request_id)
+
+    async def validate(self, request_id: str) -> ForceValidationRequestRecord:
+        record = await self.store.get_request(request_id)
+        try:
+            await self.store.update(
+                request_id,
+                status="running",
+                stage="resolving_miner",
+            )
+            miner = await self._resolve_miner(record.miner_hotkey)
+
+            await self.store.update(request_id, stage="preparing_validation")
+            rented_data = await self.backend_client.get_all_rented_executors()
+            if rented_data is None:
+                rented_data = RentedExecutorsResponse(executors={})
+            encrypted_files = self.file_encrypt_service.ecrypt_miner_job_files()
+
+            payload = MinerJobRequestPayload(
+                job_batch_id=f"forced-{request_id}",
+                miner_hotkey=miner.hotkey,
+                miner_coldkey=miner.coldkey,
+                miner_address=miner.axon_info.ip,
+                miner_port=miner.axon_info.port,
+            )
+
+            await self.store.update(request_id, stage="running_validation")
+            result = await self.miner_service.request_single_executor_validation(
+                payload=payload,
+                encrypted_files=encrypted_files,
+                rented_data=rented_data,
+                executor_id=record.executor_id,
+            )
+
+            await self.store.update(request_id, stage="finalizing")
+            await self.miner_service.publish_machine_specs(
+                [result],
+                record.miner_hotkey,
+                miner.coldkey,
+            )
+
+            terminal_result = self._build_terminal_result(result)
+            return await self.store.update(
+                request_id,
+                status="succeeded" if terminal_result.success else "failed",
+                stage="completed",
+                result=terminal_result,
+            )
+        except Exception as exc:
+            logger.exception(
+                "Forced validation failed",
+                extra={
+                    "request_id": request_id,
+                    "executor_id": record.executor_id,
+                    "miner_hotkey": record.miner_hotkey,
+                },
+            )
+            return await self.store.update(
+                request_id,
+                status="failed",
+                stage="completed",
+                error=ForceValidationError(message=str(exc)),
+            )
+        finally:
+            await self.store.release_active_executor(record.executor_id, request_id)
+
+    async def _resolve_miner(self, miner_hotkey: str):
+        miners = await self.subtensor_client.get_miners()
+        matches = [miner for miner in miners if miner.hotkey == miner_hotkey]
+        if not matches:
+            raise ValueError(f"Miner {miner_hotkey} was not found in subtensor")
+        return matches[0]
+
+    @staticmethod
+    def _build_terminal_result(result: JobResult) -> ForceValidationResult:
+        success = result.log_status == "info"
+        return ForceValidationResult(
+            success=success,
+            message=result.log_text,
+            score=result.score,
+            job_score=result.job_score,
+            gpu_model=result.gpu_model,
+            gpu_count=result.gpu_count,
+        )

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -6,10 +6,9 @@ import time
 from typing import Annotated
 
 import aiohttp
-from asyncssh import SSHKey
 import asyncssh
 import bittensor
-from clients.miner_client import MinerClient
+from asyncssh import SSHKey
 from datura.requests.miner_requests import (
     AcceptJobRequest,
     AcceptSSHKeyRequest,
@@ -21,38 +20,39 @@ from datura.requests.miner_requests import (
     SSHKeyRemoved,
 )
 from datura.requests.validator_requests import (
+    AuthenticationPayload,
+    GetPodLogsRequest,
     SSHPubKeyRemoveRequest,
     SSHPubKeySubmitRequest,
-    GetPodLogsRequest,
-    AuthenticationPayload,
 )
 from fastapi import Depends
-from clients.validator_portal_api import ValidatorPortalAPI
 from payload_models.payloads import (
+    AddDebugSshKeyRequest,
+    AddSshPublicKeyRequest,
     BackupContainerRequest,
-    RestoreContainerRequest,
     ContainerBaseRequest,
     ContainerCreateRequest,
     ContainerDeleteRequest,
-    AddSshPublicKeyRequest,
-    RemoveSshPublicKeysRequest,
+    DebugSshKeyAdded,
+    FailedAddDebugSshKey,
     FailedContainerErrorCodes,
     FailedContainerErrorTypes,
     FailedContainerRequest,
+    FailedGetPodLogs,
+    GetPodLogsRequestFromServer,
+    InstallJupyterServerRequest,
+    JupyterInstallationFailed,
+    JupyterServerInstalled,
     MinerJobEnryptedFiles,
     MinerJobRequestPayload,
-    GetPodLogsRequestFromServer,
     PodLogsResponseToServer,
-    FailedGetPodLogs,
-    AddDebugSshKeyRequest,
-    DebugSshKeyAdded,
-    FailedAddDebugSshKey,
-    InstallJupyterServerRequest,
-    JupyterServerInstalled,
-    JupyterInstallationFailed,
+    RemoveSshPublicKeysRequest,
+    RestoreContainerRequest,
 )
 from tenacity import RetryError
 
+from clients.miner_client import MinerClient
+from clients.validator_portal_api import ValidatorPortalAPI
 from core.config import settings
 from core.utils import _m, get_extra_info
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
@@ -60,7 +60,7 @@ from services.attestation_service import AttestationService
 from services.docker_service import DockerService
 from services.redis_service import MACHINE_SPEC_CHANNEL, RedisService
 from services.ssh_service import SSHService
-from services.task_service import TaskService, JobResult
+from services.task_service import JobResult, TaskService
 
 logger = logging.getLogger(__name__)
 
@@ -431,6 +431,126 @@ class MinerService:
             "miner_coldkey": payload.miner_coldkey,
             "results": [job_result],
         }
+
+    async def request_single_executor_validation(
+        self,
+        payload: MinerJobRequestPayload,
+        encrypted_files: MinerJobEnryptedFiles,
+        rented_data: RentedExecutorsResponse,
+        executor_id: str,
+    ) -> JobResult:
+        if settings.USE_REST_API:
+            return await self._request_single_executor_validation_via_rest(
+                payload,
+                encrypted_files,
+                rented_data,
+                executor_id,
+            )
+        return await self._request_single_executor_validation_via_websocket(
+            payload,
+            encrypted_files,
+            rented_data,
+            executor_id,
+        )
+
+    @staticmethod
+    def _get_single_matching_executor(
+        executors: list[ExecutorSSHInfo],
+        executor_id: str,
+    ) -> ExecutorSSHInfo:
+        matches = [executor for executor in executors if executor.uuid == executor_id]
+        if len(matches) != 1:
+            raise ValueError(
+                f"Miner returned {len(matches)} executors matching {executor_id}"
+            )
+        return matches[0]
+
+    async def _request_single_executor_validation_via_websocket(
+        self,
+        payload: MinerJobRequestPayload,
+        encrypted_files: MinerJobEnryptedFiles,
+        rented_data: RentedExecutorsResponse,
+        executor_id: str,
+    ) -> JobResult:
+        loop = asyncio.get_event_loop()
+        my_key: bittensor.Keypair = settings.get_bittensor_wallet().get_hotkey()
+        default_extra = {
+            "job_batch_id": payload.job_batch_id,
+            "miner_hotkey": payload.miner_hotkey,
+            "miner_address": payload.miner_address,
+            "miner_port": payload.miner_port,
+            "executor_id": executor_id,
+        }
+
+        miner_client = MinerClient(
+            loop=loop,
+            miner_address=payload.miner_address,
+            miner_port=payload.miner_port,
+            miner_hotkey=payload.miner_hotkey,
+            my_hotkey=my_key.ss58_address,
+            keypair=my_key,
+            miner_url=f"ws://{payload.miner_address}:{payload.miner_port}/websocket/{my_key.ss58_address}",
+        )
+
+        private_key = None
+        public_key = None
+        async with miner_client:
+            try:
+                private_key, public_key = self.ssh_service.generate_ssh_key(my_key.ss58_address)
+                await miner_client.send_model(
+                    SSHPubKeySubmitRequest(
+                        public_key=public_key,
+                        validator_signature=self._sign_validator_pubkey(my_key, public_key),
+                        executor_id=executor_id,
+                        miner_hotkey=payload.miner_hotkey,
+                    )
+                )
+
+                msg = await asyncio.wait_for(
+                    miner_client.job_state.miner_accepted_ssh_key_or_failed_future,
+                    timeout=JOB_LENGTH,
+                )
+                if isinstance(msg, FailedRequest):
+                    raise RuntimeError(
+                        f"Miner returned FailedRequest: {msg.details or 'unknown reason'}"
+                    )
+                if not isinstance(msg, AcceptSSHKeyRequest):
+                    raise RuntimeError(f"Unexpected response from miner: {msg}")
+
+                executor = self._get_single_matching_executor(msg.executors, executor_id)
+                return await asyncio.wait_for(
+                    self.task_service.create_task(
+                        miner_info=payload,
+                        executor_info=executor,
+                        keypair=my_key,
+                        private_key=private_key.decode("utf-8"),
+                        public_key=public_key.decode("utf-8"),
+                        encrypted_files=encrypted_files,
+                        rented_data=rented_data,
+                    ),
+                    timeout=settings.JOB_TIME_OUT - 120,
+                )
+            finally:
+                if public_key is not None:
+                    try:
+                        await miner_client.send_model(
+                            SSHPubKeyRemoveRequest(
+                                public_key=public_key,
+                                validator_signature=self._sign_validator_pubkey(my_key, public_key),
+                                executor_id=executor_id,
+                                miner_hotkey=payload.miner_hotkey,
+                            )
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            _m(
+                                "Failed to remove SSH key after forced validation",
+                                extra=get_extra_info({
+                                    **default_extra,
+                                    "error": _get_error_details(e),
+                                }),
+                            ),
+                        )
 
     async def publish_machine_specs(
         self, results: list[JobResult], miner_hotkey: str, miner_coldkey: str
@@ -1412,6 +1532,80 @@ class MinerService:
         # Use model_dump_json and parse back to ensure proper serialization
         # This handles bytes fields correctly (base64 encoding)
         return json.loads(request.model_dump_json())
+
+    async def _request_single_executor_validation_via_rest(
+        self,
+        payload: MinerJobRequestPayload,
+        encrypted_files: MinerJobEnryptedFiles,
+        rented_data: RentedExecutorsResponse,
+        executor_id: str,
+    ) -> JobResult:
+        my_key: bittensor.Keypair = settings.get_bittensor_wallet().get_hotkey()
+        default_extra = {
+            "job_batch_id": payload.job_batch_id,
+            "miner_hotkey": payload.miner_hotkey,
+            "miner_address": payload.miner_address,
+            "miner_port": payload.miner_port,
+            "executor_id": executor_id,
+        }
+        base_url = f"http://{payload.miner_address}:{payload.miner_port}"
+        private_key = None
+        public_key = None
+
+        try:
+            private_key, public_key = self.ssh_service.generate_ssh_key(my_key.ss58_address)
+            ssh_request = SSHPubKeySubmitRequest(
+                public_key=public_key,
+                validator_signature=self._sign_validator_pubkey(my_key, public_key),
+                executor_id=executor_id,
+                miner_hotkey=payload.miner_hotkey,
+            )
+            headers = self._generate_auth_headers(my_key, payload.miner_hotkey)
+            headers["Content-Type"] = "application/json"
+
+            status, response_data = await self._make_rest_request(
+                method="POST",
+                url=f"{base_url}/api/validator/ssh-pubkey-submit",
+                json_data=self._serialize_request(ssh_request),
+                headers=headers,
+                timeout=REST_SSH_SUBMIT_TIMEOUT,
+                log_extra=default_extra,
+                operation_name="Forced validation SSH key submit",
+            )
+            if status != 200 or response_data is None:
+                raise RuntimeError("Failed to submit SSH key to miner via REST API")
+
+            msg = _parse_miner_response(response_data)
+            if isinstance(msg, FailedRequest):
+                raise RuntimeError(
+                    f"Miner returned FailedRequest: {msg.details or 'unknown reason'}"
+                )
+            if not isinstance(msg, AcceptSSHKeyRequest):
+                raise RuntimeError(f"Unexpected response from miner: {msg}")
+
+            executor = self._get_single_matching_executor(msg.executors, executor_id)
+            return await asyncio.wait_for(
+                self.task_service.create_task(
+                    miner_info=payload,
+                    executor_info=executor,
+                    keypair=my_key,
+                    private_key=private_key.decode("utf-8"),
+                    public_key=public_key.decode("utf-8"),
+                    encrypted_files=encrypted_files,
+                    rented_data=rented_data,
+                ),
+                timeout=settings.JOB_TIME_OUT - 120,
+            )
+        finally:
+            if public_key is not None:
+                await self._remove_ssh_key_via_rest(
+                    base_url=base_url,
+                    my_key=my_key,
+                    public_key=public_key,
+                    miner_hotkey=payload.miner_hotkey,
+                    executor_id=executor_id,
+                    log_extra=default_extra,
+                )
 
     async def _request_job_to_miner(
         self,

--- a/neurons/validators/src/validator.py
+++ b/neurons/validators/src/validator.py
@@ -1,12 +1,18 @@
 import asyncio
 import logging
+from typing import Annotated
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, Header, HTTPException, Request
+from payload_models.forced_validation import (
+    ForceValidationCreateRequest,
+    ForceValidationRequestRecord,
+)
 
 from core.config import settings
 from core.utils import configure_logs_of_other_modules, wait_for_services_sync
 from core.validator import Validator
+from services.forced_validation import ForceValidationConflict, ForceValidationNotFound
 
 configure_logs_of_other_modules()
 wait_for_services_sync()
@@ -14,6 +20,7 @@ wait_for_services_sync()
 
 async def app_lifespan(app: FastAPI):
     validator = Validator()
+    app.state.validator = validator
     # Run the miner in the background
     task = asyncio.create_task(validator.start())
 
@@ -36,6 +43,65 @@ app = FastAPI(
     title=settings.PROJECT_NAME,
     lifespan=app_lifespan,
 )
+
+
+def validate_internal_token(
+    x_internal_token: Annotated[str | None, Header(alias="X-Internal-Token")] = None,
+) -> None:
+    expected_token = settings.FORCED_VALIDATION_INTERNAL_TOKEN
+    if expected_token:
+        if x_internal_token != expected_token:
+            raise HTTPException(status_code=401, detail="Invalid internal token")
+        return
+    if settings.ENV != "dev" and settings.DEPLOY_ENV in {"PROD", "STAGE"}:
+        raise HTTPException(
+            status_code=503,
+            detail="Forced validation internal token is not configured",
+        )
+
+
+def get_force_validation_service(request: Request):
+    validator = getattr(request.app.state, "validator", None)
+    if validator is None or not hasattr(validator, "force_validation_service"):
+        raise HTTPException(status_code=503, detail="Validator services are not ready")
+    return validator.force_validation_service
+
+
+@app.post(
+    "/internal/forced-validations",
+    response_model=ForceValidationRequestRecord,
+    dependencies=[Depends(validate_internal_token)],
+)
+async def create_forced_validation(
+    payload: ForceValidationCreateRequest,
+    service=Depends(get_force_validation_service),
+):
+    try:
+        return await service.create_request(
+            executor_id=payload.executor_id,
+            miner_hotkey=payload.miner_hotkey,
+        )
+    except ForceValidationConflict:
+        raise HTTPException(
+            status_code=409,
+            detail="Forced validation is already running for this executor",
+        )
+
+
+@app.get(
+    "/internal/forced-validations/{request_id}",
+    response_model=ForceValidationRequestRecord,
+    dependencies=[Depends(validate_internal_token)],
+)
+async def get_forced_validation(
+    request_id: str,
+    service=Depends(get_force_validation_service),
+):
+    try:
+        return await service.get_request(request_id)
+    except ForceValidationNotFound:
+        raise HTTPException(status_code=404, detail="Forced validation request not found")
+
 
 reload = True if settings.ENV == "dev" else False
 

--- a/neurons/validators/tests/test_forced_validation.py
+++ b/neurons/validators/tests/test_forced_validation.py
@@ -1,0 +1,199 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from datura.requests.miner_requests import AcceptSSHKeyRequest, ExecutorSSHInfo
+from payload_models.payloads import MinerJobEnryptedFiles, MinerJobRequestPayload
+
+import services.miner_service as miner_service_module
+from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
+from services.forced_validation import (
+    ForceValidationConflict,
+    ForceValidationRequestStore,
+)
+from services.miner_service import MinerService
+from services.task_service import JobResult
+
+
+class FakeRedis:
+    def __init__(self):
+        self.data = {}
+
+    async def set(self, key, value, nx=False, ex=None):
+        if nx and key in self.data:
+            return None
+        self.data[key] = value
+        return True
+
+    async def get(self, key):
+        return self.data.get(key)
+
+    async def delete(self, key):
+        self.data.pop(key, None)
+
+
+class FakeRedisService:
+    def __init__(self):
+        self.redis = FakeRedis()
+
+
+def _executor(executor_id: str = "exec-1") -> ExecutorSSHInfo:
+    return ExecutorSSHInfo(
+        uuid=executor_id,
+        address="10.0.0.1",
+        port=8000,
+        ssh_username="root",
+        ssh_port=22,
+        python_path="/usr/bin/python3",
+        root_dir="/root",
+    )
+
+
+def _payload() -> MinerJobRequestPayload:
+    return MinerJobRequestPayload(
+        job_batch_id="forced-req",
+        miner_hotkey="miner-hotkey",
+        miner_coldkey="miner-coldkey",
+        miner_address="127.0.0.1",
+        miner_port=8000,
+    )
+
+
+def _encrypted_files() -> MinerJobEnryptedFiles:
+    return MinerJobEnryptedFiles(
+        encrypt_key="key",
+        all_keys={},
+        tmp_directory="/tmp",
+        machine_scrape_file_name="machine.py",
+    )
+
+
+def _job_result(executor: ExecutorSSHInfo) -> JobResult:
+    return JobResult(
+        spec={},
+        executor_info=executor,
+        score=1,
+        job_score=1,
+        job_batch_id="forced-req",
+        log_status="info",
+        log_text="ok",
+        gpu_model="H100",
+        gpu_count=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_store_accepts_request_and_returns_status():
+    store = ForceValidationRequestStore(
+        FakeRedisService(), request_ttl_seconds=60, active_ttl_seconds=60
+    )
+
+    record = await store.create_request(
+        executor_id="exec-1",
+        miner_hotkey="miner-hotkey",
+    )
+    loaded = await store.get_request(record.request_id)
+
+    assert loaded.request_id == record.request_id
+    assert loaded.executor_id == "exec-1"
+    assert loaded.status == "queued"
+
+
+@pytest.mark.asyncio
+async def test_store_rejects_duplicate_active_executor():
+    store = ForceValidationRequestStore(
+        FakeRedisService(), request_ttl_seconds=60, active_ttl_seconds=60
+    )
+    await store.create_request(executor_id="exec-1", miner_hotkey="miner-hotkey")
+
+    with pytest.raises(ForceValidationConflict):
+        await store.create_request(executor_id="exec-1", miner_hotkey="miner-hotkey")
+
+
+@pytest.mark.asyncio
+async def test_store_releases_active_marker_after_terminal_state():
+    store = ForceValidationRequestStore(
+        FakeRedisService(), request_ttl_seconds=60, active_ttl_seconds=60
+    )
+    record = await store.create_request(
+        executor_id="exec-1",
+        miner_hotkey="miner-hotkey",
+    )
+    await store.update(record.request_id, status="failed", stage="completed")
+    await store.release_active_executor("exec-1", record.request_id)
+
+    next_record = await store.create_request(
+        executor_id="exec-1",
+        miner_hotkey="miner-hotkey",
+    )
+    assert next_record.request_id != record.request_id
+
+
+@pytest.mark.asyncio
+async def test_single_executor_validation_runs_matching_executor_and_cleans_up(monkeypatch):
+    executor = _executor("exec-1")
+    service = MinerService.__new__(MinerService)
+    service.ssh_service = MagicMock()
+    service.ssh_service.generate_ssh_key.return_value = (b"private", b"public")
+    service.task_service = MagicMock()
+    service.task_service.create_task = AsyncMock(return_value=_job_result(executor))
+    service._make_rest_request = AsyncMock(
+        return_value=(200, AcceptSSHKeyRequest(executors=[executor]).model_dump(mode="json"))
+    )
+    service._remove_ssh_key_via_rest = AsyncMock(return_value=True)
+
+    keypair = MagicMock(ss58_address="validator-hotkey")
+    keypair.sign.return_value = b"sig"
+    wallet = MagicMock()
+    wallet.get_hotkey.return_value = keypair
+    monkeypatch.setattr("services.miner_service.settings.USE_REST_API", True)
+    monkeypatch.setattr(
+        type(miner_service_module.settings),
+        "get_bittensor_wallet",
+        lambda self: wallet,
+    )
+
+    result = await service.request_single_executor_validation(
+        payload=_payload(),
+        encrypted_files=_encrypted_files(),
+        rented_data=RentedExecutorsResponse(executors={}),
+        executor_id="exec-1",
+    )
+
+    assert result.executor_info.uuid == "exec-1"
+    service.task_service.create_task.assert_awaited_once()
+    service._remove_ssh_key_via_rest.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_single_executor_validation_rejects_missing_executor_and_cleans_up(monkeypatch):
+    service = MinerService.__new__(MinerService)
+    service.ssh_service = MagicMock()
+    service.ssh_service.generate_ssh_key.return_value = (b"private", b"public")
+    service.task_service = MagicMock()
+    service.task_service.create_task = AsyncMock()
+    service._make_rest_request = AsyncMock(
+        return_value=(200, AcceptSSHKeyRequest(executors=[_executor("other")]).model_dump(mode="json"))
+    )
+    service._remove_ssh_key_via_rest = AsyncMock(return_value=True)
+
+    keypair = MagicMock(ss58_address="validator-hotkey")
+    keypair.sign.return_value = b"sig"
+    wallet = MagicMock()
+    wallet.get_hotkey.return_value = keypair
+    monkeypatch.setattr("services.miner_service.settings.USE_REST_API", True)
+    monkeypatch.setattr(
+        type(miner_service_module.settings),
+        "get_bittensor_wallet",
+        lambda self: wallet,
+    )
+
+    with pytest.raises(ValueError):
+        await service.request_single_executor_validation(
+            payload=_payload(),
+            encrypted_files=_encrypted_files(),
+            rented_data=RentedExecutorsResponse(executors={}),
+            executor_id="exec-1",
+        )
+
+    service.task_service.create_task.assert_not_called()
+    service._remove_ssh_key_via_rest.assert_awaited_once()


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2090](https://www.notion.so/Add-forced-executor-validation-endpoint-35fb8bfdbde9814ebaf3c2f6a4b094dd)

---

## Problem

New executors can take too long to appear in compute-app because validation only happens when the regular validator cycle reaches the target executor. Operators need an internal path that can request validation for one known `executor_id` + `miner_hotkey`, poll the request status, and inspect the result.

## Solution

Add a validator-side forced validation workflow backed by Redis. The validator now exposes internal create/read endpoints, rejects duplicate active requests for the same executor, runs the existing validation pipeline against exactly one executor, publishes machine specs through the existing ingestion path, and stores terminal status/result for polling.

## Changes

- Added forced validation request/result payload models.
- Added `ForceValidationRequestStore` with request TTL and active-executor locking via Redis `SET NX EX`.
- Added `ForceValidationService` for request creation, status updates, background validation, terminal result storage, and active marker cleanup.
- Added single-executor validation helpers to `MinerService` for both REST and websocket miner paths.
- Added internal validator endpoints:
  - `POST /internal/forced-validations`
  - `GET /internal/forced-validations/{request_id}`
- Added optional `FORCED_VALIDATION_INTERNAL_TOKEN` guard for non-dev deployments.
- Added focused tests for request store behavior, duplicate rejection, cleanup, and single-executor validation cleanup.

## Deployment Steps

Use GitHub Action.

Before wiring this into callers, deployment config should provide `FORCED_VALIDATION_INTERNAL_TOKEN` and a stable internal validator service URL.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

No companion PRs are open for `DAH-2090` at the moment. Compute-app / Miner Portal wiring is expected as follow-up work before the feature is user-facing.

## Risks

- The internal endpoint must stay behind trusted networking and the internal token outside dev.
- Forced validation reuses SSH key submission/removal and task execution paths, so regressions would affect targeted validation cleanup or single-executor job execution.
- Live staging verification with a real executor is still required before enabling a caller broadly.

## Test Cases

### Test Case 1

**Actions**

Run from `neurons/validators`:

```bash
pdm run pytest -q
```

**Expected Output**

The validator test suite passes.

Observed locally: `503 passed, 4 skipped`.

### Test Case 2

**Actions**

Run from repo root:

```bash
git diff --check origin/main...HEAD
```

**Expected Output**

No whitespace or conflict-marker issues are reported.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described