### PR TITLE
DAH-2164 - Run stale container cleanup before port checks

### DIFF
--- a/neurons/validators/src/services/task/checks/__init__.py
+++ b/neurons/validators/src/services/task/checks/__init__.py
@@ -12,12 +12,13 @@ from .machine_spec_scrape import MachineSpecScrapeCheck
 from .nvml_digest import NvmlDigestCheck
 from .port_connectivity import PortConnectivityCheck
 from .port_count import PortCountCheck
-from .rented_machine import TenantEnforcementCheck
 from .rental_verification import RentalVerificationCheck
-from .tdx_host import TdxHostCheck
+from .rented_machine import TenantEnforcementCheck
 from .score import ScoreCheck
-from .start_gpu_monitor import StartGPUMonitorCheck
 from .spec_change import SpecChangeCheck
+from .stale_container_cleanup import StaleContainerCleanupCheck
+from .start_gpu_monitor import StartGPUMonitorCheck
+from .tdx_host import TdxHostCheck
 from .upload_files import UploadFilesCheck
 from .verifyx import VerifyXCheck
 
@@ -40,6 +41,7 @@ __all__ = [
     "TdxHostCheck",
     "TenantEnforcementCheck",
     "ScoreCheck",
+    "StaleContainerCleanupCheck",
     "StartGPUMonitorCheck",
     "SpecChangeCheck",
     "UploadFilesCheck",

--- a/neurons/validators/src/services/task/checks/rented_machine.py
+++ b/neurons/validators/src/services/task/checks/rented_machine.py
@@ -3,6 +3,7 @@ import shlex
 from collections.abc import Iterable
 
 import asyncssh
+
 from core.docker_utils import DockerCommand
 from protocol.vc_protocol.validator_requests import ResetVerifiedJobReason
 
@@ -91,12 +92,9 @@ class TenantEnforcementCheck:
     fatal = True
 
     async def run(self, ctx: Context) -> CheckResult:
-        # Clean up stale containers
-        await ctx.services.container_cleanup.cleanup(
-            ssh_client=ctx.ssh,
-            rented_data=ctx.state.rented_data,
-            executor_uuid=ctx.executor.uuid,
-        )
+        # NOTE: stale-container cleanup now runs earlier, in StaleContainerCleanupCheck
+        # (before the port checks), so an orphaned non-rented container can't deadlock
+        # port verification. See that check for the full rationale (DAH-2164 follow-up).
 
         # Get rented executor from context instead of Redis
         rented_data = ctx.state.rented_data

--- a/neurons/validators/src/services/task/checks/stale_container_cleanup.py
+++ b/neurons/validators/src/services/task/checks/stale_container_cleanup.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from ..messages import StaleContainerCleanupMessages as Msg
+from ..messages import render_message
+from ..pipeline import CheckResult, Context
+
+
+class StaleContainerCleanupCheck:
+    """Reap orphaned rental containers *before* port verification.
+
+    DAH-2164 follow-up. When a pod container outlives its rental — most clearly when a pod
+    is marked ``BROKEN_BY_PROVIDER`` and the platform intentionally does NOT tear the
+    container down — the orphan keeps binding the rental port range (e.g. 40000-40009).
+    The backend then reports the executor as NOT rented, so:
+
+      * ``PortConnectivityCheck`` deploys its DinD probe and Docker rejects the bind
+        ("port is already allocated") -> 0 working ports, and
+      * ``PortCountCheck`` (``fatal=True``) fails on ``not is_rented and
+        port_count < MIN_PORT_COUNT`` and the pipeline runner halts there.
+
+    The only place that used to run the stale-container cleanup was
+    ``TenantEnforcementCheck`` (``executor.validate.rented_state``), which sits *after*
+    those port checks. So the cleanup was never reached, the orphan was never removed, and
+    the executor was stuck at score 0 every cycle with no path to self-heal.
+
+    Running the cleanup here — ahead of the port checks — breaks that deadlock: orphaned
+    (non-rented) containers older than the grace window are force-removed, freeing the
+    ports so the very next port probe in the same cycle can bind them. Containers that are
+    present in ``rented_data`` (real tenants + the filler) are never touched. The cleanup is
+    best-effort and never fatal: a failure here must not change the executor's verdict.
+    """
+
+    check_id = "executor.cleanup.stale_containers"
+    fatal = False
+
+    async def run(self, ctx: Context) -> CheckResult:
+        removed_count, removed_names = await ctx.services.container_cleanup.cleanup(
+            ssh_client=ctx.ssh,
+            rented_data=ctx.state.rented_data,
+            executor_uuid=ctx.executor.uuid,
+        )
+
+        event = render_message(
+            Msg.CLEANED,
+            ctx=ctx,
+            check_id=self.check_id,
+            what={
+                "removed_count": removed_count,
+                "removed_containers": removed_names,
+            },
+        )
+        return CheckResult(passed=True, event=event)

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -371,6 +371,16 @@ class CollateralMessages:
     )
 
 
+class StaleContainerCleanupMessages:
+    CLEANED = MessageTemplate(
+        event="Stale container cleanup complete",
+        reason="STALE_CLEANUP_DONE",
+        severity="info",
+        category="prep",
+        impact="Proceed",
+    )
+
+
 class TenantEnforcementMessages:
     NOT_RENTED = MessageTemplate(
         event="Executor not rented",

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -14,10 +14,11 @@ from payload_models.payloads import MinerJobEnryptedFiles, MinerJobRequestPayloa
 
 from clients.backend_client import BackendClient
 from core.config import settings
+from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.collateral_contract_service import CollateralContractService
 from services.const import GPU_MODEL_RATES, LIB_NVIDIA_ML_DIGESTS, MAX_GPU_COUNT
-from services.executor_connectivity_service import ExecutorConnectivityService
 from services.container_cleanup import ContainerCleanup
+from services.executor_connectivity_service import ExecutorConnectivityService
 from services.interactive_shell_service import InteractiveShellService
 from services.matrix_validation_service import ValidationService
 from services.redis_service import RENTAL_SUCCEED_MACHINE_SET, RedisService
@@ -42,13 +43,13 @@ from .checks import (
     RentalVerificationCheck,
     ScoreCheck,
     SpecChangeCheck,
+    StaleContainerCleanupCheck,
     StartGPUMonitorCheck,
     TdxHostCheck,
     TenantEnforcementCheck,
     UploadFilesCheck,
     VerifyXCheck,
 )
-from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from .pipeline import (
     Check,
     Context,
@@ -227,6 +228,13 @@ class PipelineFactory:
                 BannedGpuCheck(),
                 DuplicateExecutorCheck(),
                 CollateralCheck(),
+                # Reap orphaned (non-rented) rental containers BEFORE the port checks.
+                # A pod container that outlives its rental (e.g. BROKEN_BY_PROVIDER, which the
+                # platform deliberately does not tear down) keeps binding the rental port range.
+                # Cleaning it here frees those ports so PortConnectivityCheck can bind them this
+                # cycle; otherwise PortCountCheck (fatal) halts the pipeline before the cleanup
+                # that used to live in TenantEnforcementCheck ever runs -> executor stuck at 0.
+                StaleContainerCleanupCheck(),
                 PortConnectivityCheck(),
                 PortCountCheck(),
                 TenantEnforcementCheck(),
@@ -268,6 +276,7 @@ class PipelineFactory:
                 BannedGpuCheck(),
                 DuplicateExecutorCheck(),
                 CollateralCheck(),
+                # StaleContainerCleanupCheck(),  # SKIP: removes containers on the executor
                 PortConnectivityCheck(),
                 PortCountCheck(),
                 TenantEnforcementCheck(),

--- a/neurons/validators/tests/test_stale_container_cleanup_check.py
+++ b/neurons/validators/tests/test_stale_container_cleanup_check.py
@@ -1,0 +1,119 @@
+"""Tests for StaleContainerCleanupCheck (DAH-2164 follow-up).
+
+The check reaps orphaned non-rented rental containers BEFORE the port checks so an
+orphan that outlived its rental (e.g. a BROKEN_BY_PROVIDER pod whose container the
+platform does not tear down) cannot keep binding the rental port range and deadlock
+port verification.
+"""
+
+import pytest
+from helpers import build_services, build_state, default_executor, make_context
+from neurons.validators.src.services.task.checks import StaleContainerCleanupCheck
+from neurons.validators.src.services.task.checks.stale_container_cleanup import (
+    StaleContainerCleanupCheck as DirectImport,
+)
+from neurons.validators.src.services.task.pipeline_factory import PipelineFactory
+
+from protocol.vc_protocol.compute_requests import (
+    RentedExecutor,
+    RentedExecutorsResponse,
+    RentedPod,
+)
+
+
+class RecordingContainerCleanup:
+    """Records cleanup() calls and returns a configurable (count, names) result."""
+
+    def __init__(self, result=(0, [])):
+        self._result = result
+        self.calls = []
+
+    async def cleanup(self, ssh_client, rented_data, executor_uuid):
+        self.calls.append(
+            {
+                "ssh_client": ssh_client,
+                "rented_data": rented_data,
+                "executor_uuid": executor_uuid,
+            }
+        )
+        return self._result
+
+
+def _make_ctx(cleanup, rented_data=None):
+    services = build_services(container_cleanup=cleanup)
+    state = build_state(rented_data=rented_data)
+    return make_context(services=services, state=state, ssh="ssh-conn-sentinel")
+
+
+@pytest.mark.asyncio
+async def test_runs_cleanup_and_passes():
+    cleanup = RecordingContainerCleanup(result=(2, ["pod_orphan", "filler_old"]))
+    ctx = _make_ctx(cleanup)
+
+    result = await StaleContainerCleanupCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.check_id == "executor.cleanup.stale_containers"
+    assert result.event.reason_code == "STALE_CLEANUP_DONE"
+    assert result.event.what_we_saw["removed_count"] == 2
+    assert result.event.what_we_saw["removed_containers"] == ["pod_orphan", "filler_old"]
+
+
+@pytest.mark.asyncio
+async def test_passes_cleanup_args_through():
+    cleanup = RecordingContainerCleanup()
+    executor = default_executor()
+    rented_data = RentedExecutorsResponse(
+        executors={
+            executor.uuid: RentedExecutor(
+                miner_hotkey="miner-hotkey",
+                executor_ip_address="127.0.0.1",
+                executor_ip_port="8080",
+                pods=[RentedPod(pod_id="p1", container_name="pod_p1")],
+                owner_flag=False,
+            )
+        },
+        banned_guids=[],
+    )
+    services = build_services(container_cleanup=cleanup)
+    state = build_state(rented_data=rented_data)
+    ctx = make_context(executor=executor, services=services, state=state, ssh="ssh-conn-sentinel")
+
+    await StaleContainerCleanupCheck().run(ctx)
+
+    assert len(cleanup.calls) == 1
+    call = cleanup.calls[0]
+    assert call["ssh_client"] == "ssh-conn-sentinel"
+    assert call["executor_uuid"] == executor.uuid
+    assert call["rented_data"] is rented_data
+
+
+@pytest.mark.asyncio
+async def test_noop_cleanup_still_passes():
+    cleanup = RecordingContainerCleanup(result=(0, []))
+    ctx = _make_ctx(cleanup)
+
+    result = await StaleContainerCleanupCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.what_we_saw["removed_count"] == 0
+
+
+def test_check_is_not_fatal():
+    # Cleanup must never change the executor's verdict on its own.
+    assert StaleContainerCleanupCheck.fatal is False
+    assert StaleContainerCleanupCheck is DirectImport
+
+
+def test_cleanup_runs_before_port_checks_in_production_pipeline():
+    """Regression guard for the deadlock: cleanup must precede the port checks so a
+    fatal PortCountCheck can never halt the pipeline before the orphan is reaped."""
+    check_ids = [type(c).__name__ for c in PipelineFactory.build_checks()]
+
+    assert "StaleContainerCleanupCheck" in check_ids
+    idx_cleanup = check_ids.index("StaleContainerCleanupCheck")
+    idx_conn = check_ids.index("PortConnectivityCheck")
+    idx_count = check_ids.index("PortCountCheck")
+    idx_tenant = check_ids.index("TenantEnforcementCheck")
+
+    assert idx_cleanup < idx_conn < idx_count < idx_tenant


### PR DESCRIPTION
## Describe your changes

Orphaned rental-container cleanup is moved out of `TenantEnforcementCheck` into a new, dedicated `StaleContainerCleanupCheck` that runs **before** the port checks in the verification pipeline.

**Problem:** When a pod container outlives its rental — most clearly when a pod is marked `BROKEN_BY_PROVIDER`, which the platform deliberately does not tear down — the orphan keeps binding the rental port range. The backend reports the executor as NOT rented, so:

- `PortConnectivityCheck` tries to bind those ports, Docker rejects with "port is already allocated" → 0 working ports, and
- `PortCountCheck` (`fatal=True`) fails on `not is_rented and port_count < MIN_PORT_COUNT` and halts the pipeline.

The only place that ran the cleanup was `TenantEnforcementCheck`, which sits *after* those port checks. So the cleanup was never reached, the orphan was never removed, and the executor was stuck at score 0 every cycle with no path to self-heal.

**Solution:** Run the cleanup ahead of the port checks so orphaned (non-rented) containers older than the grace window are force-removed, freeing the ports for the very next port probe in the same cycle. Containers present in `rented_data` (real tenants + the filler) are never touched. The check is non-fatal and best-effort — a failure here must not change the executor's verdict. It is skipped in the GPU-split pipeline because it removes containers on the executor.

### Changes

- Add `StaleContainerCleanupCheck` (`executor.cleanup.stale_containers`, non-fatal) that calls `container_cleanup.cleanup(...)` and reports removed count/names via a `CheckResult` event.
- Add `StaleContainerCleanupMessages.CLEANED` message template (`STALE_CLEANUP_DONE`).
- Insert the check after `CollateralCheck` and before `PortConnectivityCheck` in the standard pipeline; leave it commented-out in the GPU-split pipeline.
- Remove the inline cleanup from `TenantEnforcementCheck` (now redundant).
- Export the new check from `checks/__init__.py`.
- Add `test_stale_container_cleanup_check.py` (5 tests, all passing).

## Issue ticket number and link

DAH-2164

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?

🤖 Generated with [Claude Code](https://claude.com/claude-code)