### PR TITLE
Update max price rate

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -173,7 +173,7 @@ class Settings(BaseSettings):
     USE_REST_API: bool = Field(env="USE_REST_API", default=False)
     
     # Machine Price Limit
-    MACHINE_MAX_PRICE_RATE: float = Field(env="MACHINE_MAX_PRICE_RATE", default=2.0)
+    MACHINE_MAX_PRICE_RATE: float = Field(env="MACHINE_MAX_PRICE_RATE", default=4)
 
     DEPLOY_ENV: Literal["PROD", "LOCAL", "STAGE"] = Field(env="DEPLOY_ENV", default="PROD")
 


### PR DESCRIPTION
## Summary

Increase the validator `MACHINE_MAX_PRICE_RATE` default from `2.0` to `4.0` so validator-side price checks align with the backend shared-config limit.

### Task Link

N/A

---

## Problem

The backend shared config is being raised to allow machine prices up to `4x` base price, but the validator config still defaults to `2x`. Without the validator-side update, validator price checks can reject prices that the backend and provider-facing flows allow.

## Solution

Update the validator `MACHINE_MAX_PRICE_RATE` default to `4.0`. Existing environment overrides still take precedence.

## Changes

- Changed `MACHINE_MAX_PRICE_RATE` in `neurons/validators/src/core/config.py` from `2.0` to `4.0`.
- Kept the existing `MACHINE_MAX_PRICE_RATE` environment override unchanged.

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

- Backend: https://github.com/Datura-ai/lium-io-backend/pull/643

## Risks

- Validators using the default config will accept machine prices up to `4x` base price instead of `2x`.
- Deployments with explicit `MACHINE_MAX_PRICE_RATE` environment values are unchanged.

## Test Cases

### Test Case 1

**Actions**

Ran `scripts/agent/agentctl verify lium-io --quick --quiet`.

**Expected Output**

Verification passes for `lium-io`.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
