### PR TITLE
DAH-2083 Fix validator backup reliability

### DIFF
--- a/neurons/validators/src/miner_jobs/backup_storage.py
+++ b/neurons/validators/src/miner_jobs/backup_storage.py
@@ -32,16 +32,14 @@ def redact_sensitive_text(text: str | None) -> str:
         return ""
     # Use one sanitizer for backend payloads and local executor logs so credentials
     # cannot leak and diagnostic text does not block FAILED status updates.
-    text = re.sub(r"(AWS_SECRET_ACCESS_KEY|AWSSECRETACCESSKEY)=\S+", r"\1=<redacted>", text)
+    text = re.sub(
+        r"(AWS_SECRET_ACCESS_KEY|AWSSECRETACCESSKEY)\s*=\s*(\"[^\"]*\"|'[^']*'|[^\s]+)",
+        r"\1=<redacted>",
+        text,
+    )
     for unsafe_path, replacement in STREAM_PATH_REPLACEMENTS.items():
         text = text.replace(unsafe_path, replacement)
     return text
-
-
-def command_for_log(command: str | list[str]) -> str:
-    if isinstance(command, list):
-        return redact_sensitive_text(" ".join(command))
-    return redact_sensitive_text(command)
 
 
 def compact_output(label: str, output: str | None, limit: int = 500) -> str:
@@ -77,71 +75,71 @@ def upload_failure_message(
     return message
 
 
-def run_command(command):
+def run_command(command, command_label: str = "command"):
     result = subprocess.run(command, shell=True, capture_output=True, text=True)
     if result.returncode != 0:
-        logger.error(f"Command failed: {command_for_log(command)}")
+        logger.error(f"Command failed: {command_label}")
         raise RuntimeError(
-            f"Command failed with exit code {result.returncode}: {command_for_log(command)}\n"
+            f"{command_label} failed with exit code {result.returncode}\n"
             f"{compact_output('stderr', result.stderr)}"
         )
     else:
-        logger.info(f"Command succeeded: {command_for_log(command)}")
+        logger.info(f"Command succeeded: {command_label}")
     return result
 
 
-def run_command_args(command: list[str], input_stream=None, stdout=None):
+def run_command_args(command: list[str], input_stream=None, stdout=None, command_label: str = "command"):
     result = subprocess.run(command, stdin=input_stream, stdout=stdout, capture_output=stdout is None, text=True)
     if result.returncode != 0:
-        logger.error(f"Command failed: {command_for_log(command)}")
+        logger.error(f"Command failed: {command_label}")
         raise RuntimeError(
-            f"Command failed with exit code {result.returncode}: {command_for_log(command)}\n"
+            f"{command_label} failed with exit code {result.returncode}\n"
             f"{compact_output('stderr', result.stderr)}"
         )
-    logger.info(f"Command succeeded: {command_for_log(command)}")
+    logger.info(f"Command succeeded: {command_label}")
     return result
 
 
 def create_backup_container(args):
     # install docker volume plugin
     command = f"/usr/bin/docker plugin install mochoa/s3fs-volume-plugin --alias {plugin_name} --grant-all-permissions --disable"
-    run_command(command)
+    run_command(command, command_label="docker plugin install mochoa/s3fs-volume-plugin")
 
     # disable volume plugin and set credential
     command = f"/usr/bin/docker plugin disable {plugin_name} -f"
-    run_command(command)
+    run_command(command, command_label="docker plugin disable s3fs-backup")
     command = f"/usr/bin/docker plugin set {plugin_name} AWSACCESSKEYID={args.backup_volume_iam_user_access_key} AWSSECRETACCESSKEY={args.backup_volume_iam_user_secret_key}"
-    run_command(command)
+    run_command(command, command_label="docker plugin set s3fs-backup credentials")
     command = f'/usr/bin/docker plugin set s3fs-backup DEFAULT_S3FSOPTS="url=https://s3-accelerate.amazonaws.com"'
-    run_command(command)
+    run_command(command, command_label="docker plugin set s3fs-backup options")
     command = f"/usr/bin/docker plugin enable {plugin_name}"
-    run_command(command)
+    run_command(command, command_label="docker plugin enable s3fs-backup")
 
     # clean up all existing volumes and containers for s3 backup 
     # Find and remove all containers whose names start with s3fs-backup
     list_cmd = "/usr/bin/docker ps -a --filter 'name=^/s3fs-backup' --format '{{.Names}}'"
-    result = run_command(list_cmd)
+    result = run_command(list_cmd, command_label="docker ps s3fs-backup containers")
     container_names = [name for name in result.stdout.strip().split('\n') if name]
     if container_names:
         names_str = " ".join(container_names)
         rm_cmd = f"/usr/bin/docker rm -f {names_str}"
-        run_command(rm_cmd)
+        run_command(rm_cmd, command_label="docker rm stale s3fs-backup containers")
 
     # Find and remove all Docker volumes whose names start with "celium-backup-volume"
     list_volumes_cmd = "/usr/bin/docker volume ls --format '{{.Name}}'"
-    result = run_command(list_volumes_cmd)
+    result = run_command(list_volumes_cmd, command_label="docker volume ls")
     volume_names = [name for name in result.stdout.strip().split('\n') if name.startswith("celium-backup-volume")]
     if volume_names:
         names_str = " ".join(volume_names)
         rm_volumes_cmd = f"/usr/bin/docker volume rm {names_str}"
-        run_command(rm_volumes_cmd)
+        run_command(rm_volumes_cmd, command_label="docker volume rm stale backup volumes")
     
     # create volume
     volume_name = args.backup_volume_name
     command = " ".join([
         "/usr/bin/docker", "volume", "create", "-d", plugin_name, volume_name,
     ])
-    run_command(command)
+    run_command(command, command_label="docker volume create s3fs-backup")
 
     # create s3fs backup container
     container_name = f"s3fs-backup-{args.backup_log_id}"
@@ -153,28 +151,31 @@ def create_backup_container(args):
         f"--entrypoint bash "
         f'ubuntu -c "tail -f /dev/null"'
     )
-    run_command(command)
+    run_command(command, command_label="docker run s3fs-backup container")
     return container_name
 
 
 def start_backup(args, container_name):
     # Run cp command inside the container to copy from source_volume_path to /mnt
-    run_command(f"/usr/bin/docker exec {container_name} sh -lc 'mkdir -p /mnt/{args.backup_target_path}'")
+    run_command(
+        f"/usr/bin/docker exec {container_name} sh -lc 'mkdir -p /mnt/{args.backup_target_path}'",
+        command_label="docker exec mkdir backup target",
+    )
     command = f"/usr/bin/docker exec {container_name} sh -lc 'cp -a {args.backup_path} /mnt/{args.backup_target_path}'"
-    run_command(command)
+    run_command(command, command_label="docker exec cp backup path")
 
 
 def clean_backup_container(container_name):
     command = f"/usr/bin/docker rm -f {container_name}"
-    run_command(command)
+    run_command(command, command_label="docker rm backup container")
 
 def clean_backup_volume(volume_name):
     command = f"/usr/bin/docker volume rm {volume_name}"
-    run_command(command)
+    run_command(command, command_label="docker volume rm backup volume")
 
 def disable_backup_volume_plugin():
     command = f"/usr/bin/docker plugin disable {plugin_name} -f"
-    run_command(command)
+    run_command(command, command_label="docker plugin disable s3fs-backup")
 
 
 def update_backup_log(
@@ -229,7 +230,7 @@ def update_backup_log(
 
 
 def pull_aws_cli():
-    run_command_args(["/usr/bin/docker", "pull", "daturaai/aws-cli"])
+    run_command_args(["/usr/bin/docker", "pull", "daturaai/aws-cli"], command_label="docker pull daturaai/aws-cli")
 
 
 def docker_base_command(args, volumes=None, entrypoint=None, interactive=False):
@@ -256,14 +257,17 @@ def estimate_backup_sizes(args, backup_path) -> tuple[int, int]:
     # Run du inside Docker with the workload volume mounted; the miner host may not have this path.
     du_command = docker_base_command(args, volumes=[source_volume], entrypoint="du") + ["-sb", backup_path]
     try:
-        result = run_command_args(du_command)
+        result = run_command_args(du_command, command_label="docker run du -sb <backup_path>")
         source_bytes = int(result.stdout.split()[0])
     except Exception:
-        result = run_command_args(docker_base_command(args, volumes=[source_volume], entrypoint="du") + ["-sk", backup_path])
+        result = run_command_args(
+            docker_base_command(args, volumes=[source_volume], entrypoint="du") + ["-sk", backup_path],
+            command_label="docker run du -sk <backup_path>",
+        )
         source_bytes = int(result.stdout.split()[0]) * 1024
 
     find_command = docker_base_command(args, volumes=[source_volume], entrypoint="find") + [backup_path, "-print"]
-    entry_count = count_command_output_lines(find_command)
+    entry_count = count_command_output_lines(find_command, command_label="docker run find <backup_path> -print")
     entry_count = max(entry_count, 1)
 
     # source_bytes is the user-facing estimate. expected_upload_size is only for AWS CLI's
@@ -278,7 +282,7 @@ def estimate_expected_size(args, backup_path):
     return expected_upload_size
 
 
-def count_command_output_lines(command: list[str]) -> int:
+def count_command_output_lines(command: list[str], command_label: str = "command") -> int:
     # Stream line counting instead of materializing potentially huge find output in memory.
     with tempfile.TemporaryFile(mode="w+") as stderr_file:
         proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=stderr_file, text=True)
@@ -294,12 +298,12 @@ def count_command_output_lines(command: list[str]) -> int:
             raise
 
     if status != 0:
-        logger.error(f"Command failed: {command_for_log(command)}")
+        logger.error(f"Command failed: {command_label}")
         raise RuntimeError(
-            f"Command failed with exit code {status}: {command_for_log(command)}\n"
+            f"{command_label} failed with exit code {status}\n"
             f"{compact_output('stderr', stderr)}"
         )
-    logger.info(f"Command succeeded: {command_for_log(command)}")
+    logger.info(f"Command succeeded: {command_label}")
     return count
 
 
@@ -377,7 +381,7 @@ def aws_head_object(args):
         "--output",
         "json",
     ]
-    result = run_command_args(command)
+    result = run_command_args(command, command_label="docker run aws s3api head-object")
     return json.loads(result.stdout)
 
 

--- a/neurons/validators/src/miner_jobs/backup_storage.py
+++ b/neurons/validators/src/miner_jobs/backup_storage.py
@@ -81,8 +81,6 @@ def run_command(command):
     result = subprocess.run(command, shell=True, capture_output=True, text=True)
     if result.returncode != 0:
         logger.error(f"Command failed: {command_for_log(command)}")
-        logger.error(f"stdout: {result.stdout}")
-        logger.error(f"stderr: {result.stderr}")
         raise RuntimeError(
             f"Command failed with exit code {result.returncode}: {command_for_log(command)}\n"
             f"{compact_output('stderr', result.stderr)}"
@@ -96,8 +94,6 @@ def run_command_args(command: list[str], input_stream=None, stdout=None):
     result = subprocess.run(command, stdin=input_stream, stdout=stdout, capture_output=stdout is None, text=True)
     if result.returncode != 0:
         logger.error(f"Command failed: {command_for_log(command)}")
-        logger.error(f"stdout: {result.stdout}")
-        logger.error(f"stderr: {result.stderr}")
         raise RuntimeError(
             f"Command failed with exit code {result.returncode}: {command_for_log(command)}\n"
             f"{compact_output('stderr', result.stderr)}"
@@ -299,7 +295,6 @@ def count_command_output_lines(command: list[str]) -> int:
 
     if status != 0:
         logger.error(f"Command failed: {command_for_log(command)}")
-        logger.error(f"stderr: {stderr}")
         raise RuntimeError(
             f"Command failed with exit code {status}: {command_for_log(command)}\n"
             f"{compact_output('stderr', stderr)}"
@@ -365,9 +360,6 @@ def aws_cp(args, expected_size: int | None = None):
             raise
 
     if tar_status != 0 or aws_proc.returncode != 0:
-        logger.error(f"tar stderr: {tar_stderr}")
-        logger.error(f"aws stdout: {aws_stdout}")
-        logger.error(f"aws stderr: {aws_stderr}")
         raise RuntimeError(upload_failure_message(tar_status, aws_proc.returncode, tar_stderr, aws_stdout, aws_stderr))
 
     logger.info("Tar-to-S3 streaming backup completed")

--- a/neurons/validators/src/miner_jobs/backup_storage.py
+++ b/neurons/validators/src/miner_jobs/backup_storage.py
@@ -3,6 +3,7 @@ import subprocess
 import logging
 import json
 import tempfile
+import re
 
 # Setup logger
 logging.basicConfig(level=logging.INFO)
@@ -14,28 +15,80 @@ plugin_name = "s3fs-backup"
 # large guessed value for small gzip streams can make aws-cli use multipart
 # behavior and return without a usable object, so keep small backups simple.
 AWS_CLI_EXPECTED_SIZE_THRESHOLD_BYTES = 50 * 1024 * 1024 * 1024
+MAX_ERROR_DETAIL_CHARS = 1200
+
+
+def redact_sensitive_text(text: str | None) -> str:
+    if not text:
+        return ""
+    return re.sub(r"(AWS_SECRET_ACCESS_KEY|AWSSECRETACCESSKEY)=\S+", r"\1=<redacted>", text)
+
+
+def command_for_log(command: str | list[str]) -> str:
+    if isinstance(command, list):
+        return redact_sensitive_text(" ".join(command))
+    return redact_sensitive_text(command)
+
+
+def compact_output(label: str, output: str | None, limit: int = 500) -> str:
+    output = redact_sensitive_text((output or "").strip())
+    if not output:
+        return ""
+    output = " | ".join(line.strip() for line in output.splitlines() if line.strip())
+    if len(output) > limit:
+        output = f"{output[:limit]}...<truncated>"
+    return f"{label}: {output}"
+
+
+def upload_failure_message(
+    tar_status: int,
+    aws_status: int,
+    tar_stderr: str | None,
+    aws_stdout: str | None,
+    aws_stderr: str | None,
+) -> str:
+    parts = [f"Backup upload failed: tar_status={tar_status}, aws_status={aws_status}"]
+    parts.extend(
+        detail
+        for detail in [
+            compact_output("tar stderr", tar_stderr),
+            compact_output("aws stdout", aws_stdout),
+            compact_output("aws stderr", aws_stderr),
+        ]
+        if detail
+    )
+    message = "; ".join(parts)
+    if len(message) > MAX_ERROR_DETAIL_CHARS:
+        message = f"{message[:MAX_ERROR_DETAIL_CHARS]}...<truncated>"
+    return message
 
 
 def run_command(command):
     result = subprocess.run(command, shell=True, capture_output=True, text=True)
     if result.returncode != 0:
-        logger.error(f"Command failed: {command}")
+        logger.error(f"Command failed: {command_for_log(command)}")
         logger.error(f"stdout: {result.stdout}")
         logger.error(f"stderr: {result.stderr}")
-        raise RuntimeError(f"Command failed with exit code {result.returncode}: {command}\nstderr: {result.stderr}")
+        raise RuntimeError(
+            f"Command failed with exit code {result.returncode}: {command_for_log(command)}\n"
+            f"{compact_output('stderr', result.stderr)}"
+        )
     else:
-        logger.info(f"Command succeeded: {command}")
+        logger.info(f"Command succeeded: {command_for_log(command)}")
     return result
 
 
 def run_command_args(command: list[str], input_stream=None, stdout=None):
     result = subprocess.run(command, stdin=input_stream, stdout=stdout, capture_output=stdout is None, text=True)
     if result.returncode != 0:
-        logger.error(f"Command failed: {' '.join(command)}")
+        logger.error(f"Command failed: {command_for_log(command)}")
         logger.error(f"stdout: {result.stdout}")
         logger.error(f"stderr: {result.stderr}")
-        raise RuntimeError(f"Command failed with exit code {result.returncode}: {' '.join(command)}\nstderr: {result.stderr}")
-    logger.info(f"Command succeeded: {' '.join(command)}")
+        raise RuntimeError(
+            f"Command failed with exit code {result.returncode}: {command_for_log(command)}\n"
+            f"{compact_output('stderr', result.stderr)}"
+        )
+    logger.info(f"Command succeeded: {command_for_log(command)}")
     return result
 
 
@@ -212,10 +265,13 @@ def count_command_output_lines(command: list[str]) -> int:
             raise
 
     if status != 0:
-        logger.error(f"Command failed: {' '.join(command)}")
+        logger.error(f"Command failed: {command_for_log(command)}")
         logger.error(f"stderr: {stderr}")
-        raise RuntimeError(f"Command failed with exit code {status}: {' '.join(command)}\nstderr: {stderr}")
-    logger.info(f"Command succeeded: {' '.join(command)}")
+        raise RuntimeError(
+            f"Command failed with exit code {status}: {command_for_log(command)}\n"
+            f"{compact_output('stderr', stderr)}"
+        )
+    logger.info(f"Command succeeded: {command_for_log(command)}")
     return count
 
 
@@ -227,9 +283,6 @@ def aws_cp(args, expected_size: int | None = None):
     backup_path_parent = os.path.dirname(backup_path) or "."
     backup_path_current = os.path.basename(backup_path)
     source_volume = f"{args.source_volume}:{args.source_volume_path}"
-    # Caller normally passes this from estimate_backup_sizes() to avoid running du/find twice.
-    if expected_size is None:
-        expected_size = estimate_expected_size(args, backup_path)
 
     # tar runs inside Docker with the source volume mounted and writes the archive to stdout.
     tar_command = docker_base_command(args, volumes=[source_volume], entrypoint="tar") + [
@@ -282,9 +335,7 @@ def aws_cp(args, expected_size: int | None = None):
         logger.error(f"tar stderr: {tar_stderr}")
         logger.error(f"aws stdout: {aws_stdout}")
         logger.error(f"aws stderr: {aws_stderr}")
-        raise RuntimeError(
-            f"Backup upload failed: tar_status={tar_status}, aws_status={aws_proc.returncode}"
-        )
+        raise RuntimeError(upload_failure_message(tar_status, aws_proc.returncode, tar_stderr, aws_stdout, aws_stderr))
 
     logger.info("Tar-to-S3 streaming backup completed")
 

--- a/neurons/validators/src/miner_jobs/backup_storage.py
+++ b/neurons/validators/src/miner_jobs/backup_storage.py
@@ -1,6 +1,8 @@
 import os
 import subprocess
 import logging
+import json
+import tempfile
 
 # Setup logger
 logging.basicConfig(level=logging.INFO)
@@ -15,8 +17,20 @@ def run_command(command):
         logger.error(f"Command failed: {command}")
         logger.error(f"stdout: {result.stdout}")
         logger.error(f"stderr: {result.stderr}")
+        raise RuntimeError(f"Command failed with exit code {result.returncode}: {command}\nstderr: {result.stderr}")
     else:
         logger.info(f"Command succeeded: {command}")
+    return result
+
+
+def run_command_args(command: list[str], input_stream=None, stdout=None):
+    result = subprocess.run(command, stdin=input_stream, stdout=stdout, capture_output=stdout is None, text=True)
+    if result.returncode != 0:
+        logger.error(f"Command failed: {' '.join(command)}")
+        logger.error(f"stdout: {result.stdout}")
+        logger.error(f"stderr: {result.stderr}")
+        raise RuntimeError(f"Command failed with exit code {result.returncode}: {' '.join(command)}\nstderr: {result.stderr}")
+    logger.info(f"Command succeeded: {' '.join(command)}")
     return result
 
 
@@ -96,39 +110,194 @@ def disable_backup_volume_plugin():
 
 
 def update_backup_log(
-        api_url: str, status: str, logs: list[str], error_message: str, progress: float, auth_token: str
+        api_url: str,
+        backup_log_id: str,
+        status: str,
+        logs: list[str],
+        error_message: str,
+        progress: float,
+        auth_token: str,
+        s3_metadata: dict | None = None,
+        estimated_backup_size_bytes: int | None = None,
     ):
     import requests
-    url = f"{api_url}/backup-logs/{args.backup_log_id}/progress"
+
+    payload = {"status": status, "logs": logs, "error_message": error_message, "progress": progress}
+    # Size estimate is sent before upload so API/UI can show expected backup size while the job is running.
+    if estimated_backup_size_bytes is not None:
+        payload["estimated_backup_size_bytes"] = estimated_backup_size_bytes
+    if s3_metadata:
+        payload.update(
+            {
+                "s3_content_length": s3_metadata.get("ContentLength"),
+                "s3_last_modified": s3_metadata.get("LastModified"),
+                "s3_etag": s3_metadata.get("ETag"),
+            }
+        )
+
+    url = f"{api_url}/backup-logs/{backup_log_id}/progress"
     response = requests.put(
-        url, json={"status": status, "logs": logs, "error_message": error_message, "progress": progress},
+        url, json=payload,
         headers={"Authorization": f"Bearer {auth_token}"}
     )
     response.raise_for_status()
 
 
 def pull_aws_cli():
-    run_command("/usr/bin/docker pull daturaai/aws-cli")
+    run_command_args(["/usr/bin/docker", "pull", "daturaai/aws-cli"])
 
 
-def aws_cp(args):
-    backup_path = (args.backup_path or '').rstrip('/')
-    backup_path_parent = os.path.dirname(backup_path)
-    backup_path_current = os.path.basename(backup_path)
-
-    command = (
-        "docker run --rm "
-        f"-v {args.source_volume}:{args.source_volume_path} "
-        f"-e AWS_ACCESS_KEY_ID={args.backup_volume_iam_user_access_key} "
-        f"-e AWS_SECRET_ACCESS_KEY={args.backup_volume_iam_user_secret_key} "
-        f"-e AWS_DEFAULT_REGION=us-east-1 "
-        "--entrypoint sh "
-        "daturaai/aws-cli  -lc "
-        f'"tar --xattrs --acls -C {backup_path_parent} -czf - {backup_path_current} '
-        f"| aws s3 cp - s3://{args.backup_volume_name}/{args.backup_target_path} "
-        f'  --sse AES256 --expected-size $(tar -C {backup_path_parent} -cf - {backup_path_current} | wc -c)" '
+def docker_base_command(args, volumes=None, entrypoint=None):
+    command = ["/usr/bin/docker", "run", "--rm"]
+    for volume in volumes or []:
+        command.extend(["-v", volume])
+    if entrypoint:
+        command.extend(["--entrypoint", entrypoint])
+    command.extend(
+        [
+            "-e", f"AWS_ACCESS_KEY_ID={args.backup_volume_iam_user_access_key}",
+            "-e", f"AWS_SECRET_ACCESS_KEY={args.backup_volume_iam_user_secret_key}",
+            "-e", "AWS_DEFAULT_REGION=us-east-1",
+            "daturaai/aws-cli",
+        ]
     )
-    run_command(command)
+    return command
+
+
+def estimate_backup_sizes(args, backup_path) -> tuple[int, int]:
+    source_volume = f"{args.source_volume}:{args.source_volume_path}"
+    # Run du inside Docker with the workload volume mounted; the miner host may not have this path.
+    du_command = docker_base_command(args, volumes=[source_volume], entrypoint="du") + ["-sb", backup_path]
+    try:
+        result = run_command_args(du_command)
+        source_bytes = int(result.stdout.split()[0])
+    except Exception:
+        result = run_command_args(docker_base_command(args, volumes=[source_volume], entrypoint="du") + ["-sk", backup_path])
+        source_bytes = int(result.stdout.split()[0]) * 1024
+
+    find_command = docker_base_command(args, volumes=[source_volume], entrypoint="find") + [backup_path, "-print"]
+    entry_count = count_command_output_lines(find_command)
+    entry_count = max(entry_count, 1)
+
+    # source_bytes is the user-facing estimate. expected_upload_size is only for AWS CLI's
+    # streamed multipart upload planner and intentionally has a safety cushion.
+    cushion = max(source_bytes // 20, 100 * 1024 * 1024)
+    expected_upload_size = source_bytes + cushion + entry_count * 4096
+    return source_bytes, expected_upload_size
+
+
+def estimate_expected_size(args, backup_path):
+    _, expected_upload_size = estimate_backup_sizes(args, backup_path)
+    return expected_upload_size
+
+
+def count_command_output_lines(command: list[str]) -> int:
+    # Stream line counting instead of materializing potentially huge find output in memory.
+    with tempfile.TemporaryFile(mode="w+") as stderr_file:
+        proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=stderr_file, text=True)
+        count = 0
+        try:
+            for _ in proc.stdout:
+                count += 1
+            status = proc.wait()
+            stderr_file.seek(0)
+            stderr = stderr_file.read()
+        except Exception:
+            proc.kill()
+            raise
+
+    if status != 0:
+        logger.error(f"Command failed: {' '.join(command)}")
+        logger.error(f"stderr: {stderr}")
+        raise RuntimeError(f"Command failed with exit code {status}: {' '.join(command)}\nstderr: {stderr}")
+    logger.info(f"Command succeeded: {' '.join(command)}")
+    return count
+
+
+def aws_cp(args, expected_size: int | None = None):
+    backup_path = os.path.expanduser((args.backup_path or '').rstrip('/'))
+    if not backup_path:
+        raise ValueError("Backup path is required")
+
+    backup_path_parent = os.path.dirname(backup_path) or "."
+    backup_path_current = os.path.basename(backup_path)
+    source_volume = f"{args.source_volume}:{args.source_volume_path}"
+    # Caller normally passes this from estimate_backup_sizes() to avoid running du/find twice.
+    if expected_size is None:
+        expected_size = estimate_expected_size(args, backup_path)
+
+    # tar runs inside Docker with the source volume mounted and writes the archive to stdout.
+    tar_command = docker_base_command(args, volumes=[source_volume], entrypoint="tar") + [
+        "--xattrs",
+        "--acls",
+        "-C",
+        backup_path_parent,
+        "-czf",
+        "-",
+        backup_path_current,
+    ]
+    # AWS CLI reads stdin and uploads directly to S3; no local archive is created on miner disk.
+    aws_command = docker_base_command(args, entrypoint="aws") + [
+        "s3",
+        "cp",
+        "-",
+        f"s3://{args.backup_volume_name}/{args.backup_target_path}",
+        "--sse",
+        "AES256",
+        "--expected-size",
+        str(expected_size),
+    ]
+
+    logger.info("Starting tar-to-S3 streaming backup")
+    aws_proc = None
+    with tempfile.TemporaryFile() as tar_stderr_file:
+        # Keep tar stderr in a temp file so verbose warnings cannot fill a pipe and deadlock the stream.
+        tar_proc = subprocess.Popen(tar_command, stdout=subprocess.PIPE, stderr=tar_stderr_file)
+        try:
+            # AWS reads tar stdout directly; no archive is written to local disk.
+            aws_proc = subprocess.Popen(
+                aws_command,
+                stdin=tar_proc.stdout,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            tar_proc.stdout.close()
+            aws_stdout, aws_stderr = aws_proc.communicate()
+            tar_status = tar_proc.wait()
+            tar_stderr_file.seek(0)
+            tar_stderr = tar_stderr_file.read().decode(errors="replace")
+        except Exception:
+            tar_proc.kill()
+            if aws_proc:
+                aws_proc.kill()
+            raise
+
+    if tar_status != 0 or aws_proc.returncode != 0:
+        logger.error(f"tar stderr: {tar_stderr}")
+        logger.error(f"aws stdout: {aws_stdout}")
+        logger.error(f"aws stderr: {aws_stderr}")
+        raise RuntimeError(
+            f"Backup upload failed: tar_status={tar_status}, aws_status={aws_proc.returncode}"
+        )
+
+    logger.info("Tar-to-S3 streaming backup completed")
+
+
+def aws_head_object(args):
+    # A successful upload alone is not enough; completion requires S3 to acknowledge the object exists.
+    command = docker_base_command(args, entrypoint="aws") + [
+        "s3api",
+        "head-object",
+        "--bucket",
+        args.backup_volume_name,
+        "--key",
+        args.backup_target_path,
+        "--output",
+        "json",
+    ]
+    result = run_command_args(command)
+    return json.loads(result.stdout)
 
 
 def backup_storage(args):
@@ -179,17 +348,58 @@ def backup_storage(args):
         logger.info("Step 1: Pulling aws cli...")
         pull_aws_cli()
         logger.info("Aws cli pulled")
-        progress += 30 # 30
-        update_backup_log(args.api_url, "IN_PROGRESS", ["Info: Aws cli pulled"], "", progress, args.auth_token)
+        progress = 10
+        update_backup_log(args.api_url, args.backup_log_id, "IN_PROGRESS", ["Info: Aws cli pulled"], "", progress, args.auth_token)
 
-        logger.info("Step 2: Copying to aws s3...")
-        aws_cp(args)
+        backup_path = os.path.expanduser((args.backup_path or '').rstrip('/'))
+        if not backup_path:
+            raise ValueError("Backup path is required")
+        logger.info("Step 2: Estimating backup size...")
+        estimated_backup_size_bytes, expected_upload_size = estimate_backup_sizes(args, backup_path)
+        progress = 20
+        update_backup_log(
+            args.api_url,
+            args.backup_log_id,
+            "IN_PROGRESS",
+            ["Info: Backup size estimated"],
+            "",
+            progress,
+            args.auth_token,
+            estimated_backup_size_bytes=estimated_backup_size_bytes,
+        )
+
+        logger.info("Step 3: Copying to aws s3...")
+        aws_cp(args, expected_size=expected_upload_size)
         logger.info("Copying to aws s3 completed")
-        progress += 70 # 100
-        update_backup_log(args.api_url, "COMPLETED", ["Info: Copying to aws s3 completed"], "", progress, args.auth_token)
+        progress = 90
+        update_backup_log(
+            args.api_url,
+            args.backup_log_id,
+            "IN_PROGRESS",
+            ["Info: Copying to aws s3 completed"],
+            "",
+            progress,
+            args.auth_token,
+        )
+
+        logger.info("Step 4: Verifying aws s3 object...")
+        s3_metadata = aws_head_object(args)
+        logger.info("Aws s3 object verified")
+
+        progress = 100
+        update_backup_log(
+            args.api_url,
+            args.backup_log_id,
+            "COMPLETED",
+            ["Info: Aws s3 object verified"],
+            "",
+            progress,
+            args.auth_token,
+            s3_metadata=s3_metadata,
+        )
     except Exception as e:
         logger.error(f"Backup failed: {e}", exc_info=True)
-        update_backup_log(args.api_url, "FAILED", ["Error: Backup failed"], str(e), progress, args.auth_token)
+        update_backup_log(args.api_url, args.backup_log_id, "FAILED", ["Error: Backup failed"], str(e), progress, args.auth_token)
         raise e
 
 

--- a/neurons/validators/src/miner_jobs/backup_storage.py
+++ b/neurons/validators/src/miner_jobs/backup_storage.py
@@ -16,6 +16,9 @@ plugin_name = "s3fs-backup"
 # behavior and return without a usable object, so keep small backups simple.
 AWS_CLI_EXPECTED_SIZE_THRESHOLD_BYTES = 50 * 1024 * 1024 * 1024
 MAX_ERROR_DETAIL_CHARS = 1200
+# These scripts are copied to executor hosts and report status through the public API.
+# Some diagnostic path strings can be rejected before they reach the backend, so
+# normalize stream paths before sending status updates or writing command logs.
 STREAM_PATH_REPLACEMENTS = {
     "/dev/stdout": "stdout",
     "/dev/stderr": "stderr",
@@ -27,8 +30,9 @@ GENERIC_BACKUP_FAILURE_MESSAGE = "Backup failed. Detailed error could not be rep
 def redact_sensitive_text(text: str | None) -> str:
     if not text:
         return ""
+    # Use one sanitizer for backend payloads and local executor logs so credentials
+    # cannot leak and diagnostic text does not block FAILED status updates.
     text = re.sub(r"(AWS_SECRET_ACCESS_KEY|AWSSECRETACCESSKEY)=\S+", r"\1=<redacted>", text)
-    # sanitize the JSON bodies
     for unsafe_path, replacement in STREAM_PATH_REPLACEMENTS.items():
         text = text.replace(unsafe_path, replacement)
     return text
@@ -219,6 +223,8 @@ def update_backup_log(
     except requests.HTTPError:
         if status != "FAILED":
             raise
+        # If a future diagnostic string is still rejected by the API edge, preserve
+        # state correctness by marking the job failed with a known-safe message.
         logger.warning("Detailed backup failure update was rejected; retrying with a generic error message")
         fallback_payload = dict(payload)
         fallback_payload["error_message"] = GENERIC_BACKUP_FAILURE_MESSAGE

--- a/neurons/validators/src/miner_jobs/backup_storage.py
+++ b/neurons/validators/src/miner_jobs/backup_storage.py
@@ -205,8 +205,10 @@ def pull_aws_cli():
     run_command_args(["/usr/bin/docker", "pull", "daturaai/aws-cli"])
 
 
-def docker_base_command(args, volumes=None, entrypoint=None):
+def docker_base_command(args, volumes=None, entrypoint=None, interactive=False):
     command = ["/usr/bin/docker", "run", "--rm"]
+    if interactive:
+        command.append("-i")
     for volume in volumes or []:
         command.extend(["-v", volume])
     if entrypoint:
@@ -295,7 +297,7 @@ def aws_cp(args, expected_size: int | None = None):
         backup_path_current,
     ]
     # AWS CLI reads stdin and uploads directly to S3; no local archive is created on miner disk.
-    aws_command = docker_base_command(args, entrypoint="aws") + [
+    aws_command = docker_base_command(args, entrypoint="aws", interactive=True) + [
         "s3",
         "cp",
         "-",

--- a/neurons/validators/src/miner_jobs/backup_storage.py
+++ b/neurons/validators/src/miner_jobs/backup_storage.py
@@ -459,6 +459,16 @@ def backup_storage(args):
             if estimated_backup_size_bytes >= AWS_CLI_EXPECTED_SIZE_THRESHOLD_BYTES
             else None
         )
+        progress = 30
+        update_backup_log(
+            args.api_url,
+            args.backup_log_id,
+            "IN_PROGRESS",
+            ["Info: Backup upload started"],
+            "",
+            progress,
+            args.auth_token,
+        )
         aws_cp(args, expected_size=expected_size_arg)
         logger.info("Copying to aws s3 completed")
         progress = 90

--- a/neurons/validators/src/miner_jobs/backup_storage.py
+++ b/neurons/validators/src/miner_jobs/backup_storage.py
@@ -16,12 +16,22 @@ plugin_name = "s3fs-backup"
 # behavior and return without a usable object, so keep small backups simple.
 AWS_CLI_EXPECTED_SIZE_THRESHOLD_BYTES = 50 * 1024 * 1024 * 1024
 MAX_ERROR_DETAIL_CHARS = 1200
+STREAM_PATH_REPLACEMENTS = {
+    "/dev/stdout": "stdout",
+    "/dev/stderr": "stderr",
+    "/dev/stdin": "stdin",
+}
+GENERIC_BACKUP_FAILURE_MESSAGE = "Backup failed. Detailed error could not be reported; check executor logs."
 
 
 def redact_sensitive_text(text: str | None) -> str:
     if not text:
         return ""
-    return re.sub(r"(AWS_SECRET_ACCESS_KEY|AWSSECRETACCESSKEY)=\S+", r"\1=<redacted>", text)
+    text = re.sub(r"(AWS_SECRET_ACCESS_KEY|AWSSECRETACCESSKEY)=\S+", r"\1=<redacted>", text)
+    # sanitize the JSON bodies
+    for unsafe_path, replacement in STREAM_PATH_REPLACEMENTS.items():
+        text = text.replace(unsafe_path, replacement)
+    return text
 
 
 def command_for_log(command: str | list[str]) -> str:
@@ -180,7 +190,12 @@ def update_backup_log(
     ):
     import requests
 
-    payload = {"status": status, "logs": logs, "error_message": error_message, "progress": progress}
+    payload = {
+        "status": status,
+        "logs": [redact_sensitive_text(log) for log in logs],
+        "error_message": redact_sensitive_text(error_message),
+        "progress": progress,
+    }
     # Size estimate is sent before upload so API/UI can show expected backup size while the job is running.
     if estimated_backup_size_bytes is not None:
         payload["estimated_backup_size_bytes"] = estimated_backup_size_bytes
@@ -194,11 +209,21 @@ def update_backup_log(
         )
 
     url = f"{api_url}/backup-logs/{backup_log_id}/progress"
+    headers = {"Authorization": f"Bearer {auth_token}"}
     response = requests.put(
         url, json=payload,
-        headers={"Authorization": f"Bearer {auth_token}"}
+        headers=headers,
     )
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except requests.HTTPError:
+        if status != "FAILED":
+            raise
+        logger.warning("Detailed backup failure update was rejected; retrying with a generic error message")
+        fallback_payload = dict(payload)
+        fallback_payload["error_message"] = GENERIC_BACKUP_FAILURE_MESSAGE
+        fallback_response = requests.put(url, json=fallback_payload, headers=headers)
+        fallback_response.raise_for_status()
 
 
 def pull_aws_cli():
@@ -462,8 +487,11 @@ def backup_storage(args):
         )
     except Exception as e:
         logger.error(f"Backup failed: {e}", exc_info=True)
-        update_backup_log(args.api_url, args.backup_log_id, "FAILED", ["Error: Backup failed"], str(e), progress, args.auth_token)
-        raise e
+        try:
+            update_backup_log(args.api_url, args.backup_log_id, "FAILED", ["Error: Backup failed"], str(e), progress, args.auth_token)
+        except Exception:
+            logger.error("Failed to update backup log after backup failure", exc_info=True)
+        raise
 
 
 if __name__ == "__main__":

--- a/neurons/validators/src/miner_jobs/backup_storage.py
+++ b/neurons/validators/src/miner_jobs/backup_storage.py
@@ -10,6 +10,11 @@ logger = logging.getLogger("backup_storage")
 
 plugin_name = "s3fs-backup"
 
+# AWS CLI only needs --expected-size for very large stdin uploads. Passing a
+# large guessed value for small gzip streams can make aws-cli use multipart
+# behavior and return without a usable object, so keep small backups simple.
+AWS_CLI_EXPECTED_SIZE_THRESHOLD_BYTES = 50 * 1024 * 1024 * 1024
+
 
 def run_command(command):
     result = subprocess.run(command, shell=True, capture_output=True, text=True)
@@ -244,9 +249,9 @@ def aws_cp(args, expected_size: int | None = None):
         f"s3://{args.backup_volume_name}/{args.backup_target_path}",
         "--sse",
         "AES256",
-        "--expected-size",
-        str(expected_size),
     ]
+    if expected_size is not None:
+        aws_command.extend(["--expected-size", str(expected_size)])
 
     logger.info("Starting tar-to-S3 streaming backup")
     aws_proc = None
@@ -369,7 +374,12 @@ def backup_storage(args):
         )
 
         logger.info("Step 3: Copying to aws s3...")
-        aws_cp(args, expected_size=expected_upload_size)
+        expected_size_arg = (
+            expected_upload_size
+            if estimated_size_bytes >= AWS_CLI_EXPECTED_SIZE_THRESHOLD_BYTES
+            else None
+        )
+        aws_cp(args, expected_size=expected_size_arg)
         logger.info("Copying to aws s3 completed")
         progress = 90
         update_backup_log(

--- a/neurons/validators/src/miner_jobs/backup_storage.py
+++ b/neurons/validators/src/miner_jobs/backup_storage.py
@@ -427,7 +427,7 @@ def backup_storage(args):
         logger.info("Step 3: Copying to aws s3...")
         expected_size_arg = (
             expected_upload_size
-            if estimated_size_bytes >= AWS_CLI_EXPECTED_SIZE_THRESHOLD_BYTES
+            if estimated_backup_size_bytes >= AWS_CLI_EXPECTED_SIZE_THRESHOLD_BYTES
             else None
         )
         aws_cp(args, expected_size=expected_size_arg)

--- a/neurons/validators/src/miner_jobs/restore_storage.py
+++ b/neurons/validators/src/miner_jobs/restore_storage.py
@@ -9,6 +9,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("restore_storage")
 
 plugin_name = "s3fs-restore"
+MAX_ERROR_DETAIL_CHARS = 1200
 # These scripts are copied to executor hosts and report status through the public API.
 # Some diagnostic path strings can be rejected before they reach the backend, so
 # normalize stream paths before sending status updates or writing command logs.
@@ -37,15 +38,46 @@ def command_for_log(command: str | list[str]) -> str:
     return sanitize_report_text(command)
 
 
+def compact_output(label: str, output: str | None, limit: int = 500) -> str:
+    output = sanitize_report_text((output or "").strip())
+    if not output:
+        return ""
+    output = " | ".join(line.strip() for line in output.splitlines() if line.strip())
+    if len(output) > limit:
+        output = f"{output[:limit]}...<truncated>"
+    return f"{label}: {output}"
+
+
+def restore_failure_message(
+    aws_status: int,
+    tar_status: int,
+    aws_stderr: str | None,
+    tar_stdout: str | None,
+    tar_stderr: str | None,
+) -> str:
+    parts = [f"Restore failed: aws_status={aws_status}, tar_status={tar_status}"]
+    parts.extend(
+        detail
+        for detail in [
+            compact_output("aws stderr", aws_stderr),
+            compact_output("tar stdout", tar_stdout),
+            compact_output("tar stderr", tar_stderr),
+        ]
+        if detail
+    )
+    message = "; ".join(parts)
+    if len(message) > MAX_ERROR_DETAIL_CHARS:
+        message = f"{message[:MAX_ERROR_DETAIL_CHARS]}...<truncated>"
+    return message
+
+
 def run_command(command):
     result = subprocess.run(command, shell=True, capture_output=True, text=True)
     if result.returncode != 0:
         logger.error(f"Command failed: {command_for_log(command)}")
-        logger.error(f"stdout: {result.stdout}")
-        logger.error(f"stderr: {result.stderr}")
         raise RuntimeError(
             f"Command failed with exit code {result.returncode}: {command_for_log(command)}\n"
-            f"stderr: {sanitize_report_text(result.stderr)}"
+            f"{compact_output('stderr', result.stderr)}"
         )
     else:
         logger.info(f"Command succeeded: {command_for_log(command)}")
@@ -56,11 +88,9 @@ def run_command_args(command: list[str]):
     result = subprocess.run(command, capture_output=True, text=True)
     if result.returncode != 0:
         logger.error(f"Command failed: {command_for_log(command)}")
-        logger.error(f"stdout: {result.stdout}")
-        logger.error(f"stderr: {result.stderr}")
         raise RuntimeError(
             f"Command failed with exit code {result.returncode}: {command_for_log(command)}\n"
-            f"stderr: {sanitize_report_text(result.stderr)}"
+            f"{compact_output('stderr', result.stderr)}"
         )
     logger.info(f"Command succeeded: {command_for_log(command)}")
     return result
@@ -191,12 +221,7 @@ def aws_restore(args):
             raise
 
     if aws_status != 0 or tar_proc.returncode != 0:
-        logger.error(f"aws stderr: {aws_stderr}")
-        logger.error(f"tar stdout: {tar_stdout}")
-        logger.error(f"tar stderr: {tar_stderr}")
-        raise RuntimeError(
-            f"Restore failed: aws_status={aws_status}, tar_status={tar_proc.returncode}"
-        )
+        raise RuntimeError(restore_failure_message(aws_status, tar_proc.returncode, aws_stderr, tar_stdout, tar_stderr))
 
     logger.info("S3-to-tar streaming restore completed")
 

--- a/neurons/validators/src/miner_jobs/restore_storage.py
+++ b/neurons/validators/src/miner_jobs/restore_storage.py
@@ -1,5 +1,7 @@
 import logging
+import os
 import subprocess
+import tempfile
 
 # Setup logger
 logging.basicConfig(level=logging.INFO)
@@ -14,8 +16,20 @@ def run_command(command):
         logger.error(f"Command failed: {command}")
         logger.error(f"stdout: {result.stdout}")
         logger.error(f"stderr: {result.stderr}")
+        raise RuntimeError(f"Command failed with exit code {result.returncode}: {command}\nstderr: {result.stderr}")
     else:
         logger.info(f"Command succeeded: {command}")
+    return result
+
+
+def run_command_args(command: list[str]):
+    result = subprocess.run(command, capture_output=True, text=True)
+    if result.returncode != 0:
+        logger.error(f"Command failed: {' '.join(command)}")
+        logger.error(f"stdout: {result.stdout}")
+        logger.error(f"stderr: {result.stderr}")
+        raise RuntimeError(f"Command failed with exit code {result.returncode}: {' '.join(command)}\nstderr: {result.stderr}")
+    logger.info(f"Command succeeded: {' '.join(command)}")
     return result
 
 
@@ -40,24 +54,93 @@ def update_restore_log(
 
 
 def pull_aws_cli():
-    run_command("/usr/bin/docker pull daturaai/aws-cli")
+    run_command_args(["/usr/bin/docker", "pull", "daturaai/aws-cli"])
+
+
+def docker_base_command(args, volumes=None, entrypoint=None):
+    command = ["/usr/bin/docker", "run", "--rm"]
+    for volume in volumes or []:
+        command.extend(["-v", volume])
+    if entrypoint:
+        command.extend(["--entrypoint", entrypoint])
+    command.extend(
+        [
+            "-e", f"AWS_ACCESS_KEY_ID={args.backup_volume_iam_user_access_key}",
+            "-e", f"AWS_SECRET_ACCESS_KEY={args.backup_volume_iam_user_secret_key}",
+            "-e", "AWS_DEFAULT_REGION=us-east-1",
+            "daturaai/aws-cli",
+        ]
+    )
+    return command
+
+
+def aws_head_object(args):
+    command = docker_base_command(args, entrypoint="aws") + [
+        "s3api",
+        "head-object",
+        "--bucket",
+        args.backup_volume_name,
+        "--key",
+        args.backup_source_path,
+        "--output",
+        "json",
+    ]
+    run_command_args(command)
 
 
 def aws_restore(args):
     # aws s3 cp s3://$BUCKET_NAME/backups/my-folder-2025-09-02.tar.gz - \
     # | tar -xzpf - -C $RESTORE_PATH
-    command = (
-        "docker run --rm "
-        f"-v {args.target_volume}:{args.target_volume_path} "
-        f"-e AWS_ACCESS_KEY_ID={args.backup_volume_iam_user_access_key} "
-        f"-e AWS_SECRET_ACCESS_KEY={args.backup_volume_iam_user_secret_key} "
-        f"-e AWS_DEFAULT_REGION=us-east-1 "
-        "--entrypoint sh "
-        "daturaai/aws-cli  -lc "
-        f'"aws s3 cp s3://{args.backup_volume_name}/{args.backup_source_path} - '
-        f'| tar --xattrs --acls -xzpf - -C {args.restore_path} --strip-components=1 "'
-    )
-    run_command(command)
+    restore_path = os.path.expanduser(args.restore_path)
+    aws_command = docker_base_command(args, entrypoint="aws") + [
+        "s3",
+        "cp",
+        f"s3://{args.backup_volume_name}/{args.backup_source_path}",
+        "-",
+    ]
+    tar_command = docker_base_command(args, volumes=[f"{args.target_volume}:{args.target_volume_path}"], entrypoint="tar") + [
+        "--xattrs",
+        "--acls",
+        "-xzpf",
+        "-",
+        "-C",
+        restore_path,
+        "--strip-components=1",
+    ]
+
+    logger.info("Starting S3-to-tar streaming restore")
+    tar_proc = None
+    with tempfile.TemporaryFile() as aws_stderr_file:
+        aws_proc = subprocess.Popen(aws_command, stdout=subprocess.PIPE, stderr=aws_stderr_file)
+        try:
+            # tar reads the S3 object stream directly; no local archive is written.
+            tar_proc = subprocess.Popen(
+                tar_command,
+                stdin=aws_proc.stdout,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            aws_proc.stdout.close()
+            tar_stdout, tar_stderr = tar_proc.communicate()
+            aws_status = aws_proc.wait()
+            aws_stderr_file.seek(0)
+            aws_stderr = aws_stderr_file.read().decode(errors="replace")
+        except Exception:
+            aws_proc.kill()
+            if tar_proc:
+                tar_proc.kill()
+            raise
+
+    if aws_status != 0 or tar_proc.returncode != 0:
+        logger.error(f"aws stderr: {aws_stderr}")
+        logger.error(f"tar stdout: {tar_stdout}")
+        logger.error(f"tar stderr: {tar_stderr}")
+        raise RuntimeError(
+            f"Restore failed: aws_status={aws_status}, tar_status={tar_proc.returncode}"
+        )
+
+    logger.info("S3-to-tar streaming restore completed")
 
 
 def restore_storage(args):
@@ -81,7 +164,11 @@ def restore_storage(args):
             args.restore_log_id,
         )
 
-        logger.info("Step 2: Restoring from aws s3...")
+        logger.info("Step 2: Verifying aws s3 object...")
+        aws_head_object(args)
+        logger.info("Aws s3 object verified")
+
+        logger.info("Step 3: Restoring from aws s3...")
         aws_restore(args)
         logger.info("Restore from aws s3 completed")
         progress += 70  # 100

--- a/neurons/validators/src/miner_jobs/restore_storage.py
+++ b/neurons/validators/src/miner_jobs/restore_storage.py
@@ -9,6 +9,9 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("restore_storage")
 
 plugin_name = "s3fs-restore"
+# These scripts are copied to executor hosts and report status through the public API.
+# Some diagnostic path strings can be rejected before they reach the backend, so
+# normalize stream paths before sending status updates or writing command logs.
 STREAM_PATH_REPLACEMENTS = {
     "/dev/stdout": "stdout",
     "/dev/stderr": "stderr",
@@ -20,33 +23,46 @@ GENERIC_RESTORE_FAILURE_MESSAGE = "Restore failed. Detailed error could not be r
 def sanitize_report_text(text: str | None) -> str:
     if not text:
         return ""
+    # Use one sanitizer for backend payloads and local executor logs so credentials
+    # cannot leak and diagnostic text does not block FAILED status updates.
     text = re.sub(r"(AWS_SECRET_ACCESS_KEY|AWSSECRETACCESSKEY)=\S+", r"\1=<redacted>", text)
-    # Sanitize the JSON bodies
     for unsafe_path, replacement in STREAM_PATH_REPLACEMENTS.items():
         text = text.replace(unsafe_path, replacement)
     return text
 
 
+def command_for_log(command: str | list[str]) -> str:
+    if isinstance(command, list):
+        return sanitize_report_text(" ".join(command))
+    return sanitize_report_text(command)
+
+
 def run_command(command):
     result = subprocess.run(command, shell=True, capture_output=True, text=True)
     if result.returncode != 0:
-        logger.error(f"Command failed: {command}")
+        logger.error(f"Command failed: {command_for_log(command)}")
         logger.error(f"stdout: {result.stdout}")
         logger.error(f"stderr: {result.stderr}")
-        raise RuntimeError(f"Command failed with exit code {result.returncode}: {command}\nstderr: {result.stderr}")
+        raise RuntimeError(
+            f"Command failed with exit code {result.returncode}: {command_for_log(command)}\n"
+            f"stderr: {sanitize_report_text(result.stderr)}"
+        )
     else:
-        logger.info(f"Command succeeded: {command}")
+        logger.info(f"Command succeeded: {command_for_log(command)}")
     return result
 
 
 def run_command_args(command: list[str]):
     result = subprocess.run(command, capture_output=True, text=True)
     if result.returncode != 0:
-        logger.error(f"Command failed: {' '.join(command)}")
+        logger.error(f"Command failed: {command_for_log(command)}")
         logger.error(f"stdout: {result.stdout}")
         logger.error(f"stderr: {result.stderr}")
-        raise RuntimeError(f"Command failed with exit code {result.returncode}: {' '.join(command)}\nstderr: {result.stderr}")
-    logger.info(f"Command succeeded: {' '.join(command)}")
+        raise RuntimeError(
+            f"Command failed with exit code {result.returncode}: {command_for_log(command)}\n"
+            f"stderr: {sanitize_report_text(result.stderr)}"
+        )
+    logger.info(f"Command succeeded: {command_for_log(command)}")
     return result
 
 
@@ -79,6 +95,8 @@ def update_restore_log(
     except requests.HTTPError:
         if status != "FAILED":
             raise
+        # If a future diagnostic string is still rejected by the API edge, preserve
+        # state correctness by marking the job failed with a known-safe message.
         logger.warning("Detailed restore failure update was rejected; retrying with a generic error message")
         fallback_payload = dict(payload)
         fallback_payload["error_message"] = GENERIC_RESTORE_FAILURE_MESSAGE

--- a/neurons/validators/src/miner_jobs/restore_storage.py
+++ b/neurons/validators/src/miner_jobs/restore_storage.py
@@ -57,8 +57,10 @@ def pull_aws_cli():
     run_command_args(["/usr/bin/docker", "pull", "daturaai/aws-cli"])
 
 
-def docker_base_command(args, volumes=None, entrypoint=None):
+def docker_base_command(args, volumes=None, entrypoint=None, interactive=False):
     command = ["/usr/bin/docker", "run", "--rm"]
+    if interactive:
+        command.append("-i")
     for volume in volumes or []:
         command.extend(["-v", volume])
     if entrypoint:
@@ -98,7 +100,12 @@ def aws_restore(args):
         f"s3://{args.backup_volume_name}/{args.backup_source_path}",
         "-",
     ]
-    tar_command = docker_base_command(args, volumes=[f"{args.target_volume}:{args.target_volume_path}"], entrypoint="tar") + [
+    tar_command = docker_base_command(
+        args,
+        volumes=[f"{args.target_volume}:{args.target_volume_path}"],
+        entrypoint="tar",
+        interactive=True,
+    ) + [
         "--xattrs",
         "--acls",
         "-xzpf",

--- a/neurons/validators/src/miner_jobs/restore_storage.py
+++ b/neurons/validators/src/miner_jobs/restore_storage.py
@@ -234,7 +234,7 @@ def restore_storage(args):
         logger.info("Step 1: Pulling aws cli...")
         pull_aws_cli()
         logger.info("Aws cli pulled")
-        progress += 30  # 30
+        progress = 10
         update_restore_log(
             args.api_url,
             "IN_PROGRESS",
@@ -248,15 +248,46 @@ def restore_storage(args):
         logger.info("Step 2: Verifying aws s3 object...")
         aws_head_object(args)
         logger.info("Aws s3 object verified")
+        progress = 20
+        update_restore_log(
+            args.api_url,
+            "IN_PROGRESS",
+            ["Info: Restore source object verified"],
+            "",
+            progress,
+            args.auth_token,
+            args.restore_log_id,
+        )
 
         logger.info("Step 3: Restoring from aws s3...")
+        progress = 30
+        update_restore_log(
+            args.api_url,
+            "IN_PROGRESS",
+            ["Info: Restore stream started"],
+            "",
+            progress,
+            args.auth_token,
+            args.restore_log_id,
+        )
         aws_restore(args)
         logger.info("Restore from aws s3 completed")
-        progress += 70  # 100
+        progress = 90
+        update_restore_log(
+            args.api_url,
+            "IN_PROGRESS",
+            ["Info: Restore from aws s3 completed"],
+            "",
+            progress,
+            args.auth_token,
+            args.restore_log_id,
+        )
+
+        progress = 100
         update_restore_log(
             args.api_url,
             "COMPLETED",
-            ["Info: Restore from aws s3 completed"],
+            ["Info: Restore completed"],
             "",
             progress,
             args.auth_token,

--- a/neurons/validators/src/miner_jobs/restore_storage.py
+++ b/neurons/validators/src/miner_jobs/restore_storage.py
@@ -26,16 +26,14 @@ def sanitize_report_text(text: str | None) -> str:
         return ""
     # Use one sanitizer for backend payloads and local executor logs so credentials
     # cannot leak and diagnostic text does not block FAILED status updates.
-    text = re.sub(r"(AWS_SECRET_ACCESS_KEY|AWSSECRETACCESSKEY)=\S+", r"\1=<redacted>", text)
+    text = re.sub(
+        r"(AWS_SECRET_ACCESS_KEY|AWSSECRETACCESSKEY)\s*=\s*(\"[^\"]*\"|'[^']*'|[^\s]+)",
+        r"\1=<redacted>",
+        text,
+    )
     for unsafe_path, replacement in STREAM_PATH_REPLACEMENTS.items():
         text = text.replace(unsafe_path, replacement)
     return text
-
-
-def command_for_log(command: str | list[str]) -> str:
-    if isinstance(command, list):
-        return sanitize_report_text(" ".join(command))
-    return sanitize_report_text(command)
 
 
 def compact_output(label: str, output: str | None, limit: int = 500) -> str:
@@ -71,28 +69,28 @@ def restore_failure_message(
     return message
 
 
-def run_command(command):
+def run_command(command, command_label: str = "command"):
     result = subprocess.run(command, shell=True, capture_output=True, text=True)
     if result.returncode != 0:
-        logger.error(f"Command failed: {command_for_log(command)}")
+        logger.error(f"Command failed: {command_label}")
         raise RuntimeError(
-            f"Command failed with exit code {result.returncode}: {command_for_log(command)}\n"
+            f"{command_label} failed with exit code {result.returncode}\n"
             f"{compact_output('stderr', result.stderr)}"
         )
     else:
-        logger.info(f"Command succeeded: {command_for_log(command)}")
+        logger.info(f"Command succeeded: {command_label}")
     return result
 
 
-def run_command_args(command: list[str]):
+def run_command_args(command: list[str], command_label: str = "command"):
     result = subprocess.run(command, capture_output=True, text=True)
     if result.returncode != 0:
-        logger.error(f"Command failed: {command_for_log(command)}")
+        logger.error(f"Command failed: {command_label}")
         raise RuntimeError(
-            f"Command failed with exit code {result.returncode}: {command_for_log(command)}\n"
+            f"{command_label} failed with exit code {result.returncode}\n"
             f"{compact_output('stderr', result.stderr)}"
         )
-    logger.info(f"Command succeeded: {command_for_log(command)}")
+    logger.info(f"Command succeeded: {command_label}")
     return result
 
 
@@ -135,7 +133,7 @@ def update_restore_log(
 
 
 def pull_aws_cli():
-    run_command_args(["/usr/bin/docker", "pull", "daturaai/aws-cli"])
+    run_command_args(["/usr/bin/docker", "pull", "daturaai/aws-cli"], command_label="docker pull daturaai/aws-cli")
 
 
 def docker_base_command(args, volumes=None, entrypoint=None, interactive=False):
@@ -168,7 +166,7 @@ def aws_head_object(args):
         "--output",
         "json",
     ]
-    run_command_args(command)
+    run_command_args(command, command_label="docker run aws s3api head-object")
 
 
 def aws_restore(args):

--- a/neurons/validators/src/miner_jobs/restore_storage.py
+++ b/neurons/validators/src/miner_jobs/restore_storage.py
@@ -2,12 +2,29 @@ import logging
 import os
 import subprocess
 import tempfile
+import re
 
 # Setup logger
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("restore_storage")
 
 plugin_name = "s3fs-restore"
+STREAM_PATH_REPLACEMENTS = {
+    "/dev/stdout": "stdout",
+    "/dev/stderr": "stderr",
+    "/dev/stdin": "stdin",
+}
+GENERIC_RESTORE_FAILURE_MESSAGE = "Restore failed. Detailed error could not be reported; check executor logs."
+
+
+def sanitize_report_text(text: str | None) -> str:
+    if not text:
+        return ""
+    text = re.sub(r"(AWS_SECRET_ACCESS_KEY|AWSSECRETACCESSKEY)=\S+", r"\1=<redacted>", text)
+    # Sanitize the JSON bodies
+    for unsafe_path, replacement in STREAM_PATH_REPLACEMENTS.items():
+        text = text.replace(unsafe_path, replacement)
+    return text
 
 
 def run_command(command):
@@ -45,12 +62,28 @@ def update_restore_log(
     import requests
 
     url = f"{api_url}/restore-logs/{restore_log_id}/progress"
+    payload = {
+        "status": status,
+        "logs": [sanitize_report_text(log) for log in logs],
+        "error_message": sanitize_report_text(error_message),
+        "progress": progress,
+    }
+    headers = {"Authorization": f"Bearer {auth_token}"}
     response = requests.put(
         url,
-        json={"status": status, "logs": logs, "error_message": error_message, "progress": progress},
-        headers={"Authorization": f"Bearer {auth_token}"},
+        json=payload,
+        headers=headers,
     )
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except requests.HTTPError:
+        if status != "FAILED":
+            raise
+        logger.warning("Detailed restore failure update was rejected; retrying with a generic error message")
+        fallback_payload = dict(payload)
+        fallback_payload["error_message"] = GENERIC_RESTORE_FAILURE_MESSAGE
+        fallback_response = requests.put(url, json=fallback_payload, headers=headers)
+        fallback_response.raise_for_status()
 
 
 def pull_aws_cli():
@@ -190,16 +223,19 @@ def restore_storage(args):
         )
     except Exception as e:
         logger.error(f"Restore failed: {e}", exc_info=True)
-        update_restore_log(
-            args.api_url,
-            "FAILED",
-            ["Error: Restore failed"],
-            str(e),
-            progress,
-            args.auth_token,
-            args.restore_log_id,
-        )
-        raise e
+        try:
+            update_restore_log(
+                args.api_url,
+                "FAILED",
+                ["Error: Restore failed"],
+                str(e),
+                progress,
+                args.auth_token,
+                args.restore_log_id,
+            )
+        except Exception:
+            logger.error("Failed to update restore log after restore failure", exc_info=True)
+        raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Describe your changes

Fixes validator-side backup and restore execution reliability:

- Replaces brittle shell-pipe backup/restore orchestration with Python subprocess streaming.
- Keeps Docker stdin open for stream-consuming AWS/tar containers.
- Estimates backup source size and reports it to backend before upload.
- Uses AWS CLI `--expected-size` only for large stdin uploads to avoid small-upload multipart issues.
- Verifies S3 object existence with `head-object` before marking backups completed.
- Sanitizes error/status reporting and adds a safe fallback FAILED update.
- Avoids logging full Docker/AWS command argv or raw stdout/stderr from executor scripts; logs use safe static command labels.
- Strengthens AWS secret redaction for quoted/spaced values and keeps compact sanitized failure diagnostics for backup and restore.

## Issue ticket number and link

[DAH-2083](https://www.notion.so/DAH-2083)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Need to take care of performance? Streaming avoids local archives; size estimation streams `find` output; AWS expected-size is only used for large backups.

## Validation

- `python3 -m py_compile neurons/validators/src/miner_jobs/backup_storage.py neurons/validators/src/miner_jobs/restore_storage.py`
- Staging smoke backup completed and populated S3 verification metadata.
- S3 `head-object` matched DB content length, last modified, and ETag.
- Staging restore completed and restored files matched source checksums.
- Subpath backup restored only the configured subpath contents.
- Verified sanitizer handles `KEY=value`, quoted/spaced secret values, and `/dev/std*` stream paths.
