### PR TITLE
DAH-2193, skip stale pod not running resets

### DIFF
--- a/neurons/validators/src/clients/backend_client.py
+++ b/neurons/validators/src/clients/backend_client.py
@@ -12,7 +12,11 @@ from pydantic import BaseModel, ValidationError
 from tenacity import retry, retry_if_result, stop_after_attempt, wait_fixed
 
 from core.utils import _m, get_extra_info
-from protocol.vc_protocol.compute_requests import ExecutorHealthCheckResponse, RentedExecutorsResponse
+from protocol.vc_protocol.compute_requests import (
+    ExecutorHealthCheckResponse,
+    PodRentalActiveResponse,
+    RentedExecutorsResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -201,6 +205,14 @@ class BackendClient:
             "/internal/executors/rented",
             RentedExecutorsResponse,
             timeout=30,
+        )
+
+    async def get_pod_rental_active(self, pod_id: str) -> PodRentalActiveResponse | None:
+        """Fetch whether the backend still considers a pod rental active."""
+        return await self.get(
+            f"/internal/pods/{pod_id}/rental-active",
+            PodRentalActiveResponse,
+            timeout=10,
         )
 
     async def check_executor_health(

--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -92,6 +92,11 @@ class RentedExecutorsResponse(BaseModel):
         return self.filler_containers_by_executor.get(str(executor_uuid))
 
 
+class PodRentalActiveResponse(BaseModel):
+    active: bool
+    rental_closed_at: datetime | None = None
+
+
 class ExecutorUptimeResponse(BaseModel):
     executor_ip_address: str
     executor_ip_port: str

--- a/neurons/validators/src/services/task/checks/rented_machine.py
+++ b/neurons/validators/src/services/task/checks/rented_machine.py
@@ -162,6 +162,35 @@ class TenantEnforcementCheck:
                 )
             if not pod_running:
                 diagnostics = await _collect_pod_diagnostics(ctx.ssh, pod_container_name)
+                rental_active = await ctx.services.backend.get_pod_rental_active(pod_id)
+                if rental_active and not rental_active.active:
+                    event = render_message(
+                        Msg.STALE_POD_NOT_RUNNING,
+                        ctx=ctx,
+                        check_id=self.check_id,
+                        what={
+                            "pod_id": pod_id,
+                            "container_name": pod_container_name,
+                            "executor_uuid": ctx.executor.uuid,
+                            "rental_closed_at": (
+                                rental_active.rental_closed_at.isoformat()
+                                if rental_active.rental_closed_at
+                                else None
+                            ),
+                            "diagnostics": diagnostics,
+                        },
+                        extra=extra,
+                    )
+                    return CheckResult(
+                        passed=True,
+                        event=event,
+                        updates={
+                            "default_extra": extra,
+                            "rented": False,
+                            "ssh_pub_keys": None,
+                        },
+                    )
+
                 event = render_message(
                     Msg.POD_NOT_RUNNING,
                     ctx=ctx,

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -426,6 +426,14 @@ class TenantEnforcementMessages:
         impact="Score set to 0; verification cleared",
         remediation="Start container and ensure it stays healthy.",
     )
+    STALE_POD_NOT_RUNNING = MessageTemplate(
+        event="Stale rented pod not running signal skipped",
+        reason="STALE_POD_NOT_RUNNING",
+        severity="info",
+        category="runtime",
+        impact="No reset sent because backend no longer considers the pod rental active",
+        remediation="No action needed.",
+    )
     EXECUTOR_TRANSPORT_UNREACHABLE = MessageTemplate(
         event="Executor unreachable over SSH",
         reason="EXECUTOR_TRANSPORT_UNREACHABLE",

--- a/neurons/validators/tests/test_backend_client.py
+++ b/neurons/validators/tests/test_backend_client.py
@@ -1,14 +1,13 @@
 """Tests for BackendClient."""
 
 import asyncio
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import aiohttp
+import pytest
+from neurons.validators.src.clients.backend_client import BackendClient
 from pydantic import BaseModel
 
-from neurons.validators.src.clients.backend_client import BackendClient
-from neurons.validators.src.protocol.vc_protocol.compute_requests import RentedExecutorsResponse
+from protocol.vc_protocol.compute_requests import PodRentalActiveResponse, RentedExecutorsResponse
 
 
 class SampleResponse(BaseModel):
@@ -77,6 +76,21 @@ async def test_get_success(reset_session, client):
 
 
 @pytest.mark.asyncio
+async def test_get_pod_rental_active_uses_internal_endpoint(client):
+    expected = MagicMock()
+
+    with patch.object(client, "get", AsyncMock(return_value=expected)) as mock_get:
+        result = await client.get_pod_rental_active("pod-1")
+
+    assert result is expected
+    mock_get.assert_awaited_once_with(
+        "/internal/pods/pod-1/rental-active",
+        PodRentalActiveResponse,
+        timeout=10,
+    )
+
+
+@pytest.mark.asyncio
 async def test_get_non_200_status(reset_session, client):
     mock_response = create_mock_response(500)
     mock_session = create_mock_session(mock_response, "get")
@@ -101,7 +115,7 @@ async def test_get_validation_error(reset_session, client):
 async def test_get_timeout(reset_session, client):
     mock_session = AsyncMock()
     async_cm = AsyncMock()
-    async_cm.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError())
+    async_cm.__aenter__ = AsyncMock(side_effect=TimeoutError())
     async_cm.__aexit__ = AsyncMock()
     mock_session.get = MagicMock(return_value=async_cm)
 

--- a/neurons/validators/tests/test_rented_machine_check.py
+++ b/neurons/validators/tests/test_rented_machine_check.py
@@ -10,6 +10,7 @@ from neurons.validators.src.services.task.checks.rented_machine import (
     _collect_pod_diagnostics,
 )
 from neurons.validators.src.services.task.messages import TenantEnforcementMessages as Msg
+
 from protocol.vc_protocol.compute_requests import RentedExecutor, RentedExecutorsResponse, RentedPod
 from protocol.vc_protocol.validator_requests import ResetVerifiedJobReason
 
@@ -164,6 +165,18 @@ class DummyScoreCalculator:
         return self.actual_score, self.job_score, self.warning
 
 
+class DummyBackendClient:
+    def __init__(self, *, active: bool | None = True):
+        self.active = active
+        self.called_with: list[str] = []
+
+    async def get_pod_rental_active(self, pod_id: str):
+        self.called_with.append(pod_id)
+        if self.active is None:
+            return None
+        return Mock(active=self.active, rental_closed_at=None)
+
+
 @pytest.mark.parametrize(
     "rented_machine,pod_running,ssh_keys,owner_flag,gpu_processes,gpu_details,port_count_db,port_maps,expected_pass,expected_reason,expect_halt",
     [
@@ -296,6 +309,7 @@ async def test_tenant_enforcement_check(
     services = build_services(
         score_calculator=score_calculator,
         container_cleanup=MockContainerCleanup(),
+        backend=DummyBackendClient(active=True),
     )
 
     # Setup config
@@ -369,6 +383,82 @@ async def test_tenant_enforcement_check(
             assert "gpu_utilization" in result.event.what_we_saw
             assert "vram_utilization" in result.event.what_we_saw
             assert "process_count" in result.event.what_we_saw
+
+
+@pytest.mark.asyncio
+async def test_tenant_enforcement_skips_pod_not_running_when_backend_says_inactive(context_factory):
+    executor_uuid = "executor-123"
+    rented_data = build_rented_data(
+        executor_uuid,
+        {"containers": [{"name": "tenant-123", "pod_id": "pod-1"}], "owner_flag": False},
+    )
+    backend = DummyBackendClient(active=False)
+    services = build_services(
+        score_calculator=DummyScoreCalculator(actual_score=1.0, job_score=1.0, warning=""),
+        container_cleanup=MockContainerCleanup(),
+        backend=backend,
+    )
+    state = build_state(
+        gpu_processes=[],
+        gpu_details=[],
+        gpu_model="NVIDIA RTX 4090",
+        rented_data=rented_data,
+    )
+    ctx = context_factory(
+        services=services,
+        config=build_context_config(),
+        state=state,
+        ssh=DummySSHClient(pod_running=False),
+        collateral_deposited=True,
+        is_rental_succeed=True,
+        contract_version="v1.0.0",
+    )
+
+    result = await TenantEnforcementCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.STALE_POD_NOT_RUNNING.reason
+    assert backend.called_with == ["pod-1"]
+    assert "clear_verified_job_info" not in result.updates
+    assert "clear_verified_job_reason" not in result.updates
+
+
+@pytest.mark.asyncio
+async def test_tenant_enforcement_keeps_pod_not_running_when_backend_state_unknown(context_factory):
+    executor_uuid = "executor-123"
+    rented_data = build_rented_data(
+        executor_uuid,
+        {"containers": [{"name": "tenant-123", "pod_id": "pod-1"}], "owner_flag": False},
+    )
+    backend = DummyBackendClient(active=None)
+    services = build_services(
+        score_calculator=DummyScoreCalculator(actual_score=1.0, job_score=1.0, warning=""),
+        container_cleanup=MockContainerCleanup(),
+        backend=backend,
+    )
+    state = build_state(
+        gpu_processes=[],
+        gpu_details=[],
+        gpu_model="NVIDIA RTX 4090",
+        rented_data=rented_data,
+    )
+    ctx = context_factory(
+        services=services,
+        config=build_context_config(),
+        state=state,
+        ssh=DummySSHClient(pod_running=False),
+        collateral_deposited=True,
+        is_rental_succeed=True,
+        contract_version="v1.0.0",
+    )
+
+    result = await TenantEnforcementCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.POD_NOT_RUNNING.reason
+    assert backend.called_with == ["pod-1"]
+    assert result.updates["clear_verified_job_info"] is True
+    assert result.updates["clear_verified_job_reason"] == ResetVerifiedJobReason.POD_NOT_RUNNING.value
 
 
 class DiagnosticsSSHClient:
@@ -560,6 +650,7 @@ async def test_tenant_enforcement_emits_transport_unreachable_on_ssh_failure(
     services = build_services(
         score_calculator=DummyScoreCalculator(actual_score=1.0, job_score=1.0, warning=""),
         container_cleanup=MockContainerCleanup(),
+        backend=DummyBackendClient(active=True),
     )
     state = build_state(
         gpu_processes=[],
@@ -601,6 +692,7 @@ async def test_tenant_enforcement_keeps_pod_not_running_for_non_transport_errors
     services = build_services(
         score_calculator=DummyScoreCalculator(actual_score=1.0, job_score=1.0, warning=""),
         container_cleanup=MockContainerCleanup(),
+        backend=DummyBackendClient(active=True),
     )
     state = build_state(
         gpu_processes=[],


### PR DESCRIPTION
## Summary

Skip stale `POD_NOT_RUNNING` resets when the backend no longer considers the pod rental active.

### Task Link

[DAH-2193](https://app.notion.com/p/Guard-POD_NOT_RUNNING-against-stale-pod-rental-snapshots-379b8bfdbde98136a75beb1f26237e85)

---

## Problem

A validator can emit `POD_NOT_RUNNING` from a stale backend rented-pods snapshot after the backend has already started or finished deleting the pod. That stale signal must not clear verified-job info for a pod the backend no longer considers active.

The reference incident involved pod `9c3daa65-c68b-447a-90b6-4c2c367d05ef` on executor `ce34847c-e515-4e15-aec6-8b0df2a59cfa`; backend deletion started before the validator emitted `POD_NOT_RUNNING`.

## Solution

Before the validator turns a missing rented pod container into `POD_NOT_RUNNING`, it calls the backend probe `GET /internal/pods/{pod_id}/rental-active`.

If backend returns `active=false`, the validator emits `STALE_POD_NOT_RUNNING`, marks the check as passed for this stale snapshot, and does not set `clear_verified_job_info` or `clear_verified_job_reason`. If backend returns `active=true` or the probe fails/returns `None`, the existing `POD_NOT_RUNNING` reset behavior is unchanged.

This intentionally does not change `ResetVerifiedJobRequest`.

## Changes

- Added `PodRentalActiveResponse` to validator protocol models.
- Added `BackendClient.get_pod_rental_active()`.
- Added a stale inactive-pod guard to `TenantEnforcementCheck` before the `POD_NOT_RUNNING` reset path.
- Added `STALE_POD_NOT_RUNNING` event metadata.
- Added tests for active, inactive, and unknown backend states.

## Deployment Steps

Use GitHub Action.

Deploy backend PR first, then deploy this validator PR. The validator keeps old behavior if the backend endpoint is unavailable, but staging verification should use the backend endpoint once deployed.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

- Backend PR: https://github.com/Datura-ai/lium-io-backend/pull/674

## Risks

- If backend incorrectly returns `active=false`, validator could skip a real `POD_NOT_RUNNING` reset.
- If backend is unavailable or returns an invalid response, validator intentionally keeps the previous reset behavior.
- This PR depends on the backend endpoint for the fixed stale-snapshot behavior.
- This PR does not change `ResetVerifiedJobRequest`.

## Test Cases

### Test Case 1

**Actions**

`pdm run pytest tests/test_rented_machine_check.py tests/test_backend_client.py -q`

**Expected Output**

Targeted validator tests pass, including stale inactive pod skip and unknown backend state fallback.

### Test Case 2

**Actions**

`pdm run ruff check src/clients/backend_client.py src/protocol/vc_protocol/compute_requests.py src/services/task/checks/rented_machine.py src/services/task/messages.py tests/test_backend_client.py tests/test_rented_machine_check.py`

**Expected Output**

Ruff passes for changed validator files.

### Test Case 3

**Actions**

`scripts/agent/agentctl verify lium-io --quick --quiet`

**Expected Output**

Full quick validator verification passes.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described