### PR TITLE
DAH-2146 - Harden GPU model↔VRAM pre-check: per-variant windows + gate rented executors

### DIFF
--- a/neurons/validators/src/services/gpu_precheck.py
+++ b/neurons/validators/src/services/gpu_precheck.py
@@ -12,7 +12,7 @@ from typing import Optional
 
 from .gpu_spec_table import (
     KNOWN_UNRANGED,
-    get_expected_vram_range,
+    get_expected_vram_windows,
     normalize_gpu_model,
 )
 
@@ -28,7 +28,7 @@ class UnsupportedGpuModelError(GpuPrecheckError):
 
 
 class VramRangeMismatchError(GpuPrecheckError):
-    """gpu_capacity_mb is outside the expected range for the normalized model."""
+    """gpu_capacity_mb falls in none of the expected windows for the normalized model."""
 
 
 class MissingGpuFieldError(GpuPrecheckError):
@@ -41,7 +41,7 @@ def precheck_gpu_spec(gpu_model: Optional[str], gpu_capacity_mb: int) -> None:
     Raises:
         MissingGpuFieldError: gpu_model empty or gpu_capacity_mb <= 0.
         UnsupportedGpuModelError: normalized model not in GPU_VRAM_RANGES.
-        VramRangeMismatchError: VRAM outside the expected range.
+        VramRangeMismatchError: VRAM falls in none of the expected windows.
 
     Returns:
         None on pass (including models in KNOWN_UNRANGED).
@@ -59,14 +59,13 @@ def precheck_gpu_spec(gpu_model: Optional[str], gpu_capacity_mb: int) -> None:
         logger.debug("precheck: %r in KNOWN_UNRANGED; passthrough", normalized)
         return
 
-    rng = get_expected_vram_range(normalized)
-    if rng is None:
+    windows = get_expected_vram_windows(normalized)
+    if windows is None:
         raise UnsupportedGpuModelError(
-            f"no VRAM range for normalized model {normalized!r} (raw={raw!r})"
+            f"no VRAM windows for normalized model {normalized!r} (raw={raw!r})"
         )
 
-    vmin, vmax = rng
-    if not (vmin <= gpu_capacity_mb <= vmax):
+    if not any(vmin <= gpu_capacity_mb <= vmax for vmin, vmax in windows):
         raise VramRangeMismatchError(
-            f"gpu_capacity_mb={gpu_capacity_mb} outside [{vmin},{vmax}] for {normalized!r}"
+            f"gpu_capacity_mb={gpu_capacity_mb} in none of {windows} for {normalized!r}"
         )

--- a/neurons/validators/src/services/gpu_spec_table.py
+++ b/neurons/validators/src/services/gpu_spec_table.py
@@ -1,14 +1,18 @@
-"""GPU model -> VRAM range table for validator-side pre-check.
+"""GPU model -> VRAM window table for validator-side pre-check.
 
 # SYNC: This table mirrors compile-time data inside libdmcompverify.so.
 # libdmcompverify is LIEF-obfuscated; its internal VRAM table cannot be
 # extracted programmatically, so parity is enforced via a CI test against
 # const.GPU_MODEL_RATES (see tests/test_gpu_precheck.py::test_gpu_model_rates_parity).
 # Whenever a model is added to GPU_MODEL_RATES, it MUST be added here (with
-# a VRAM range) or to KNOWN_UNRANGED (intentional passthrough).
+# one or more VRAM windows) or to KNOWN_UNRANGED (intentional passthrough).
 
-VRAM range calibration:
-    - Bounds are nominal × [0.90, 1.05].
+VRAM window calibration:
+    - Each model maps to a LIST of (vram_mb_min, vram_mb_max) windows — one per
+      real shipping VRAM SKU. A reading passes if it falls in ANY window.
+      Single-SKU cards have a 1-element list; multi-variant cards have one
+      window per variant (e.g. RTX 3060 8/12 GB -> two windows).
+    - Per-window bounds are nominal × [0.90, 1.05].
     - The 0.90 floor exists because NVML's `.total` is NOT marketing capacity —
       it is `physical_VRAM - vendor_reserved_regions - ECC_overhead - driver_firmware
       reservation`. In production we observed NVML reporting up to ~6.3% below the
@@ -17,123 +21,127 @@ VRAM range calibration:
       The 0.90 floor gives ~10% headroom to absorb this reservation safely.
     - The 1.05 ceiling absorbs upward vendor drift (e.g. H100 80GB reports
       81559 MB, slightly above 80×1024).
-    - Multi-variant cards (same model name across different VRAM SKUs, e.g.
-      RTX 3060 8/12GB) use widened ranges covering all variants, flagged
-      `# multi-variant`.
-    - B200 special-case: prod data shows 99.75% of B200 entries at 183359 MB
-      (correct for 192 GB), but 0.25% report 49140 MB (likely MIG slice or
-      mislabeled). Lower bound widened to 47000 to avoid false-rejection of
-      the rare outlier; matmul check downstream is authoritative for any
-      cryptographic substitution.
+    - DISCRETE windows (not one widened span) are deliberate: a single span from
+      the smallest variant's floor to the largest variant's ceiling would accept
+      every intermediate capacity that corresponds to no real SKU — e.g. a 24 GB
+      card masquerading as a 16/32 GB V100, or an 80 GB H100 masquerading as a
+      192 GB B200. Per-variant windows reject those intermediate impostors while
+      the matmul check downstream remains authoritative for everything else.
+    - B200: only the 192 GB window is allowed. Prod data showed 99.75% of B200
+      entries at 183359 MB (correct for 192 GB) and 0.25% at 49140 MB (a ~48 GB
+      MIG slice or mislabel). The ~48 GB outlier is intentionally NOT given a
+      window — it must fail precheck rather than widen the span into the
+      64/80/94/96/141 GB range that real impostors would land in.
 
 Calibration source: prod executor_gpu.capacity samples (lium_db); see PR #1043
 follow-up calibration query.
 
 Pre-check policy:
-    - Models present here -> VRAM range-checked.
+    - Models present here -> VRAM window-checked.
     - Models in KNOWN_UNRANGED -> passthrough with code='unranged'.
     - Models in neither -> raises UnsupportedGpuModelError.
 """
 from __future__ import annotations
-from typing import Dict, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
-# --- VRAM ranges (canonical model -> (vram_mb_min, vram_mb_max)) -------------
+# --- VRAM windows (canonical model -> [(vram_mb_min, vram_mb_max), ...]) ------
 # Annotations:
 #   `observed: X` notes the prod NVML-reported value(s) we've seen for that
-#   model (most-common first). Used to verify the chosen range covers reality.
-GPU_VRAM_RANGES: Dict[str, Tuple[int, int]] = {
+#   model (most-common first). Used to verify the chosen window covers reality.
+#   Multi-variant cards list one window per real SKU (flagged `# multi-variant`).
+GPU_VRAM_RANGES: Dict[str, List[Tuple[int, int]]] = {
     # Blackwell data-center
-    "NVIDIA B300 SXM6 AC":                                  (265421, 309658),  # 288 GB; observed: 275040
-    "NVIDIA B200":                                          (47000, 206438),   # 192 GB; observed: 183359 (99.75%), 49140 (0.25% MIG/outlier)
+    "NVIDIA B300 SXM6 AC":                                  [(265421, 309658)],                  # 288 GB; observed: 275040
+    "NVIDIA B200":                                          [(176947, 206438)],                  # 192 GB; observed: 183359 (49140 ~48GB outlier rejected)
     # Hopper data-center
-    "NVIDIA H200":                                          (129946, 151603),  # 141 GB; observed: 143771
-    "NVIDIA H200 NVL":                                      (129946, 151603),  # 141 GB; observed: 143771
-    "NVIDIA H100 80GB HBM3":                                (73728, 86016),    # 80 GB; observed: 81559
-    "NVIDIA H100 NVL":                                      (86630, 101069),   # 94 GB; observed: 95830
-    "NVIDIA H100 PCIe":                                     (73728, 86016),    # 80 GB; observed: 81559
-    "NVIDIA H800 80GB HBM3":                                (73728, 86016),    # 80 GB
-    "NVIDIA H800 NVL":                                      (86630, 101069),   # 94 GB
-    "NVIDIA H800 PCIe":                                     (73728, 86016),    # 80 GB
+    "NVIDIA H200":                                          [(129946, 151603)],                  # 141 GB; observed: 143771
+    "NVIDIA H200 NVL":                                      [(129946, 151603)],                  # 141 GB; observed: 143771
+    "NVIDIA H100 80GB HBM3":                                [(73728, 86016)],                    # 80 GB; observed: 81559
+    "NVIDIA H100 NVL":                                      [(86630, 101069)],                   # 94 GB; observed: 95830
+    "NVIDIA H100 PCIe":                                     [(73728, 86016)],                    # 80 GB; observed: 81559
+    "NVIDIA H800 80GB HBM3":                                [(73728, 86016)],                    # 80 GB
+    "NVIDIA H800 NVL":                                      [(86630, 101069)],                   # 94 GB
+    "NVIDIA H800 PCIe":                                     [(73728, 86016)],                    # 80 GB
     # Blackwell consumer
-    "NVIDIA GeForce RTX 5090":                              (29491, 34406),    # 32 GB; observed: 32607
-    "NVIDIA GeForce RTX 5080":                              (14746, 17203),    # 16 GB
-    "NVIDIA GeForce RTX 5070 Ti":                           (14746, 17203),    # 16 GB
-    "NVIDIA GeForce RTX 5070":                              (11059, 12902),    # 12 GB
-    "NVIDIA GeForce RTX 5060 Ti":                           (7373, 17203),     # 8/16 GB multi-variant
-    "NVIDIA GeForce RTX 5060":                              (7373, 8602),      # 8 GB
+    "NVIDIA GeForce RTX 5090":                              [(29491, 34406)],                    # 32 GB; observed: 32607
+    "NVIDIA GeForce RTX 5080":                              [(14746, 17203)],                    # 16 GB
+    "NVIDIA GeForce RTX 5070 Ti":                           [(14746, 17203)],                    # 16 GB
+    "NVIDIA GeForce RTX 5070":                              [(11059, 12902)],                    # 12 GB
+    "NVIDIA GeForce RTX 5060 Ti":                           [(7373, 8602), (14746, 17203)],      # 8/16 GB multi-variant
+    "NVIDIA GeForce RTX 5060":                              [(7373, 8602)],                      # 8 GB
     # Ada consumer
-    "NVIDIA GeForce RTX 4090":                              (22118, 25805),    # 24 GB; observed: 24564 (99.6%), 23028 (0.4%)
-    "NVIDIA GeForce RTX 4090 D":                            (22118, 25805),    # 24 GB
-    "NVIDIA GeForce RTX 4080 SUPER":                        (14746, 17203),    # 16 GB
-    "NVIDIA GeForce RTX 4080":                              (14746, 17203),    # 16 GB
-    "NVIDIA GeForce RTX 4070 Ti SUPER":                     (14746, 17203),    # 16 GB
-    "NVIDIA GeForce RTX 4070 Ti":                           (11059, 12902),    # 12 GB
-    "NVIDIA GeForce RTX 4070 SUPER":                        (11059, 12902),    # 12 GB
-    "NVIDIA GeForce RTX 4070":                              (11059, 12902),    # 12 GB
-    "NVIDIA GeForce RTX 4060 Ti":                           (7373, 17203),     # 8/16 GB multi-variant
-    "NVIDIA GeForce RTX 4060":                              (7373, 8602),      # 8 GB
+    "NVIDIA GeForce RTX 4090":                              [(22118, 25805)],                    # 24 GB; observed: 24564 (99.6%), 23028 (0.4%)
+    "NVIDIA GeForce RTX 4090 D":                            [(22118, 25805)],                    # 24 GB
+    "NVIDIA GeForce RTX 4080 SUPER":                        [(14746, 17203)],                    # 16 GB
+    "NVIDIA GeForce RTX 4080":                              [(14746, 17203)],                    # 16 GB
+    "NVIDIA GeForce RTX 4070 Ti SUPER":                     [(14746, 17203)],                    # 16 GB
+    "NVIDIA GeForce RTX 4070 Ti":                           [(11059, 12902)],                    # 12 GB
+    "NVIDIA GeForce RTX 4070 SUPER":                        [(11059, 12902)],                    # 12 GB
+    "NVIDIA GeForce RTX 4070":                              [(11059, 12902)],                    # 12 GB
+    "NVIDIA GeForce RTX 4060 Ti":                           [(7373, 8602), (14746, 17203)],      # 8/16 GB multi-variant
+    "NVIDIA GeForce RTX 4060":                              [(7373, 8602)],                      # 8 GB
     # Blackwell pro / Ada pro / Quadro-class
-    "NVIDIA RTX PRO 4000 Blackwell":                        (22118, 25805),    # 24 GB
-    "NVIDIA RTX PRO 5000 Blackwell":                        (44237, 51610),    # 48 GB
-    "NVIDIA RTX PRO 6000 Blackwell Server Edition":         (88474, 103219),   # 96 GB; observed: 97887
-    "NVIDIA RTX PRO 6000 Blackwell Workstation Edition":    (88474, 103219),   # 96 GB; observed: 97887
-    "NVIDIA RTX 5000 Ada Generation":                       (29491, 34406),    # 32 GB
-    "NVIDIA RTX 5880 Ada Generation":                       (44237, 51610),    # 48 GB
-    "NVIDIA RTX 6000 Ada Generation":                       (44237, 51610),    # 48 GB; observed: 49140 (92%), 46068 (8%)
+    "NVIDIA RTX PRO 4000 Blackwell":                        [(22118, 25805)],                    # 24 GB
+    "NVIDIA RTX PRO 5000 Blackwell":                        [(44237, 51610), (66355, 77414)],    # 48/72 GB multi-variant
+    "NVIDIA RTX PRO 6000 Blackwell Server Edition":         [(88474, 103219)],                   # 96 GB; observed: 97887
+    "NVIDIA RTX PRO 6000 Blackwell Workstation Edition":    [(88474, 103219)],                   # 96 GB; observed: 97887
+    "NVIDIA RTX 5000 Ada Generation":                       [(29491, 34406)],                    # 32 GB
+    "NVIDIA RTX 5880 Ada Generation":                       [(44237, 51610)],                    # 48 GB
+    "NVIDIA RTX 6000 Ada Generation":                       [(44237, 51610)],                    # 48 GB; observed: 49140 (92%), 46068 (8%)
     # Lovelace data-center
-    "NVIDIA L4":                                            (22118, 25805),    # 24 GB; observed: 23034
-    "NVIDIA L40S":                                          (44237, 51610),    # 48 GB; observed: 46068 (91%), 49140 (9%)
-    "NVIDIA L40":                                           (44237, 51610),    # 48 GB; observed: 46068 (75%), 49140 (25%)
+    "NVIDIA L4":                                            [(22118, 25805)],                    # 24 GB; observed: 23034
+    "NVIDIA L40S":                                          [(44237, 51610)],                    # 48 GB; observed: 46068 (91%), 49140 (9%)
+    "NVIDIA L40":                                           [(44237, 51610)],                    # 48 GB; observed: 46068 (75%), 49140 (25%)
     # Ampere data-center
-    "NVIDIA A100 80GB PCIe":                                (73728, 86016),    # 80 GB; observed: 81920
-    "NVIDIA A100-SXM4-80GB":                                (73728, 86016),    # 80 GB; observed: 81920
-    "NVIDIA A10 Tensor Core GPU":                           (22118, 25805),    # 24 GB
+    "NVIDIA A100 80GB PCIe":                                [(73728, 86016)],                    # 80 GB; observed: 81920
+    "NVIDIA A100-SXM4-80GB":                                [(73728, 86016)],                    # 80 GB; observed: 81920
+    "NVIDIA A10 Tensor Core GPU":                           [(22118, 25805)],                    # 24 GB
     # Ampere pro
-    "NVIDIA RTX A6000":                                     (44237, 51610),    # 48 GB; observed: 49140
-    "NVIDIA RTX A5000":                                     (22118, 25805),    # 24 GB; observed: 24564
-    "NVIDIA RTX A4500":                                     (18432, 21504),    # 20 GB
-    "NVIDIA RTX A4000":                                     (14746, 17203),    # 16 GB; observed: 16376 (71%), 15352 (29%)
-    "NVIDIA RTX A2000":                                     (5530, 12902),     # 6/12 GB multi-variant
+    "NVIDIA RTX A6000":                                     [(44237, 51610)],                    # 48 GB; observed: 49140
+    "NVIDIA RTX A5000":                                     [(22118, 25805)],                    # 24 GB; observed: 24564
+    "NVIDIA RTX A4500":                                     [(18432, 21504)],                    # 20 GB
+    "NVIDIA RTX A4000":                                     [(14746, 17203)],                    # 16 GB; observed: 16376 (71%), 15352 (29%)
+    "NVIDIA RTX A2000":                                     [(5530, 6451), (11059, 12902)],      # 6/12 GB multi-variant
     # Turing data-center / pro
-    "NVIDIA T4 Tensor Core GPU":                            (14746, 17203),    # 16 GB
-    "NVIDIA Tesla V100 Tensor Core GPU":                    (14746, 34406),    # 16/32 GB multi-variant
-    "NVIDIA Quadro RTX 8000":                               (44237, 51610),    # 48 GB
-    "NVIDIA Quadro RTX 6000":                               (22118, 25805),    # 24 GB
-    "NVIDIA Quadro RTX 5000":                               (14746, 17203),    # 16 GB
-    "NVIDIA TITAN V":                                       (11059, 12902),    # 12 GB
-    "NVIDIA TITAN RTX":                                     (22118, 25805),    # 24 GB
+    "NVIDIA T4 Tensor Core GPU":                            [(14746, 17203)],                    # 16 GB
+    "NVIDIA Tesla V100 Tensor Core GPU":                    [(14746, 17203), (29491, 34406)],    # 16/32 GB multi-variant
+    "NVIDIA Quadro RTX 8000":                               [(44237, 51610)],                    # 48 GB
+    "NVIDIA Quadro RTX 6000":                               [(22118, 25805)],                    # 24 GB
+    "NVIDIA Quadro RTX 5000":                               [(14746, 17203)],                    # 16 GB
+    "NVIDIA TITAN V":                                       [(11059, 12902)],                    # 12 GB
+    "NVIDIA TITAN RTX":                                     [(22118, 25805)],                    # 24 GB
     # Ampere consumer
-    "NVIDIA GeForce RTX 3090 Ti":                           (22118, 25805),    # 24 GB
-    "NVIDIA GeForce RTX 3090":                              (22118, 25805),    # 24 GB; observed: 24576
-    "NVIDIA GeForce RTX 3080 Ti":                           (11059, 12902),    # 12 GB
-    "NVIDIA GeForce RTX 3080":                              (9216, 12902),     # 10/12 GB multi-variant
-    "NVIDIA GeForce RTX 3070 Ti":                           (7373, 8602),      # 8 GB; observed: 8192
-    "NVIDIA GeForce RTX 3070":                              (7373, 8602),      # 8 GB
-    "NVIDIA GeForce RTX 3060 Ti":                           (7373, 8602),      # 8 GB
-    "NVIDIA GeForce RTX 3060":                              (7373, 12902),     # 8/12 GB multi-variant
-    "NVIDIA GeForce RTX 3060 Laptop GPU":                   (5530, 6451),      # 6 GB
-    "NVIDIA GeForce RTX 3050":                              (5530, 8602),      # 6/8 GB multi-variant
+    "NVIDIA GeForce RTX 3090 Ti":                           [(22118, 25805)],                    # 24 GB
+    "NVIDIA GeForce RTX 3090":                              [(22118, 25805)],                    # 24 GB; observed: 24576
+    "NVIDIA GeForce RTX 3080 Ti":                           [(11059, 12902)],                    # 12 GB
+    "NVIDIA GeForce RTX 3080":                              [(9216, 10752), (11059, 12902)],     # 10/12 GB multi-variant
+    "NVIDIA GeForce RTX 3070 Ti":                           [(7373, 8602)],                      # 8 GB; observed: 8192
+    "NVIDIA GeForce RTX 3070":                              [(7373, 8602)],                      # 8 GB
+    "NVIDIA GeForce RTX 3060 Ti":                           [(7373, 8602)],                      # 8 GB
+    "NVIDIA GeForce RTX 3060":                              [(7373, 8602), (11059, 12902)],      # 8/12 GB multi-variant
+    "NVIDIA GeForce RTX 3060 Laptop GPU":                   [(5530, 6451)],                      # 6 GB
+    "NVIDIA GeForce RTX 3050":                              [(5530, 6451), (7373, 8602)],        # 6/8 GB multi-variant
     # Turing consumer
-    "NVIDIA GeForce RTX 2080 Ti":                           (10138, 11827),    # 11 GB
-    "NVIDIA GeForce RTX 2080 SUPER":                        (7373, 8602),      # 8 GB
-    "NVIDIA GeForce RTX 2070 SUPER":                        (7373, 8602),      # 8 GB
-    "NVIDIA GeForce RTX 2060 SUPER":                        (7373, 8602),      # 8 GB
-    "NVIDIA GeForce RTX 2060":                              (5530, 12902),     # 6/12 GB multi-variant
-    "NVIDIA GeForce GTX 1660 Ti":                           (5530, 6451),      # 6 GB
-    "NVIDIA GeForce GTX 1660 SUPER":                        (5530, 6451),      # 6 GB
-    "NVIDIA GeForce GTX 1660":                              (5530, 6451),      # 6 GB
+    "NVIDIA GeForce RTX 2080 Ti":                           [(10138, 11827)],                    # 11 GB
+    "NVIDIA GeForce RTX 2080 SUPER":                        [(7373, 8602)],                      # 8 GB
+    "NVIDIA GeForce RTX 2070 SUPER":                        [(7373, 8602)],                      # 8 GB
+    "NVIDIA GeForce RTX 2060 SUPER":                        [(7373, 8602)],                      # 8 GB
+    "NVIDIA GeForce RTX 2060":                              [(5530, 6451), (11059, 12902)],      # 6/12 GB multi-variant
+    "NVIDIA GeForce GTX 1660 Ti":                           [(5530, 6451)],                      # 6 GB
+    "NVIDIA GeForce GTX 1660 SUPER":                        [(5530, 6451)],                      # 6 GB
+    "NVIDIA GeForce GTX 1660":                              [(5530, 6451)],                      # 6 GB
     # Pascal
-    "NVIDIA Tesla P100":                                    (11059, 17203),    # 12/16 GB multi-variant
-    "NVIDIA Tesla P40":                                     (22118, 25805),    # 24 GB
-    "NVIDIA Quadro P4000":                                  (7373, 8602),      # 8 GB
-    "NVIDIA TITAN Xp":                                      (11059, 12902),    # 12 GB
-    "NVIDIA GeForce GTX 1080 Ti":                           (10138, 11827),    # 11 GB
-    "NVIDIA GeForce GTX 1080":                              (7373, 8602),      # 8 GB
-    "NVIDIA GeForce GTX 1070 Ti":                           (7373, 8602),      # 8 GB
-    "NVIDIA GeForce GTX 1070":                              (7373, 8602),      # 8 GB
-    "NVIDIA GeForce GTX 1060":                              (2765, 6451),      # 3/6 GB multi-variant
+    "NVIDIA Tesla P100":                                    [(11059, 12902), (14746, 17203)],    # 12/16 GB multi-variant
+    "NVIDIA Tesla P40":                                     [(22118, 25805)],                    # 24 GB
+    "NVIDIA Quadro P4000":                                  [(7373, 8602)],                      # 8 GB
+    "NVIDIA TITAN Xp":                                      [(11059, 12902)],                    # 12 GB
+    "NVIDIA GeForce GTX 1080 Ti":                           [(10138, 11827)],                    # 11 GB
+    "NVIDIA GeForce GTX 1080":                              [(7373, 8602)],                      # 8 GB
+    "NVIDIA GeForce GTX 1070 Ti":                           [(7373, 8602)],                      # 8 GB
+    "NVIDIA GeForce GTX 1070":                              [(7373, 8602)],                      # 8 GB
+    "NVIDIA GeForce GTX 1060":                              [(2765, 3226), (5530, 6451)],        # 3/6 GB multi-variant (rare 5GB SKU not covered)
     # Maxwell
-    "NVIDIA Tesla M40":                                     (11059, 25805),    # 12/24 GB multi-variant
+    "NVIDIA Tesla M40":                                     [(11059, 12902), (22118, 25805)],    # 12/24 GB multi-variant
 }
 
 # --- Intentionally unranged models (passthrough) -----------------------------
@@ -179,6 +187,10 @@ def normalize_gpu_model(name: Optional[str]) -> str:
     return NORMALIZATION_MAP.get(stripped, stripped)
 
 
-def get_expected_vram_range(canonical_model: str) -> Optional[Tuple[int, int]]:
-    """Return (vram_mb_min, vram_mb_max) for `canonical_model`, or None if unknown."""
+def get_expected_vram_windows(canonical_model: str) -> Optional[List[Tuple[int, int]]]:
+    """Return the list of (vram_mb_min, vram_mb_max) windows for `canonical_model`.
+
+    Returns None if the model is unknown. A reading passes the pre-check if it
+    falls within ANY returned window.
+    """
     return GPU_VRAM_RANGES.get(canonical_model)

--- a/neurons/validators/src/services/matrix_validation_service.py
+++ b/neurons/validators/src/services/matrix_validation_service.py
@@ -8,8 +8,6 @@ from dataclasses import dataclass
 from core.utils import _m, get_extra_info
 from ctypes import CDLL, c_longlong, POINTER, c_void_p, c_char_p
 
-from services.gpu_precheck import GpuPrecheckError, precheck_gpu_spec
-
 logger = logging.getLogger(__name__)
 
 
@@ -208,21 +206,10 @@ class ValidationService:
             }
             machine_info = json.dumps(gpu_info, sort_keys=True)
 
-            # Python-side GPU model+VRAM pre-check. Runs before any native call so
-            # we don't waste an SSH round-trip on obviously-bad specs.
+            # GPU model<->VRAM consistency is gated earlier in the pipeline by
+            # GpuVramPrecheck (before the rented short-circuit), so it is NOT
+            # repeated here. gpu_capacity_mb is still needed to size the matmul.
             gpu_capacity_mb = self.get_gpu_memory(machine_spec)
-            try:
-                precheck_gpu_spec(
-                    gpu_model=gpu_model,
-                    gpu_capacity_mb=int(gpu_capacity_mb or 0),
-                )
-            except GpuPrecheckError as e:
-                error_msg = f"GPU spec precheck rejected: {e}"
-                logger.warning(_m(error_msg, extra={**default_extra, "machine_info": machine_info}))
-                return ValidationResult(
-                    success=False,
-                    error_message=error_msg,
-                )
 
             verifier_params = VerifierParams()
             verifier_params.generate()
@@ -247,11 +234,10 @@ class ValidationService:
             }
 
             # Short-circuit if encrypt_challenge returned empty. This happens when
-            # the Python pre-check rejected the spec (typed GpuPrecheckError) or
             # the native call raised. No point SSHing an empty cipher to the
             # executor — it would surface as a misleading "UUID mismatch" downstream.
             if not verifier_params.cipher_text:
-                error_msg = "Cipher text generation failed (precheck rejection or native error)"
+                error_msg = "Cipher text generation failed (native error)"
                 logger.warning(_m(error_msg, extra=get_extra_info(log_extra)))
                 return ValidationResult(
                     success=False,

--- a/neurons/validators/src/services/task/checks/__init__.py
+++ b/neurons/validators/src/services/task/checks/__init__.py
@@ -7,6 +7,7 @@ from .gpu_count import GpuCountCheck
 from .gpu_fingerprint import GpuFingerprintCheck
 from .gpu_model_valid import GpuModelValidCheck
 from .gpu_usage import GpuUsageCheck
+from .gpu_vram_precheck import GpuVramPrecheck
 from .machine_spec_scrape import MachineSpecScrapeCheck
 from .nvml_digest import NvmlDigestCheck
 from .port_connectivity import PortConnectivityCheck
@@ -30,6 +31,7 @@ __all__ = [
     "GpuFingerprintCheck",
     "GpuModelValidCheck",
     "GpuUsageCheck",
+    "GpuVramPrecheck",
     "MachineSpecScrapeCheck",
     "NvmlDigestCheck",
     "PortConnectivityCheck",

--- a/neurons/validators/src/services/task/checks/gpu_vram_precheck.py
+++ b/neurons/validators/src/services/task/checks/gpu_vram_precheck.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from services.gpu_precheck import GpuPrecheckError, precheck_gpu_spec
+
+from ..messages import GpuVramMessages as Msg, render_message
+from ..pipeline import CheckResult, Context
+
+
+class GpuVramPrecheck:
+    """Gate validation on GPU model <-> VRAM consistency.
+
+    This is a pure-data check: it only needs ``gpu_model`` and the first GPU's
+    reported ``capacity`` (MB), both populated by MachineSpecScrapeCheck. It has
+    no SSH/GPU/native dependency, so it runs early — right after
+    GpuModelValidCheck and BEFORE the rented short-circuit
+    (TenantEnforcementCheck). Previously the same precheck only ran inside
+    CapabilityCheck (the matmul), which sits after the short-circuit, so rented
+    executors bypassed it entirely. Running it here gates rented and idle
+    executors alike. The native matmul in CapabilityCheck remains authoritative
+    for everything the precheck does not cover.
+    """
+
+    check_id = "gpu.validate.vram_precheck"
+    fatal = True
+
+    async def run(self, ctx: Context) -> CheckResult:
+        gpu_model = ctx.state.gpu_model
+        gpu_details = ctx.state.gpu_details
+        capacity_mb = 0
+        if gpu_details:
+            capacity_mb = gpu_details[0].get("capacity", 0) or 0
+
+        try:
+            precheck_gpu_spec(gpu_model=gpu_model, gpu_capacity_mb=int(capacity_mb))
+        except GpuPrecheckError as exc:
+            event = render_message(
+                Msg.VRAM_REJECTED,
+                ctx=ctx,
+                check_id=self.check_id,
+                what={
+                    "gpu_model": gpu_model,
+                    "gpu_capacity_mb": capacity_mb,
+                    "error": str(exc),
+                },
+            )
+            return CheckResult(passed=False, event=event)
+
+        event = render_message(
+            Msg.VRAM_OK,
+            ctx=ctx,
+            check_id=self.check_id,
+            what={"gpu_model": gpu_model, "gpu_capacity_mb": capacity_mb},
+        )
+        return CheckResult(passed=True, event=event)

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -228,6 +228,25 @@ class GpuModelMessages:
     )
 
 
+class GpuVramMessages:
+    VRAM_REJECTED = MessageTemplate(
+        event="GPU model/VRAM precheck rejected",
+        reason="GPU_VRAM_MISMATCH",
+        severity="warning",
+        category="policy",
+        impact="Job skipped; score set to 0",
+        remediation="Reported GPU model and VRAM capacity are inconsistent. "
+        "Ensure the executor advertises unmodified, matching GPU specs.",
+    )
+    VRAM_OK = MessageTemplate(
+        event="GPU model/VRAM precheck passed",
+        reason="GPU_VRAM_OK",
+        severity="info",
+        category="env",
+        impact="Proceed",
+    )
+
+
 class NvmlDigestMessages:
     DIGEST_MISMATCH = MessageTemplate(
         event="NVML library digest mismatch",

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -34,6 +34,7 @@ from .checks import (
     GpuFingerprintCheck,
     GpuModelValidCheck,
     GpuUsageCheck,
+    GpuVramPrecheck,
     MachineSpecScrapeCheck,
     NvmlDigestCheck,
     PortConnectivityCheck,
@@ -216,6 +217,10 @@ class PipelineFactory:
                 MachineSpecScrapeCheck(),
                 GpuCountCheck(),
                 GpuModelValidCheck(),
+                # Pure-data model<->VRAM gate. No SSH/GPU dependency, so it runs
+                # here — before the rented short-circuit (TenantEnforcementCheck)
+                # — to gate rented and idle executors alike.
+                GpuVramPrecheck(),
                 NvmlDigestCheck(),
                 SpecChangeCheck(),
                 GpuFingerprintCheck(),
@@ -256,6 +261,7 @@ class PipelineFactory:
                 MachineSpecScrapeCheck(),
                 GpuCountCheck(),
                 GpuModelValidCheck(),
+                GpuVramPrecheck(),
                 NvmlDigestCheck(),
                 SpecChangeCheck(),
                 GpuFingerprintCheck(),

--- a/neurons/validators/tests/test_gpu_precheck.py
+++ b/neurons/validators/tests/test_gpu_precheck.py
@@ -126,10 +126,53 @@ def test_gpu_model_rates_parity():
 
 
 def test_gpu_vram_ranges_well_formed():
-    """Every range tuple is (int, int) with vmin <= vmax and both positive."""
-    for model, rng in gpu_spec_table.GPU_VRAM_RANGES.items():
-        assert isinstance(rng, tuple) and len(rng) == 2, f"{model}: not a 2-tuple"
-        vmin, vmax = rng
-        assert isinstance(vmin, int) and isinstance(vmax, int), f"{model}: non-int bounds"
-        assert vmin > 0 and vmax > 0, f"{model}: non-positive bounds"
-        assert vmin <= vmax, f"{model}: vmin {vmin} > vmax {vmax}"
+    """Every model maps to a non-empty list of (int, int) windows with
+    vmin <= vmax, both positive, and windows sorted/non-overlapping."""
+    for model, windows in gpu_spec_table.GPU_VRAM_RANGES.items():
+        assert isinstance(windows, list) and windows, f"{model}: not a non-empty list"
+        prev_max = None
+        for rng in windows:
+            assert isinstance(rng, tuple) and len(rng) == 2, f"{model}: window not a 2-tuple"
+            vmin, vmax = rng
+            assert isinstance(vmin, int) and isinstance(vmax, int), f"{model}: non-int bounds"
+            assert vmin > 0 and vmax > 0, f"{model}: non-positive bounds"
+            assert vmin <= vmax, f"{model}: vmin {vmin} > vmax {vmax}"
+            if prev_max is not None:
+                assert vmin > prev_max, f"{model}: windows overlap/unsorted at {rng}"
+            prev_max = vmax
+
+
+# --- Multi-variant: impostor rejection in the inter-variant gap -------------
+@pytest.mark.parametrize("model,mb", [
+    # Tesla V100 16/32 GB: a 24 GB reading (e.g. RTX 4090) must NOT pass.
+    ("NVIDIA Tesla V100 Tensor Core GPU", 24564),
+    # RTX 4060 Ti 8/16 GB: a 12 GB reading must NOT pass.
+    ("NVIDIA GeForce RTX 4060 Ti", 12030),
+    # Tesla M40 12/24 GB: 16 GB and 20 GB readings must NOT pass.
+    ("NVIDIA Tesla M40", 16376),
+    ("NVIDIA Tesla M40", 20480),
+    # RTX A2000 6/12 GB: an 8 GB reading must NOT pass.
+    ("NVIDIA RTX A2000", 8192),
+    # B200 192 GB only: the ~48 GB MIG/outlier and an 80 GB H100 must NOT pass.
+    ("NVIDIA B200", 49140),
+    ("NVIDIA B200", 81559),
+])
+def test_multivariant_intermediate_rejected(model, mb):
+    with pytest.raises(VramRangeMismatchError):
+        precheck_gpu_spec(model, mb)
+
+
+@pytest.mark.parametrize("model,mb", [
+    # Each real variant of a multi-variant card must pass.
+    ("NVIDIA Tesla V100 Tensor Core GPU", 16384),   # 16 GB
+    ("NVIDIA Tesla V100 Tensor Core GPU", 32768),   # 32 GB
+    ("NVIDIA GeForce RTX 4060 Ti", 8192),           # 8 GB
+    ("NVIDIA GeForce RTX 4060 Ti", 16376),          # 16 GB
+    ("NVIDIA Tesla M40", 12288),                    # 12 GB
+    ("NVIDIA Tesla M40", 24564),                    # 24 GB
+    ("NVIDIA RTX PRO 5000 Blackwell", 49140),       # 48 GB
+    ("NVIDIA RTX PRO 5000 Blackwell", 73728),       # 72 GB (previously false-rejected)
+    ("NVIDIA B200", 183359),                        # 192 GB
+])
+def test_multivariant_real_variants_pass(model, mb):
+    assert precheck_gpu_spec(model, mb) is None

--- a/neurons/validators/tests/test_gpu_vram_precheck_check.py
+++ b/neurons/validators/tests/test_gpu_vram_precheck_check.py
@@ -1,0 +1,75 @@
+"""Unit tests for the GpuVramPrecheck pipeline check.
+
+The model<->VRAM precheck was moved out of CapabilityCheck (which runs after
+the rented short-circuit, TenantEnforcementCheck) into this dedicated early
+check, so it now gates rented and idle executors alike. It is a pure-data check
+reading only ctx.state.gpu_model and ctx.state.gpu_details[0]["capacity"].
+"""
+from __future__ import annotations
+
+import pytest
+
+from helpers import build_state
+from services.task.checks.gpu_vram_precheck import GpuVramPrecheck
+
+
+def _state(gpu_model, capacity, count=1):
+    details = [{"name": gpu_model, "uuid": "GPU-abc", "capacity": capacity}]
+    return build_state(gpu_model=gpu_model, gpu_count=count, gpu_details=details)
+
+
+@pytest.mark.asyncio
+async def test_pass_valid_model_and_vram(context_factory):
+    ctx = context_factory(state=_state("NVIDIA H100 80GB HBM3", 81920))
+    result = await GpuVramPrecheck().run(ctx)
+    assert result.passed is True
+    assert result.event.reason_code == "GPU_VRAM_OK"
+
+
+@pytest.mark.asyncio
+async def test_reject_vram_out_of_range(context_factory):
+    ctx = context_factory(state=_state("NVIDIA H100 80GB HBM3", 24064))
+    result = await GpuVramPrecheck().run(ctx)
+    assert result.passed is False
+    assert result.event.reason_code == "GPU_VRAM_MISMATCH"
+
+
+@pytest.mark.asyncio
+async def test_reject_unknown_model(context_factory):
+    # In the real pipeline GpuModelValidCheck rejects unknowns first, but the
+    # check must still fail closed if it ever sees one.
+    ctx = context_factory(state=_state("Totally Unknown GPU", 24064))
+    result = await GpuVramPrecheck().run(ctx)
+    assert result.passed is False
+    assert result.event.reason_code == "GPU_VRAM_MISMATCH"
+
+
+@pytest.mark.asyncio
+async def test_reject_missing_capacity(context_factory):
+    ctx = context_factory(state=_state("NVIDIA H100 80GB HBM3", 0))
+    result = await GpuVramPrecheck().run(ctx)
+    assert result.passed is False
+
+
+@pytest.mark.asyncio
+async def test_reject_no_gpu_details(context_factory):
+    ctx = context_factory(state=build_state(gpu_model=None, gpu_count=0, gpu_details=[]))
+    result = await GpuVramPrecheck().run(ctx)
+    assert result.passed is False
+
+
+@pytest.mark.asyncio
+async def test_multivariant_intermediate_rejected(context_factory):
+    # V100 is 16/32 GB; a 24 GB reading corresponds to no real variant.
+    ctx = context_factory(state=_state("NVIDIA Tesla V100 Tensor Core GPU", 24564))
+    result = await GpuVramPrecheck().run(ctx)
+    assert result.passed is False
+    assert result.event.reason_code == "GPU_VRAM_MISMATCH"
+
+
+@pytest.mark.asyncio
+async def test_multivariant_real_variant_passes(context_factory):
+    # RTX PRO 5000 Blackwell ships in 48 and 72 GB; the 72 GB variant must pass.
+    ctx = context_factory(state=_state("NVIDIA RTX PRO 5000 Blackwell", 73728))
+    result = await GpuVramPrecheck().run(ctx)
+    assert result.passed is True

--- a/neurons/validators/tests/test_matrix_validation_service_precheck.py
+++ b/neurons/validators/tests/test_matrix_validation_service_precheck.py
@@ -1,10 +1,13 @@
-"""Integration tests for the validator-side GPU pre-check.
+"""Tests for `validate_gpu_model_and_process_job` invariants.
 
-Pre-check now lives at the top of `validate_gpu_model_and_process_job` (the
-caller), NOT inside `encrypt_challenge`. This is required because anything
-embedded in `machine_info` JSON passed to libdmcompverify must exactly
-match what the executor's .so reconstructs locally via getGPUInfo() —
-adding fields breaks the cryptographic binding.
+The GPU model<->VRAM pre-check no longer lives here — it moved to the
+GpuVramPrecheck pipeline check (see tests/test_gpu_vram_precheck_check.py),
+which runs before the rented short-circuit so it gates rented and idle
+executors alike. What remains tested here:
+  - machine_info passed to libdmcompverify must NOT contain gpu_capacity_mb
+    (anything embedded must exactly match what the executor's .so reconstructs
+    locally via getGPUInfo(), or the cryptographic binding breaks);
+  - an empty cipher_text from the native call short-circuits before SSH.
 """
 from __future__ import annotations
 
@@ -49,57 +52,7 @@ def _executor_info():
     )
 
 
-# --- Bad spec short-circuits before any native call AND no SSH --------------
-@pytest.mark.asyncio
-async def test_bad_vram_short_circuits(service_with_mock_wrapper):
-    """Out-of-range VRAM → ValidationResult(success=False), no .so call, no SSH."""
-    svc, wrapper = service_with_mock_wrapper
-    ssh = _ssh_client()
-    result = await svc.validate_gpu_model_and_process_job(
-        ssh_client=ssh,
-        executor_info=_executor_info(),
-        default_extra={},
-        machine_spec=_machine_spec(gpu_model="NVIDIA H100 80GB HBM3", capacity=24064),
-    )
-    assert result.success is False
-    assert "precheck" in result.error_message.lower()
-    wrapper.setDimension.assert_not_called()
-    wrapper.generateChallenge.assert_not_called()
-    ssh.run.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_unknown_model_short_circuits(service_with_mock_wrapper):
-    svc, wrapper = service_with_mock_wrapper
-    ssh = _ssh_client()
-    result = await svc.validate_gpu_model_and_process_job(
-        ssh_client=ssh,
-        executor_info=_executor_info(),
-        default_extra={},
-        machine_spec=_machine_spec(gpu_model="Totally Unknown GPU", capacity=24064),
-    )
-    assert result.success is False
-    assert "precheck" in result.error_message.lower()
-    wrapper.setDimension.assert_not_called()
-    ssh.run.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_missing_capacity_short_circuits(service_with_mock_wrapper):
-    svc, wrapper = service_with_mock_wrapper
-    ssh = _ssh_client()
-    result = await svc.validate_gpu_model_and_process_job(
-        ssh_client=ssh,
-        executor_info=_executor_info(),
-        default_extra={},
-        machine_spec=_machine_spec(capacity=0),
-    )
-    assert result.success is False
-    wrapper.setDimension.assert_not_called()
-    ssh.run.assert_not_called()
-
-
-# --- Happy path: pre-check passes, machine_info has no gpu_capacity_mb ------
+# --- machine_info must not contain gpu_capacity_mb -------------------------
 @pytest.mark.asyncio
 async def test_machine_info_does_not_contain_gpu_capacity_mb(
     service_with_mock_wrapper,


### PR DESCRIPTION
## Describe your changes

Hardens the validator-side GPU model↔VRAM pre-check on two fronts.

**1. Discrete per-variant VRAM windows.** The pre-check table mapped each GPU model to a single continuous `(min, max)` span. For multi-SKU models that span accepted every capacity *between* the real variants — values matching no real card. A 24 GB card could pass as a 16/32 GB V100, and an 80 GB H100 (or 141 GB H200) could pass as a 192 GB B200. The table is now `model -> [(min,max), ...]` with one window per real SKU; a reading passes only if it lands in one of them.

Corrected against NVIDIA official datasheets:
- **RTX PRO 5000 Blackwell** ships in **48 GB and 72 GB** — it was 48 GB-only, which false-rejected legitimate 72 GB units.
- **B200** tightened to the 192 GB window only (the ~0.25% reporting ~48 GB are dropped rather than widening the span into the 64–141 GB impostor range).
- All other models were re-verified against NVIDIA specs; capacities are correct.

**2. Pre-check moved ahead of the rented short-circuit.** It previously ran only inside `CapabilityCheck`, which sits *after* `TenantEnforcementCheck` halts the pipeline for rented executors — so rented machines bypassed it entirely. It is now a dedicated `GpuVramPrecheck` at pipeline position 6 (right after `GpuModelValidCheck`, before the rented short-circuit), gating rented and idle executors alike. It is a pure-data check (model + capacity from `MachineSpecScrapeCheck`) with no SSH/GPU dependency, so running it early is safe. The redundant in-service copy was removed from `matrix_validation_service`.

**Behavior note:** a currently-rented executor with inconsistent model/VRAM will now fail validation (previously skipped). This is the intended effect of gating rented executors.

**Testing:** full validator suite passes locally — `557 passed, 4 skipped`. Added unit tests for the new check (pass/reject, missing capacity, no-GPU, multi-variant impostor rejection, real-variant pass) and impostor/per-variant boundary tests for the window table.

## Issue ticket number and link

DAH-2146

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance? (No — pure dict lookup on already-scraped data; negligible cost.)