### PR TITLE
DAH-2133, fix stale volume mountpoint cleanup

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -2,6 +2,7 @@ import asyncio
 import random
 from datetime import datetime
 import logging
+import re
 import time
 from pathlib import Path
 from typing import Annotated, Any
@@ -81,6 +82,15 @@ DOCKER_VOLUME_PLUGINS = {
 _PORT_ALLOCATED_PHRASES = ("port is already allocated", "address already in use", "failed to bind host port")
 _PORT_ALLOCATED_RETRY_BUDGET_SEC = 90
 _PORT_ALLOCATED_RETRY_SLEEP_SEC = 5
+_VLOOPBACK_MOUNT_ERROR_PHRASES = (
+    "VolumeDriver.Mount",
+    "cannot create mount point dir",
+    "file exists",
+)
+_VLOOPBACK_DRIVER_PREFIX = "vloopback"
+_VLOOPBACK_REPAIR_IMAGE = "docker.io/library/alpine:3.19"
+_VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC = 30
+_DOCKER_VOLUME_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 _LOCAL_VOLUME_TIMEOUT_THRESHOLD_GB = 100
 _LOCAL_VOLUME_TIMEOUT_BASE_SEC = 30
 _LOCAL_VOLUME_TIMEOUT_GB_PER_SEC = 10
@@ -99,6 +109,31 @@ def _is_missing_docker_container_error(exc: Exception) -> bool:
             and _DOCKER_NO_SUCH_CONTAINER_PHRASE in str(last_exception)
         )
     return False
+
+
+def _is_stale_vloopback_mountpoint_error(exc: Exception) -> bool:
+    text = str(exc)
+    return all(phrase in text for phrase in _VLOOPBACK_MOUNT_ERROR_PHRASES)
+
+
+def _is_safe_docker_volume_name(volume_name: str) -> bool:
+    return bool(_DOCKER_VOLUME_NAME_RE.fullmatch(volume_name))
+
+
+def _is_vloopback_driver(driver: str) -> bool:
+    return driver == _VLOOPBACK_DRIVER_PREFIX or driver.startswith(f"{_VLOOPBACK_DRIVER_PREFIX}:")
+
+
+def _should_repair_stale_mountpoint(
+    exc: Exception,
+    local_volume: str | None,
+    already_repaired: bool,
+) -> bool:
+    return (
+        bool(local_volume)
+        and not already_repaired
+        and _is_stale_vloopback_mountpoint_error(exc)
+    )
 
 
 class DockerService:
@@ -133,8 +168,9 @@ class DockerService:
         log_tag: str,
         default_extra: dict,
         timeout: int,
+        local_volume: str | None = None,
     ) -> None:
-        """Run `docker run` with same-command retry on port-allocated races.
+        """Run `docker run` with same-command retry on known Docker races.
 
         DAH-1991: backend-spawned `health_check_*` probes (TTL ~30s) can land
         on a port we already accepted into `port_maps` during the 20-60s gap
@@ -150,9 +186,14 @@ class DockerService:
         attempts (after the backoff sleep, just before the next `docker run`)
         we issue `docker rm -f <container_name>` so the rm→run window stays
         tight. Cleanup failures are warning-logged but do not abort the loop.
+
+        DAH-2133: if Docker fails to mount an existing vloopback volume because
+        an empty stale plugin mountpoint already exists, repair only that
+        empty unmounted mountpoint and retry the same command once.
         """
         deadline = time.monotonic() + _PORT_ALLOCATED_RETRY_BUDGET_SEC
         attempt = 0
+        vloopback_mount_repair_attempted = False
         while True:
             try:
                 await self.execute_and_stream_logs(
@@ -165,42 +206,139 @@ class DockerService:
                 )
                 return
             except Exception as e:
-                matched_phrase = next((p for p in _PORT_ALLOCATED_PHRASES if p in str(e)), None)
-                if matched_phrase is None or time.monotonic() >= deadline:
-                    raise
-                attempt += 1
-                logger.info(
-                    _m(
-                        "PORT_ALREADY_ALLOCATED_RETRY",
-                        extra=get_extra_info({
-                            **default_extra,
-                            "attempt": attempt,
-                            "remaining_sec": int(deadline - time.monotonic()),
-                            "sleep_seconds": _PORT_ALLOCATED_RETRY_SLEEP_SEC,
-                            "matched_phrase": matched_phrase,
-                        }),
-                    )
-                )
-                await asyncio.sleep(_PORT_ALLOCATED_RETRY_SLEEP_SEC)
-                # DAH-2018: drop the Created-state container Docker reserved
-                # during the prior `docker run` parse, so the next same-command
-                # attempt cannot collide with "container name already in use".
-                try:
-                    rm_cmd = f"/usr/bin/docker rm -f {shlex.quote(container_name)}"
-                    await ssh_client.run(rm_cmd)
-                except asyncio.CancelledError:
-                    raise
-                except Exception as rm_exc:
-                    logger.warning(
+                # Known Docker races:
+                # repair stale vloopback mountpoints once;
+                # retry port allocation failures until the short budget expires.
+                if _should_repair_stale_mountpoint(e, local_volume, vloopback_mount_repair_attempted):
+                    vloopback_mount_repair_attempted = True
+                    if await self.repair_stale_vloopback_mountpoint(ssh_client, local_volume, default_extra):
+                        logger.info(
+                            _m(
+                                "VLOOPBACK_STALE_MOUNTPOINT_RETRY",
+                                extra=get_extra_info({**default_extra, "local_volume": local_volume}),
+                            )
+                        )
+                        continue
+
+                port_allocation_phrase = next((p for p in _PORT_ALLOCATED_PHRASES if p in str(e)), None)
+                port_retry_deadline_expired = time.monotonic() >= deadline
+                port_retry_needed = bool(port_allocation_phrase) and not port_retry_deadline_expired
+                if port_retry_needed:
+                    attempt += 1
+                    logger.info(
                         _m(
-                            "PORT_RETRY_STALE_RM_FAILED",
+                            "PORT_ALREADY_ALLOCATED_RETRY",
                             extra=get_extra_info({
                                 **default_extra,
-                                "container_name": container_name,
-                                "rm_error": str(rm_exc),
+                                "attempt": attempt,
+                                "remaining_sec": int(deadline - time.monotonic()),
+                                "sleep_seconds": _PORT_ALLOCATED_RETRY_SLEEP_SEC,
+                                "port_allocation_phrase": port_allocation_phrase,
                             }),
                         )
                     )
+                    await asyncio.sleep(_PORT_ALLOCATED_RETRY_SLEEP_SEC)
+                    await self._remove_failed_container_for_retry(
+                        ssh_client=ssh_client,
+                        container_name=container_name,
+                        default_extra=default_extra,
+                        warning_event="PORT_RETRY_STALE_RM_FAILED",
+                    )
+
+                    continue
+
+                raise
+
+    async def _remove_failed_container_for_retry(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        container_name: str,
+        default_extra: dict,
+        warning_event: str,
+    ) -> None:
+        try:
+            # Remove only the failed container object; named volumes stay intact.
+            await ssh_client.run(f"/usr/bin/docker rm -f {shlex.quote(container_name)}")
+        except asyncio.CancelledError:
+            raise
+        except Exception as rm_exc:
+            logger.warning(
+                _m(
+                    warning_event,
+                    extra=get_extra_info({
+                        **default_extra,
+                        "container_name": container_name,
+                        "rm_error": str(rm_exc),
+                    }),
+                )
+            )
+
+    async def repair_stale_vloopback_mountpoint(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        local_volume: str,
+        default_extra: dict,
+    ) -> bool:
+        if not _is_safe_docker_volume_name(local_volume):
+            return False
+
+        # Get the exact Docker-reported mountpoint path as the repair target.
+        volume = shlex.quote(local_volume)
+        inspect_result = await ssh_client.run(
+            f"/usr/bin/docker volume inspect {volume} --format '{{{{.Driver}}}} {{{{.Mountpoint}}}}'",
+            timeout=_VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC,
+        )
+        if getattr(inspect_result, "exit_status", 0) != 0:
+            return False
+
+        driver, _, target = (inspect_result.stdout or "").strip().partition(" ")
+        if not _is_vloopback_driver(driver) or target != f"/mnt/{local_volume}":
+            return False
+
+        # Recheck that the target is not currently mounted before removing it.
+        mounted_result = await ssh_client.run(
+            f"/usr/bin/findmnt {shlex.quote(target)} >/dev/null 2>&1",
+            timeout=_VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC,
+        )
+        mounted_exit_status = getattr(mounted_result, "exit_status", 1)
+        if mounted_exit_status == 0:
+            logger.warning(
+                _m(
+                    "VLOOPBACK_STALE_MOUNTPOINT_STILL_MOUNTED",
+                    extra=get_extra_info({**default_extra, "local_volume": local_volume}),
+                )
+            )
+            return False
+        if mounted_exit_status != 1:
+            return False
+
+        # Repair by removing only the empty stale mountpoint directory.
+        helper_cmd = (
+            "/usr/bin/docker run --rm "
+            f"-v /mnt:/mnt {_VLOOPBACK_REPAIR_IMAGE} rmdir {shlex.quote(target)}"
+        )
+        repair_result = await ssh_client.run(helper_cmd, timeout=_VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC)
+        if getattr(repair_result, "exit_status", 0) != 0:
+            logger.warning(
+                _m(
+                    "VLOOPBACK_STALE_MOUNTPOINT_REPAIR_SKIPPED",
+                    extra=get_extra_info({
+                        **default_extra,
+                        "local_volume": local_volume,
+                        "exit_status": getattr(repair_result, "exit_status", None),
+                        "stderr": getattr(repair_result, "stderr", ""),
+                    }),
+                )
+            )
+            return False
+
+        logger.info(
+            _m(
+                "VLOOPBACK_STALE_MOUNTPOINT_REPAIRED",
+                extra=get_extra_info({**default_extra, "local_volume": local_volume}),
+            )
+        )
+        return True
 
     async def _prepare_known_hosts_policy(
         self,
@@ -1093,10 +1231,17 @@ class DockerService:
         ]):
             raise Exception(error)
 
-    async def get_docker_root_dir(self, ssh_client: asyncssh.SSHClientConnection):
+    async def get_docker_root_dir(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        timeout: int | None = None,
+    ):
         """Get Docker storage info using docker info command"""
         command = f"/usr/bin/docker info --format '{{{{.DockerRootDir}}}}'"
-        result = await ssh_client.run(command)
+        if timeout is None:
+            result = await ssh_client.run(command)
+        else:
+            result = await ssh_client.run(command, timeout=timeout)
         return result.stdout.strip()
 
     @staticmethod
@@ -1557,6 +1702,7 @@ class DockerService:
                         log_tag=log_tag,
                         default_extra=default_extra,
                         timeout=timeout,
+                        local_volume=local_volume,
                     )
 
                     logger.info(f"Container creation step finished")

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -294,6 +294,14 @@ class DockerService:
         driver, _, target = (inspect_result.stdout or "").strip().partition(" ")
         if not _is_vloopback_driver(driver) or target != f"/mnt/{local_volume}":
             return False
+        plugin_result = await ssh_client.run(
+            f"/usr/bin/docker plugin inspect {shlex.quote(driver)} --format '{{{{.Id}}}}'",
+            timeout=_VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC,
+        )
+        plugin_id = (plugin_result.stdout or "").strip()
+        if getattr(plugin_result, "exit_status", 0) != 0 or not plugin_id:
+            return False
+        target = f"/var/lib/docker/plugins/{plugin_id}/propagated-mount/{local_volume}"
 
         # Recheck that the target is not currently mounted before removing it.
         mounted_result = await ssh_client.run(
@@ -315,7 +323,8 @@ class DockerService:
         # Repair by removing only the empty stale mountpoint directory.
         helper_cmd = (
             "/usr/bin/docker run --rm "
-            f"-v /mnt:/mnt {_VLOOPBACK_REPAIR_IMAGE} rmdir {shlex.quote(target)}"
+            f"-v {shlex.quote(str(Path(target).parent))}:/mnt "
+            f"{_VLOOPBACK_REPAIR_IMAGE} rmdir /mnt/{shlex.quote(local_volume)}"
         )
         repair_result = await ssh_client.run(helper_cmd, timeout=_VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC)
         if getattr(repair_result, "exit_status", 0) != 0:

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -1756,6 +1756,7 @@ async def test_repair_stale_vloopback_mountpoint_uses_rmdir_helper(docker_servic
     ssh_client.run = AsyncMock(
         side_effect=[
             _make_ssh_command_result(stdout="vloopback:latest /mnt/volume_test\n"),
+            _make_ssh_command_result(stdout="plugin123\n"),
             _make_ssh_command_result(exit_status=1),
             _make_ssh_command_result(exit_status=0),
         ]
@@ -1772,7 +1773,7 @@ async def test_repair_stale_vloopback_mountpoint_uses_rmdir_helper(docker_servic
     assert "docker.io/library/alpine:3.19" in helper_cmd
     assert "rmdir" in helper_cmd
     assert "rm -rf" not in helper_cmd
-    assert "-v /mnt:/mnt" in helper_cmd
+    assert "-v /var/lib/docker/plugins/plugin123/propagated-mount:/mnt" in helper_cmd
     assert "/mnt/volume_test" in helper_cmd
     assert all(
         call.kwargs.get("timeout") == 30
@@ -1786,6 +1787,7 @@ async def test_repair_stale_vloopback_mountpoint_refuses_active_mount(docker_ser
     ssh_client.run = AsyncMock(
         side_effect=[
             _make_ssh_command_result(stdout="vloopback:latest /mnt/volume_test\n"),
+            _make_ssh_command_result(stdout="plugin123\n"),
             _make_ssh_command_result(exit_status=0),
         ]
     )
@@ -1797,7 +1799,7 @@ async def test_repair_stale_vloopback_mountpoint_refuses_active_mount(docker_ser
     )
 
     assert repaired is False
-    assert ssh_client.run.await_count == 2
+    assert ssh_client.run.await_count == 3
 
 
 @pytest.mark.asyncio
@@ -1860,6 +1862,7 @@ async def test_repair_stale_vloopback_mountpoint_refuses_non_empty_target(docker
     ssh_client.run = AsyncMock(
         side_effect=[
             _make_ssh_command_result(stdout="vloopback:latest /mnt/volume_test\n"),
+            _make_ssh_command_result(stdout="plugin123\n"),
             _make_ssh_command_result(exit_status=1),
             _make_ssh_command_result(exit_status=12, stderr="not empty"),
         ]

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -1269,6 +1269,9 @@ async def test_create_container_cleans_stale_vloopback_when_active_volumes_missi
     assert docker_service.clean_stale_vloopback_volumes.await_args.kwargs[
         "skip_volume_names"
     ] == set()
+    assert docker_service._run_docker_create_with_port_retry.await_args.kwargs[
+        "local_volume"
+    ] == f"volume_{payload.pod_id}"
 
 
 @pytest.mark.asyncio
@@ -1541,6 +1544,13 @@ _EADDRINUSE_ERR = (
     "docker: Error response from daemon: failed to bind host port "
     "0.0.0.0:9030/tcp: address already in use"
 )
+_VLOOPBACK_STALE_MOUNT_ERR = (
+    "docker: Error response from daemon: failed to populate volume: "
+    "error while mounting volume '/mnt/volume_test': "
+    "VolumeDriver.Mount: error while mounting volume: "
+    "cannot create mount point dir '/mnt/volume_test': "
+    "mkdir /mnt/volume_test: file exists"
+)
 
 
 @pytest.mark.asyncio
@@ -1648,6 +1658,220 @@ async def test_create_container_does_not_retry_on_other_docker_errors(
 
     assert calls["n"] == 1
     assert sleep_called["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_create_container_repairs_stale_vloopback_mountpoint_then_retries(
+    docker_service, monkeypatch,
+):
+    calls = {"n": 0}
+    seen_commands: list[str] = []
+
+    async def fake_execute(*, ssh_client, command, log_tag, log_text, log_extra, timeout):
+        calls["n"] += 1
+        seen_commands.append(command)
+        if calls["n"] == 1:
+            raise Exception(_VLOOPBACK_STALE_MOUNT_ERR)
+
+    monkeypatch.setattr(docker_service, "execute_and_stream_logs", fake_execute)
+    repair = AsyncMock(return_value=True)
+    monkeypatch.setattr(docker_service, "repair_stale_vloopback_mountpoint", repair)
+
+    ssh_client = Mock()
+    ssh_client.run = AsyncMock(return_value=Mock(exit_status=0, stdout="", stderr=""))
+
+    await docker_service._run_docker_create_with_port_retry(
+        ssh_client=ssh_client,
+        command="/usr/bin/docker run -d -v volume_test:/root --name pod_test img",
+        container_name="pod_test",
+        log_tag="t",
+        default_extra={},
+        timeout=120,
+        local_volume="volume_test",
+    )
+
+    assert calls["n"] == 2
+    assert seen_commands[0] == seen_commands[1]
+    repair.assert_awaited_once_with(ssh_client, "volume_test", {})
+    ssh_client.run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_container_does_not_repair_vloopback_mountpoint_twice(
+    docker_service, monkeypatch,
+):
+    async def always_fail(*, ssh_client, command, log_tag, log_text, log_extra, timeout):
+        raise Exception(_VLOOPBACK_STALE_MOUNT_ERR)
+
+    monkeypatch.setattr(docker_service, "execute_and_stream_logs", always_fail)
+    repair = AsyncMock(return_value=True)
+    monkeypatch.setattr(docker_service, "repair_stale_vloopback_mountpoint", repair)
+
+    ssh_client = Mock()
+    ssh_client.run = AsyncMock(return_value=Mock(exit_status=0, stdout="", stderr=""))
+
+    with pytest.raises(Exception) as exc:
+        await docker_service._run_docker_create_with_port_retry(
+            ssh_client=ssh_client,
+            command="/usr/bin/docker run -d -v volume_test:/root --name pod_test img",
+            container_name="pod_test",
+            log_tag="t",
+            default_extra={},
+            timeout=120,
+            local_volume="volume_test",
+        )
+
+    assert _VLOOPBACK_STALE_MOUNT_ERR in str(exc.value)
+    repair.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_container_skips_mountpoint_repair_without_local_volume(
+    docker_service, monkeypatch,
+):
+    async def fail_stale_mount(*, ssh_client, command, log_tag, log_text, log_extra, timeout):
+        raise Exception(_VLOOPBACK_STALE_MOUNT_ERR)
+
+    monkeypatch.setattr(docker_service, "execute_and_stream_logs", fail_stale_mount)
+    repair = AsyncMock(return_value=True)
+    monkeypatch.setattr(docker_service, "repair_stale_vloopback_mountpoint", repair)
+
+    with pytest.raises(Exception) as exc:
+        await docker_service._run_docker_create_with_port_retry(
+            ssh_client=Mock(),
+            command="/usr/bin/docker run -d --name pod_test img",
+            container_name="pod_test",
+            log_tag="t",
+            default_extra={},
+            timeout=120,
+        )
+
+    assert _VLOOPBACK_STALE_MOUNT_ERR in str(exc.value)
+    repair.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_repair_stale_vloopback_mountpoint_uses_rmdir_helper(docker_service):
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(
+        side_effect=[
+            _make_ssh_command_result(stdout="vloopback:latest /mnt/volume_test\n"),
+            _make_ssh_command_result(exit_status=1),
+            _make_ssh_command_result(exit_status=0),
+        ]
+    )
+
+    repaired = await docker_service.repair_stale_vloopback_mountpoint(
+        ssh_client=ssh_client,
+        local_volume="volume_test",
+        default_extra={},
+    )
+
+    assert repaired is True
+    helper_cmd = ssh_client.run.await_args_list[-1].args[0]
+    assert "docker.io/library/alpine:3.19" in helper_cmd
+    assert "rmdir" in helper_cmd
+    assert "rm -rf" not in helper_cmd
+    assert "-v /mnt:/mnt" in helper_cmd
+    assert "/mnt/volume_test" in helper_cmd
+    assert all(
+        call.kwargs.get("timeout") == 30
+        for call in ssh_client.run.await_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_repair_stale_vloopback_mountpoint_refuses_active_mount(docker_service):
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(
+        side_effect=[
+            _make_ssh_command_result(stdout="vloopback:latest /mnt/volume_test\n"),
+            _make_ssh_command_result(exit_status=0),
+        ]
+    )
+
+    repaired = await docker_service.repair_stale_vloopback_mountpoint(
+        ssh_client=ssh_client,
+        local_volume="volume_test",
+        default_extra={},
+    )
+
+    assert repaired is False
+    assert ssh_client.run.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_repair_stale_vloopback_mountpoint_refuses_unsafe_volume_name(docker_service):
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock()
+
+    for local_volume in ("../volume_test", ".", "volume test"):
+        repaired = await docker_service.repair_stale_vloopback_mountpoint(
+            ssh_client=ssh_client,
+            local_volume=local_volume,
+            default_extra={},
+        )
+        assert repaired is False
+
+    ssh_client.run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_repair_stale_vloopback_mountpoint_refuses_non_vloopback_driver(docker_service):
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(
+        side_effect=[
+            _make_ssh_command_result(stdout="local /mnt/volume_test\n"),
+        ]
+    )
+
+    repaired = await docker_service.repair_stale_vloopback_mountpoint(
+        ssh_client=ssh_client,
+        local_volume="volume_test",
+        default_extra={},
+    )
+
+    assert repaired is False
+    ssh_client.run.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_repair_stale_vloopback_mountpoint_refuses_unexpected_mountpoint(docker_service):
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(
+        side_effect=[
+            _make_ssh_command_result(stdout="vloopback:latest /tmp/volume_test\n"),
+        ]
+    )
+
+    repaired = await docker_service.repair_stale_vloopback_mountpoint(
+        ssh_client=ssh_client,
+        local_volume="volume_test",
+        default_extra={},
+    )
+
+    assert repaired is False
+    ssh_client.run.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_repair_stale_vloopback_mountpoint_refuses_non_empty_target(docker_service):
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(
+        side_effect=[
+            _make_ssh_command_result(stdout="vloopback:latest /mnt/volume_test\n"),
+            _make_ssh_command_result(exit_status=1),
+            _make_ssh_command_result(exit_status=12, stderr="not empty"),
+        ]
+    )
+
+    repaired = await docker_service.repair_stale_vloopback_mountpoint(
+        ssh_client=ssh_client,
+        local_volume="volume_test",
+        default_extra={},
+    )
+
+    assert repaired is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes `create_container` failures caused by stale `vloopback` plugin mountpoint directories when Docker reports `VolumeDriver.Mount ... cannot create mount point dir ... file exists`.

### Task Link

[DAH-2133](https://www.notion.so/Fix-stale-volume-mountpoint-cleanup-for-create_container-failures-365b8bfdbde9817394ecec7b51d2b305)

---

## Problem

After a host or executor restart, a Docker volume can remain valid while the vloopback plugin's propagated mountpoint is left behind as an empty stale directory. Docker reports that failure as `mkdir /mnt/volume_<pod_id>: file exists`, but the host-side stale path is under Docker's managed plugin directory.

Existing retry and cleanup paths handle stale containers and port allocation races, but they did not repair this specific empty stale plugin mountpoint before retrying the same Docker create command.

## Solution

Add a narrow one-shot repair path inside validator-side Docker create retry handling:

- detect the exact stale vloopback mountpoint error signature;
- verify the local volume name is safe;
- inspect Docker's volume metadata and require a `vloopback` driver;
- require Docker's reported mountpoint to be exactly `/mnt/<volume_name>`;
- resolve the managed plugin id with `docker plugin inspect`;
- target `/var/lib/docker/plugins/<plugin_id>/propagated-mount/<volume_name>` for the host-side repair;
- recheck that the target is not currently mounted with `findmnt`;
- remove only the empty stale directory with non-privileged `rmdir` from a helper container bound to the plugin propagated-mount directory;
- retry the same Docker create command once.

The existing port allocation retry path remains separate and still removes the failed Created-state container between port retry attempts.

## Changes

- Added stale vloopback mountpoint detection to `_run_docker_create_with_port_retry`.
- Added `repair_stale_vloopback_mountpoint` with scoped checks around safe volume names, `vloopback` driver, `/mnt/<volume>` Docker-reported mountpoint, plugin propagated mountpoint resolution, active mount refusal, and `rmdir` repair.
- Passed the resolved local volume name into create retry handling for both reused volumes and default `volume_<pod_id>` volumes.
- Added focused DockerService tests for stale mountpoint retry behavior, active mount refusal, unsafe volume names, non-vloopback drivers, unexpected mountpoints, non-empty targets, and default volume coverage.

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

None.

## Risks

- The repair intentionally handles only empty, unmounted propagated mountpoint directories for vloopback volumes whose Docker-reported mountpoint is `/mnt/<volume>`. If Docker reports a different layout, repair is skipped and the original create failure remains visible.
- The helper image must be available on the executor. If it is unavailable, repair is skipped through the existing failure path.
- This does not implement automatic customer process recovery, broad stale mountpoint cleanup, or billing/rental state changes.

## Test Cases

### Test Case 1

**Actions**

Run focused DockerService tests:

```bash
cd neurons/validators
pdm run pytest tests/test_docker_service.py -q
```

**Expected Output**

`81 passed, 36 warnings`

### Test Case 2

**Actions**

Run repository pre-push verification:

```bash
scripts/agent/agentctl push lium-io --all --full --quiet -m "fix: repair vloopback propagated mountpoints"
```

**Expected Output**

`609 passed, 4 skipped, 72 warnings`

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described