### PR TITLE
DAH-2180: Stop executor monitor from holding GPU device handles

### DIFF
--- a/neurons/executor/docker-compose.app.dev.yml
+++ b/neurons/executor/docker-compose.app.dev.yml
@@ -59,13 +59,6 @@ services:
       - DB_URI=postgresql://postgres:password@db:5432/compute-subnet-db
     depends_on:
       - executor
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [ gpu ]
 
   autoheal:
     restart: always

--- a/neurons/executor/docker-compose.app.yml
+++ b/neurons/executor/docker-compose.app.yml
@@ -62,13 +62,6 @@ services:
       - executor
     cap_add:
       - SYSLOG
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [ gpu ]
 
   autoheal:
     restart: always

--- a/neurons/executor/src/monitor.py
+++ b/neurons/executor/src/monitor.py
@@ -1,9 +1,6 @@
 import docker
-import psutil
-import pynvml
 import logging
 import json
-import threading
 import time
 from datetime import datetime
 from core.config import settings
@@ -14,85 +11,8 @@ from daos.pod_log import PodLog, PodLogDao
 logging.basicConfig(filename="container_monitor.log", level=logging.INFO,
                     format='%(message)s')  # we will log pre-formatted JSON strings
 
-# Initialize NVML for GPU monitoring
-try:
-    pynvml.nvmlInit()
-    NVML_AVAILABLE = True
-except Exception as e:
-    NVML_AVAILABLE = False
-    logging.error(json.dumps({
-        "timestamp": datetime.utcnow().isoformat() + "Z",
-        "error": f"Failed to initialize NVML: {e}"
-    }))
-
-# Data structures for tracking
-monitored = {}  # dict container_id -> {"name": ..., "pid": ..., "last_stats": {...}}
 monitor_prefix = "container_"  # only monitor containers with this prefix
 
-# # Helper: get current GPU usage for a container (if NVML is available)
-# def get_container_gpu_stats(container_pid):
-#     """Return GPU utilization% and memory usage (MB) for processes in the container."""
-#     stats = {"gpu_util": 0, "gpu_mem_mb": 0}
-#     if not NVML_AVAILABLE:
-#         return stats
-#     try:
-#         device_count = pynvml.nvmlDeviceGetCount()
-#     except pynvml.NVMLError as e:
-#         # NVML error, log and return zeros
-#         logging.error(json.dumps({
-#             "timestamp": datetime.utcnow().isoformat() + "Z",
-#             "error": f"NVML error in get_count: {str(e)}"
-#         }))
-#         return stats
-#     total_util = 0
-#     total_mem = 0
-#     for i in range(device_count):
-#         try:
-#             handle = pynvml.nvmlDeviceGetHandleByIndex(i)
-#             util = pynvml.nvmlDeviceGetUtilizationRates(handle)
-#             procs = pynvml.nvmlDeviceGetComputeRunningProcesses(handle)
-#         except pynvml.NVMLError:
-#             continue  # skip this GPU if any issue
-#         # Sum usage for processes belonging to this container (match by PID namespace via container_pid, or cgroup check)
-#         for p in procs:
-#             pid = p.pid
-#             # Check if this process is in the same container by comparing its ancestral PID namespace root or cgroup.
-#             # Simplest approach: check if the container's init PID matches this or is an ancestor.
-#             try:
-#                 proc = psutil.Process(pid)
-#                 ancestors = proc.parents()
-#             except psutil.NoSuchProcess:
-#                 continue
-#             # If container_pid is this pid or any parent pid, assume it's part of the container
-#             if any(parent.pid == container_pid for parent in ancestors) or pid == container_pid:
-#                 total_util += util.gpu   # add GPU core utilization (this is per-device, so if multiple containers share, it will sum >100 possibly)
-#                 # Add memory used by this process on this GPU (pynvml gives bytes)
-#                 try:
-#                     total_mem += p.usedGpuMemory // (1024 * 1024)  # convert to MB
-#                 except Exception:
-#                     # p.usedGpuMemory might be None or not available for some drivers
-#                     pass
-#     if device_count > 0:
-#         # Clip util to 100 if one container per GPU assumption, or leave as sum if multi-GPU usage
-#         stats["gpu_util"] = min(total_util, 100)
-#         stats["gpu_mem_mb"] = total_mem
-#     return stats
-
-# # Thread: periodically sample GPU stats for each monitored container
-# def metrics_sampler():
-#     while True:
-#         for cid, info in list(monitored.items()):
-#             pid = info.get("pid")
-#             if not pid:
-#                 continue
-#             stats = get_container_gpu_stats(pid)
-#             # Store the latest stats in our dict (so event thread can use it)
-#             monitored[cid]["last_stats"] = stats
-#         time.sleep(5)  # sample interval (seconds)
-
-# # Start metrics sampling thread
-# thread = threading.Thread(target=metrics_sampler, daemon=True)
-# thread.start()
 
 # Helper: Determine stop reason classification
 
@@ -102,7 +22,7 @@ def classify_stop(exit_code):
     # Default classification
     reason = "unknown"
 
-    # If NVML is available, check for recent GPU errors in dmesg
+    # Check for recent GPU errors in dmesg
     try:
         # Read kernel messages (dmesg) for GPU errors
         import subprocess

--- a/neurons/executor/tests/test_monitor_gpu_access.py
+++ b/neurons/executor/tests/test_monitor_gpu_access.py
@@ -1,0 +1,47 @@
+import ast
+from pathlib import Path
+
+import yaml
+
+
+EXECUTOR_DIR = Path(__file__).resolve().parents[1]
+MONITOR_PATH = EXECUTOR_DIR / "src" / "monitor.py"
+COMPOSE_PATHS = [
+    EXECUTOR_DIR / "docker-compose.app.yml",
+    EXECUTOR_DIR / "docker-compose.app.dev.yml",
+]
+
+
+def test_monitor_does_not_import_or_initialize_nvml():
+    tree = ast.parse(MONITOR_PATH.read_text())
+
+    for node in ast.walk(tree):
+        assert not (
+            isinstance(node, ast.Import)
+            and any(alias.name == "pynvml" for alias in node.names)
+        )
+        assert not (
+            isinstance(node, ast.ImportFrom)
+            and node.module is not None
+            and node.module.startswith("pynvml")
+        )
+        assert not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "nvmlInit"
+        )
+
+
+def test_monitor_service_does_not_reserve_gpu_devices():
+    for compose_path in COMPOSE_PATHS:
+        compose = yaml.safe_load(compose_path.read_text())
+        monitor_service = compose["services"]["monitor"]
+
+        devices = (
+            monitor_service.get("deploy", {})
+            .get("resources", {})
+            .get("reservations", {})
+            .get("devices")
+        )
+
+        assert devices is None, f"{compose_path.name} monitor service reserves GPU devices"


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2180](https://app.notion.com/p/Stop-executor-monitor-from-holding-GPU-device-handles-374b8bfdbde981c6a0c4db0d87e13361)

---

## Problem

A production incident on 2026-06-03 showed executor `52510e59-d0c5-419e-9173-622c3baa2e8a`, pod `29b30a6e-b4c5-4385-8115-b6a2df359be6`, IP `5.130.180.236` with one RTX 5090 reporting 100% GPU utilization while the rented pod had no compute process.

Host-side evidence showed `/root/app/.venv/bin/python src/monitor.py` inside `executor-monitor-1` holding `/dev/nvidia*`. The monitor only needs Docker events and kernel log access, not GPU device access.

## Solution

Removed monitor-side NVML initialization and the stale commented GPU sampler from `neurons/executor/src/monitor.py`.

Removed NVIDIA GPU reservations from the `monitor` service in both executor compose definitions while leaving the main `executor` service GPU reservation and healthcheck intact. UI/API GPU metrics still come from `services.hardware_service`, not from the monitor process.

## Changes

- Removed `pynvml`, `psutil`, `threading`, `nvmlInit()`, and old commented GPU sampling code from `monitor.py`.
- Removed `deploy.resources.reservations.devices` from `monitor` in `docker-compose.app.yml`.
- Removed `deploy.resources.reservations.devices` from `monitor` in `docker-compose.app.dev.yml`.
- Added `tests/test_monitor_gpu_access.py` to prevent monitor NVML init and monitor GPU reservations from coming back.

## Deployment Steps

Use GitHub Action. For executor validation, run the manual executor dev deployment workflow after review:

`CD: Deploying Executor (dev) with Manual Trigger`

## Review Request

- [ ] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

None.

## Risks

- Monitor pod lifecycle logging should continue to work because Docker socket, DB access, `/dev/kmsg`, and `SYSLOG` remain in place.
- Immediate staging/dev verification can confirm the executor stack still starts and API GPU metrics still work; the original production symptom may not be directly reproducible on staging.
- The existing `monitor_prefix = "container_"` vs `pod_` naming mismatch is adjacent and intentionally left out of this PR.

## Test Cases

### Local Verification

**Actions**

- `pdm run pytest tests/test_monitor_gpu_access.py -q`
- `DB_URI="sqlite:///$(mktemp -u /tmp/lium-executor-dah2180.XXXXXX).db" pdm run pytest tests -q`
- `scripts/agent/agentctl verify lium-io --quick --quiet`
- `scripts/agent/agentctl push lium-io --all --full --quiet -m "DAH-2180, stop monitor GPU handles"`

**Expected Output**

- New focused test passes.
- Executor tests pass.
- Full push gate passes: `622 passed, 4 skipped, 72 warnings`.

### Pre-deploy Verification

**Actions**

On staging, deploy the executor stack and confirm host-side `fuser -v /dev/nvidia*` does not list `executor-monitor-1`. Create and stop a test pod, then confirm pod lifecycle logs are still written. Query container utilization through the executor API and confirm GPU metrics still return for the rented pod.

**Expected Output**

`executor-monitor-1` is absent from NVIDIA device holders; pod lifecycle logging still works; GPU utilization metrics still return from the executor API.

### Post-deploy Verification

**Actions**

- +1 d — sample several active executors: `executor-monitor-1` is absent from `fuser -v /dev/nvidia*`, while rented pod utilization still updates.
- +7 d — check support reports for freshly rented idle pods showing 100% GPU utilization with no compute process and `executor-monitor-1` holding NVIDIA devices.

**Expected Output**

No sampled executor monitor process holds NVIDIA devices, rented pod utilization still updates, and no matching recurring support reports appear.

## Checklist

- [x] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described