### PR TITLE
DAH-2158: Exclude paused executors from incentives

### DIFF
--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -311,6 +311,9 @@ class Validator:
                                         and job_result.gpu_count
                                         and (job_result.score > 0 or job_result.job_score > 0)
                                         and not job_result.is_spot
+                                        and not (
+                                            job_result.is_new_rentals_paused and not job_result.is_rented
+                                        )
                                     ):
                                         total_gpu_model_count_map[job_result.gpu_model] = total_gpu_model_count_map.get(job_result.gpu_model, 0) + job_result.gpu_count
 

--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -114,6 +114,28 @@ class DefaultIncentive(BaseIncentive):
             job_result.mining_score = 0
             return job_result
 
+        # Fallback for deployments using the legacy/default incentive algorithm
+        # directly. The active rental_price algorithm handles this before it
+        # calls into DefaultIncentive.
+        if job_result.is_new_rentals_paused and not job_result.is_rented:
+            logger.info(
+                _m(
+                    "Executor excluded from mining pool - paused for new rentals",
+                    extra=get_extra_info(
+                        {
+                            "executor_id": str(job_result.executor_info.uuid),
+                            "gpu_model": job_result.gpu_model,
+                            "gpu_count": job_result.gpu_count,
+                            "reason": "new_rentals_paused",
+                            "score": 0,
+                            "pool": "none",
+                        }
+                    ),
+                )
+            )
+            job_result.mining_score = 0
+            return job_result
+
         # GPU count calculation
         job_result.total_gpu_count = self.total_gpu_model_count_map.get(job_result.gpu_model, 0)
         if not job_result.total_gpu_count:

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -386,6 +386,24 @@ class RentalPriceIncentive(DefaultIncentive):
             job_result.eligible_for_rental_share = False
             return job_result
 
+        if job_result.is_new_rentals_paused and not job_result.is_rented:
+            logger.info(
+                _m(
+                    "Executor excluded from both pools - paused for new rentals",
+                    extra={
+                        "executor_id": str(job_result.executor_info.uuid),
+                        "gpu_model": job_result.gpu_model,
+                        "gpu_count": job_result.gpu_count,
+                        "reason": "new_rentals_paused",
+                        "score": 0,
+                        "pool": "none",
+                    },
+                )
+            )
+            job_result.mining_score = 0
+            job_result.eligible_for_rental_share = False
+            return job_result
+
         # Check if GPU is unrented and eligible (has positive cap in max_unrented_gpus)
         base_model = self.get_base_model_for_gpu(job_result.gpu_model)
         job_result.eligible_for_rental_share = (

--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -75,6 +75,7 @@ class RentedExecutorsResponse(BaseModel):
     gpu_splitting_config: dict[str, int] = {}  # executor_id → min_gpu_count_for_rental
     network_ema: dict[str, NetworkEMA] = {}  # executor_id → EMA network speeds, all active executors
     spot_executor_ids: list[str] = []  # executor_ids in spot tier (no incentive, no penalty)
+    new_rentals_paused_executor_ids: list[str] = []  # executor_ids paused from new rentals and incentives
 
     @field_validator("filler_containers_by_executor")
     @classmethod

--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -75,7 +75,7 @@ class RentedExecutorsResponse(BaseModel):
     gpu_splitting_config: dict[str, int] = {}  # executor_id → min_gpu_count_for_rental
     network_ema: dict[str, NetworkEMA] = {}  # executor_id → EMA network speeds, all active executors
     spot_executor_ids: list[str] = []  # executor_ids in spot tier (no incentive, no penalty)
-    new_rentals_paused_executor_ids: list[str] = []  # executor_ids paused from new rentals and incentives
+    new_rentals_paused_executor_ids: list[str] = []  # executor_ids paused from unrented incentives
 
     @field_validator("filler_containers_by_executor")
     @classmethod

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -168,6 +168,19 @@ class MinerService:
         pubkey = self._normalize_public_key(public_key)
         return f"0x{keypair.sign(pubkey).hex()}"
 
+    @staticmethod
+    def _filter_new_rentals_paused_executors(executors: list, rented_data: RentedExecutorsResponse) -> list:
+        paused_ids = set(rented_data.new_rentals_paused_executor_ids or [])
+        if not paused_ids:
+            return executors
+
+        rented_ids = set(rented_data.executors.keys())
+        return [
+            executor
+            for executor in executors
+            if str(executor.uuid) not in paused_ids or str(executor.uuid) in rented_ids
+        ]
+
     async def request_job_to_miner(
         self,
         payload: MinerJobRequestPayload,
@@ -272,6 +285,12 @@ class MinerService:
                             payload,
                             "Miner returned zero executors in AcceptSSHKeyRequest",
                         )
+                    eligible_executors = self._filter_new_rentals_paused_executors(msg.executors, rented_data)
+                    if len(eligible_executors) == 0:
+                        return self._build_failed_job_result(
+                            payload,
+                            "Miner returned zero eligible executors after new rentals pause filter",
+                        )
 
                     tasks = [
                         asyncio.create_task(
@@ -288,7 +307,7 @@ class MinerService:
                                 timeout=settings.JOB_TIME_OUT - 120
                             )
                         )
-                        for executor_info in msg.executors
+                        for executor_info in eligible_executors
                     ]
 
                     results = [
@@ -1496,6 +1515,12 @@ class MinerService:
                         payload,
                         "Miner returned zero executors in AcceptSSHKeyRequest",
                     )
+                eligible_executors = self._filter_new_rentals_paused_executors(msg.executors, rented_data)
+                if len(eligible_executors) == 0:
+                    return self._build_failed_job_result(
+                        payload,
+                        "Miner returned zero eligible executors after new rentals pause filter",
+                    )
 
                 tasks = [
                     asyncio.create_task(
@@ -1512,7 +1537,7 @@ class MinerService:
                             timeout=settings.JOB_TIME_OUT - 120
                         )
                     )
-                    for executor_info in msg.executors
+                    for executor_info in eligible_executors
                 ]
 
                 results = [

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -168,19 +168,6 @@ class MinerService:
         pubkey = self._normalize_public_key(public_key)
         return f"0x{keypair.sign(pubkey).hex()}"
 
-    @staticmethod
-    def _filter_new_rentals_paused_executors(executors: list, rented_data: RentedExecutorsResponse) -> list:
-        paused_ids = set(rented_data.new_rentals_paused_executor_ids or [])
-        if not paused_ids:
-            return executors
-
-        rented_ids = set(rented_data.executors.keys())
-        return [
-            executor
-            for executor in executors
-            if str(executor.uuid) not in paused_ids or str(executor.uuid) in rented_ids
-        ]
-
     async def request_job_to_miner(
         self,
         payload: MinerJobRequestPayload,
@@ -285,13 +272,6 @@ class MinerService:
                             payload,
                             "Miner returned zero executors in AcceptSSHKeyRequest",
                         )
-                    eligible_executors = self._filter_new_rentals_paused_executors(msg.executors, rented_data)
-                    if len(eligible_executors) == 0:
-                        return self._build_failed_job_result(
-                            payload,
-                            "Miner returned zero eligible executors after new rentals pause filter",
-                        )
-
                     tasks = [
                         asyncio.create_task(
                             asyncio.wait_for(
@@ -307,7 +287,7 @@ class MinerService:
                                 timeout=settings.JOB_TIME_OUT - 120
                             )
                         )
-                        for executor_info in eligible_executors
+                        for executor_info in msg.executors
                     ]
 
                     results = [
@@ -1515,13 +1495,6 @@ class MinerService:
                         payload,
                         "Miner returned zero executors in AcceptSSHKeyRequest",
                     )
-                eligible_executors = self._filter_new_rentals_paused_executors(msg.executors, rented_data)
-                if len(eligible_executors) == 0:
-                    return self._build_failed_job_result(
-                        payload,
-                        "Miner returned zero eligible executors after new rentals pause filter",
-                    )
-
                 tasks = [
                     asyncio.create_task(
                         asyncio.wait_for(
@@ -1537,7 +1510,7 @@ class MinerService:
                             timeout=settings.JOB_TIME_OUT - 120
                         )
                     )
-                    for executor_info in eligible_executors
+                    for executor_info in msg.executors
                 ]
 
                 results = [

--- a/neurons/validators/src/services/task/models.py
+++ b/neurons/validators/src/services/task/models.py
@@ -24,6 +24,7 @@ class JobResult(BaseModel):
     ssh_pub_keys: list[str] | None = None
     is_rented: bool = False
     is_spot: bool = False
+    is_new_rentals_paused: bool = False
     rental_created_at: datetime | None = None
 
     # tdx attestation relevant fields

--- a/neurons/validators/src/services/task/result_handler.py
+++ b/neurons/validators/src/services/task/result_handler.py
@@ -103,6 +103,10 @@ class ResultHandler:
             context.state.rented_data
             and executor_info.uuid in context.state.rented_data.spot_executor_ids
         )
+        is_new_rentals_paused = bool(
+            context.state.rented_data
+            and executor_info.uuid in context.state.rented_data.new_rentals_paused_executor_ids
+        )
 
         # add TDX attestation and spot tier to specs (propagated to compute-app
         # via MACHINE_SPEC_CHANNEL → executor.specs)
@@ -130,6 +134,7 @@ class ResultHandler:
             ssh_pub_keys=context.ssh_pub_keys,
             is_rented=context.rented,
             is_spot=is_spot,
+            is_new_rentals_paused=is_new_rentals_paused,
             rental_created_at=self._get_rental_created_at(context),
             tdx_attestation_passed=context.tdx_attestation_passed,
         )

--- a/neurons/validators/tests/conftest.py
+++ b/neurons/validators/tests/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -8,6 +9,13 @@ from datura.requests.miner_requests import ExecutorSSHInfo
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
+
+# Settings is instantiated during test collection through app imports. These
+# defaults keep unit tests self-contained without requiring a local validator env.
+os.environ.setdefault("BITTENSOR_WALLET_NAME", "test-wallet")
+os.environ.setdefault("BITTENSOR_WALLET_HOTKEY_NAME", "test-hotkey")
+os.environ.setdefault("SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")
+os.environ.setdefault("ASYNC_SQLALCHEMY_DATABASE_URI", "sqlite+aiosqlite:///:memory:")
 
 from helpers import make_context
 
@@ -172,5 +180,4 @@ def port_mapping_dao(mock_async_session_maker):
     from daos.port_mapping_dao import PortMappingDao
 
     return PortMappingDao()
-
 

--- a/neurons/validators/tests/test_new_rentals_pause_filter.py
+++ b/neurons/validators/tests/test_new_rentals_pause_filter.py
@@ -1,0 +1,262 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from datura.requests.miner_requests import (
+    AcceptSSHKeyRequest,
+    ExecutorSSHInfo,
+    RequestType,
+)
+
+from core.config import settings
+from payload_models.payloads import MinerJobRequestPayload
+from protocol.vc_protocol.compute_requests import (
+    RentedExecutor,
+    RentedExecutorsResponse,
+    RentedPod,
+)
+from services.miner_service import MinerService
+
+
+def _executor(executor_id: str) -> ExecutorSSHInfo:
+    return ExecutorSSHInfo(
+        uuid=executor_id,
+        address="127.0.0.1",
+        port=22,
+        ssh_username="root",
+        ssh_port=22,
+        python_path="/usr/bin/python3",
+        root_dir="/tmp",
+    )
+
+
+def _rented_data(
+    *,
+    rented_ids: list[str] | None = None,
+    paused_ids: list[str] | None = None,
+) -> RentedExecutorsResponse:
+    executors = {
+        executor_id: RentedExecutor(
+            miner_hotkey="miner-hotkey",
+            executor_ip_address="127.0.0.1",
+            executor_ip_port="22",
+            pods=[
+                RentedPod(
+                    pod_id=f"pod-{executor_id}",
+                    container_name=f"pod_{executor_id}",
+                )
+            ],
+        )
+        for executor_id in rented_ids or []
+    }
+    return RentedExecutorsResponse(
+        executors=executors,
+        banned_guids=[],
+        new_rentals_paused_executor_ids=paused_ids or [],
+    )
+
+
+def _payload() -> MinerJobRequestPayload:
+    return MinerJobRequestPayload(
+        job_batch_id="2026-05-28 00:00:00",
+        miner_hotkey="miner-hotkey",
+        miner_coldkey="miner-coldkey",
+        miner_address="127.0.0.1",
+        miner_port=8091,
+    )
+
+
+def _accepted_response(*executor_ids: str) -> AcceptSSHKeyRequest:
+    return AcceptSSHKeyRequest(
+        message_type=RequestType.AcceptSSHKeyRequest,
+        executors=[_executor(executor_id) for executor_id in executor_ids],
+    )
+
+
+def _keypair() -> MagicMock:
+    keypair = MagicMock()
+    keypair.ss58_address = "validator-hotkey"
+    keypair.sign.return_value = b"\x01" * 64
+    return keypair
+
+
+def _wallet(keypair: MagicMock) -> MagicMock:
+    wallet = MagicMock()
+    wallet.get_hotkey.return_value = keypair
+    return wallet
+
+
+def _miner_service() -> MinerService:
+    service = MinerService.__new__(MinerService)
+    service.ssh_service = MagicMock()
+    service.ssh_service.generate_ssh_key.return_value = (
+        b"private-key",
+        b"public-key",
+    )
+    service.task_service = MagicMock()
+    service.redis_service = MagicMock()
+    service.attestation_service = MagicMock()
+    return service
+
+
+async def _create_task_result(**kwargs):
+    return SimpleNamespace(executor_info=kwargs["executor_info"], score=1)
+
+
+class _FakeMinerClient:
+    def __init__(self, accepted_message: AcceptSSHKeyRequest):
+        future = asyncio.get_running_loop().create_future()
+        future.set_result(accepted_message)
+        self.job_state = SimpleNamespace(
+            miner_accepted_ssh_key_or_failed_future=future
+        )
+        self.send_model = AsyncMock()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+
+def test_rented_executors_response_defaults_new_rentals_paused_executor_ids():
+    """Older backend responses without paused IDs remain compatible."""
+    result = RentedExecutorsResponse.model_validate({"executors": {}})
+
+    assert result.new_rentals_paused_executor_ids == []
+
+
+def test_rented_executors_response_parses_new_rentals_paused_executor_ids():
+    """Backend paused executor IDs are available to validator filtering."""
+    result = RentedExecutorsResponse.model_validate(
+        {
+            "executors": {},
+            "new_rentals_paused_executor_ids": ["paused-executor"],
+        }
+    )
+
+    assert result.new_rentals_paused_executor_ids == ["paused-executor"]
+
+
+def test_filter_removes_paused_unrented_executors():
+    """Fully paused, unrented executors are skipped for validation and incentives."""
+    executors = [_executor("paused-executor"), _executor("available-executor")]
+    rented_data = _rented_data(paused_ids=["paused-executor"])
+
+    result = MinerService._filter_new_rentals_paused_executors(
+        executors,
+        rented_data,
+    )
+
+    assert [executor.uuid for executor in result] == ["available-executor"]
+
+
+def test_filter_keeps_paused_executor_when_currently_rented():
+    """Pending pause must not hide the executor while an active rental exists."""
+    executors = [_executor("paused-rented-executor"), _executor("available-executor")]
+    rented_data = _rented_data(
+        rented_ids=["paused-rented-executor"],
+        paused_ids=["paused-rented-executor"],
+    )
+
+    result = MinerService._filter_new_rentals_paused_executors(
+        executors,
+        rented_data,
+    )
+
+    assert [executor.uuid for executor in result] == [
+        "paused-rented-executor",
+        "available-executor",
+    ]
+
+
+def test_filter_noops_when_backend_reports_no_paused_executor_ids():
+    """Normal validator behavior is unchanged when the backend reports no paused IDs."""
+    executors = [_executor("executor-a"), _executor("executor-b")]
+    rented_data = _rented_data()
+
+    result = MinerService._filter_new_rentals_paused_executors(
+        executors,
+        rented_data,
+    )
+
+    assert result is executors
+
+
+@pytest.mark.asyncio
+async def test_websocket_request_job_filters_paused_unrented_executors(monkeypatch):
+    """The WebSocket miner path only schedules validation for eligible executors."""
+    service = _miner_service()
+    service.task_service.create_task = AsyncMock(side_effect=_create_task_result)
+    keypair = _keypair()
+    fake_client = _FakeMinerClient(
+        _accepted_response("paused-executor", "available-executor")
+    )
+    rented_data = _rented_data(paused_ids=["paused-executor"])
+
+    monkeypatch.setattr(settings, "USE_REST_API", False)
+    monkeypatch.setattr(settings, "JOB_TIME_OUT", 300)
+    monkeypatch.setattr(
+        type(settings),
+        "get_bittensor_wallet",
+        lambda self: _wallet(keypair),
+    )
+
+    with patch("services.miner_service.MinerClient", return_value=fake_client):
+        result = await service.request_job_to_miner(
+            _payload(),
+            MagicMock(),
+            rented_data,
+        )
+
+    assert [job.executor_info.uuid for job in result["results"]] == [
+        "available-executor"
+    ]
+    created_executor_ids = [
+        call.kwargs["executor_info"].uuid
+        for call in service.task_service.create_task.call_args_list
+    ]
+    assert created_executor_ids == ["available-executor"]
+
+
+@pytest.mark.asyncio
+async def test_rest_request_job_filters_paused_unrented_executors(monkeypatch):
+    """The REST miner path applies the same paused executor filter."""
+    service = _miner_service()
+    service.task_service.create_task = AsyncMock(side_effect=_create_task_result)
+    service._generate_auth_headers = MagicMock(return_value={})
+    service._make_rest_request = AsyncMock(
+        return_value=(
+            200,
+            _accepted_response(
+                "paused-executor",
+                "available-executor",
+            ).model_dump(mode="json"),
+        )
+    )
+    service._remove_ssh_key_via_rest = AsyncMock()
+    keypair = _keypair()
+    rented_data = _rented_data(paused_ids=["paused-executor"])
+
+    monkeypatch.setattr(settings, "JOB_TIME_OUT", 300)
+    monkeypatch.setattr(
+        type(settings),
+        "get_bittensor_wallet",
+        lambda self: _wallet(keypair),
+    )
+
+    result = await service._request_job_to_miner(
+        _payload(),
+        MagicMock(),
+        rented_data,
+    )
+
+    assert [job.executor_info.uuid for job in result["results"]] == [
+        "available-executor"
+    ]
+    created_executor_ids = [
+        call.kwargs["executor_info"].uuid
+        for call in service.task_service.create_task.call_args_list
+    ]
+    assert created_executor_ids == ["available-executor"]

--- a/neurons/validators/tests/test_new_rentals_pause_filter.py
+++ b/neurons/validators/tests/test_new_rentals_pause_filter.py
@@ -128,7 +128,7 @@ def test_rented_executors_response_defaults_new_rentals_paused_executor_ids():
 
 
 def test_rented_executors_response_parses_new_rentals_paused_executor_ids():
-    """Backend paused executor IDs are available to validator filtering."""
+    """Backend paused executor IDs are available to incentive handling."""
     result = RentedExecutorsResponse.model_validate(
         {
             "executors": {},
@@ -139,54 +139,9 @@ def test_rented_executors_response_parses_new_rentals_paused_executor_ids():
     assert result.new_rentals_paused_executor_ids == ["paused-executor"]
 
 
-def test_filter_removes_paused_unrented_executors():
-    """Fully paused, unrented executors are skipped for validation and incentives."""
-    executors = [_executor("paused-executor"), _executor("available-executor")]
-    rented_data = _rented_data(paused_ids=["paused-executor"])
-
-    result = MinerService._filter_new_rentals_paused_executors(
-        executors,
-        rented_data,
-    )
-
-    assert [executor.uuid for executor in result] == ["available-executor"]
-
-
-def test_filter_keeps_paused_executor_when_currently_rented():
-    """Pending pause must not hide the executor while an active rental exists."""
-    executors = [_executor("paused-rented-executor"), _executor("available-executor")]
-    rented_data = _rented_data(
-        rented_ids=["paused-rented-executor"],
-        paused_ids=["paused-rented-executor"],
-    )
-
-    result = MinerService._filter_new_rentals_paused_executors(
-        executors,
-        rented_data,
-    )
-
-    assert [executor.uuid for executor in result] == [
-        "paused-rented-executor",
-        "available-executor",
-    ]
-
-
-def test_filter_noops_when_backend_reports_no_paused_executor_ids():
-    """Normal validator behavior is unchanged when the backend reports no paused IDs."""
-    executors = [_executor("executor-a"), _executor("executor-b")]
-    rented_data = _rented_data()
-
-    result = MinerService._filter_new_rentals_paused_executors(
-        executors,
-        rented_data,
-    )
-
-    assert result is executors
-
-
 @pytest.mark.asyncio
-async def test_websocket_request_job_filters_paused_unrented_executors(monkeypatch):
-    """The WebSocket miner path only schedules validation for eligible executors."""
+async def test_websocket_request_job_validates_paused_unrented_executors(monkeypatch):
+    """Paused executors are still scheduled for validation and spec updates."""
     service = _miner_service()
     service.task_service.create_task = AsyncMock(side_effect=_create_task_result)
     keypair = _keypair()
@@ -210,19 +165,17 @@ async def test_websocket_request_job_filters_paused_unrented_executors(monkeypat
             rented_data,
         )
 
-    assert [job.executor_info.uuid for job in result["results"]] == [
-        "available-executor"
-    ]
+    assert [job.executor_info.uuid for job in result["results"]] == ["paused-executor", "available-executor"]
     created_executor_ids = [
         call.kwargs["executor_info"].uuid
         for call in service.task_service.create_task.call_args_list
     ]
-    assert created_executor_ids == ["available-executor"]
+    assert created_executor_ids == ["paused-executor", "available-executor"]
 
 
 @pytest.mark.asyncio
-async def test_rest_request_job_filters_paused_unrented_executors(monkeypatch):
-    """The REST miner path applies the same paused executor filter."""
+async def test_rest_request_job_validates_paused_unrented_executors(monkeypatch):
+    """The REST miner path also validates paused executors."""
     service = _miner_service()
     service.task_service.create_task = AsyncMock(side_effect=_create_task_result)
     service._generate_auth_headers = MagicMock(return_value={})
@@ -252,11 +205,9 @@ async def test_rest_request_job_filters_paused_unrented_executors(monkeypatch):
         rented_data,
     )
 
-    assert [job.executor_info.uuid for job in result["results"]] == [
-        "available-executor"
-    ]
+    assert [job.executor_info.uuid for job in result["results"]] == ["paused-executor", "available-executor"]
     created_executor_ids = [
         call.kwargs["executor_info"].uuid
         for call in service.task_service.create_task.call_args_list
     ]
-    assert created_executor_ids == ["available-executor"]
+    assert created_executor_ids == ["paused-executor", "available-executor"]

--- a/neurons/validators/tests/test_rental_price_incentive_flow.py
+++ b/neurons/validators/tests/test_rental_price_incentive_flow.py
@@ -139,6 +139,7 @@ def _make_rented_data(
     rented_executor_ids: list[str] | None = None,
     gpu_splitting_config: dict[str, int] | None = None,
     spot_executor_ids: list[str] | None = None,
+    new_rentals_paused_executor_ids: list[str] | None = None,
 ) -> RentedExecutorsResponse:
     executors = {}
     for executor_id in rented_executor_ids or []:
@@ -153,6 +154,7 @@ def _make_rented_data(
         banned_guids=[],
         gpu_splitting_config=gpu_splitting_config or {},
         spot_executor_ids=spot_executor_ids or [],
+        new_rentals_paused_executor_ids=new_rentals_paused_executor_ids or [],
     )
 
 
@@ -2656,6 +2658,76 @@ async def test_rental_price_spot_excluded_from_both_pools(
     # secure H100 executors (8+8=16) but must NOT include the spot's 8 GPUs;
     # an inflated denominator (24) would silently reduce the rented executor's
     # mining incentive by 1/3 (formula: score * gpu_portion * gpu_count / total).
+    assert secure_rented.is_rented is True
+    assert secure_rented.total_gpu_count == 16
+    assert validator.miner_scores["miner_secure_rented"] > 0
+
+
+@pytest.mark.asyncio
+async def test_rental_price_paused_unrented_excluded_from_incentives_but_still_validated(
+    validator_with_rental_price,
+    mock_subtensor_client,
+    mock_settings,
+    create_job_result,
+    create_neuron_info,
+    mock_price_provider,
+):
+    """A paused unrented executor is validated but does not enter either
+    incentive pool:
+    - it earns zero
+    - it does not dilute secure unrented bucket caps
+    - it does not inflate rented mining denominators
+    """
+    validator = validator_with_rental_price
+    validator.miner_scores = {}
+
+    miners = [
+        create_neuron_info(uid=100, hotkey="burner1"),
+        create_neuron_info(uid=101, hotkey="burner2"),
+        create_neuron_info(uid=2, hotkey="miner_secure_unrented"),
+        create_neuron_info(uid=3, hotkey="miner_secure_rented"),
+        create_neuron_info(uid=4, hotkey="miner_paused"),
+    ]
+
+    secure_unrented = _job(
+        create_job_result, executor_id="exec-secure-unrented",
+        gpu_model="H100", gpu_count=8, is_rented=False,
+    )
+    secure_rented = _job(
+        create_job_result, executor_id="exec-secure-rented",
+        gpu_model="H100", gpu_count=8, is_rented=True,
+    )
+    paused = _job(
+        create_job_result, executor_id="exec-paused",
+        gpu_model="H100", gpu_count=8, is_rented=False,
+    )
+    paused.is_new_rentals_paused = True
+
+    all_job_results = {
+        "miner_secure_unrented": [secure_unrented],
+        "miner_secure_rented": [secure_rented],
+        "miner_paused": [paused],
+    }
+
+    validator.backend_client.get_all_rented_executors = AsyncMock(
+        return_value=_make_rented_data(
+            rented_executor_ids=["exec-secure-rented"],
+            new_rentals_paused_executor_ids=["exec-paused"],
+        )
+    )
+
+    await _run_sync_with_jobs(validator, miners, all_job_results)
+
+    assert paused.mining_score == 0
+    assert paused.eligible_for_rental_share is False
+    assert (paused.incentive or 0.0) == 0.0
+    assert validator.miner_scores.get("miner_paused", 0.0) == pytest.approx(0.0, abs=0.0001)
+
+    assert secure_unrented.eligible_for_rental_share is True
+    assert secure_unrented.total_unrented_by_gpu_type == 8
+    assert secure_unrented.unrented_cap_multiplier == pytest.approx(1.0)
+    assert (secure_unrented.incentive or 0.0) > 0.0
+
     assert secure_rented.is_rented is True
     assert secure_rented.total_gpu_count == 16
     assert validator.miner_scores["miner_secure_rented"] > 0


### PR DESCRIPTION
## Describe your changes

Accept `new_rentals_paused_executor_ids` from the backend rented-executors response as an incentive-exclusion signal, while continuing to validate all executors returned by miners.

## Issue ticket number and link

[DAH-2158](https://app.notion.com/p/Disable-node-for-new-rentals-after-current-rental-ends-36cb8bfdbde981f597e7ddec058dd776)

## Design Notes

- The validator no longer filters paused executors before scheduling validation tasks.
- WebSocket and REST miner paths still call `create_task` for every executor returned by the miner.
- `JobResult` now carries `is_new_rentals_paused`.
- Paused and unrented executors are excluded from mining score and rental-share incentive pools.
- Paused and rented executors continue through rented scoring so active rentals are not interrupted.
- Paused and unrented executors are also excluded from GPU denominator totals, matching spot-tier reward math.
- `DefaultIncentive` has a fallback guard for direct legacy/default algorithm usage; the active `rental_price` algorithm handles this before calling into the default scoring path.

## Testing

- Focused validator tests passed.
- Covers backward-compatible parsing when backend responses do not include paused executor IDs.
- Covers parsing paused executor IDs when the backend sends them.
- Covers both WebSocket and REST miner paths scheduling paused executors for validation.
- Covers paused and unrented executors earning zero incentive, not entering rental-share eligibility, and not diluting denominators.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?
