### PR TITLE
DAH-2183, validator-side fresh vloopback sizing with disk_share contract

### DIFF
--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -226,6 +226,15 @@ class PayloadPortMapping(BaseModel):
 
 
 class ContainerCreateRequest(ContainerBaseRequest):
+    """Container creation request from the backend.
+
+    Disk sizing contract: when ``disk_share`` is set, the validator computes
+    effective volume/storage limits from fresh on-host disk state and
+    ``volume_limit_gb``/``storage_limit_gb`` act only as upper-bound caps.
+    When ``disk_share`` is absent, ``volume_limit_gb``/``storage_limit_gb``
+    are exact sizes (legacy behavior).
+    """
+
     message_type: ContainerRequestType = ContainerRequestType.ContainerCreateRequest
     docker_image: str
     user_public_keys: list[str] = []
@@ -237,6 +246,8 @@ class ContainerCreateRequest(ContainerBaseRequest):
     local_volume: str | None = None
     volume_limit_gb: int | None = None
     storage_limit_gb: int | None = None
+    disk_share: float | None = None  # pod's share of machine disk (rented_gpus/total_gpus); None -> legacy sizing
+    min_volume_gb: int | None = None  # reject floor for fresh sizing; None -> never reject (shrink only)
     external_volume_info: ExternalVolumeInfo | None = None
     is_sysbox: bool | None = None
     docker_username: str | None = None  # when edit pod, docker_username is required

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1437,7 +1437,7 @@ class DockerService:
             )
 
         total_bytes = 0
-        for line in (inspect_result.stdout or "").splitlines():
+        for volume_name, line in zip(volume_names, (inspect_result.stdout or "").splitlines()):
             line = line.strip()
             if not line:
                 continue
@@ -1447,6 +1447,17 @@ class DockerService:
                 size_bytes = _parse_volume_size_to_bytes(size_option_raw)
             if size_bytes is not None:
                 total_bytes += size_bytes
+            else:
+                # Undercounting existing volumes inflates the reconstructed pool.
+                logger.info(
+                    _m(
+                        "vloopback_fresh_sizing_unparsable_volume_size",
+                        extra=get_extra_info({
+                            "volume_name": volume_name,
+                            "inspect_line": line,
+                        }),
+                    )
+                )
         return total_bytes
 
     async def resolve_volume_sizing(
@@ -1496,10 +1507,14 @@ class DockerService:
                 path="fresh_fallback",
             )
 
-        pool_bytes = (
+        # Clamp negative intermediates: a nearly-full disk must degrade to the
+        # 1 GB floor (or a min-size rejection), never to a negative candidate
+        # winning min().
+        pool_bytes = max(
             df_avail_bytes
             + existing_volumes_bytes
-            - _FRESH_SIZING_OVERHEAD_GB * _FRESH_SIZING_GB_BYTES
+            - _FRESH_SIZING_OVERHEAD_GB * _FRESH_SIZING_GB_BYTES,
+            0,
         )
         slice_candidates = [("pool", payload.disk_share * pool_bytes)]
         if payload.volume_limit_gb is not None:
@@ -1509,13 +1524,18 @@ class DockerService:
         slice_candidates.append(
             (
                 "df_guard",
-                (df_avail_bytes - _FRESH_SIZING_HEADROOM_GB * _FRESH_SIZING_GB_BYTES) * 1.5,
+                max(
+                    (df_avail_bytes - _FRESH_SIZING_HEADROOM_GB * _FRESH_SIZING_GB_BYTES) * 1.5,
+                    0,
+                ),
             )
         )
         capped_by, slice_bytes = min(slice_candidates, key=lambda item: item[1])
 
-        volume_limit_gb = math.floor(slice_bytes * 2 / 3 / _FRESH_SIZING_GB_BYTES)
-        storage_limit_gb = math.floor(slice_bytes / 3 / _FRESH_SIZING_GB_BYTES)
+        # -o size= requires a positive integer; floor to at least 1 GB before
+        # the min-size check so the check runs against the final value.
+        volume_limit_gb = max(math.floor(slice_bytes * 2 / 3 / _FRESH_SIZING_GB_BYTES), 1)
+        storage_limit_gb = max(math.floor(slice_bytes / 3 / _FRESH_SIZING_GB_BYTES), 1)
 
         if payload.min_volume_gb is not None and volume_limit_gb < payload.min_volume_gb:
             logger.error(
@@ -1537,10 +1557,6 @@ class DockerService:
                 f"Fresh vloopback sizing produced {volume_limit_gb}GB volume, "
                 f"below required minimum {payload.min_volume_gb}GB"
             )
-
-        # -o size= requires a positive integer; floor to at least 1 GB.
-        volume_limit_gb = max(volume_limit_gb, 1)
-        storage_limit_gb = max(storage_limit_gb, 1)
 
         logger.info(
             _m(

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1395,13 +1395,24 @@ class DockerService:
         ssh_client: asyncssh.SSHClientConnection,
         docker_root_dir: str,
     ) -> int:
-        result = await ssh_client.run(f"df -B1 --output=avail {shlex.quote(docker_root_dir)}")
+        # The validator's SSH session lands inside the miner's executor container,
+        # where DockerRootDir (a host path) does not exist. Measure through the
+        # docker daemon instead: bind-mount the host path into a helper container
+        # and run df there. Alpine's busybox df has no --output, so use POSIX -P
+        # and parse the "Available" column (4th) of the data line.
+        result = await ssh_client.run(
+            f"/usr/bin/docker run --rm -v {shlex.quote(docker_root_dir)}:/hostfs:ro "
+            f"{_VLOOPBACK_REPAIR_IMAGE} df -P -B1 /hostfs"
+        )
         if getattr(result, "exit_status", 0) != 0:
-            raise Exception(f"df failed: {getattr(result, 'stderr', '')}")
+            raise Exception(f"df via helper container failed: {getattr(result, 'stderr', '')}")
         lines = (result.stdout or "").strip().splitlines()
         if len(lines) < 2:
             raise Exception(f"Unexpected df output: {result.stdout!r}")
-        return int(lines[1].strip())
+        columns = lines[1].split()
+        if len(columns) < 4 or not columns[3].isdigit():
+            raise Exception(f"Unexpected df output: {result.stdout!r}")
+        return int(columns[3])
 
     async def _get_existing_vloopback_bytes(
         self,

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1,5 +1,7 @@
 import asyncio
+import math
 import random
+from dataclasses import dataclass
 from datetime import datetime
 import logging
 import re
@@ -102,6 +104,49 @@ _DOCKER_NO_SUCH_CONTAINER_PHRASE = "No such container"
 _CREATE_CONTAINER_SSH_KEEPALIVE_INTERVAL_SEC = 30
 _CREATE_CONTAINER_SSH_KEEPALIVE_COUNT_MAX = 4
 _DOCKER_PULL_TIMEOUT_SECONDS = 3 * 60 * 60 # 3 hours
+# DAH-2183: fresh vloopback sizing — compute effective volume/storage limits
+# from on-host disk state when the backend sends disk_share.
+_FRESH_SIZING_OVERHEAD_GB = 20   # reserved for system/docker overhead when reconstructing the pool
+_FRESH_SIZING_HEADROOM_GB = 10   # min free space left on the fs after volume allocation
+_FRESH_SIZING_GB_BYTES = 1024 ** 3
+_VOLUME_SIZE_OPTION_RE = re.compile(r"(\d+(?:\.\d+)?)\s*([kmgt]?)b?", re.IGNORECASE)
+_VOLUME_SIZE_SUFFIX_MULTIPLIERS = {
+    "": 1,
+    "k": 1024,
+    "m": 1024 ** 2,
+    "g": 1024 ** 3,
+    "t": 1024 ** 4,
+}
+
+
+class VolumeMinSizeError(Exception):
+    """Fresh vloopback sizing produced a volume smaller than the requested minimum."""
+
+
+@dataclass
+class VolumeSizingResult:
+    volume_limit_gb: int | None    # -> docker volume create -o size=
+    storage_limit_gb: int | None   # -> docker run --storage-opt size=
+    path: str                      # "fresh" | "legacy" | "fresh_fallback"
+    capped_by: str | None = None   # "pool" | "request_cap" | "df_guard" (fresh path only)
+    df_avail_bytes: int | None = None
+    existing_volumes_bytes: int | None = None
+
+
+def _parse_volume_size_to_bytes(value: str | None) -> int | None:
+    """Parse a docker volume size into bytes.
+
+    Accepts raw byte counts (vloopback ``Status.size-max``) and human size
+    strings like ``19g`` / ``1t`` (vloopback ``Options.size``).
+    """
+    text = (value or "").strip()
+    if not text:
+        return None
+    match = _VOLUME_SIZE_OPTION_RE.fullmatch(text)
+    if not match:
+        return None
+    number, suffix = match.groups()
+    return int(float(number) * _VOLUME_SIZE_SUFFIX_MULTIPLIERS[suffix.lower()])
 
 
 def _is_missing_docker_container_error(exc: Exception) -> bool:
@@ -1345,6 +1390,208 @@ class DockerService:
             timeout=timeout,
         )
 
+    async def _get_fs_available_bytes(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        docker_root_dir: str,
+    ) -> int:
+        result = await ssh_client.run(f"df -B1 --output=avail {shlex.quote(docker_root_dir)}")
+        if getattr(result, "exit_status", 0) != 0:
+            raise Exception(f"df failed: {getattr(result, 'stderr', '')}")
+        lines = (result.stdout or "").strip().splitlines()
+        if len(lines) < 2:
+            raise Exception(f"Unexpected df output: {result.stdout!r}")
+        return int(lines[1].strip())
+
+    async def _get_existing_vloopback_bytes(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+    ) -> int:
+        list_result = await ssh_client.run(
+            '/usr/bin/docker volume ls --format "{{.Name}} {{.Driver}}"'
+        )
+        if getattr(list_result, "exit_status", 0) != 0:
+            raise Exception(
+                f"docker volume ls failed: {getattr(list_result, 'stderr', '')}"
+            )
+
+        volume_names = []
+        for line in (list_result.stdout or "").splitlines():
+            parts = line.strip().split(maxsplit=1)
+            if len(parts) != 2:
+                continue
+            name, driver = parts
+            if _is_vloopback_driver(driver) and _is_safe_docker_volume_name(name):
+                volume_names.append(name)
+        if not volume_names:
+            return 0
+
+        names = " ".join(shlex.quote(name) for name in volume_names)
+        inspect_result = await ssh_client.run(
+            f"/usr/bin/docker volume inspect {names} "
+            "--format '{{index .Status \"size-max\"}}|{{index .Options \"size\"}}'"
+        )
+        if getattr(inspect_result, "exit_status", 0) != 0:
+            raise Exception(
+                f"docker volume inspect failed: {getattr(inspect_result, 'stderr', '')}"
+            )
+
+        total_bytes = 0
+        for line in (inspect_result.stdout or "").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            size_max_raw, _, size_option_raw = line.partition("|")
+            size_bytes = _parse_volume_size_to_bytes(size_max_raw)
+            if size_bytes is None:
+                size_bytes = _parse_volume_size_to_bytes(size_option_raw)
+            if size_bytes is not None:
+                total_bytes += size_bytes
+        return total_bytes
+
+    async def resolve_volume_sizing(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        payload: ContainerCreateRequest,
+        log_tag: str,
+        log_extra: dict,
+    ) -> VolumeSizingResult:
+        """Resolve effective volume/storage limits for a new pod volume (DAH-2183).
+
+        Legacy contract (payload.disk_share is None): backend-sent
+        volume_limit_gb/storage_limit_gb are exact sizes and are returned
+        untouched, without any SSH calls.
+
+        Fresh contract (payload.disk_share set): measure fresh on-host disk
+        state over the existing ssh_client and compute the pod's slice;
+        backend-sent limits act only as upper-bound caps. Measurement
+        failures fall back to legacy passthrough (never break the rent);
+        a VolumeMinSizeError (effective volume below payload.min_volume_gb)
+        propagates to the caller.
+        """
+        if payload.disk_share is None:
+            return VolumeSizingResult(
+                volume_limit_gb=payload.volume_limit_gb,
+                storage_limit_gb=payload.storage_limit_gb,
+                path="legacy",
+            )
+
+        try:
+            docker_root_dir = await self.get_docker_root_dir(ssh_client)
+            df_avail_bytes = await self._get_fs_available_bytes(ssh_client, docker_root_dir)
+            existing_volumes_bytes = await self._get_existing_vloopback_bytes(ssh_client)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                _m(
+                    "vloopback_fresh_sizing_fallback",
+                    extra=get_extra_info({**log_extra, "error": str(exc)}),
+                ),
+                exc_info=True,
+            )
+            return VolumeSizingResult(
+                volume_limit_gb=payload.volume_limit_gb,
+                storage_limit_gb=payload.storage_limit_gb,
+                path="fresh_fallback",
+            )
+
+        pool_bytes = (
+            df_avail_bytes
+            + existing_volumes_bytes
+            - _FRESH_SIZING_OVERHEAD_GB * _FRESH_SIZING_GB_BYTES
+        )
+        slice_candidates = [("pool", payload.disk_share * pool_bytes)]
+        if payload.volume_limit_gb is not None:
+            slice_candidates.append(
+                ("request_cap", payload.volume_limit_gb * _FRESH_SIZING_GB_BYTES * 1.5)
+            )
+        slice_candidates.append(
+            (
+                "df_guard",
+                (df_avail_bytes - _FRESH_SIZING_HEADROOM_GB * _FRESH_SIZING_GB_BYTES) * 1.5,
+            )
+        )
+        capped_by, slice_bytes = min(slice_candidates, key=lambda item: item[1])
+
+        volume_limit_gb = math.floor(slice_bytes * 2 / 3 / _FRESH_SIZING_GB_BYTES)
+        storage_limit_gb = math.floor(slice_bytes / 3 / _FRESH_SIZING_GB_BYTES)
+
+        if payload.min_volume_gb is not None and volume_limit_gb < payload.min_volume_gb:
+            logger.error(
+                _m(
+                    "vloopback_fresh_sizing_below_min",
+                    extra=get_extra_info({
+                        **log_extra,
+                        "requested_volume_limit_gb": payload.volume_limit_gb,
+                        "min_volume_gb": payload.min_volume_gb,
+                        "computed_volume_limit_gb": volume_limit_gb,
+                        "df_avail_bytes": df_avail_bytes,
+                        "existing_volumes_bytes": existing_volumes_bytes,
+                        "disk_share": payload.disk_share,
+                        "docker_root_dir": docker_root_dir,
+                    }),
+                )
+            )
+            raise VolumeMinSizeError(
+                f"Fresh vloopback sizing produced {volume_limit_gb}GB volume, "
+                f"below required minimum {payload.min_volume_gb}GB"
+            )
+
+        # -o size= requires a positive integer; floor to at least 1 GB.
+        volume_limit_gb = max(volume_limit_gb, 1)
+        storage_limit_gb = max(storage_limit_gb, 1)
+
+        logger.info(
+            _m(
+                "vloopback_fresh_sizing_calc",
+                extra=get_extra_info({
+                    **log_extra,
+                    "disk_share": payload.disk_share,
+                    "df_avail_bytes": df_avail_bytes,
+                    "existing_volumes_bytes": existing_volumes_bytes,
+                    "overhead_gb": _FRESH_SIZING_OVERHEAD_GB,
+                    "headroom_gb": _FRESH_SIZING_HEADROOM_GB,
+                    "pool_bytes": pool_bytes,
+                    "slice_bytes": int(slice_bytes),
+                    "slice_candidates": {name: int(value) for name, value in slice_candidates},
+                    "capped_by": capped_by,
+                    "effective_volume_limit_gb": volume_limit_gb,
+                    "effective_storage_limit_gb": storage_limit_gb,
+                    "requested_volume_limit_gb": payload.volume_limit_gb,
+                    "requested_storage_limit_gb": payload.storage_limit_gb,
+                    "docker_root_dir": docker_root_dir,
+                }),
+            )
+        )
+
+        if payload.volume_limit_gb is not None and volume_limit_gb < payload.volume_limit_gb:
+            shrink_key = (
+                "vloopback_fresh_sizing_severe_shrink"
+                if volume_limit_gb < payload.volume_limit_gb / 2
+                else "vloopback_fresh_sizing_shrink"
+            )
+            logger.warning(
+                _m(
+                    shrink_key,
+                    extra=get_extra_info({
+                        **log_extra,
+                        "requested_volume_limit_gb": payload.volume_limit_gb,
+                        "effective_volume_limit_gb": volume_limit_gb,
+                        "capped_by": capped_by,
+                    }),
+                )
+            )
+
+        return VolumeSizingResult(
+            volume_limit_gb=volume_limit_gb,
+            storage_limit_gb=storage_limit_gb,
+            path="fresh",
+            capped_by=capped_by,
+            df_avail_bytes=df_avail_bytes,
+            existing_volumes_bytes=existing_volumes_bytes,
+        )
+
     async def create_container(
         self,
         payload: ContainerCreateRequest,
@@ -1637,8 +1884,23 @@ class DockerService:
                 profilers.append({"name": "Container cleaning step finished", "duration": int(datetime.utcnow().timestamp() * 1000) - prev_timestamp})
                 prev_timestamp = int(datetime.utcnow().timestamp() * 1000)
 
+                # Effective limits default to the backend-sent values (legacy /
+                # restart-edit path); the fresh-sizing path overrides them below.
+                effective_volume_limit_gb = payload.volume_limit_gb
+                effective_storage_limit_gb = payload.storage_limit_gb
+
                 if not local_volume:
-                    # create docker volume
+                    # resolve effective sizing, then create docker volume
+                    current_step = "volume_sizing"
+                    sizing = await self.resolve_volume_sizing(
+                        ssh_client=ssh_client,
+                        payload=payload,
+                        log_tag=log_tag,
+                        log_extra=default_extra,
+                    )
+                    effective_volume_limit_gb = sizing.volume_limit_gb
+                    effective_storage_limit_gb = sizing.storage_limit_gb
+
                     current_step = "volume_creation"
                     local_volume = f"volume_{payload.pod_id}"
                     await self.create_local_volume(
@@ -1647,7 +1909,7 @@ class DockerService:
                         log_tag=log_tag,
                         log_text=f"Creating docker volume {local_volume}",
                         log_extra=default_extra,
-                        limit=payload.volume_limit_gb,
+                        limit=effective_volume_limit_gb,
                     )
                     created_local_volume = True
 
@@ -1697,7 +1959,7 @@ class DockerService:
                     cpu_flag = f"--cpus {payload.cpu_count} " if payload.cpu_count else ""
                 memory_flag = f"--memory {payload.memory_gb}g " if payload.memory_gb else ""
                 
-                storage_flag = f"--storage-opt size={payload.storage_limit_gb}g " if payload.storage_limit_gb else ""
+                storage_flag = f"--storage-opt size={effective_storage_limit_gb}g " if effective_storage_limit_gb else ""
 
                 command = (
                     f'/usr/bin/docker run -d '
@@ -1925,8 +2187,8 @@ class DockerService:
                     restore_path=payload.restore_path,
                     jupyter_url=jupyter_url,
                     warnings=warnings,
-                    storage_limit_gb=payload.storage_limit_gb,
-                    volume_limit_gb=payload.volume_limit_gb,
+                    storage_limit_gb=effective_storage_limit_gb,
+                    volume_limit_gb=effective_volume_limit_gb,
                     local_volume_path=local_volume_path,
                 )
         except Exception as e:

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -2599,3 +2599,131 @@ def test_parse_volume_size_to_bytes_handles_bytes_and_size_strings():
     assert _parse_volume_size_to_bytes("<no value>") is None
     assert _parse_volume_size_to_bytes("") is None
     assert _parse_volume_size_to_bytes(None) is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_volume_sizing_low_free_space_clamps_to_floor(docker_service):
+    # Arrange: df_avail=5GB is below both overhead (20GB) and headroom (10GB);
+    # pool and df_guard candidates must clamp to 0, not go negative.
+    payload = _make_sizing_payload(disk_share=1.0)
+    ssh_client = _make_sizing_ssh_client(df_avail_bytes=5 * _SIZING_GB)
+
+    # Act
+    result = await docker_service.resolve_volume_sizing(ssh_client, payload, "tag", {})
+
+    # Assert
+    assert result.path == "fresh"
+    assert result.volume_limit_gb == 1
+    assert result.storage_limit_gb == 1
+
+
+@pytest.mark.asyncio
+async def test_resolve_volume_sizing_low_free_space_below_min_raises(docker_service):
+    # Arrange: same nearly-full disk, but a min floor is set -> reject.
+    payload = _make_sizing_payload(disk_share=1.0, min_volume_gb=10)
+    ssh_client = _make_sizing_ssh_client(df_avail_bytes=5 * _SIZING_GB)
+
+    # Act / Assert
+    with pytest.raises(VolumeMinSizeError):
+        await docker_service.resolve_volume_sizing(ssh_client, payload, "tag", {})
+
+
+@pytest.mark.asyncio
+async def test_create_container_fresh_sizing_uses_effective_values(
+    docker_service,
+    monkeypatch,
+):
+    """disk_share set: effective fresh values (not payload echoes) must flow into
+    create_local_volume, the docker run --storage-opt flag, and ContainerCreated."""
+    # Arrange: df_avail=900GB, existing vloopback=300GB, share=0.5 -> pool 1180GB,
+    # slice 590GB (request cap 500*1.5=750GB does not bind) -> volume 393, storage 196.
+    def ssh_run(command, **kwargs):
+        if "docker info" in command:
+            return _make_ssh_command_result(stdout="/var/lib/docker\n")
+        if command.startswith("df "):
+            return _make_ssh_command_result(stdout=f"       Avail\n{900 * _SIZING_GB}\n")
+        if "volume ls" in command:
+            return _make_ssh_command_result(stdout="volume_other vloopback\n")
+        if "volume inspect" in command:
+            return _make_ssh_command_result(stdout=f"{300 * _SIZING_GB}|<no value>\n")
+        return _make_ssh_command_result()
+
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(side_effect=ssh_run)
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr("services.docker_service.build_gpu_flags", AsyncMock(return_value=""))
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.add_pending_pod = AsyncMock()
+    docker_service.redis_service.remove_pending_pod = AsyncMock()
+    docker_service.redis_service.add_rented_pod = AsyncMock()
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        docker_service,
+        "generate_portMappings",
+        AsyncMock(return_value=([(22, 20001, 20001)], None)),
+    )
+    monkeypatch.setattr(docker_service, "execute_and_stream_logs", AsyncMock())
+    monkeypatch.setattr(docker_service, "clean_existing_containers", AsyncMock())
+    monkeypatch.setattr(docker_service, "clean_stale_vloopback_volumes", AsyncMock())
+    monkeypatch.setattr(docker_service, "create_local_volume", AsyncMock())
+    monkeypatch.setattr(
+        docker_service,
+        "wait_for_port_check_containers",
+        AsyncMock(return_value=(True, "ok")),
+    )
+    monkeypatch.setattr(docker_service, "_run_docker_create_with_port_retry", AsyncMock())
+    monkeypatch.setattr(docker_service, "check_container_running", AsyncMock(return_value=True))
+    monkeypatch.setattr(docker_service, "install_open_ssh_server_and_start_ssh_service", AsyncMock())
+    monkeypatch.setattr(docker_service, "stream_log", AsyncMock())
+    monkeypatch.setattr(docker_service, "finish_stream_logs", AsyncMock())
+    monkeypatch.setattr(docker_service, "handle_stream_logs", AsyncMock())
+
+    payload = ContainerCreateRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        docker_image="daturaai/pytorch:test",
+        user_public_keys=["ssh-ed25519 test-key"],
+        gpu_uuids=["GPU-test"],
+        cpu_count=1,
+        memory_gb=1,
+        volume_limit_gb=500,
+        storage_limit_gb=250,
+        disk_share=0.5,
+        available_ports=[PayloadPortMapping(internal_port=20001, external_port=20001)],
+        pod_mapping=[],
+        active_container_names=[],
+        active_volume_names=[],
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+    )
+    keypair = Mock(ss58_address="validator-hotkey")
+
+    # Act
+    result = await docker_service.create_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=keypair,
+        private_key="encrypted",
+    )
+
+    # Assert: fresh-computed volume limit reaches docker volume create
+    assert docker_service.create_local_volume.await_args.kwargs["limit"] == 393
+    # Assert: fresh-computed storage limit reaches docker run --storage-opt
+    run_command = docker_service._run_docker_create_with_port_retry.await_args.kwargs["command"]
+    assert "--storage-opt size=196g" in run_command
+    # Assert: ContainerCreated carries effective values, not payload echoes
+    assert result.volume_limit_gb == 393
+    assert result.storage_limit_gb == 196

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -2445,10 +2445,16 @@ def _make_sizing_ssh_client(
     def run(command, **kwargs):
         if "docker info" in command:
             return Mock(stdout="/var/lib/docker\n", exit_status=0)
-        if command.startswith("df "):
+        if "df -P -B1 /hostfs" in command:
             if df_error:
                 raise Exception("df boom")
-            return Mock(stdout=f"       Avail\n{df_avail_bytes}\n", exit_status=0)
+            return Mock(
+                stdout=(
+                    "Filesystem           1-blocks       Used Available Capacity Mounted on\n"
+                    f"/dev/vda1            1000 500 {df_avail_bytes}  80% /hostfs\n"
+                ),
+                exit_status=0,
+            )
         if "volume ls" in command:
             return Mock(stdout=volume_ls_stdout, exit_status=0)
         if "volume inspect" in command:
@@ -2458,6 +2464,69 @@ def _make_sizing_ssh_client(
     ssh_client = Mock()
     ssh_client.run = AsyncMock(side_effect=run)
     return ssh_client
+
+
+@pytest.mark.asyncio
+async def test_get_fs_available_bytes_happy_parse(docker_service):
+    # Arrange: df runs via helper container; POSIX -P output, Available = 4th column.
+    ssh_client = Mock()
+    ssh_client.run = AsyncMock(
+        return_value=Mock(
+            stdout=(
+                "Filesystem           1-blocks       Used Available Capacity Mounted on\n"
+                "/dev/vda1            103865303040 83581857792 20266668032  80% /hostfs\n"
+            ),
+            exit_status=0,
+        )
+    )
+
+    # Act
+    avail = await docker_service._get_fs_available_bytes(ssh_client, "/var/lib/docker")
+
+    # Assert
+    assert avail == 20266668032
+    command = ssh_client.run.call_args.args[0]
+    assert command == (
+        "/usr/bin/docker run --rm -v /var/lib/docker:/hostfs:ro "
+        "docker.io/library/alpine:3.19 df -P -B1 /hostfs"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_fs_available_bytes_nonzero_exit_raises(docker_service):
+    # Arrange
+    ssh_client = Mock()
+    ssh_client.run = AsyncMock(
+        return_value=Mock(stdout="", stderr="docker: boom", exit_status=125)
+    )
+
+    # Act / Assert
+    with pytest.raises(Exception, match="docker: boom"):
+        await docker_service._get_fs_available_bytes(ssh_client, "/var/lib/docker")
+
+
+@pytest.mark.asyncio
+async def test_get_fs_available_bytes_garbage_output_raises(docker_service):
+    # Arrange: data line lacks a numeric 4th column.
+    ssh_client = Mock()
+    ssh_client.run = AsyncMock(
+        return_value=Mock(stdout="Filesystem\ngarbage line\n", exit_status=0)
+    )
+
+    # Act / Assert
+    with pytest.raises(Exception, match="Unexpected df output"):
+        await docker_service._get_fs_available_bytes(ssh_client, "/var/lib/docker")
+
+
+@pytest.mark.asyncio
+async def test_get_fs_available_bytes_short_output_raises(docker_service):
+    # Arrange: only the header line, no data line.
+    ssh_client = Mock()
+    ssh_client.run = AsyncMock(return_value=Mock(stdout="Filesystem\n", exit_status=0))
+
+    # Act / Assert
+    with pytest.raises(Exception, match="Unexpected df output"):
+        await docker_service._get_fs_available_bytes(ssh_client, "/var/lib/docker")
 
 
 @pytest.mark.asyncio
@@ -2640,8 +2709,13 @@ async def test_create_container_fresh_sizing_uses_effective_values(
     def ssh_run(command, **kwargs):
         if "docker info" in command:
             return _make_ssh_command_result(stdout="/var/lib/docker\n")
-        if command.startswith("df "):
-            return _make_ssh_command_result(stdout=f"       Avail\n{900 * _SIZING_GB}\n")
+        if "df -P -B1 /hostfs" in command:
+            return _make_ssh_command_result(
+                stdout=(
+                    "Filesystem           1-blocks       Used Available Capacity Mounted on\n"
+                    f"/dev/vda1            1000 500 {900 * _SIZING_GB}  80% /hostfs\n"
+                )
+            )
         if "volume ls" in command:
             return _make_ssh_command_result(stdout="volume_other vloopback\n")
         if "volume inspect" in command:

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -1,5 +1,5 @@
 import shlex
-from unittest.mock import AsyncMock, Mock, MagicMock
+from unittest.mock import AsyncMock, Mock, MagicMock, patch
 from uuid import uuid4, UUID
 from datetime import datetime
 
@@ -7,7 +7,11 @@ import pytest
 import pytest_asyncio
 from tenacity import Future, RetryError
 
-from services.docker_service import DockerService
+from services.docker_service import (
+    DockerService,
+    VolumeMinSizeError,
+    _parse_volume_size_to_bytes,
+)
 from payload_models.payloads import (
     ContainerCreateRequest,
     ContainerDeleteRequest,
@@ -2410,3 +2414,188 @@ async def test_wait_for_port_check_late_call_force_cleans_stale_health_check(
         "docker rm -f" in c and "health_check_" in c and "container_5TestMiner_" in c
         for c in FakeSSHClient.seen
     ), f"force-rm xargs missing. Seen: {FakeSSHClient.seen}"
+
+
+# ---------------------------------------------------------------------------
+# DAH-2183: validator-side fresh vloopback sizing
+# ---------------------------------------------------------------------------
+
+_SIZING_GB = 1024 ** 3
+
+
+def _make_sizing_payload(**overrides) -> ContainerCreateRequest:
+    defaults = dict(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        docker_image="daturaai/pytorch:test",
+        user_public_keys=["ssh-ed25519 test-key"],
+        gpu_uuids=["GPU-test"],
+    )
+    defaults.update(overrides)
+    return ContainerCreateRequest(**defaults)
+
+
+def _make_sizing_ssh_client(
+    df_avail_bytes: int,
+    volume_ls_stdout: str = "",
+    volume_inspect_stdout: str = "",
+    df_error: bool = False,
+) -> Mock:
+    def run(command, **kwargs):
+        if "docker info" in command:
+            return Mock(stdout="/var/lib/docker\n", exit_status=0)
+        if command.startswith("df "):
+            if df_error:
+                raise Exception("df boom")
+            return Mock(stdout=f"       Avail\n{df_avail_bytes}\n", exit_status=0)
+        if "volume ls" in command:
+            return Mock(stdout=volume_ls_stdout, exit_status=0)
+        if "volume inspect" in command:
+            return Mock(stdout=volume_inspect_stdout, exit_status=0)
+        raise AssertionError(f"unexpected ssh command: {command}")
+
+    ssh_client = Mock()
+    ssh_client.run = AsyncMock(side_effect=run)
+    return ssh_client
+
+
+@pytest.mark.asyncio
+async def test_resolve_volume_sizing_legacy_passthrough(docker_service):
+    # Arrange
+    payload = _make_sizing_payload(volume_limit_gb=40, storage_limit_gb=20)
+    ssh_client = Mock()
+    ssh_client.run = AsyncMock()
+
+    # Act
+    result = await docker_service.resolve_volume_sizing(ssh_client, payload, "tag", {})
+
+    # Assert
+    assert result.path == "legacy"
+    assert result.volume_limit_gb == 40
+    assert result.storage_limit_gb == 20
+    assert result.capped_by is None
+    ssh_client.run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_volume_sizing_fresh_pool_bound(docker_service):
+    # Arrange: df_avail=900GB, existing volumes=300GB, overhead 20 -> pool 1180GB,
+    # disk_share 0.5 -> slice 590GB -> volume 393GB, storage 196GB.
+    payload = _make_sizing_payload(disk_share=0.5)
+    ssh_client = _make_sizing_ssh_client(
+        df_avail_bytes=900 * _SIZING_GB,
+        volume_ls_stdout="volume_abc vloopback:latest\nother_volume local\n",
+        volume_inspect_stdout=f"{300 * _SIZING_GB}|<no value>\n",
+    )
+
+    # Act
+    result = await docker_service.resolve_volume_sizing(ssh_client, payload, "tag", {})
+
+    # Assert
+    assert result.path == "fresh"
+    assert result.capped_by == "pool"
+    assert result.volume_limit_gb == 393
+    assert result.storage_limit_gb == 196
+    assert result.df_avail_bytes == 900 * _SIZING_GB
+    assert result.existing_volumes_bytes == 300 * _SIZING_GB
+
+
+@pytest.mark.asyncio
+async def test_resolve_volume_sizing_fresh_request_cap_bound(docker_service):
+    # Arrange: pool slice would be 590GB but request cap is 100GB * 1.5 = 150GB.
+    payload = _make_sizing_payload(disk_share=0.5, volume_limit_gb=100, storage_limit_gb=50)
+    ssh_client = _make_sizing_ssh_client(
+        df_avail_bytes=900 * _SIZING_GB,
+        volume_ls_stdout="volume_abc vloopback\n",
+        volume_inspect_stdout=f"{300 * _SIZING_GB}|<no value>\n",
+    )
+
+    # Act
+    result = await docker_service.resolve_volume_sizing(ssh_client, payload, "tag", {})
+
+    # Assert
+    assert result.path == "fresh"
+    assert result.capped_by == "request_cap"
+    assert result.volume_limit_gb == 100
+    assert result.storage_limit_gb == 50
+
+
+@pytest.mark.asyncio
+async def test_resolve_volume_sizing_fresh_df_guard_bound(docker_service):
+    # Arrange: df_avail=50GB, existing=1000GB, share=0.9 -> pool slice 927GB,
+    # df guard (50-10)*1.5 = 60GB wins -> volume 40GB, storage 20GB.
+    payload = _make_sizing_payload(disk_share=0.9)
+    ssh_client = _make_sizing_ssh_client(
+        df_avail_bytes=50 * _SIZING_GB,
+        volume_ls_stdout="volume_abc vloopback\n",
+        volume_inspect_stdout="<no value>|1000g\n",
+    )
+
+    # Act
+    result = await docker_service.resolve_volume_sizing(ssh_client, payload, "tag", {})
+
+    # Assert
+    assert result.path == "fresh"
+    assert result.capped_by == "df_guard"
+    assert result.volume_limit_gb == 40
+    assert result.storage_limit_gb == 20
+
+
+@pytest.mark.asyncio
+async def test_resolve_volume_sizing_below_min_raises(docker_service):
+    # Arrange: df_avail=30GB, no volumes, share=0.5 -> pool 10GB, slice 5GB,
+    # volume 3GB < min_volume_gb=10.
+    payload = _make_sizing_payload(disk_share=0.5, min_volume_gb=10)
+    ssh_client = _make_sizing_ssh_client(df_avail_bytes=30 * _SIZING_GB)
+
+    # Act / Assert
+    with pytest.raises(VolumeMinSizeError):
+        await docker_service.resolve_volume_sizing(ssh_client, payload, "tag", {})
+
+
+@pytest.mark.asyncio
+async def test_resolve_volume_sizing_severe_shrink_logged(docker_service):
+    # Arrange: requested 1000GB, share=1.0, df_avail=100GB, no volumes ->
+    # pool 80GB binds -> volume 53GB < 1000/2 -> severe shrink.
+    payload = _make_sizing_payload(disk_share=1.0, volume_limit_gb=1000)
+    ssh_client = _make_sizing_ssh_client(df_avail_bytes=100 * _SIZING_GB)
+
+    # Act
+    with patch("services.docker_service.logger") as mock_logger:
+        result = await docker_service.resolve_volume_sizing(ssh_client, payload, "tag", {})
+
+    # Assert
+    assert result.path == "fresh"
+    assert result.capped_by == "pool"
+    assert result.volume_limit_gb == 53
+    warning_keys = [call.args[0].message for call in mock_logger.warning.call_args_list]
+    assert "vloopback_fresh_sizing_severe_shrink" in warning_keys
+
+
+@pytest.mark.asyncio
+async def test_resolve_volume_sizing_measurement_failure_falls_back(docker_service):
+    # Arrange
+    payload = _make_sizing_payload(disk_share=0.5, volume_limit_gb=40, storage_limit_gb=20)
+    ssh_client = _make_sizing_ssh_client(df_avail_bytes=0, df_error=True)
+
+    # Act
+    with patch("services.docker_service.logger") as mock_logger:
+        result = await docker_service.resolve_volume_sizing(ssh_client, payload, "tag", {})
+
+    # Assert
+    assert result.path == "fresh_fallback"
+    assert result.volume_limit_gb == 40
+    assert result.storage_limit_gb == 20
+    warning_keys = [call.args[0].message for call in mock_logger.warning.call_args_list]
+    assert "vloopback_fresh_sizing_fallback" in warning_keys
+
+
+def test_parse_volume_size_to_bytes_handles_bytes_and_size_strings():
+    # Arrange / Act / Assert
+    assert _parse_volume_size_to_bytes("20401094656") == 20401094656
+    assert _parse_volume_size_to_bytes("19g") == 19 * 1024 ** 3
+    assert _parse_volume_size_to_bytes("1t") == 1024 ** 4
+    assert _parse_volume_size_to_bytes("<no value>") is None
+    assert _parse_volume_size_to_bytes("") is None
+    assert _parse_volume_size_to_bytes(None) is None


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2183](https://www.notion.so/375b8bfdbde9819eabb7c05fe86a7657)

---

## Problem

Rents fail at volume creation because the backend sizes vloopback volumes from stale `MachineSpecs.hard_disk.free` that can describe the wrong filesystem. Last 7 days: 6 `failure_step=volume_creation` failures across 3 executors. Reference incident (2026-06-10 19:58:06 UTC, pod `e1861f34-1374-4866-a968-fccd152bf88b`, executor `4229e5b8-34b7-41e2-9c67-2c76aeeafcb9`, miner `5Eh4hsGH4X7sfNbnY1ghB5hcGR85bew8Eeyp4ku9Y2QCCU58`):

```
docker volume create -d vloopback volume_e1861f34-... -o size=866g
VolumeDriver.Create: not enough disk space: 'fallocate: fallocate failed: No space left on device'
```

The real allocation happens validator-side (`create_local_volume`, fallocate / non-sparse), so the validator is the only place that can observe fresh disk state right before creation.

## Solution

New contract fields in `ContainerCreateRequest` (both nullable, fully backward compatible):

- `disk_share` — pod's share of machine disk (`rented_gpus / total_gpus`). When set, the validator computes effective limits from fresh on-host state; the sent `volume_limit_gb`/`storage_limit_gb` become **upper-bound caps** instead of exact sizes.
- `min_volume_gb` — reject floor: if effective volume falls below it, the rent fails via the existing `FailedContainerRequest` path (`failure_step=volume_sizing`). Stays `null` until templates declare a minimum.

Fresh sizing (in `resolve_volume_sizing`, mirrors the backend's existing pool semantics with fresh data sources):

```
pool      = df_avail(DockerRootDir fs) + Σ existing vloopback volume sizes − 20 GB overhead
slice     = disk_share × pool, capped by requested volume × 3/2 and (df_avail − 10 GB) × 3/2
volume    = 2/3 × slice;  storage = 1/3 × slice   (same split as backend)
```

Effective values flow into `docker volume create -o size=`, `--storage-opt`, and are returned in `ContainerCreated` — compute-app already persists returned values in `handle_rent_success()`, no backend persistence changes needed.

When `disk_share` is absent (old backend, filler/default jobs, pod restart/edit with existing `local_volume`) the legacy exact-size path is byte-for-byte unchanged. If fresh measurement fails over SSH, the validator falls back to legacy values with a loud structured warning — measurement failure never breaks a rent.

## Changes

- `payload_models/payloads.py`: `disk_share` + `min_volume_gb` fields with contract docstring.
- `services/docker_service.py`: `resolve_volume_sizing()` (encapsulates legacy/fresh decision), `VolumeSizingResult`, `VolumeMinSizeError`, SSH measurement helpers (`df -B1`, batched `docker volume inspect` with safe-name filtering + `shlex.quote`), negative-candidate clamps for low-free-space hosts.
- Structured observability: `vloopback_fresh_sizing_calc` (full calculation breakdown), `_shrink`, `_severe_shrink` (effective < requested/2), `_below_min`, `_fallback`, `_unparsable_volume_size`.
- 11 new tests: legacy passthrough, pool/cap/df-guard binding, min rejection, severe-shrink marker, SSH-failure fallback, size parsing, low-free-space clamps, and a `create_container`-level wiring test pinning effective values into `-o size=`, `--storage-opt`, and `ContainerCreated`.

## Deployment Steps

Use GitHub Action. **Deploy this validator PR before the compute-app counterpart** — the backend starts sending `disk_share` only after the validator understands it (old validator would silently ignore the unknown field, which is also safe).

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

- Datura-ai/lium-io-backend#684 — sends `disk_share = gpu_count / total_gpus` for customer rentals (deploy after this PR; restart/filler stay legacy).

## Risks

- Fresh path mis-sizing → mitigated by request-cap (never larger than today's backend value when sent) and df-guard (never above real free space − 10 GB headroom).
- Hosts with < 20 GB free: pool clamps to 0 → 1 GB floor volume instead of negative sizes (covered by tests).
- Legacy path regression → zero SSH calls and untouched values when `disk_share` is absent; pinned by tests.
- Hostile executor output → volume names validated + quoted before shell interpolation; malformed sizes skipped with a log, never poison the sum.

## Test Cases

### Test Case 1 — unit suite

**Actions:** `cd neurons/validators && pdm run pytest -q`

**Expected Output:** 644 passed, 4 skipped (11 new DAH-2183 tests included).

### Test Case 2 — staging pre-deploy verification (from the task spec)

**Actions:** rent a pod where requested size exceeds real free space; force a severe-shrink case.

**Expected Output:** volume created at reduced size; `ContainerCreated` carries effective values; pod row persists them; `vloopback_fresh_sizing_severe_shrink` appears in validator logs.

### Test Case 3 — staging post-deploy verification (from the task spec)

**Actions:** +1 d: check `failure_step=volume_creation` ENOSPC on executors `4229e5b8-34b7-41e2-9c67-2c76aeeafcb9`, `9a683467-0727-4334-acd2-d39b810b0339`; +7 d: prod-wide fallocate failures vs baseline 6/7d.

**Expected Output:** no ENOSPC volume-creation failures on previously failing executors; shrink warnings visible in Loki.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
