### PR TITLE
DAH-2122: add create_container SSH reset mitigation

### DIFF
--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -432,6 +432,7 @@ class FailedContainerRequest(ContainerBaseResponse):
     error_type: FailedContainerErrorTypes = FailedContainerErrorTypes.ContainerCreationFailed
     msg: str
     error_code: FailedContainerErrorCodes | None = None
+    failure_step: str | None = None
 
 
 class DuplicateExecutorsResponse(BaseModel):

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -97,6 +97,11 @@ _LOCAL_VOLUME_TIMEOUT_GB_PER_SEC = 10
 _LOCAL_VOLUME_TIMEOUT_MAX_SEC = 180
 _FILLER_EXTERNAL_PORT_OFFSET = 20
 _DOCKER_NO_SUCH_CONTAINER_PHRASE = "No such container"
+# Keep the rental create_container SSH session alive while long docker pulls
+# are quiet. With 30s/4, AsyncSSH declares a dead peer after about 2 minutes.
+_CREATE_CONTAINER_SSH_KEEPALIVE_INTERVAL_SEC = 30
+_CREATE_CONTAINER_SSH_KEEPALIVE_COUNT_MAX = 4
+_DOCKER_PULL_TIMEOUT_SECONDS = 3 * 60 * 60 # 3 hours
 
 
 def _is_missing_docker_container_error(exc: Exception) -> bool:
@@ -1362,10 +1367,13 @@ class DockerService:
         )
 
         log_tag = "container_creation"
+        current_step = "start"
 
         try:
+            current_step = "prepare_request"
             custom_options = CustomOptions.sanitize(payload.custom_options)
             # generate port maps
+            current_step = "port_mapping"
             port_maps, jupyter_port_map = await self.generate_portMappings(
                 payload.miner_hotkey,
                 payload.executor_id,
@@ -1397,6 +1405,7 @@ class DockerService:
                     msg=str(log_text),
                     error_type=FailedContainerErrorTypes.ContainerCreationFailed,
                     error_code=FailedContainerErrorCodes.NoPortMappings,
+                    failure_step=current_step,
                 )
 
             default_extra = {
@@ -1421,8 +1430,10 @@ class DockerService:
                     msg=str(log_text),
                     error_type=FailedContainerErrorTypes.ContainerCreationFailed,
                     error_code=FailedContainerErrorCodes.NoJupyterPortMapping,
+                    failure_step=current_step,
                 )
 
+            current_step = "validate_request"
             if not payload.user_public_keys:
                 log_text = _m(
                     "No public keys",
@@ -1440,16 +1451,20 @@ class DockerService:
                     msg=str(log_text),
                     error_type=FailedContainerErrorTypes.ContainerCreationFailed,
                     error_code=FailedContainerErrorCodes.NoSshKeys,
+                    failure_step=current_step,
                 )
 
             # add executor in pending status dict
+            current_step = "pending_pod"
             await self.redis_service.add_pending_pod(payload.miner_hotkey, payload.executor_id, payload.pod_id)
 
+            current_step = "ssh_key_import"
             private_key = self.ssh_service.decrypt_payload(keypair.ss58_address, private_key)
             pkey = asyncssh.import_private_key(private_key)
 
             known_hosts_policy: asyncssh.SSHKnownHosts | None = None
             try:
+                current_step = "attestation"
                 known_hosts_policy = await self._prepare_known_hosts_policy(
                     executor_info,
                     payload.miner_hotkey,
@@ -1469,14 +1484,18 @@ class DockerService:
                     msg=str(log_text),
                     error_type=FailedContainerErrorTypes.ContainerCreationFailed,
                     error_code=FailedContainerErrorCodes.UnknownError,
+                    failure_step=current_step,
                 )
 
+            current_step = "ssh_connect"
             async with asyncssh.connect(
                 host=executor_info.address,
                 port=executor_info.ssh_port,
                 username=executor_info.ssh_username,
                 client_keys=[pkey],
                 known_hosts=known_hosts_policy,
+                keepalive_interval=_CREATE_CONTAINER_SSH_KEEPALIVE_INTERVAL_SEC,
+                keepalive_count_max=_CREATE_CONTAINER_SSH_KEEPALIVE_COUNT_MAX,
             ) as ssh_client:
                 # Add profiler for ssh connection
                 profilers.append({"name": "SSH connection established", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
@@ -1499,6 +1518,7 @@ class DockerService:
                 #     log_extra=default_extra,
                 # )
                 if payload.docker_username and payload.docker_password:
+                    current_step = "docker_login"
                     command = self._build_docker_login_command(
                         payload.docker_username, payload.docker_password
                     )
@@ -1515,6 +1535,7 @@ class DockerService:
                 profilers.append({"name": "Docker login step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
                 prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
 
+                current_step = "docker_pull"
                 command = f"/usr/bin/docker pull {payload.docker_image}"
                 await self.execute_and_stream_logs(
                     ssh_client=ssh_client,
@@ -1522,6 +1543,7 @@ class DockerService:
                     log_tag=log_tag,
                     log_text=f"Pulling docker image {payload.docker_image}",
                     log_extra=default_extra,
+                    timeout=_DOCKER_PULL_TIMEOUT_SECONDS,
                 )
 
                 # Add profiler for docker pull
@@ -1575,6 +1597,7 @@ class DockerService:
                 if local_volume:
                     protected_volume_names.add(local_volume)
 
+                current_step = "container_cleanup"
                 await self.clean_existing_containers(
                     ssh_client=ssh_client,
                     default_extra=default_extra,
@@ -1597,6 +1620,7 @@ class DockerService:
 
                 if not local_volume:
                     # create docker volume
+                    current_step = "volume_creation"
                     local_volume = f"volume_{payload.pod_id}"
                     await self.create_local_volume(
                         ssh_client=ssh_client,
@@ -1611,6 +1635,7 @@ class DockerService:
                 volume_flag = f"-v {local_volume}:{local_volume_path}"
 
                 if external_volume_info:
+                    current_step = "external_volume_creation"
                     success, msg = await self.create_s3fs_volume(
                         ssh_client=ssh_client,
                         log_extra=default_extra,
@@ -1641,6 +1666,7 @@ class DockerService:
                 # explicit --device entries persist the device cgroup across systemd
                 # daemon-reload (cgroup v2 + systemd cgroup driver wipe the transient
                 # nvidia hook program; HostConfig.Devices is reapplied by Docker).
+                current_step = "gpu_flags"
                 gpu_flags = await build_gpu_flags(ssh_client, payload.gpu_uuids) + " "
 
                 # CPU and memory restriction flags
@@ -1687,6 +1713,7 @@ class DockerService:
                 # Tighter budget than the early call: by this point HC should
                 # be near completion, and the port-allocated retry loop +
                 # `docker rm -f` are the backstop for any residual race.
+                current_step = "port_check_wait"
                 wait_ok, wait_msg = await self.wait_for_port_check_containers(
                     executor_info=executor_info,
                     miner_hotkey=payload.miner_hotkey,
@@ -1704,6 +1731,7 @@ class DockerService:
                 )
 
                 try:
+                    current_step = "docker_run"
                     await self._run_docker_create_with_port_retry(
                         ssh_client=ssh_client,
                         command=command,
@@ -1717,6 +1745,7 @@ class DockerService:
                     logger.info(f"Container creation step finished")
 
                     # check if the container is running correctly
+                    current_step = "container_health_check"
                     if not await self.check_container_running(ssh_client, container_name):
                         # Capture the failure reason and check whether it points to our
                         # --device flags (DAH-1987). State.Error covers cgroup / device
@@ -1786,6 +1815,7 @@ class DockerService:
                 #     )
                 # else:
                 try:
+                    current_step = "ssh_bootstrap"
                     await self.install_open_ssh_server_and_start_ssh_service(
                         ssh_client=ssh_client,
                         container_name=container_name,
@@ -1795,6 +1825,7 @@ class DockerService:
 
                     jupyter_url = None
                     if payload.enable_jupyter and jupyter_port_map:
+                        current_step = "jupyter_setup"
                         jupyter_token = secrets.token_hex(16)
                         await self.run_jupyter(
                             ssh_client=ssh_client,
@@ -1813,11 +1844,13 @@ class DockerService:
                     prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
 
                     # add rest of public keys
+                    current_step = "add_public_keys"
                     for public_key in payload.user_public_keys:
                         command = f"/usr/bin/docker exec {container_name} sh -c 'echo \"{public_key}\" >> ~/.ssh/authorized_keys'"
                         await ssh_client.run(command)
 
                     # add environment variables
+                    current_step = "set_environment"
                     if custom_options and custom_options.environment:
                         for k, v in custom_options.environment.items():
                             if k and v and k.strip() and str(v).strip():
@@ -1836,6 +1869,7 @@ class DockerService:
 
                     await self.finish_stream_logs()
 
+                    current_step = "finalize"
                     await self.redis_service.add_rented_pod(executor_info, payload.pod_id, container_name)
                 except Exception:
                     await self.cleanup_failed_container_creation(
@@ -1879,7 +1913,11 @@ class DockerService:
         except Exception as e:
             log_text = _m(
                 "Failed create_container",
-                extra=get_extra_info({**default_extra, "error": str(e)}),
+                extra=get_extra_info({
+                    **default_extra,
+                    "error": str(e),
+                    "failure_step": current_step,
+                }),
             )
             logger.error(log_text, exc_info=True)
 
@@ -1896,6 +1934,7 @@ class DockerService:
                 msg=str(log_text),
                 error_type=FailedContainerErrorTypes.ContainerCreationFailed,
                 error_code=FailedContainerErrorCodes.UnknownError,
+                failure_step=current_step,
             )
 
     async def stream_log(self, log_msg:str, log_status: str, log_tag: str):

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -1357,6 +1357,162 @@ async def test_create_container_clears_pending_pod_after_successful_filler_creat
 
 
 @pytest.mark.asyncio
+async def test_create_container_uses_keepalives_and_docker_pull_timeout(
+    docker_service,
+    monkeypatch,
+):
+    import services.docker_service as docker_service_module
+
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
+    connect_mock = Mock(return_value=DummySSHConnectionManager(ssh_client))
+    monkeypatch.setattr("services.docker_service.asyncssh.connect", connect_mock)
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr("services.docker_service.build_gpu_flags", AsyncMock(return_value=""))
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.add_pending_pod = AsyncMock()
+    docker_service.redis_service.remove_pending_pod = AsyncMock()
+    docker_service.redis_service.add_rented_pod = AsyncMock()
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        docker_service,
+        "generate_portMappings",
+        AsyncMock(return_value=([(22, 20001, 20001)], None)),
+    )
+    execute_mock = AsyncMock(return_value=(True, ""))
+    monkeypatch.setattr(docker_service, "execute_and_stream_logs", execute_mock)
+    monkeypatch.setattr(docker_service, "clean_existing_containers", AsyncMock())
+    monkeypatch.setattr(docker_service, "clean_stale_vloopback_volumes", AsyncMock())
+    monkeypatch.setattr(docker_service, "create_local_volume", AsyncMock())
+    monkeypatch.setattr(
+        docker_service,
+        "wait_for_port_check_containers",
+        AsyncMock(return_value=(True, "ok")),
+    )
+    monkeypatch.setattr(docker_service, "_run_docker_create_with_port_retry", AsyncMock())
+    monkeypatch.setattr(docker_service, "check_container_running", AsyncMock(return_value=True))
+    monkeypatch.setattr(docker_service, "install_open_ssh_server_and_start_ssh_service", AsyncMock())
+    monkeypatch.setattr(docker_service, "stream_log", AsyncMock())
+    monkeypatch.setattr(docker_service, "finish_stream_logs", AsyncMock())
+    monkeypatch.setattr(docker_service, "handle_stream_logs", AsyncMock())
+
+    payload = ContainerCreateRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        docker_image="daturaai/pytorch:test",
+        user_public_keys=["ssh-ed25519 test-key"],
+        gpu_uuids=["GPU-test"],
+        cpu_count=1,
+        memory_gb=1,
+        volume_limit_gb=2,
+        storage_limit_gb=1,
+        available_ports=[PayloadPortMapping(internal_port=20001, external_port=20001)],
+        pod_mapping=[],
+        active_container_names=[],
+        active_volume_names=[],
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+    )
+
+    await docker_service.create_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    assert connect_mock.call_args.kwargs["keepalive_interval"] == 30
+    assert connect_mock.call_args.kwargs["keepalive_count_max"] == 4
+
+    pull_calls = [
+        call for call in execute_mock.await_args_list
+        if call.kwargs["command"] == f"/usr/bin/docker pull {payload.docker_image}"
+    ]
+    assert len(pull_calls) == 1
+    assert pull_calls[0].kwargs["timeout"] == docker_service_module._DOCKER_PULL_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_create_container_reports_docker_pull_failure_step(
+    docker_service,
+    monkeypatch,
+):
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.add_pending_pod = AsyncMock()
+    docker_service.redis_service.remove_pending_pod = AsyncMock()
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        docker_service,
+        "generate_portMappings",
+        AsyncMock(return_value=([(22, 20001, 20001)], None)),
+    )
+    monkeypatch.setattr(
+        docker_service,
+        "execute_and_stream_logs",
+        AsyncMock(side_effect=Exception("[Errno 104] Connection reset by peer")),
+    )
+    monkeypatch.setattr(docker_service, "finish_stream_logs", AsyncMock())
+    monkeypatch.setattr(docker_service, "handle_stream_logs", AsyncMock())
+
+    payload = ContainerCreateRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        docker_image="daturaai/pytorch:test",
+        user_public_keys=["ssh-ed25519 test-key"],
+        gpu_uuids=["GPU-test"],
+        cpu_count=1,
+        memory_gb=1,
+        volume_limit_gb=2,
+        storage_limit_gb=1,
+        available_ports=[PayloadPortMapping(internal_port=20001, external_port=20001)],
+        pod_mapping=[],
+        active_container_names=[],
+        active_volume_names=[],
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+    )
+
+    result = await docker_service.create_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    assert result.failure_step == "docker_pull"
+    docker_service.redis_service.remove_pending_pod.assert_awaited_once_with(
+        payload.miner_hotkey,
+        payload.executor_id,
+        payload.pod_id,
+    )
+
+
+@pytest.mark.asyncio
 async def test_clean_containers_no_volume_cleanup_when_disabled(docker_service, retry_ssh_mock):
     """No volume cleanup when clear_volume=False (e.g. local volume reuse)."""
     # Arrange


### PR DESCRIPTION
## Summary
- Add AsyncSSH keepalives to the rental `create_container` SSH session.
- Track the active create_container step and propagate `failure_step` in `FailedContainerRequest`.
- Add a fixed 3 hour timeout for the docker pull command.
- Add focused DockerService tests for keepalives, docker pull timeout, and `docker_pull` failure_step.

## Reasoning
We are investigating `[Errno 104] Connection reset by peer` failures during customer rental `create_container`. The strongest evidence so far points to resets happening while the validator is waiting on a long docker pull over SSH, but the old failure path only reported a generic create_container failure. That made it hard to separate docker pull resets from failures in volume setup, container startup, verification, or cleanup.

The new `failure_step` field keeps this simple: the validator records the current create_container step locally, and when the flow fails it sends that step with the failed-container event. Backend and stats can then classify failures without parsing fragile free-form error strings or assuming every SSH reset happened during docker pull.

The SSH keepalives are a immediate mitigation for long quiet pulls. Some image downloads can spend a long time without producing useful stdout, while the validator is still holding the SSH session open. Keepalives at 30 seconds with 4 missed replies let AsyncSSH detect a dead peer after about 2 minutes and keep intermediate network/NAT paths from treating the connection as idle. This does not retry the operation or change executor-side docker behavior; it only makes the existing SSH session healthier and easier to diagnose when it dies.

The 3 hour docker pull timeout is a hard upper bound for the pull step. It avoids leaving the validator stuck indefinitely on a stalled pull while staying high enough to avoid cutting off very large legitimate image downloads.
