### PR TITLE
Score storage policy compliance - DAH-1997

### DIFF
--- a/neurons/validators/pdm.lock
+++ b/neurons/validators/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:3685d406acb7b0d5eb2d331bbd4d611adf0c2d0e409f37d7ade64328d649332a"
+content_hash = "sha256:27e9c2d712ee65de134e44357a9f923ec3562f1a9b9caeca71ec3a2c967efc8f"
 
 [[metadata.targets]]
 requires_python = ">=3.11,<3.13"
@@ -1154,6 +1154,21 @@ dependencies = [
 files = [
     {file = "jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe"},
     {file = "jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d"},
+]
+
+[[package]]
+name = "lium-core"
+version = "0.1.2"
+requires_python = ">=3.11"
+summary = "Shared core library for Lium platform"
+groups = ["default"]
+dependencies = [
+    "pydantic>=2.0.0",
+    "requests>=2.31.0",
+]
+files = [
+    {file = "lium_core-0.1.2-py3-none-any.whl", hash = "sha256:2ebddad793ca9a0eb06fc47661de0e31bca697ea4b348f670c5de7d251dc63f5"},
+    {file = "lium_core-0.1.2.tar.gz", hash = "sha256:bb23b2d6bb35fa5bd15f059ae92f2be4420ae673eb4b15868ef5382d861a2053"},
 ]
 
 [[package]]

--- a/neurons/validators/pyproject.toml
+++ b/neurons/validators/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "databases>=0.9.0",
     "datura @ file:///${PROJECT_ROOT}/../../datura",
     "fastapi>=0.110.3",
+    "lium-core>=0.1.2",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.10.1",
     "python-json-logger>=3.3.0",

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -114,6 +114,7 @@ class Settings(BaseSettings):
     COMPUTE_REST_API_URL_EXTERNAL: str | None = Field(
         env="COMPUTE_REST_API_URL_EXTERNAL", default="https://lium.io/api"
     )
+    SHARED_CONFIG_REFRESH_INTERVAL: int = Field(env="SHARED_CONFIG_REFRESH_INTERVAL", default=60)
     MINER_PORTAL_REST_API_URL: str = Field(
         env="MINER_PORTAL_REST_API_URL", default="https://provider-api.lium.io/"
     )

--- a/neurons/validators/src/miner_jobs/machine_scrape.py
+++ b/neurons/validators/src/miner_jobs/machine_scrape.py
@@ -101,6 +101,7 @@ COMMANDS = {
         "--gpus", "all",
         "daturaai/compute-subnet-executor:latest", "nvidia-smi"
     ],
+    "GET_DOCKER_INFO": ["docker", "info"],
 }
 
 
@@ -892,13 +893,88 @@ def check_sysbox_gpu_compatibility() -> tuple[bool, str]:
 
 
 
+def _normalize_docker_info_key(key: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", key.lower()).strip("_")
+
+
+def _parse_docker_storage_info(docker_info: str) -> dict[str, str]:
+    storage_info = {}
+    in_storage_section = False
+
+    for line in docker_info.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        if stripped.startswith("Storage Driver:"):
+            storage_info["storage_driver"] = stripped.split(":", 1)[1].strip().lower()
+            in_storage_section = True
+            continue
+
+        if not in_storage_section:
+            continue
+
+        if not line[:1].isspace() and ":" in stripped:
+            break
+
+        if ":" in stripped:
+            key, value = stripped.split(":", 1)
+            storage_info[_normalize_docker_info_key(key)] = value.strip().lower()
+
+    return storage_info
+
+
+def _docker_info_supports_storage_limit(docker_info: str) -> tuple[bool, str]:
+    storage_info = _parse_docker_storage_info(docker_info)
+    storage_driver = storage_info.get("storage_driver", "")
+
+    if storage_driver == "overlay2":
+        backing_filesystem = storage_info.get("backing_filesystem", "")
+        if backing_filesystem == "xfs":
+            if storage_info.get("supports_d_type") == "false":
+                return False, "Docker overlay2 storage driver uses xfs without d_type support."
+            return True, "Docker overlay2 storage driver uses xfs backing filesystem."
+
+        return (
+            False,
+            "Docker overlay2 storage driver requires xfs backing filesystem for storage limits; "
+            f"found {backing_filesystem or 'unknown'}.",
+        )
+
+    if storage_driver == "overlayfs":
+        return False, "Docker uses containerd overlayfs snapshotter, which does not support size storage-opt."
+
+    if not storage_driver:
+        return False, "Docker storage driver was not found in docker info."
+
+    return False, f"Docker storage driver {storage_driver} is not supported for size storage-opt."
+
+
 def check_storage_limit_ability() -> tuple[bool, str]:
     """
     Checks if the system supports limiting the storage size of a container.
     """
+    docker_info_command = COMMANDS["GET_DOCKER_INFO"]
     test_command = COMMANDS["CHECK_STORAGE_LIMIT_ABILITY"]
 
     try:
+        info_result = subprocess.run(
+            docker_info_command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30
+        )
+
+        if info_result.returncode != 0:
+            return False, "Docker info command failed."
+
+        docker_info_supported, docker_info_message = _docker_info_supports_storage_limit(
+            info_result.stdout
+        )
+        if not docker_info_supported:
+            return False, docker_info_message
+
         result = subprocess.run(
             test_command,
             stdout=subprocess.PIPE,
@@ -910,7 +986,7 @@ def check_storage_limit_ability() -> tuple[bool, str]:
         if result.returncode == 0:
             return True, "Storage limit is supported."
         else:
-            return False, "Storage limit is not supported."
+            return False, f"Storage limit is not supported. {docker_info_message}"
 
     except subprocess.TimeoutExpired:
         return False, "Test command timed out."

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -1,26 +1,29 @@
 import logging
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable, List, Optional, Protocol, Tuple
+from typing import Any, Protocol
 
 import asyncssh
-from pydantic import BaseModel, Field
-
-from datura.requests.miner_requests import ExecutorSSHInfo
-
-from core.utils import _m
 from clients.backend_client import BackendClient
-from services.ssh_service import SSHService
-from services.redis_service import RedisService
+from datura.requests.miner_requests import ExecutorSSHInfo
+from lium_core.shared_config.client import SharedConfigClient
+from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
+from pydantic import BaseModel, Field
 from services.collateral_contract_service import CollateralContractService
-from services.matrix_validation_service import ValidationService
-from services.verifyx_validation_service import VerifyXValidationService
+from services.container_cleanup import ContainerCleanup
 from services.executor_connectivity_service import ExecutorConnectivityService
 from services.interactive_shell_service import InteractiveShellService
-from services.container_cleanup import ContainerCleanup
-from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
+from services.matrix_validation_service import ValidationService
+from services.redis_service import RedisService
+from services.verifyx_validation_service import VerifyXValidationService
+
+from core.utils import _m
+from services.ssh_service import SSHService
+
 from .models import ValidationEvent
 from .runner import SSHCommandRunner
+
 
 @dataclass(frozen=True)
 class ContextServices:
@@ -31,9 +34,10 @@ class ContextServices:
     verifyx: VerifyXValidationService
     connectivity: ExecutorConnectivityService
     shell: InteractiveShellService
-    score_calculator: Callable[[str, bool, bool, str, bool, int], Tuple[float, float, str]]
+    score_calculator: Callable[[str, bool, bool, str, bool, int], tuple[float, float, str]]
     backend: BackendClient
     container_cleanup: ContainerCleanup
+    shared_config_client: SharedConfigClient | None = None
 
 
 @dataclass(frozen=True)
@@ -44,32 +48,32 @@ class ContextConfig:
     machine_scrape_filename: str
     machine_scrape_timeout: int
     obfuscation_keys: Any
-    validator_keypair: Optional[Any] = None
-    max_gpu_count: Optional[int] = None
-    gpu_model_rates: Optional[dict[str, Any]] = None
-    nvml_digest_map: Optional[dict[str, str]] = None
+    validator_keypair: Any | None = None
+    max_gpu_count: int | None = None
+    gpu_model_rates: dict[str, Any] | None = None
+    nvml_digest_map: dict[str, str] | None = None
     enable_no_collateral: bool = False
     verifyx_enabled: bool = False
-    port_private_key: Optional[str] = None
-    port_public_key: Optional[str] = None
-    job_batch_id: Optional[str] = None
+    port_private_key: str | None = None
+    port_public_key: str | None = None
+    job_batch_id: str | None = None
 
 
 @dataclass(frozen=True)
 class ContextState:
-    upload_local_dir: Optional[str] = None
-    upload_remote_dir: Optional[str] = None
-    remote_dir: Optional[str] = None
+    upload_local_dir: str | None = None
+    upload_remote_dir: str | None = None
+    remote_dir: str | None = None
     specs: dict[str, Any] = field(default_factory=dict)
-    gpu_model: Optional[str] = None
-    gpu_count: Optional[int] = None
+    gpu_model: str | None = None
+    gpu_count: int | None = None
     gpu_details: list[dict] = field(default_factory=list)
     gpu_processes: list[dict] = field(default_factory=list)
     sysbox_runtime: bool = False
     supports_gpu_splitting: bool = False
     gpu_splitting_min_count: int | None = None
-    gpu_model_count: Optional[str] = None
-    gpu_uuids: Optional[str] = None
+    gpu_model_count: str | None = None
+    gpu_uuids: str | None = None
     verified_port_count: int = 0
     rented_data: RentedExecutorsResponse | None = None
 
@@ -137,11 +141,11 @@ class LoggerSink:
 
 
 class Pipeline:
-    def __init__(self, checks: List[Check], sink: EventSink):
+    def __init__(self, checks: list[Check], sink: EventSink):
         self.checks = checks
         self.sink = sink
 
-    async def run(self, ctx: Context) -> Tuple[bool, list[ValidationEvent], Context]:
+    async def run(self, ctx: Context) -> tuple[bool, list[ValidationEvent], Context]:
         events: list[ValidationEvent] = []
         current_ctx = ctx
         pipeline_start_time = time.perf_counter()

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -9,20 +9,22 @@ import uuid
 from typing import cast
 
 import bittensor
-from datura.requests.miner_requests import ExecutorSSHInfo
-from payload_models.payloads import MinerJobEnryptedFiles, MinerJobRequestPayload
-
 from clients.backend_client import BackendClient
-from core.config import settings
+from datura.requests.miner_requests import ExecutorSSHInfo
+from lium_core.shared_config.client import SharedConfigClient
+from payload_models.payloads import MinerJobEnryptedFiles, MinerJobRequestPayload
+from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.collateral_contract_service import CollateralContractService
 from services.const import GPU_MODEL_RATES, LIB_NVIDIA_ML_DIGESTS, MAX_GPU_COUNT
-from services.executor_connectivity_service import ExecutorConnectivityService
 from services.container_cleanup import ContainerCleanup
+from services.executor_connectivity_service import ExecutorConnectivityService
 from services.interactive_shell_service import InteractiveShellService
 from services.matrix_validation_service import ValidationService
 from services.redis_service import RENTAL_SUCCEED_MACHINE_SET, RedisService
-from services.ssh_service import SSHService
 from services.verifyx_validation_service import VerifyXValidationService
+
+from core.config import settings
+from services.ssh_service import SSHService
 
 from .checks import (
     BannedGpuCheck,
@@ -48,7 +50,6 @@ from .checks import (
     UploadFilesCheck,
     VerifyXCheck,
 )
-from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from .pipeline import (
     Check,
     Context,
@@ -97,6 +98,10 @@ class PipelineFactory:
         self.collateral_contract_service = collateral_contract_service
         self.executor_connectivity_service = executor_connectivity_service
         self.backend_client = backend_client
+        self.shared_config_client = SharedConfigClient(
+            api_url=f"{(settings.COMPUTE_REST_API_URL or '').rstrip('/')}/v1/shared-config",
+            refresh_interval=settings.SHARED_CONFIG_REFRESH_INTERVAL,
+        )
 
         dry_run = settings.DRY_RUN or settings.CONTAINER_CLEANUP_DRY_RUN
         logger.info(f"ContainerCleanup dry_run={dry_run}")
@@ -176,6 +181,7 @@ class PipelineFactory:
                 score_calculator=calculate_scores,
                 backend=self.backend_client,
                 container_cleanup=self.container_cleanup,
+                shared_config_client=self.shared_config_client,
             ),
             config=ContextConfig(
                 executor_root=executor_info.root_dir,

--- a/neurons/validators/src/services/task/score_calculator.py
+++ b/neurons/validators/src/services/task/score_calculator.py
@@ -4,12 +4,12 @@ This module contains the business logic for calculating actual and job scores
 based on collateral status, rental state, and contract versions.
 """
 
-from typing import Tuple
 
-from core.config import settings
+from lium_core.shared_config.defaults import DEFAULT_SHARED_CONFIG
 from services.const import MACHINE_PRICES
 from services.task.pipeline import Context
 
+from core.config import settings
 
 SCORE_PORTION_FOR_OLD_CONTRACT = 0
 
@@ -17,7 +17,7 @@ SCORE_PORTION_FOR_OLD_CONTRACT = 0
 def calculate_scores(
     ctx: Context,
     rented: bool = False,
-) -> Tuple[float, float, str]:
+) -> tuple[float, float, str]:
     """Calculate actual and job scores for an executor validation.
 
     Args:
@@ -39,6 +39,9 @@ def calculate_scores(
     job_score = 1.0
     actual_score = 1.0
 
+    shared_config_client = getattr(ctx.services, "shared_config_client", None)
+    shared_config = shared_config_client.config if shared_config_client else DEFAULT_SHARED_CONFIG
+
     # Machine price check
     base_price = MACHINE_PRICES.get(gpu_model, 0)
     if price_per_gpu and price_per_gpu > base_price * settings.MACHINE_MAX_PRICE_RATE:
@@ -57,6 +60,15 @@ def calculate_scores(
         warning_messages.append(
             "EMA verifyx download speed unavailable (probe failed or never measured)"
         )
+
+    if (
+        shared_config.require_storage_limit_supported
+        and not rented
+        and (ctx.state.specs or {}).get("storage_limit_supported") is not True
+    ):
+        actual_score = 0.0
+        job_score = 0.0
+        warning_messages.append("Storage limit support required but unavailable")
 
     # Early return for collateral-excluded GPU types
     if gpu_model in settings.COLLATERAL_EXCLUDED_GPU_TYPES:
@@ -91,7 +103,7 @@ def _format_return(
     job_score: float,
     warning_messages: list[str],
     rented: bool,
-) -> Tuple[float, float, str]:
+) -> tuple[float, float, str]:
     """Format the return values for score calculation."""
     # Rented machines always report job_score=1.0
     final_job_score = 1.0 if rented else job_score

--- a/neurons/validators/tests/test_machine_scrape_storage_limit.py
+++ b/neurons/validators/tests/test_machine_scrape_storage_limit.py
@@ -1,0 +1,158 @@
+import ast
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+MACHINE_SCRAPE_PATH = (
+    Path(__file__).resolve().parents[1] / "src" / "miner_jobs" / "machine_scrape.py"
+)
+
+
+def load_storage_limit_functions():
+    names = {
+        "_docker_info_supports_storage_limit",
+        "_normalize_docker_info_key",
+        "_parse_docker_storage_info",
+        "check_storage_limit_ability",
+    }
+    tree = ast.parse(MACHINE_SCRAPE_PATH.read_text())
+    selected = [
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name in names
+    ]
+    module = ast.Module(body=selected, type_ignores=[])
+    namespace = {
+        "COMMANDS": {
+            "GET_DOCKER_INFO": ["docker", "info"],
+            "CHECK_STORAGE_LIMIT_ABILITY": [
+                "docker",
+                "run",
+                "--rm",
+                "--storage-opt",
+                "size=1g",
+                "--gpus",
+                "all",
+                "daturaai/compute-subnet-executor:latest",
+                "nvidia-smi",
+            ],
+        },
+        "re": __import__("re"),
+        "subprocess": subprocess,
+    }
+    exec(compile(module, str(MACHINE_SCRAPE_PATH), "exec"), namespace)
+    return SimpleNamespace(**namespace)
+
+
+def test_docker_info_detects_overlay2_xfs_as_supported():
+    module = load_storage_limit_functions()
+
+    supported, message = module._docker_info_supports_storage_limit(
+        """
+ Storage Driver: overlay2
+  Backing Filesystem: xfs
+  Supports d_type: true
+  Using metacopy: false
+  Native Overlay Diff: true
+  userxattr: false
+ Logging Driver: json-file
+"""
+    )
+
+    assert supported is True
+    assert "overlay2" in message
+    assert "xfs" in message
+
+
+def test_docker_info_detects_containerd_overlayfs_snapshotter_as_unsupported():
+    module = load_storage_limit_functions()
+
+    supported, message = module._docker_info_supports_storage_limit(
+        """
+ Storage Driver: overlayfs
+  driver-type: io.containerd.snapshotter.v1
+ Logging Driver: json-file
+"""
+    )
+
+    assert supported is False
+    assert "overlayfs" in message
+
+
+def test_check_storage_limit_rejects_false_positive_probe(monkeypatch):
+    module = load_storage_limit_functions()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command == module.COMMANDS["GET_DOCKER_INFO"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="""
+ Storage Driver: overlayfs
+  driver-type: io.containerd.snapshotter.v1
+ Logging Driver: json-file
+""",
+                stderr="",
+            )
+        if command == module.COMMANDS["CHECK_STORAGE_LIMIT_ABILITY"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setitem(
+        module.check_storage_limit_ability.__globals__,
+        "subprocess",
+        SimpleNamespace(
+            PIPE=subprocess.PIPE,
+            TimeoutExpired=subprocess.TimeoutExpired,
+            run=fake_run,
+        ),
+    )
+
+    supported, message = module.check_storage_limit_ability()
+
+    assert supported is False
+    assert "overlayfs" in message
+    assert calls == [module.COMMANDS["GET_DOCKER_INFO"]]
+
+
+def test_check_storage_limit_accepts_overlay2_xfs_after_successful_probe(monkeypatch):
+    module = load_storage_limit_functions()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command == module.COMMANDS["GET_DOCKER_INFO"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="""
+ Storage Driver: overlay2
+  Backing Filesystem: xfs
+  Supports d_type: true
+  Using metacopy: false
+  Native Overlay Diff: true
+  userxattr: false
+ Logging Driver: json-file
+""",
+                stderr="",
+            )
+        if command == module.COMMANDS["CHECK_STORAGE_LIMIT_ABILITY"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setitem(
+        module.check_storage_limit_ability.__globals__,
+        "subprocess",
+        SimpleNamespace(
+            PIPE=subprocess.PIPE,
+            TimeoutExpired=subprocess.TimeoutExpired,
+            run=fake_run,
+        ),
+    )
+
+    supported, message = module.check_storage_limit_ability()
+
+    assert supported is True
+    assert "Storage limit is supported" in message
+    assert calls == [
+        module.COMMANDS["GET_DOCKER_INFO"],
+        module.COMMANDS["CHECK_STORAGE_LIMIT_ABILITY"],
+    ]

--- a/neurons/validators/tests/test_score_calculator.py
+++ b/neurons/validators/tests/test_score_calculator.py
@@ -3,10 +3,23 @@ speed threshold. Other score_calculator paths (collateral, rental, price) are ex
 via integration in test_score_check.py and test_pipeline_default_scenarios.py.
 """
 import pytest
-
-from neurons.validators.src.services.task.score_calculator import calculate_scores
+from helpers import (
+    build_context_config,
+    build_services,
+    build_state,
+    default_executor,
+    make_context,
+)
+from lium_core.shared_config.defaults import DEFAULT_SHARED_CONFIG
 from neurons.validators.src.services.task.checks.verifyx import MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS
-from helpers import build_context_config, build_services, build_state, default_executor, make_context
+from neurons.validators.src.services.task.score_calculator import calculate_scores
+
+
+class StubSharedConfigClient:
+    def __init__(self, *, require_storage_limit_supported: bool):
+        self.config = DEFAULT_SHARED_CONFIG.model_copy(
+            update={"require_storage_limit_supported": require_storage_limit_supported}
+        )
 
 
 def _ctx_without_specs(specs, price_per_gpu=None):
@@ -20,6 +33,24 @@ def _ctx_without_specs(specs, price_per_gpu=None):
         config=build_context_config(),
         collateral_deposited=True,
         is_rental_succeed=True,
+    )
+
+
+def _ctx_with_storage_policy(specs, *, required: bool, rented: bool = False):
+    executor = default_executor().model_copy(update={"price_per_gpu": None})
+    state = build_state(specs=specs)
+    services = build_services(
+        shared_config_client=StubSharedConfigClient(
+            require_storage_limit_supported=required
+        )
+    )
+    return make_context(
+        executor=executor,
+        state=state,
+        services=services,
+        config=build_context_config(),
+        collateral_deposited=True,
+        is_rental_succeed=rented,
     )
 
 
@@ -98,3 +129,70 @@ def test_none_specs_rented_does_not_penalise():
     assert actual_score == 1.0
     assert job_score == 1.0
     assert warning == ""
+
+
+@pytest.mark.parametrize("storage_value", [False, None])
+def test_storage_limit_required_zeros_unrented_when_missing_or_false(storage_value):
+    ctx = _ctx_with_storage_policy(
+        {"network": {"ema_verifyx_download_speed": 120.0}, "storage_limit_supported": storage_value},
+        required=True,
+    )
+
+    actual_score, job_score, warning = calculate_scores(ctx, rented=False)
+
+    assert actual_score == 0.0
+    assert job_score == 0.0
+    assert "Storage limit support required" in warning
+
+
+def test_storage_limit_required_zeros_unrented_when_key_missing():
+    ctx = _ctx_with_storage_policy(
+        {"network": {"ema_verifyx_download_speed": 120.0}},
+        required=True,
+    )
+
+    actual_score, job_score, warning = calculate_scores(ctx, rented=False)
+
+    assert actual_score == 0.0
+    assert job_score == 0.0
+    assert "Storage limit support required" in warning
+
+
+def test_storage_limit_required_allows_compliant_unrented_executor():
+    ctx = _ctx_with_storage_policy(
+        {"network": {"ema_verifyx_download_speed": 120.0}, "storage_limit_supported": True},
+        required=True,
+    )
+
+    actual_score, job_score, warning = calculate_scores(ctx, rented=False)
+
+    assert actual_score == 1.0
+    assert job_score == 1.0
+    assert warning == ""
+
+
+def test_storage_limit_disabled_does_not_affect_unrented_score():
+    ctx = _ctx_with_storage_policy(
+        {"network": {"ema_verifyx_download_speed": 120.0}, "storage_limit_supported": False},
+        required=False,
+    )
+
+    actual_score, job_score, warning = calculate_scores(ctx, rented=False)
+
+    assert actual_score == 1.0
+    assert job_score == 1.0
+    assert warning == ""
+
+
+def test_storage_limit_required_does_not_zero_rented_executor():
+    ctx = _ctx_with_storage_policy(
+        {"storage_limit_supported": False},
+        required=True,
+        rented=True,
+    )
+
+    actual_score, job_score, warning = calculate_scores(ctx, rented=True)
+
+    assert actual_score == 1.0
+    assert job_score == 1.0
+    assert "Storage limit support required" not in warning


### PR DESCRIPTION
## Describe your changes

Use backend shared config in validator scoring so unrented executors without storage-limit support receive zero score only when `require_storage_limit_supported` is enabled. This adds the `lium-core>=0.1.2` dependency, wires a shared-config client into validator task services, and covers enabled/disabled/rented scoring behavior in tests.

## Issue ticket number and link

[DAH-1997](https://www.notion.so/DAH-1997)

Related PRs:
- lium-core: https://github.com/Datura-ai/lium-core/pull/1
- lium-io-backend: https://github.com/Datura-ai/lium-io-backend/pull/615
- lium-docs: https://github.com/Datura-ai/lium-docs/pull/49

Validation performed:
- `PYTHONPATH=/home/pyon/lium-projects/lium-core/src:src:tests pdm run pytest tests/test_score_calculator.py -q` -> `15 passed, 37 warnings`
- `pdm run ruff check neurons/validators/src/core/config.py neurons/validators/src/services/task/pipeline.py neurons/validators/src/services/task/pipeline_factory.py neurons/validators/src/services/task/score_calculator.py neurons/validators/tests/test_score_calculator.py` -> passed
- `git diff --check` -> passed

Known deployment note: `pdm lock --update-reuse` is blocked until `lium-core>=0.1.2` is published/resolvable.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?

