### PR TITLE
chore: DAH-2125 - update NEW_BURNERS validator config slots

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -136,7 +136,7 @@ class Settings(BaseSettings):
 
     BURNERS: list[int] = [4, 206, 207, 208]
     # Duplicate entries are slot weights: UID 47 holds the aggregated share of 3 retired burners.
-    NEW_BURNERS: list[int] = [187, 188, 189, 190, 191, 192, 193, 47, 47, 47]
+    NEW_BURNERS: list[int] = [187, 188, 189, 190, 191, 47, 47, 47, 47, 47]
     ENABLE_NEW_BURN_LOGIC: bool = True
 
     ENABLE_NO_COLLATERAL: bool = True

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -135,7 +135,7 @@ class Settings(BaseSettings):
     VERSION: str = (pathlib.Path(__file__).parent / ".." / ".." / "version.txt").read_text().strip()
 
     BURNERS: list[int] = [4, 206, 207, 208]
-    # Duplicate entries are slot weights: UID 47 holds the aggregated share of 3 retired burners.
+    # Duplicate entries are slot weights: UID 47 holds the aggregated share of 5 retired burners.
     NEW_BURNERS: list[int] = [187, 188, 189, 190, 191, 47, 47, 47, 47, 47]
     ENABLE_NEW_BURN_LOGIC: bool = True
 


### PR DESCRIPTION
## Describe your changes

Updates the `NEW_BURNERS` slot list in the validator config (`neurons/validators/src/core/config.py`).

- Before: `[187, 188, 189, 190, 191, 192, 193, 47, 47, 47]`
- After: `[187, 188, 189, 190, 191, 47, 47, 47, 47, 47]`

Removes retired burner UIDs `192` and `193` and reassigns their slot weights to the aggregated UID `47`, which now holds 5 slots. Duplicate entries act as slot weights, so UID 47's aggregated share grows accordingly.

## Issue ticket number and link

[DAH-2125](https://www.notion.so/Compute-SN-c27d35dd084e4c4d92374f55cdd293f2?p=f9b26856f1a6406892b5db46446260da&pm=s)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I wrote tests.
- [ ] Need to take care of performance?
