### PR TITLE
DAH-2203, quote startup_commands as container argv in docker_service

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -141,6 +141,29 @@ def _should_repair_stale_mountpoint(
     )
 
 
+def build_startup_command_args(startup_commands: str | None) -> str:
+    """Quote user-supplied startup_commands into a safe argv fragment.
+
+    The fragment is appended to the host-side ``docker run ... <image>`` command
+    that runs via ``/bin/sh -c`` over SSH as root on the executor. The user value
+    is split into tokens (honouring its own quoting) and each token is
+    ``shlex.quote``-d, so the host shell cannot interpret any metacharacter
+    inside it: the tokens become the container's command + args, never a host
+    command. Legitimate quoted commands such as ``bash -c "a && b"`` are
+    preserved (the ``&&`` runs inside the container); break-out attempts such as
+    a leading newline collapse to harmless container arguments. Unbalanced
+    quotes or an empty value fall back to the image default command.
+    """
+    if not startup_commands or not startup_commands.strip():
+        return ""
+    try:
+        tokens = shlex.split(startup_commands)
+    except ValueError:
+        # Unbalanced quotes etc. — don't risk a malformed/unsafe host command.
+        return ""
+    return " ".join(shlex.quote(token) for token in tokens)
+
+
 class DockerService:
     def __init__(
         self,
@@ -1583,12 +1606,8 @@ class DockerService:
                     if custom_options and custom_options.environment
                     else "-e NVIDIA_DRIVER_CAPABILITIES=all"
                 )
-                startup_commands = (
-                    f"{custom_options.startup_commands}"
-                    if custom_options
-                    and custom_options.startup_commands
-                    and custom_options.startup_commands.strip()
-                    else ""
+                startup_commands = build_startup_command_args(
+                    custom_options.startup_commands if custom_options else None
                 )
 
                 container_name = self.get_container_name(payload)

--- a/neurons/validators/tests/test_startup_command_quoting.py
+++ b/neurons/validators/tests/test_startup_command_quoting.py
@@ -1,0 +1,77 @@
+import shlex
+
+from services.docker_service import build_startup_command_args
+
+
+def test_simple_command_preserved():
+    result = build_startup_command_args("python /app/main.py --epochs 5")
+
+    assert shlex.split(result) == ["python", "/app/main.py", "--epochs", "5"]
+
+
+def test_legit_quoted_metacharacters_preserved():
+    # The real top template (CUDA 13.0.2) — `&&` lives inside a quoted bash -c arg
+    # and must reach the container intact, not be dropped.
+    original = '/bin/bash -c "service ssh start && tail -f /dev/null"'
+
+    result = build_startup_command_args(original)
+
+    # Host shell re-tokenizes the quoted fragment back into the original argv,
+    # so the `&&` runs inside the container, not on the host.
+    assert shlex.split(result) == shlex.split(original)
+    assert shlex.split(result) == ["/bin/bash", "-c", "service ssh start && tail -f /dev/null"]
+
+
+def test_leading_newline_breakout_neutralized():
+    # The real prod attack payload.
+    result = build_startup_command_args("\n\nsh /tmp/evil.sh")
+
+    # No raw newline survives, so the host `docker run` line cannot be terminated.
+    assert "\n" not in result
+    # The remainder is reduced to harmless container arguments.
+    assert shlex.split(result) == ["sh", "/tmp/evil.sh"]
+
+
+def test_semicolon_chaining_neutralized():
+    result = build_startup_command_args("echo hi; rm -rf /")
+
+    # The `;` is quoted (result is `echo 'hi;' rm -rf /`), so the host shell sees
+    # a single literal token rather than a command separator — it becomes a
+    # container argument and cannot start a new host command.
+    assert shlex.split(result) == ["echo", "hi;", "rm", "-rf", "/"]
+
+
+def test_env_expansion_kept_inside_container_shell():
+    # `bash -c '... $MODEL_NAME'` expands against the CONTAINER env, not the host.
+    original = "bash -c 'vllm serve $MODEL_NAME'"
+
+    result = build_startup_command_args(original)
+
+    assert shlex.split(result) == ["bash", "-c", "vllm serve $MODEL_NAME"]
+
+
+def test_empty_and_none_fall_back_to_default():
+    assert build_startup_command_args(None) == ""
+    assert build_startup_command_args("") == ""
+    assert build_startup_command_args("   ") == ""
+    assert build_startup_command_args("\n\n") == ""
+
+
+def test_unbalanced_quotes_fall_back_to_default():
+    # shlex.split raises ValueError → drop to image default rather than risk a
+    # malformed host command.
+    assert build_startup_command_args('bash -c "unterminated') == ""
+
+
+def test_quoting_round_trips_for_arbitrary_payloads():
+    # General safety invariant: the quoted fragment, when interpreted by the host
+    # shell, yields exactly the same argv as the original — semantics preserved,
+    # host interpretation neutralized.
+    for payload in [
+        "python app.py",
+        '/bin/bash -c "a && b | c > /tmp/x"',
+        "jupyter lab --ip 0.0.0.0",
+        "sh -c 'while true; do sleep 1; done'",
+    ]:
+        result = build_startup_command_args(payload)
+        assert shlex.split(result) == shlex.split(payload), payload


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2203](https://app.notion.com/p/Fix-startup_commands-host-breakout-RCE-strip-bypass-37cb8bfdbde981d3887ede8c64b36726)

---

## Problem

The validator's `docker_service.create_container` interpolates user-supplied `startup_commands` raw into the host-side `docker run ...` f-string, which runs via `/bin/sh -c` over SSH as **root on the executor host**. A newline-prefixed payload (`"\n\nsh /tmp/Jtd7.sh"`, observed in a real production attack) terminates the `docker run` line and executes the rest directly on the host.

The backend sanitizer is the first line of defense (Datura-ai/lium-io-backend#682), but the validator must not trust upstream input: this PR adds the second, defense-in-depth layer on the validator side.

## Solution

New `build_startup_command_args()` quotes `startup_commands` into a safe argv fragment before it reaches the host shell:

- The value is tokenized with `shlex.split` (honouring its own quoting), and each token is `shlex.quote`-d. The host shell can no longer interpret any metacharacter — the tokens become the **container's** command + args, never a host command.
- Legitimate quoted commands are preserved: `/bin/bash -c "service ssh start && tail -f /dev/null"` (the real top template) round-trips exactly; the `&&` runs inside the container.
- Break-out attempts collapse to harmless container arguments: a leading newline is consumed by tokenization, `;`-chaining becomes a literal argument.
- Empty values or unbalanced quotes (`shlex.split` raises `ValueError`) fall back to the image default command instead of risking a malformed host command.

## Changes

- `neurons/validators/src/services/docker_service.py`: added `build_startup_command_args()`; `create_container` uses it instead of raw f-string interpolation.
- `neurons/validators/tests/test_startup_command_quoting.py`: new test module — prod attack payload, `;`-chaining, legit quoted metacharacters, env expansion inside container shell, empty/unbalanced fallback, and a round-trip invariant over representative real templates.

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

- Datura-ai/lium-io-backend#682 — first layer: backend `TemplateSanitizer` now checks metacharacters on the raw (non-stripped) value.

## Risks

- Behavior change for templates with **unbalanced quotes** in `startup_commands`: previously interpolated raw, now fall back to the image default command. Such values were already broken or dangerous.
- Quoting round-trip is covered by an invariant test over representative real templates (`bash -c "a && b | c"`, vllm/jupyter launch lines), so legitimate workloads keep their exact argv.
- The change is limited to `create_container`; other docker_service code paths are untouched.

## Test Cases

### Test Case 1 — prod attack payload neutralized

**Actions**

`build_startup_command_args("\n\nsh /tmp/evil.sh")`

**Expected Output**

No raw `\n` in the result; the host `docker run` line cannot be terminated. Remainder reduces to harmless container arguments `["sh", "/tmp/evil.sh"]`.

### Test Case 2 — real top template preserved

**Actions**

`build_startup_command_args('/bin/bash -c "service ssh start && tail -f /dev/null"')`

**Expected Output**

Host shell re-tokenizes the fragment back into the original argv; `&&` runs inside the container.

### Test Case 3 — unbalanced quotes fall back

**Actions**

`build_startup_command_args('bash -c "unterminated')`

**Expected Output**

Empty string → container starts with the image default command.

### Test run

`pdm run pytest` in `neurons/validators` — 633 passed, 4 skipped locally (includes the new `test_startup_command_quoting.py`, 8 tests).

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
