### PR TITLE
DAH-2175, Fix GPU minor discovery fallback

### DIFF
--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -34,11 +34,26 @@ from __future__ import annotations
 
 import logging
 import shlex
+import xml.etree.ElementTree as ET
 from collections.abc import Sequence
 
 import asyncssh
 
 logger = logging.getLogger(__name__)
+
+_PROC_GPU_INFO_CMD = (
+    "for f in /proc/driver/nvidia/gpus/*/information; do "
+    '[ -r "$f" ] || continue; '
+    "awk -F: '"
+    '$1 == "GPU UUID" { uuid = $2 } '
+    '$1 == "Device Minor" { minor = $2 } '
+    "END { "
+    'gsub(/^[[:space:]]+|[[:space:]]+$/, "", uuid); '
+    'gsub(/^[[:space:]]+|[[:space:]]+$/, "", minor); '
+    'if (uuid != "" && minor != "") printf "%s, %s\\n", uuid, minor; '
+    "}' \"$f\"; "
+    "done 2>/dev/null"
+)
 
 
 async def build_gpu_flags(
@@ -109,22 +124,27 @@ async def _query_gpu_nodes_for_uuids(
     Returns (per_gpu_nodes_in_request_order, host_total_gpu_count). The host
     total lets the caller decide whether this is a partial-host rental.
     """
-    # `minor_number` is the documented driver-assigned minor that maps to /dev/nvidiaN,
-    # unlike `index` which is the CUDA enumeration order (PCI BDF) and is not formally
-    # guaranteed to equal the device-node minor.
-    res = await ssh.run("nvidia-smi --query-gpu=uuid,minor_number --format=csv,noheader")
-    if res.exit_status != 0:
-        raise RuntimeError(f"nvidia-smi query failed on executor: {res.stderr!r}")
+    errors: list[str] = []
+    try:
+        uuid_to_minor = await _query_gpu_minor_map_from_proc(ssh)
+    except RuntimeError as exc:
+        errors.append(str(exc))
+        uuid_to_minor = {}
 
-    uuid_to_minor: dict[str, int] = {}
-    for line in _stdout_lines(res.stdout):
-        uuid, _, minor = line.partition(",")
+    if not uuid_to_minor or _missing_gpu_uuids(gpu_uuids, uuid_to_minor):
         try:
-            uuid_to_minor[uuid.strip()] = int(minor.strip())
-        except ValueError:
-            continue
+            xml_uuid_to_minor = await _query_gpu_minor_map_from_nvidia_smi_xml(ssh)
+        except RuntimeError as exc:
+            errors.append(str(exc))
+        else:
+            if xml_uuid_to_minor:
+                uuid_to_minor = xml_uuid_to_minor
 
-    missing = [uuid for uuid in gpu_uuids if uuid not in uuid_to_minor]
+    if not uuid_to_minor:
+        details = f": {'; '.join(errors)}" if errors else ""
+        raise RuntimeError(f"GPU minor discovery returned no UUID/minor rows{details}")
+
+    missing = _missing_gpu_uuids(gpu_uuids, uuid_to_minor)
     if missing:
         raise RuntimeError(
             f"GPU {missing[0]!r} requested by tenant not present on executor; "
@@ -133,6 +153,34 @@ async def _query_gpu_nodes_for_uuids(
 
     per_gpu = tuple(f"/dev/nvidia{uuid_to_minor[uuid]}" for uuid in gpu_uuids)
     return per_gpu, len(uuid_to_minor)
+
+
+def _missing_gpu_uuids(gpu_uuids: Sequence[str], uuid_to_minor: dict[str, int]) -> list[str]:
+    return [uuid for uuid in gpu_uuids if uuid not in uuid_to_minor]
+
+
+async def _query_gpu_minor_map_from_proc(
+    ssh: asyncssh.SSHClientConnection,
+) -> dict[str, int]:
+    res = await ssh.run(_PROC_GPU_INFO_CMD)
+    if res.exit_status != 0:
+        raise RuntimeError(
+            "NVIDIA /proc GPU minor query failed on executor: "
+            f"exit_status={res.exit_status}, stdout={res.stdout!r}, stderr={res.stderr!r}"
+        )
+    return _parse_uuid_minor_csv(res.stdout)
+
+
+async def _query_gpu_minor_map_from_nvidia_smi_xml(
+    ssh: asyncssh.SSHClientConnection,
+) -> dict[str, int]:
+    res = await ssh.run("nvidia-smi -q -x")
+    if res.exit_status != 0:
+        raise RuntimeError(
+            "nvidia-smi XML query failed on executor: "
+            f"exit_status={res.exit_status}, stdout={res.stdout!r}, stderr={res.stderr!r}"
+        )
+    return _parse_nvidia_smi_xml_minor_map(res.stdout)
 
 
 async def _query_shared_nodes(
@@ -164,6 +212,50 @@ async def _query_shared_nodes(
 
 def _stdout_lines(stdout: str) -> tuple[str, ...]:
     return tuple(line.strip() for line in stdout.splitlines() if line.strip())
+
+
+def _parse_uuid_minor_csv(stdout: str) -> dict[str, int]:
+    uuid_to_minor: dict[str, int] = {}
+    for line in _stdout_lines(stdout):
+        uuid, _, minor = line.partition(",")
+        try:
+            uuid_to_minor[uuid.strip()] = int(minor.strip())
+        except ValueError:
+            continue
+    return uuid_to_minor
+
+
+def _parse_nvidia_smi_xml_minor_map(stdout: str) -> dict[str, int]:
+    try:
+        root = ET.fromstring(stdout)
+    except ET.ParseError as exc:
+        raise RuntimeError("nvidia-smi XML output could not be parsed") from exc
+
+    uuid_to_minor: dict[str, int] = {}
+    for gpu in root.iter():
+        if _xml_local_name(gpu.tag) != "gpu":
+            continue
+
+        uuid = _xml_child_text(gpu, "uuid")
+        minor = _xml_child_text(gpu, "minor_number")
+        if not uuid or not minor:
+            continue
+        try:
+            uuid_to_minor[uuid.strip()] = int(minor.strip())
+        except ValueError:
+            continue
+    return uuid_to_minor
+
+
+def _xml_child_text(parent: ET.Element, child_name: str) -> str | None:
+    for child in parent:
+        if _xml_local_name(child.tag) == child_name:
+            return child.text
+    return None
+
+
+def _xml_local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
 
 
 if __name__ == "__main__":

--- a/neurons/validators/tests/test_nvidia_devices.py
+++ b/neurons/validators/tests/test_nvidia_devices.py
@@ -4,11 +4,28 @@ import pytest
 from neurons.validators.src.services.nvidia_devices import (
     _device_flags,
     _gpus_flag,
+    _parse_nvidia_smi_xml_minor_map,
     _query_all_gpu_nodes,
     _query_gpu_nodes_for_uuids,
     _query_shared_nodes,
     build_gpu_flags,
 )
+
+PROC_GPU_INFO_OUTPUT = "GPU-aaa, 0\nGPU-bbb, 1\nGPU-ccc, 2\n"
+
+NVIDIA_SMI_XML_OUTPUT = """\
+<?xml version="1.0" ?>
+<nvidia_smi_log>
+    <gpu id="00000000:02:00.0">
+        <uuid>GPU-aaa</uuid>
+        <minor_number>0</minor_number>
+    </gpu>
+    <gpu id="00000000:03:00.0">
+        <uuid>GPU-bbb</uuid>
+        <minor_number>1</minor_number>
+    </gpu>
+</nvidia_smi_log>
+"""
 
 
 class FakeRun:
@@ -69,7 +86,7 @@ async def test_whole_host_rental_enumerates_all_minors():
 
 @pytest.mark.asyncio
 async def test_partial_rental_resolves_uuid_to_minor():
-    ssh = fake_ssh(FakeRun("GPU-aaa, 0\nGPU-bbb, 1\nGPU-ccc, 2\n"))
+    ssh = fake_ssh(FakeRun(PROC_GPU_INFO_OUTPUT))
     nodes, host_total = await _query_gpu_nodes_for_uuids(ssh, ["GPU-bbb"])
 
     assert nodes == ("/dev/nvidia1",)
@@ -78,26 +95,58 @@ async def test_partial_rental_resolves_uuid_to_minor():
 
 @pytest.mark.asyncio
 async def test_partial_rental_preserves_uuid_order_in_per_gpu():
-    ssh = fake_ssh(FakeRun("GPU-aaa, 0\nGPU-bbb, 1\nGPU-ccc, 2\n"))
+    ssh = fake_ssh(FakeRun("GPU-aaa, 4\nGPU-bbb, 7\nGPU-ccc, 2\n"))
     nodes, _ = await _query_gpu_nodes_for_uuids(ssh, ["GPU-ccc", "GPU-aaa"])
 
-    assert nodes == ("/dev/nvidia2", "/dev/nvidia0")
+    assert nodes == ("/dev/nvidia2", "/dev/nvidia4")
+
+
+@pytest.mark.asyncio
+async def test_partial_rental_falls_back_to_nvidia_smi_xml_when_proc_is_empty():
+    ssh = fake_ssh(FakeRun(""), FakeRun(NVIDIA_SMI_XML_OUTPUT))
+    nodes, host_total = await _query_gpu_nodes_for_uuids(ssh, ["GPU-bbb"])
+
+    assert nodes == ("/dev/nvidia1",)
+    assert host_total == 2
+
+
+@pytest.mark.asyncio
+async def test_partial_rental_falls_back_to_nvidia_smi_xml_when_proc_is_incomplete():
+    ssh = fake_ssh(FakeRun("GPU-aaa, 0\n"), FakeRun(NVIDIA_SMI_XML_OUTPUT))
+    nodes, host_total = await _query_gpu_nodes_for_uuids(ssh, ["GPU-bbb"])
+
+    assert nodes == ("/dev/nvidia1",)
+    assert host_total == 2
 
 
 @pytest.mark.asyncio
 async def test_partial_rental_unknown_uuid_raises():
-    ssh = fake_ssh(FakeRun("GPU-aaa, 0\n"))
+    ssh = fake_ssh(FakeRun("GPU-aaa, 0\n"), FakeRun(""))
 
     with pytest.raises(RuntimeError, match="not present on executor"):
         await _query_gpu_nodes_for_uuids(ssh, ["GPU-bbb"])
 
 
 @pytest.mark.asyncio
-async def test_nvidia_smi_failure_raises():
-    ssh = fake_ssh(FakeRun(stderr="nvidia-smi: not found", exit_status=127))
+async def test_gpu_minor_discovery_failure_raises_with_stdout_and_stderr():
+    ssh = fake_ssh(
+        FakeRun(stdout="proc stdout", stderr="proc stderr", exit_status=1),
+        FakeRun(
+            stdout='Field "minor_number" is not a valid field to query.\n',
+            stderr="",
+            exit_status=2,
+        ),
+    )
 
-    with pytest.raises(RuntimeError, match="nvidia-smi query failed"):
+    with pytest.raises(RuntimeError, match="minor_number"):
         await _query_gpu_nodes_for_uuids(ssh, ["GPU-aaa"])
+
+
+def test_parse_nvidia_smi_xml_minor_map():
+    assert _parse_nvidia_smi_xml_minor_map(NVIDIA_SMI_XML_OUTPUT) == {
+        "GPU-aaa": 0,
+        "GPU-bbb": 1,
+    }
 
 
 @pytest.mark.asyncio
@@ -168,6 +217,8 @@ async def test_build_gpu_flags_partial_rental():
     assert flags == (
         '--gpus \'"device=GPU-bbb"\' --device=/dev/nvidia1 --device=/dev/nvidiactl'
     )
+    commands = "\n".join(call.args[0] for call in ssh.run.call_args_list)
+    assert "nvidia-smi --query-gpu=uuid,minor_number" not in commands
 
 
 @pytest.mark.asyncio
@@ -218,8 +269,11 @@ async def test_build_gpu_flags_whole_host_via_explicit_uuids_keeps_caps():
 
 @pytest.mark.asyncio
 async def test_build_gpu_flags_falls_back_when_nvidia_smi_fails(caplog):
-    # Partial rental → first call is nvidia-smi which we make fail.
-    ssh = fake_ssh(FakeRun(stderr="nvidia-smi: not found", exit_status=127))
+    # Partial rental → both minor-discovery paths fail.
+    ssh = fake_ssh(
+        FakeRun(stderr="proc unavailable", exit_status=1),
+        FakeRun(stderr="nvidia-smi: not found", exit_status=127),
+    )
 
     with caplog.at_level("WARNING"):
         flags = await build_gpu_flags(ssh, gpu_uuids=["GPU-aaa"])


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2175](https://www.notion.so/Fix-build_gpu_flags-minor-discovery-fallback-for-NVML-Unknown-Error-protection-373b8bfdbde9812d8519f858f7ee14bc)

---

## Problem

`build_gpu_flags()` depended on `nvidia-smi --query-gpu=uuid,minor_number` to map rented GPU UUIDs to `/dev/nvidia<N>` nodes. On the reference executor `ad801688-8013-4b0b-96bc-2e831a5221c4`, that query rejected `minor_number`, so pod `0b75bd1a-fd6a-4340-80ce-7b3d116e7e0d` was created with legacy `--gpus` only and no explicit `/dev/nvidia*` devices.

## Solution

Use `/proc/driver/nvidia/gpus/*/information` as the primary UUID-to-minor source and fall back to `nvidia-smi -q -x` XML when `/proc` is unavailable or incomplete. Keep the existing legacy `--gpus` fallback only when both discovery paths fail.

## Changes

- Added Linux `/proc/driver/nvidia/gpus/*/information` GPU minor discovery.
- Added `nvidia-smi -q -x` XML fallback parsing for UUID-to-minor mapping.
- Preserved request-order `/dev/nvidia<N>` emission and partial-rental caps filtering.
- Improved discovery failure diagnostics to include stdout and stderr.
- Added unit coverage for unsupported `minor_number`, XML fallback, incomplete `/proc`, and non-contiguous minors.

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

None.

## Risks

- GPU device flag generation for rented pods is affected.
- If both `/proc` and XML discovery fail on a valid executor, the existing legacy `--gpus` fallback remains, so pods can still start but without daemon-reload protection.
- Partial-host rentals must continue skipping `/dev/nvidia-caps/*`; covered by existing tests.

## Test Cases

### Test Case 1

**Actions**

Run `pdm run pytest -q tests/test_nvidia_devices.py` from `neurons/validators`.

**Expected Output**

`25 passed`.

### Test Case 2

**Actions**

Run `scripts/agent/agentctl verify lium-io --full --quiet` from the workspace root.

**Expected Output**

`[lium-io] pass: 617 passed, 4 skipped, 72 warnings`.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described