### PR TITLE
DAH-2160 - Refactor GPU VRAM table to store only VRAM size

### DIFF
--- a/neurons/validators/src/services/gpu_precheck.py
+++ b/neurons/validators/src/services/gpu_precheck.py
@@ -24,7 +24,7 @@ class GpuPrecheckError(Exception):
 
 
 class UnsupportedGpuModelError(GpuPrecheckError):
-    """Normalized model name has no entry in GPU_VRAM_RANGES or KNOWN_UNRANGED."""
+    """Normalized model name has no entry in GPU_VRAM_SIZES_MB or KNOWN_UNRANGED."""
 
 
 class VramRangeMismatchError(GpuPrecheckError):
@@ -40,7 +40,7 @@ def precheck_gpu_spec(gpu_model: Optional[str], gpu_capacity_mb: int) -> None:
 
     Raises:
         MissingGpuFieldError: gpu_model empty or gpu_capacity_mb <= 0.
-        UnsupportedGpuModelError: normalized model not in GPU_VRAM_RANGES.
+        UnsupportedGpuModelError: normalized model not in GPU_VRAM_SIZES_MB.
         VramRangeMismatchError: VRAM falls in none of the expected windows.
 
     Returns:

--- a/neurons/validators/src/services/gpu_spec_table.py
+++ b/neurons/validators/src/services/gpu_spec_table.py
@@ -1,18 +1,23 @@
-"""GPU model -> VRAM window table for validator-side pre-check.
+"""GPU model -> VRAM size table for validator-side pre-check.
 
 # SYNC: This table mirrors compile-time data inside libdmcompverify.so.
 # libdmcompverify is LIEF-obfuscated; its internal VRAM table cannot be
 # extracted programmatically, so parity is enforced via a CI test against
 # const.GPU_MODEL_RATES (see tests/test_gpu_precheck.py::test_gpu_model_rates_parity).
 # Whenever a model is added to GPU_MODEL_RATES, it MUST be added here (with
-# one or more VRAM windows) or to KNOWN_UNRANGED (intentional passthrough).
+# one or more nominal VRAM sizes) or to KNOWN_UNRANGED (intentional passthrough).
 
-VRAM window calibration:
-    - Each model maps to a LIST of (vram_mb_min, vram_mb_max) windows — one per
-      real shipping VRAM SKU. A reading passes if it falls in ANY window.
-      Single-SKU cards have a 1-element list; multi-variant cards have one
-      window per variant (e.g. RTX 3060 8/12 GB -> two windows).
-    - Per-window bounds are nominal × [0.90, 1.05].
+Source of truth:
+    - Each model maps to a LIST of nominal VRAM sizes in MB — one entry per real
+      shipping VRAM SKU. Single-SKU cards have a 1-element list; multi-variant
+      cards have one entry per variant (e.g. RTX 3060 8/12 GB -> [8192, 12288]).
+    - The acceptance (vram_mb_min, vram_mb_max) windows are NOT stored. They are
+      computed on demand by `vram_window_for_size` as nominal × [0.90, 1.05].
+      Storing only the size removes the duplicated derived bounds and makes the
+      nominal size the single source of truth.
+
+Window calibration (applied by vram_window_for_size):
+    - Per-window bounds are nominal × [VRAM_FLOOR_RATIO, VRAM_CEIL_RATIO].
     - The 0.90 floor exists because NVML's `.total` is NOT marketing capacity —
       it is `physical_VRAM - vendor_reserved_regions - ECC_overhead - driver_firmware
       reservation`. In production we observed NVML reporting up to ~6.3% below the
@@ -21,127 +26,133 @@ VRAM window calibration:
       The 0.90 floor gives ~10% headroom to absorb this reservation safely.
     - The 1.05 ceiling absorbs upward vendor drift (e.g. H100 80GB reports
       81559 MB, slightly above 80×1024).
-    - DISCRETE windows (not one widened span) are deliberate: a single span from
-      the smallest variant's floor to the largest variant's ceiling would accept
-      every intermediate capacity that corresponds to no real SKU — e.g. a 24 GB
-      card masquerading as a 16/32 GB V100, or an 80 GB H100 masquerading as a
-      192 GB B200. Per-variant windows reject those intermediate impostors while
-      the matmul check downstream remains authoritative for everything else.
-    - B200: only the 192 GB window is allowed. Prod data showed 99.75% of B200
+    - DISCRETE windows (one per nominal size, not one widened span) are deliberate:
+      a single span from the smallest variant's floor to the largest variant's
+      ceiling would accept every intermediate capacity that corresponds to no real
+      SKU — e.g. a 24 GB card masquerading as a 16/32 GB V100, or an 80 GB H100
+      masquerading as a 192 GB B200. Per-variant windows reject those intermediate
+      impostors while the matmul check downstream remains authoritative.
+    - B200: only the 192 GB size is listed. Prod data showed 99.75% of B200
       entries at 183359 MB (correct for 192 GB) and 0.25% at 49140 MB (a ~48 GB
       MIG slice or mislabel). The ~48 GB outlier is intentionally NOT given a
-      window — it must fail precheck rather than widen the span into the
+      size — it must fail precheck rather than widen acceptance into the
       64/80/94/96/141 GB range that real impostors would land in.
 
 Calibration source: prod executor_gpu.capacity samples (lium_db); see PR #1043
 follow-up calibration query.
 
 Pre-check policy:
-    - Models present here -> VRAM window-checked.
+    - Models present here -> VRAM window-checked (windows computed from size).
     - Models in KNOWN_UNRANGED -> passthrough with code='unranged'.
     - Models in neither -> raises UnsupportedGpuModelError.
 """
 from __future__ import annotations
 from typing import Dict, List, Optional, Set, Tuple
 
-# --- VRAM windows (canonical model -> [(vram_mb_min, vram_mb_max), ...]) ------
+# Per-window bounds are nominal × [VRAM_FLOOR_RATIO, VRAM_CEIL_RATIO].
+# See the module docstring for why 0.90 / 1.05 (NVML under-reporting + vendor drift).
+# These ratios encode the libdmcompverify.so contract and must stay in sync with it.
+VRAM_FLOOR_RATIO = 0.90
+VRAM_CEIL_RATIO = 1.05
+
+# --- Nominal VRAM sizes (canonical model -> [vram_mb, ...]) -------------------
 # Annotations:
 #   `observed: X` notes the prod NVML-reported value(s) we've seen for that
-#   model (most-common first). Used to verify the chosen window covers reality.
-#   Multi-variant cards list one window per real SKU (flagged `# multi-variant`).
-GPU_VRAM_RANGES: Dict[str, List[Tuple[int, int]]] = {
+#   model (most-common first). Used to verify the computed window covers reality.
+#   Multi-variant cards list one nominal size per real SKU (flagged `# multi-variant`).
+GPU_VRAM_SIZES_MB: Dict[str, List[int]] = {
     # Blackwell data-center
-    "NVIDIA B300 SXM6 AC":                                  [(265421, 309658)],                  # 288 GB; observed: 275040
-    "NVIDIA B200":                                          [(176947, 206438)],                  # 192 GB; observed: 183359 (49140 ~48GB outlier rejected)
+    "NVIDIA B300 SXM6 AC":                                [294912],        # 288 GB; observed: 275040
+    "NVIDIA B200":                                        [196608],        # 192 GB; observed: 183359 (49140 ~48GB outlier rejected)
     # Hopper data-center
-    "NVIDIA H200":                                          [(129946, 151603)],                  # 141 GB; observed: 143771
-    "NVIDIA H200 NVL":                                      [(129946, 151603)],                  # 141 GB; observed: 143771
-    "NVIDIA H100 80GB HBM3":                                [(73728, 86016)],                    # 80 GB; observed: 81559
-    "NVIDIA H100 NVL":                                      [(86630, 101069)],                   # 94 GB; observed: 95830
-    "NVIDIA H100 PCIe":                                     [(73728, 86016)],                    # 80 GB; observed: 81559
-    "NVIDIA H800 80GB HBM3":                                [(73728, 86016)],                    # 80 GB
-    "NVIDIA H800 NVL":                                      [(86630, 101069)],                   # 94 GB
-    "NVIDIA H800 PCIe":                                     [(73728, 86016)],                    # 80 GB
+    "NVIDIA H200":                                        [144384],        # 141 GB; observed: 143771
+    "NVIDIA H200 NVL":                                    [144384],        # 141 GB; observed: 143771
+    "NVIDIA H100 80GB HBM3":                              [81920],         # 80 GB; observed: 81559
+    "NVIDIA H100 NVL":                                    [96256],         # 94 GB; observed: 95830
+    "NVIDIA H100 PCIe":                                   [81920],         # 80 GB; observed: 81559
+    "NVIDIA H800 80GB HBM3":                              [81920],         # 80 GB
+    "NVIDIA H800 NVL":                                    [96256],         # 94 GB
+    "NVIDIA H800 PCIe":                                   [81920],         # 80 GB
     # Blackwell consumer
-    "NVIDIA GeForce RTX 5090":                              [(29491, 34406)],                    # 32 GB; observed: 32607
-    "NVIDIA GeForce RTX 5080":                              [(14746, 17203)],                    # 16 GB
-    "NVIDIA GeForce RTX 5070 Ti":                           [(14746, 17203)],                    # 16 GB
-    "NVIDIA GeForce RTX 5070":                              [(11059, 12902)],                    # 12 GB
-    "NVIDIA GeForce RTX 5060 Ti":                           [(7373, 8602), (14746, 17203)],      # 8/16 GB multi-variant
-    "NVIDIA GeForce RTX 5060":                              [(7373, 8602)],                      # 8 GB
+    "NVIDIA GeForce RTX 5090":                            [32768],         # 32 GB; observed: 32607
+    "NVIDIA GeForce RTX 5080":                            [16384],         # 16 GB
+    "NVIDIA GeForce RTX 5070 Ti":                         [16384],         # 16 GB
+    "NVIDIA GeForce RTX 5070":                            [12288],         # 12 GB
+    "NVIDIA GeForce RTX 5060 Ti":                         [8192, 16384],   # 8/16 GB multi-variant
+    "NVIDIA GeForce RTX 5060":                            [8192],          # 8 GB
     # Ada consumer
-    "NVIDIA GeForce RTX 4090":                              [(22118, 25805)],                    # 24 GB; observed: 24564 (99.6%), 23028 (0.4%)
-    "NVIDIA GeForce RTX 4090 D":                            [(22118, 25805)],                    # 24 GB
-    "NVIDIA GeForce RTX 4080 SUPER":                        [(14746, 17203)],                    # 16 GB
-    "NVIDIA GeForce RTX 4080":                              [(14746, 17203)],                    # 16 GB
-    "NVIDIA GeForce RTX 4070 Ti SUPER":                     [(14746, 17203)],                    # 16 GB
-    "NVIDIA GeForce RTX 4070 Ti":                           [(11059, 12902)],                    # 12 GB
-    "NVIDIA GeForce RTX 4070 SUPER":                        [(11059, 12902)],                    # 12 GB
-    "NVIDIA GeForce RTX 4070":                              [(11059, 12902)],                    # 12 GB
-    "NVIDIA GeForce RTX 4060 Ti":                           [(7373, 8602), (14746, 17203)],      # 8/16 GB multi-variant
-    "NVIDIA GeForce RTX 4060":                              [(7373, 8602)],                      # 8 GB
+    "NVIDIA GeForce RTX 4090":                            [24576],         # 24 GB; observed: 24564 (99.6%), 23028 (0.4%)
+    "NVIDIA GeForce RTX 4090 D":                          [24576],         # 24 GB
+    "NVIDIA GeForce RTX 4080 SUPER":                      [16384],         # 16 GB
+    "NVIDIA GeForce RTX 4080":                            [16384],         # 16 GB
+    "NVIDIA GeForce RTX 4070 Ti SUPER":                   [16384],         # 16 GB
+    "NVIDIA GeForce RTX 4070 Ti":                         [12288],         # 12 GB
+    "NVIDIA GeForce RTX 4070 SUPER":                      [12288],         # 12 GB
+    "NVIDIA GeForce RTX 4070":                            [12288],         # 12 GB
+    "NVIDIA GeForce RTX 4060 Ti":                         [8192, 16384],   # 8/16 GB multi-variant
+    "NVIDIA GeForce RTX 4060":                            [8192],          # 8 GB
     # Blackwell pro / Ada pro / Quadro-class
-    "NVIDIA RTX PRO 4000 Blackwell":                        [(22118, 25805)],                    # 24 GB
-    "NVIDIA RTX PRO 5000 Blackwell":                        [(44237, 51610), (66355, 77414)],    # 48/72 GB multi-variant
-    "NVIDIA RTX PRO 6000 Blackwell Server Edition":         [(88474, 103219)],                   # 96 GB; observed: 97887
-    "NVIDIA RTX PRO 6000 Blackwell Workstation Edition":    [(88474, 103219)],                   # 96 GB; observed: 97887
-    "NVIDIA RTX 5000 Ada Generation":                       [(29491, 34406)],                    # 32 GB
-    "NVIDIA RTX 5880 Ada Generation":                       [(44237, 51610)],                    # 48 GB
-    "NVIDIA RTX 6000 Ada Generation":                       [(44237, 51610)],                    # 48 GB; observed: 49140 (92%), 46068 (8%)
+    "NVIDIA RTX PRO 4000 Blackwell":                      [24576],         # 24 GB
+    "NVIDIA RTX PRO 5000 Blackwell":                      [49152, 73728],  # 48/72 GB multi-variant
+    "NVIDIA RTX PRO 6000 Blackwell Server Edition":       [98304],         # 96 GB; observed: 97887
+    "NVIDIA RTX PRO 6000 Blackwell Workstation Edition":  [98304],         # 96 GB; observed: 97887
+    "NVIDIA RTX 5000 Ada Generation":                     [32768],         # 32 GB
+    "NVIDIA RTX 5880 Ada Generation":                     [49152],         # 48 GB
+    "NVIDIA RTX 6000 Ada Generation":                     [49152],         # 48 GB; observed: 49140 (92%), 46068 (8%)
     # Lovelace data-center
-    "NVIDIA L4":                                            [(22118, 25805)],                    # 24 GB; observed: 23034
-    "NVIDIA L40S":                                          [(44237, 51610)],                    # 48 GB; observed: 46068 (91%), 49140 (9%)
-    "NVIDIA L40":                                           [(44237, 51610)],                    # 48 GB; observed: 46068 (75%), 49140 (25%)
+    "NVIDIA L4":                                          [24576],         # 24 GB; observed: 23034
+    "NVIDIA L40S":                                        [49152],         # 48 GB; observed: 46068 (91%), 49140 (9%)
+    "NVIDIA L40":                                         [49152],         # 48 GB; observed: 46068 (75%), 49140 (25%)
     # Ampere data-center
-    "NVIDIA A100 80GB PCIe":                                [(73728, 86016)],                    # 80 GB; observed: 81920
-    "NVIDIA A100-SXM4-80GB":                                [(73728, 86016)],                    # 80 GB; observed: 81920
-    "NVIDIA A10 Tensor Core GPU":                           [(22118, 25805)],                    # 24 GB
+    "NVIDIA A100 80GB PCIe":                              [81920],         # 80 GB; observed: 81920
+    "NVIDIA A100-SXM4-80GB":                              [81920],         # 80 GB; observed: 81920
+    "NVIDIA A10 Tensor Core GPU":                         [24576],         # 24 GB
     # Ampere pro
-    "NVIDIA RTX A6000":                                     [(44237, 51610)],                    # 48 GB; observed: 49140
-    "NVIDIA RTX A5000":                                     [(22118, 25805)],                    # 24 GB; observed: 24564
-    "NVIDIA RTX A4500":                                     [(18432, 21504)],                    # 20 GB
-    "NVIDIA RTX A4000":                                     [(14746, 17203)],                    # 16 GB; observed: 16376 (71%), 15352 (29%)
-    "NVIDIA RTX A2000":                                     [(5530, 6451), (11059, 12902)],      # 6/12 GB multi-variant
+    "NVIDIA RTX A6000":                                   [49152],         # 48 GB; observed: 49140
+    "NVIDIA RTX A5000":                                   [24576],         # 24 GB; observed: 24564
+    "NVIDIA RTX A4500":                                   [20480],         # 20 GB
+    "NVIDIA RTX A4000":                                   [16384],         # 16 GB; observed: 16376 (71%), 15352 (29%)
+    "NVIDIA RTX A2000":                                   [6144, 12288],   # 6/12 GB multi-variant
     # Turing data-center / pro
-    "NVIDIA T4 Tensor Core GPU":                            [(14746, 17203)],                    # 16 GB
-    "NVIDIA Tesla V100 Tensor Core GPU":                    [(14746, 17203), (29491, 34406)],    # 16/32 GB multi-variant
-    "NVIDIA Quadro RTX 8000":                               [(44237, 51610)],                    # 48 GB
-    "NVIDIA Quadro RTX 6000":                               [(22118, 25805)],                    # 24 GB
-    "NVIDIA Quadro RTX 5000":                               [(14746, 17203)],                    # 16 GB
-    "NVIDIA TITAN V":                                       [(11059, 12902)],                    # 12 GB
-    "NVIDIA TITAN RTX":                                     [(22118, 25805)],                    # 24 GB
+    "NVIDIA T4 Tensor Core GPU":                          [16384],         # 16 GB
+    "NVIDIA Tesla V100 Tensor Core GPU":                  [16384, 32768],  # 16/32 GB multi-variant
+    "NVIDIA Quadro RTX 8000":                             [49152],         # 48 GB
+    "NVIDIA Quadro RTX 6000":                             [24576],         # 24 GB
+    "NVIDIA Quadro RTX 5000":                             [16384],         # 16 GB
+    "NVIDIA TITAN V":                                     [12288],         # 12 GB
+    "NVIDIA TITAN RTX":                                   [24576],         # 24 GB
     # Ampere consumer
-    "NVIDIA GeForce RTX 3090 Ti":                           [(22118, 25805)],                    # 24 GB
-    "NVIDIA GeForce RTX 3090":                              [(22118, 25805)],                    # 24 GB; observed: 24576
-    "NVIDIA GeForce RTX 3080 Ti":                           [(11059, 12902)],                    # 12 GB
-    "NVIDIA GeForce RTX 3080":                              [(9216, 10752), (11059, 12902)],     # 10/12 GB multi-variant
-    "NVIDIA GeForce RTX 3070 Ti":                           [(7373, 8602)],                      # 8 GB; observed: 8192
-    "NVIDIA GeForce RTX 3070":                              [(7373, 8602)],                      # 8 GB
-    "NVIDIA GeForce RTX 3060 Ti":                           [(7373, 8602)],                      # 8 GB
-    "NVIDIA GeForce RTX 3060":                              [(7373, 8602), (11059, 12902)],      # 8/12 GB multi-variant
-    "NVIDIA GeForce RTX 3060 Laptop GPU":                   [(5530, 6451)],                      # 6 GB
-    "NVIDIA GeForce RTX 3050":                              [(5530, 6451), (7373, 8602)],        # 6/8 GB multi-variant
+    "NVIDIA GeForce RTX 3090 Ti":                         [24576],         # 24 GB
+    "NVIDIA GeForce RTX 3090":                            [24576],         # 24 GB; observed: 24576
+    "NVIDIA GeForce RTX 3080 Ti":                         [12288],         # 12 GB
+    "NVIDIA GeForce RTX 3080":                            [10240, 12288],  # 10/12 GB multi-variant
+    "NVIDIA GeForce RTX 3070 Ti":                         [8192],          # 8 GB; observed: 8192
+    "NVIDIA GeForce RTX 3070":                            [8192],          # 8 GB
+    "NVIDIA GeForce RTX 3060 Ti":                         [8192],          # 8 GB
+    "NVIDIA GeForce RTX 3060":                            [8192, 12288],   # 8/12 GB multi-variant
+    "NVIDIA GeForce RTX 3060 Laptop GPU":                 [6144],          # 6 GB
+    "NVIDIA GeForce RTX 3050":                            [6144, 8192],    # 6/8 GB multi-variant
     # Turing consumer
-    "NVIDIA GeForce RTX 2080 Ti":                           [(10138, 11827)],                    # 11 GB
-    "NVIDIA GeForce RTX 2080 SUPER":                        [(7373, 8602)],                      # 8 GB
-    "NVIDIA GeForce RTX 2070 SUPER":                        [(7373, 8602)],                      # 8 GB
-    "NVIDIA GeForce RTX 2060 SUPER":                        [(7373, 8602)],                      # 8 GB
-    "NVIDIA GeForce RTX 2060":                              [(5530, 6451), (11059, 12902)],      # 6/12 GB multi-variant
-    "NVIDIA GeForce GTX 1660 Ti":                           [(5530, 6451)],                      # 6 GB
-    "NVIDIA GeForce GTX 1660 SUPER":                        [(5530, 6451)],                      # 6 GB
-    "NVIDIA GeForce GTX 1660":                              [(5530, 6451)],                      # 6 GB
+    "NVIDIA GeForce RTX 2080 Ti":                         [11264],         # 11 GB
+    "NVIDIA GeForce RTX 2080 SUPER":                      [8192],          # 8 GB
+    "NVIDIA GeForce RTX 2070 SUPER":                      [8192],          # 8 GB
+    "NVIDIA GeForce RTX 2060 SUPER":                      [8192],          # 8 GB
+    "NVIDIA GeForce RTX 2060":                            [6144, 12288],   # 6/12 GB multi-variant
+    "NVIDIA GeForce GTX 1660 Ti":                         [6144],          # 6 GB
+    "NVIDIA GeForce GTX 1660 SUPER":                      [6144],          # 6 GB
+    "NVIDIA GeForce GTX 1660":                            [6144],          # 6 GB
     # Pascal
-    "NVIDIA Tesla P100":                                    [(11059, 12902), (14746, 17203)],    # 12/16 GB multi-variant
-    "NVIDIA Tesla P40":                                     [(22118, 25805)],                    # 24 GB
-    "NVIDIA Quadro P4000":                                  [(7373, 8602)],                      # 8 GB
-    "NVIDIA TITAN Xp":                                      [(11059, 12902)],                    # 12 GB
-    "NVIDIA GeForce GTX 1080 Ti":                           [(10138, 11827)],                    # 11 GB
-    "NVIDIA GeForce GTX 1080":                              [(7373, 8602)],                      # 8 GB
-    "NVIDIA GeForce GTX 1070 Ti":                           [(7373, 8602)],                      # 8 GB
-    "NVIDIA GeForce GTX 1070":                              [(7373, 8602)],                      # 8 GB
-    "NVIDIA GeForce GTX 1060":                              [(2765, 3226), (5530, 6451)],        # 3/6 GB multi-variant (rare 5GB SKU not covered)
+    "NVIDIA Tesla P100":                                  [12288, 16384],  # 12/16 GB multi-variant
+    "NVIDIA Tesla P40":                                   [24576],         # 24 GB
+    "NVIDIA Quadro P4000":                                [8192],          # 8 GB
+    "NVIDIA TITAN Xp":                                    [12288],         # 12 GB
+    "NVIDIA GeForce GTX 1080 Ti":                         [11264],         # 11 GB
+    "NVIDIA GeForce GTX 1080":                            [8192],          # 8 GB
+    "NVIDIA GeForce GTX 1070 Ti":                         [8192],          # 8 GB
+    "NVIDIA GeForce GTX 1070":                            [8192],          # 8 GB
+    "NVIDIA GeForce GTX 1060":                            [3072, 6144],    # 3/6 GB multi-variant (rare 5GB SKU not covered)
     # Maxwell
-    "NVIDIA Tesla M40":                                     [(11059, 12902), (22118, 25805)],    # 12/24 GB multi-variant
+    "NVIDIA Tesla M40":                                   [12288, 24576],  # 12/24 GB multi-variant
 }
 
 # --- Intentionally unranged models (passthrough) -----------------------------
@@ -187,10 +198,23 @@ def normalize_gpu_model(name: Optional[str]) -> str:
     return NORMALIZATION_MAP.get(stripped, stripped)
 
 
+def vram_window_for_size(nominal_mb: int) -> Tuple[int, int]:
+    """Compute the (vram_mb_min, vram_mb_max) acceptance window for one nominal size.
+
+    Bounds are nominal × [VRAM_FLOOR_RATIO, VRAM_CEIL_RATIO], rounded to int. This
+    is the single place min/max VRAM is derived; the table stores only the size.
+    """
+    return (round(nominal_mb * VRAM_FLOOR_RATIO), round(nominal_mb * VRAM_CEIL_RATIO))
+
+
 def get_expected_vram_windows(canonical_model: str) -> Optional[List[Tuple[int, int]]]:
     """Return the list of (vram_mb_min, vram_mb_max) windows for `canonical_model`.
 
-    Returns None if the model is unknown. A reading passes the pre-check if it
-    falls within ANY returned window.
+    Windows are computed from the model's nominal VRAM size(s) via
+    `vram_window_for_size`. Returns None if the model is unknown. A reading passes
+    the pre-check if it falls within ANY returned window.
     """
-    return GPU_VRAM_RANGES.get(canonical_model)
+    sizes = GPU_VRAM_SIZES_MB.get(canonical_model)
+    if sizes is None:
+        return None
+    return [vram_window_for_size(size_mb) for size_mb in sizes]

--- a/neurons/validators/tests/test_gpu_precheck.py
+++ b/neurons/validators/tests/test_gpu_precheck.py
@@ -114,21 +114,36 @@ def test_normalize_passthrough_unmapped():
 # --- CI parity --------------------------------------------------------------
 def test_gpu_model_rates_parity():
     """Every active key in const.GPU_MODEL_RATES MUST be covered by either
-    GPU_VRAM_RANGES or KNOWN_UNRANGED.
+    GPU_VRAM_SIZES_MB or KNOWN_UNRANGED.
     """
     rates_keys = {k for k in GPU_MODEL_RATES.keys() if k is not None}
-    covered = set(gpu_spec_table.GPU_VRAM_RANGES.keys()) | gpu_spec_table.KNOWN_UNRANGED
+    covered = set(gpu_spec_table.GPU_VRAM_SIZES_MB.keys()) | gpu_spec_table.KNOWN_UNRANGED
     missing = sorted(rates_keys - covered)
     assert not missing, (
-        f"GPU_MODEL_RATES has {len(missing)} active key(s) with no GPU_VRAM_RANGES "
+        f"GPU_MODEL_RATES has {len(missing)} active key(s) with no GPU_VRAM_SIZES_MB "
         f"or KNOWN_UNRANGED entry: {missing}"
     )
 
 
-def test_gpu_vram_ranges_well_formed():
-    """Every model maps to a non-empty list of (int, int) windows with
-    vmin <= vmax, both positive, and windows sorted/non-overlapping."""
-    for model, windows in gpu_spec_table.GPU_VRAM_RANGES.items():
+def test_gpu_vram_sizes_well_formed():
+    """Every model maps to a non-empty list of positive, strictly-increasing
+    nominal MB sizes (one per real SKU)."""
+    for model, sizes in gpu_spec_table.GPU_VRAM_SIZES_MB.items():
+        assert isinstance(sizes, list) and sizes, f"{model}: not a non-empty list"
+        prev = None
+        for size in sizes:
+            assert isinstance(size, int), f"{model}: non-int size {size!r}"
+            assert size > 0, f"{model}: non-positive size {size}"
+            if prev is not None:
+                assert size > prev, f"{model}: sizes not strictly increasing at {size}"
+            prev = size
+
+
+def test_computed_windows_well_formed():
+    """Windows computed from the sizes table are non-empty lists of (int, int)
+    with vmin <= vmax, both positive, and sorted/non-overlapping."""
+    for model in gpu_spec_table.GPU_VRAM_SIZES_MB:
+        windows = gpu_spec_table.get_expected_vram_windows(model)
         assert isinstance(windows, list) and windows, f"{model}: not a non-empty list"
         prev_max = None
         for rng in windows:
@@ -176,3 +191,132 @@ def test_multivariant_intermediate_rejected(model, mb):
 ])
 def test_multivariant_real_variants_pass(model, mb):
     assert precheck_gpu_spec(model, mb) is None
+
+
+# --- DAH-2160: format-only refactor guards ----------------------------------
+# The table now stores nominal MB sizes; windows are derived by
+# vram_window_for_size. These tests prove the refactor changes only the storage
+# FORMAT, not any pre-check value or range.
+
+@pytest.mark.parametrize("nominal_mb,expected", [
+    (81920, (73728, 86016)),    # 80 GB -> H100 window
+    (8192, (7373, 8602)),       # 8 GB
+    (16384, (14746, 17203)),    # 16 GB
+    (196608, (176947, 206438)), # 192 GB -> B200 window
+    (11264, (10138, 11827)),    # 11 GB -> RTX 2080 Ti window
+])
+def test_vram_window_for_size(nominal_mb, expected):
+    assert gpu_spec_table.vram_window_for_size(nominal_mb) == expected
+
+
+def test_vram_window_uses_named_ratios():
+    # The ratios are the calibration contract; lock their values.
+    assert gpu_spec_table.VRAM_FLOOR_RATIO == 0.90
+    assert gpu_spec_table.VRAM_CEIL_RATIO == 1.05
+
+
+def test_get_expected_vram_windows_from_sizes():
+    # Single-SKU and multi-variant models both derive windows from their sizes.
+    assert gpu_spec_table.get_expected_vram_windows("NVIDIA H100 80GB HBM3") == [(73728, 86016)]
+    assert gpu_spec_table.get_expected_vram_windows("NVIDIA GeForce RTX 4060 Ti") == [
+        (7373, 8602), (14746, 17203),
+    ]
+    # Unknown model -> None (unchanged contract).
+    assert gpu_spec_table.get_expected_vram_windows("NVIDIA Foo Bar") is None
+
+
+# Frozen snapshot of the (vram_mb_min, vram_mb_max) windows BEFORE the DAH-2160
+# refactor — copied VERBATIM from the pre-refactor GPU_VRAM_RANGES dict (the
+# hand-stored tuples), NOT recomputed from the new sizes table. This makes the
+# test an independent regression guard: the computed windows MUST match these
+# exact values for every model, proving no pre-check value or range changed.
+_EXPECTED_WINDOWS: dict[str, list[tuple[int, int]]] = {
+    "NVIDIA B300 SXM6 AC": [(265421, 309658)],
+    "NVIDIA B200": [(176947, 206438)],
+    "NVIDIA H200": [(129946, 151603)],
+    "NVIDIA H200 NVL": [(129946, 151603)],
+    "NVIDIA H100 80GB HBM3": [(73728, 86016)],
+    "NVIDIA H100 NVL": [(86630, 101069)],
+    "NVIDIA H100 PCIe": [(73728, 86016)],
+    "NVIDIA H800 80GB HBM3": [(73728, 86016)],
+    "NVIDIA H800 NVL": [(86630, 101069)],
+    "NVIDIA H800 PCIe": [(73728, 86016)],
+    "NVIDIA GeForce RTX 5090": [(29491, 34406)],
+    "NVIDIA GeForce RTX 5080": [(14746, 17203)],
+    "NVIDIA GeForce RTX 5070 Ti": [(14746, 17203)],
+    "NVIDIA GeForce RTX 5070": [(11059, 12902)],
+    "NVIDIA GeForce RTX 5060 Ti": [(7373, 8602), (14746, 17203)],
+    "NVIDIA GeForce RTX 5060": [(7373, 8602)],
+    "NVIDIA GeForce RTX 4090": [(22118, 25805)],
+    "NVIDIA GeForce RTX 4090 D": [(22118, 25805)],
+    "NVIDIA GeForce RTX 4080 SUPER": [(14746, 17203)],
+    "NVIDIA GeForce RTX 4080": [(14746, 17203)],
+    "NVIDIA GeForce RTX 4070 Ti SUPER": [(14746, 17203)],
+    "NVIDIA GeForce RTX 4070 Ti": [(11059, 12902)],
+    "NVIDIA GeForce RTX 4070 SUPER": [(11059, 12902)],
+    "NVIDIA GeForce RTX 4070": [(11059, 12902)],
+    "NVIDIA GeForce RTX 4060 Ti": [(7373, 8602), (14746, 17203)],
+    "NVIDIA GeForce RTX 4060": [(7373, 8602)],
+    "NVIDIA RTX PRO 4000 Blackwell": [(22118, 25805)],
+    "NVIDIA RTX PRO 5000 Blackwell": [(44237, 51610), (66355, 77414)],
+    "NVIDIA RTX PRO 6000 Blackwell Server Edition": [(88474, 103219)],
+    "NVIDIA RTX PRO 6000 Blackwell Workstation Edition": [(88474, 103219)],
+    "NVIDIA RTX 5000 Ada Generation": [(29491, 34406)],
+    "NVIDIA RTX 5880 Ada Generation": [(44237, 51610)],
+    "NVIDIA RTX 6000 Ada Generation": [(44237, 51610)],
+    "NVIDIA L4": [(22118, 25805)],
+    "NVIDIA L40S": [(44237, 51610)],
+    "NVIDIA L40": [(44237, 51610)],
+    "NVIDIA A100 80GB PCIe": [(73728, 86016)],
+    "NVIDIA A100-SXM4-80GB": [(73728, 86016)],
+    "NVIDIA A10 Tensor Core GPU": [(22118, 25805)],
+    "NVIDIA RTX A6000": [(44237, 51610)],
+    "NVIDIA RTX A5000": [(22118, 25805)],
+    "NVIDIA RTX A4500": [(18432, 21504)],
+    "NVIDIA RTX A4000": [(14746, 17203)],
+    "NVIDIA RTX A2000": [(5530, 6451), (11059, 12902)],
+    "NVIDIA T4 Tensor Core GPU": [(14746, 17203)],
+    "NVIDIA Tesla V100 Tensor Core GPU": [(14746, 17203), (29491, 34406)],
+    "NVIDIA Quadro RTX 8000": [(44237, 51610)],
+    "NVIDIA Quadro RTX 6000": [(22118, 25805)],
+    "NVIDIA Quadro RTX 5000": [(14746, 17203)],
+    "NVIDIA TITAN V": [(11059, 12902)],
+    "NVIDIA TITAN RTX": [(22118, 25805)],
+    "NVIDIA GeForce RTX 3090 Ti": [(22118, 25805)],
+    "NVIDIA GeForce RTX 3090": [(22118, 25805)],
+    "NVIDIA GeForce RTX 3080 Ti": [(11059, 12902)],
+    "NVIDIA GeForce RTX 3080": [(9216, 10752), (11059, 12902)],
+    "NVIDIA GeForce RTX 3070 Ti": [(7373, 8602)],
+    "NVIDIA GeForce RTX 3070": [(7373, 8602)],
+    "NVIDIA GeForce RTX 3060 Ti": [(7373, 8602)],
+    "NVIDIA GeForce RTX 3060": [(7373, 8602), (11059, 12902)],
+    "NVIDIA GeForce RTX 3060 Laptop GPU": [(5530, 6451)],
+    "NVIDIA GeForce RTX 3050": [(5530, 6451), (7373, 8602)],
+    "NVIDIA GeForce RTX 2080 Ti": [(10138, 11827)],
+    "NVIDIA GeForce RTX 2080 SUPER": [(7373, 8602)],
+    "NVIDIA GeForce RTX 2070 SUPER": [(7373, 8602)],
+    "NVIDIA GeForce RTX 2060 SUPER": [(7373, 8602)],
+    "NVIDIA GeForce RTX 2060": [(5530, 6451), (11059, 12902)],
+    "NVIDIA GeForce GTX 1660 Ti": [(5530, 6451)],
+    "NVIDIA GeForce GTX 1660 SUPER": [(5530, 6451)],
+    "NVIDIA GeForce GTX 1660": [(5530, 6451)],
+    "NVIDIA Tesla P100": [(11059, 12902), (14746, 17203)],
+    "NVIDIA Tesla P40": [(22118, 25805)],
+    "NVIDIA Quadro P4000": [(7373, 8602)],
+    "NVIDIA TITAN Xp": [(11059, 12902)],
+    "NVIDIA GeForce GTX 1080 Ti": [(10138, 11827)],
+    "NVIDIA GeForce GTX 1080": [(7373, 8602)],
+    "NVIDIA GeForce GTX 1070 Ti": [(7373, 8602)],
+    "NVIDIA GeForce GTX 1070": [(7373, 8602)],
+    "NVIDIA GeForce GTX 1060": [(2765, 3226), (5530, 6451)],
+    "NVIDIA Tesla M40": [(11059, 12902), (22118, 25805)],
+}
+
+
+def test_computed_windows_match_pre_refactor_snapshot():
+    """Every model's computed windows MUST equal the pre-refactor hand-stored
+    windows — the refactor changes storage format only, never a pre-check range."""
+    # No model added or dropped relative to the frozen snapshot.
+    assert set(gpu_spec_table.GPU_VRAM_SIZES_MB) == set(_EXPECTED_WINDOWS)
+    for model, expected in _EXPECTED_WINDOWS.items():
+        assert gpu_spec_table.get_expected_vram_windows(model) == expected, model


### PR DESCRIPTION
## Describe your changes

Refactor the validator-side GPU VRAM table so it stores only the nominal VRAM size per GPU model; the min/max acceptance windows are now computed dynamically by a shared utility instead of being hand-maintained. **Format-only change — no pre-check value or range changes.**

- `gpu_spec_table.py`: replaced `GPU_VRAM_RANGES` (`Dict[str, List[Tuple[int, int]]]`, hand-stored `(min, max)` windows) with `GPU_VRAM_SIZES_MB` (`Dict[str, List[int]]`, nominal MB size per real SKU). Multi-variant cards keep one size per variant (e.g. RTX 4060 Ti → `[8192, 16384]`).
- Added `vram_window_for_size(nominal_mb)` — the single place min/max is derived — plus named calibration constants `VRAM_FLOOR_RATIO = 0.90` / `VRAM_CEIL_RATIO = 1.05`.
- `get_expected_vram_windows()` now computes windows from the sizes table but keeps its signature/return type, so `gpu_precheck.py` (docstring-only change), `task/checks/gpu_vram_precheck.py`, and `preflight/checks/matrix_check.py` are functionally untouched.
- Rewrote the module docstring for the new shape while preserving the calibration rationale (0.90 floor / 1.05 ceiling, discrete-windows-reject-impostors, B200-only-192GB note) and the `libdmcompverify.so` SYNC note.

Verified up front that all 79 entries' windows reproduce exactly from `round(nominal_mb × 0.90)` / `round(nominal_mb × 1.05)` (no off-formula entries, no `.5` rounding ties). The new table and golden snapshot were generated mechanically from the previous table — no hand transcription.

Performance: windows are computed per call (~1 per single-SKU model), which is negligible; no caching needed.

## Issue ticket number and link

[DAH-2160 — Refactor GPU VRAM mapping table to store only VRAM size](https://www.notion.so/Refactor-GPU-VRAM-mapping-table-to-store-only-VRAM-size-36cb8bfdbde98157844ed339783f76d8)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?

### Tests
- New `test_computed_windows_match_pre_refactor_snapshot` freezes the pre-refactor windows for all 79 models (copied verbatim from the old `GPU_VRAM_RANGES`) and asserts the computed windows match exactly + the model key set is unchanged — proving no range changed.
- Added unit tests for `vram_window_for_size`, the ratio constants, and `get_expected_vram_windows` (single/multi-variant/unknown); updated the parity test and split the well-formed test into source-shape + computed-window invariants.
- `test_gpu_precheck.py` + `test_gpu_vram_precheck_check.py`: 61 passed. Full validator suite: 593 passed, 4 skipped (pre-existing).
