### PR TITLE
DAH-2157: Fail rental verification on NVML mismatch

### DIFF
--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -5,6 +5,8 @@ from pydantic import BaseModel, field_validator
 
 from services.const import FILLER_CONTAINER_PREFIX
 
+GPU_RUNTIME_NVML_MISMATCH_REASON = "GPU_RUNTIME_NVML_MISMATCH"
+
 
 class Error(BaseModel, extra="allow"):
     msg: str
@@ -104,3 +106,4 @@ class ExecutorHealthCheckResponse(BaseModel):
     success: bool
     error: str | None = None
     details: dict | None = None
+    reason_code: str | None = None

--- a/neurons/validators/src/protocol/vc_protocol/validator_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/validator_requests.py
@@ -88,7 +88,6 @@ class LogStreamRequest(BaseValidatorRequest):
 class ResetVerifiedJobReason(int, enum.Enum):
     DEFAULT = 0
     POD_NOT_RUNNING = 1         # container for pod is not running
-    GPU_RUNTIME_NVML_MISMATCH = 2
 
 
 class ResetVerifiedJobRequest(BaseValidatorRequest):

--- a/neurons/validators/src/protocol/vc_protocol/validator_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/validator_requests.py
@@ -88,6 +88,7 @@ class LogStreamRequest(BaseValidatorRequest):
 class ResetVerifiedJobReason(int, enum.Enum):
     DEFAULT = 0
     POD_NOT_RUNNING = 1         # container for pod is not running
+    GPU_RUNTIME_NVML_MISMATCH = 2
 
 
 class ResetVerifiedJobRequest(BaseValidatorRequest):

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from core.config import settings
+from protocol.vc_protocol.compute_requests import GPU_RUNTIME_NVML_MISMATCH_REASON
+from protocol.vc_protocol.validator_requests import ResetVerifiedJobReason
+
 from ..messages import RentalVerificationMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
 
@@ -133,6 +136,34 @@ class RentalVerificationCheck:
                     passed=True,
                     event=event,
                     updates={},
+                )
+            elif response.reason_code == GPU_RUNTIME_NVML_MISMATCH_REASON:
+                details = response.details or {}
+                stderr = details.get("docker_stderr") or response.error
+                event = render_message(
+                    Msg.GPU_RUNTIME_NVML_MISMATCH,
+                    ctx=ctx,
+                    check_id=self.check_id,
+                    what={
+                        "verified": False,
+                        "executor_uuid": executor.uuid,
+                        "source": "rental_verification",
+                        "reason_code": response.reason_code,
+                        "stderr": stderr,
+                        "details": details,
+                    },
+                    extra={"gpu_runtime_issue_code": response.reason_code},
+                )
+                return CheckResult(
+                    passed=False,
+                    event=event,
+                    updates={
+                        "score": 0.0,
+                        "job_score": 0.0,
+                        "score_warning": "GPU runtime NVML driver/library mismatch",
+                        "clear_verified_job_info": True,
+                        "clear_verified_job_reason": ResetVerifiedJobReason.GPU_RUNTIME_NVML_MISMATCH.value,
+                    },
                 )
             else:
                 # Verification failed - this is fatal

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from core.config import settings
 from protocol.vc_protocol.compute_requests import GPU_RUNTIME_NVML_MISMATCH_REASON
-from protocol.vc_protocol.validator_requests import ResetVerifiedJobReason
 
 from ..messages import RentalVerificationMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
@@ -162,7 +161,6 @@ class RentalVerificationCheck:
                         "job_score": 0.0,
                         "score_warning": "GPU runtime NVML driver/library mismatch",
                         "clear_verified_job_info": True,
-                        "clear_verified_job_reason": ResetVerifiedJobReason.GPU_RUNTIME_NVML_MISMATCH.value,
                     },
                 )
             else:

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -685,6 +685,17 @@ class RentalVerificationMessages:
         impact="Validation halted",
         remediation="Check executor health with backend or review rental status",
     )
+    GPU_RUNTIME_NVML_MISMATCH = MessageTemplate(
+        event="GPU runtime health check failed",
+        reason="GPU_RUNTIME_NVML_MISMATCH",
+        severity="error",
+        category="runtime",
+        impact="New rentals are disabled because Docker cannot initialize NVIDIA NVML on this host.",
+        remediation=(
+            "Reconcile the NVIDIA driver, libnvidia-ml.so.1, NVIDIA Container "
+            "Toolkit, and Docker runtime. Then reboot the host with `sudo reboot`."
+        ),
+    )
     API_ERROR = MessageTemplate(
         event="Rental verification API error",
         reason="RENTAL_CHECK_API_ERROR",

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -5,7 +5,6 @@ from neurons.validators.src.protocol.vc_protocol.compute_requests import (
     GPU_RUNTIME_NVML_MISMATCH_REASON,
     ExecutorHealthCheckResponse,
 )
-from neurons.validators.src.protocol.vc_protocol.validator_requests import ResetVerifiedJobReason
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from neurons.validators.src.services.container_cleanup import ContainerCleanup
 from neurons.validators.src.services.task.checks.rental_verification import RentalVerificationCheck
@@ -192,10 +191,7 @@ async def test_rental_verification_nvml_mismatch_clears_verified_job_info():
     assert result.event.what_we_saw["source"] == "rental_verification"
     assert "failed to initialize NVML" in result.event.what_we_saw["stderr"]
     assert result.updates["clear_verified_job_info"] is True
-    assert (
-        result.updates["clear_verified_job_reason"]
-        == ResetVerifiedJobReason.GPU_RUNTIME_NVML_MISMATCH.value
-    )
+    assert "clear_verified_job_reason" not in result.updates
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -1,7 +1,11 @@
 import pytest
 from unittest.mock import patch
 
-from neurons.validators.src.protocol.vc_protocol.compute_requests import ExecutorHealthCheckResponse
+from neurons.validators.src.protocol.vc_protocol.compute_requests import (
+    GPU_RUNTIME_NVML_MISMATCH_REASON,
+    ExecutorHealthCheckResponse,
+)
+from neurons.validators.src.protocol.vc_protocol.validator_requests import ResetVerifiedJobReason
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from neurons.validators.src.services.container_cleanup import ContainerCleanup
 from neurons.validators.src.services.task.checks.rental_verification import RentalVerificationCheck
@@ -154,6 +158,44 @@ async def test_rental_verification_failed():
     assert result.event.what_we_saw["verified"] is False
     assert result.event.what_we_saw["error"] == "Container not responding"
     assert result.event.what_we_saw["details"]["timeout"] is True
+    assert "clear_verified_job_info" not in result.updates
+    assert "clear_verified_job_reason" not in result.updates
+
+
+@pytest.mark.asyncio
+async def test_rental_verification_nvml_mismatch_clears_verified_job_info():
+    """Exact GPU runtime mismatch should mark the executor unhealthy."""
+    stderr = (
+        "docker: Error response from daemon: failed to create task for container: "
+        "failed to initialize NVML: Driver/library version mismatch"
+    )
+    backend_client = DummyBackendClient(
+        response=ExecutorHealthCheckResponse(
+            success=False,
+            error=stderr,
+            details={"docker_stderr": stderr},
+            reason_code=GPU_RUNTIME_NVML_MISMATCH_REASON,
+        )
+    )
+    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
+    state = build_state(specs={"verified_ports": [8080]})
+
+    from tests.helpers import make_context
+    ctx = make_context(services=services, state=state)
+
+    with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
+        mock_settings.SKIP_RENTAL_VERIFICATION = False
+        result = await RentalVerificationCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == GPU_RUNTIME_NVML_MISMATCH_REASON
+    assert result.event.what_we_saw["source"] == "rental_verification"
+    assert "failed to initialize NVML" in result.event.what_we_saw["stderr"]
+    assert result.updates["clear_verified_job_info"] is True
+    assert (
+        result.updates["clear_verified_job_reason"]
+        == ResetVerifiedJobReason.GPU_RUNTIME_NVML_MISMATCH.value
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Describe your changes

Classify backend rental health check NVML mismatch responses as fatal rental verification failures. The validator emits a structured GPU runtime event, includes provider-facing impact and remediation, and clears verified job info through the existing default reset path.

## Issue ticket number and link

[Quarantine executors with NVML driver library mismatch before pod creation](https://app.notion.com/p/Quarantine-executors-with-NVML-driver-library-mismatch-before-pod-creation-36cb8bfdbde98178ac3dc3a154e295dc)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [x] Need to take care of performance?