### PR TITLE
DAH-2200 - Add phased min NVIDIA driver requirement (rented executors exempt)

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -132,9 +132,11 @@ class Settings(BaseSettings):
 
     # Minimum NVIDIA driver requirement. Compared as a dotted version tuple against the
     # executor's reported gpu.driver (e.g. "580.95.05"). 580.65.06 is the r580 floor that
-    # ships CUDA 13.0. Non-compliant unrented executors are fully gated (multiplier 0);
-    # currently-rented executors are exempt.
+    # ships CUDA 13.0. Before MIN_DRIVER_CUTOFF providers get a grace period (no penalty);
+    # on/after the cutoff, non-compliant unrented executors are fully gated (multiplier 0).
+    # Currently-rented executors are always exempt.
     MIN_NVIDIA_DRIVER_VERSION: str = Field(env="MIN_NVIDIA_DRIVER_VERSION", default="580.65.06")
+    MIN_DRIVER_CUTOFF: datetime = datetime(2026, 7, 15, 12, 0, 0)
 
     TIME_DELTA_FOR_EMISSION: float = 0.01
 

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -136,7 +136,7 @@ class Settings(BaseSettings):
     # on/after the cutoff, non-compliant unrented executors are fully gated (multiplier 0).
     # Currently-rented executors are always exempt.
     MIN_NVIDIA_DRIVER_VERSION: str = Field(env="MIN_NVIDIA_DRIVER_VERSION", default="580.65.06")
-    MIN_DRIVER_CUTOFF: datetime = datetime(2026, 6, 16, 12, 0, 0)
+    MIN_DRIVER_CUTOFF: datetime = datetime(2026, 6, 24, 12, 0, 0)
 
     TIME_DELTA_FOR_EMISSION: float = 0.01
 

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -136,7 +136,7 @@ class Settings(BaseSettings):
     # on/after the cutoff, non-compliant unrented executors are fully gated (multiplier 0).
     # Currently-rented executors are always exempt.
     MIN_NVIDIA_DRIVER_VERSION: str = Field(env="MIN_NVIDIA_DRIVER_VERSION", default="580.65.06")
-    MIN_DRIVER_CUTOFF: datetime = datetime(2026, 7, 15, 12, 0, 0)
+    MIN_DRIVER_CUTOFF: datetime = datetime(2026, 6, 19, 12, 0, 0)
 
     TIME_DELTA_FOR_EMISSION: float = 0.01
 

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -130,6 +130,15 @@ class Settings(BaseSettings):
     SYSBOX_RENTED_CUTOFF: datetime = datetime(2026, 4, 3, 12, 0, 0)
     DISCORD_INCENTIVE_CUTOFF: datetime = datetime(2026, 6, 15, 12, 0, 0)
 
+    # Minimum NVIDIA driver requirement (phased gate, mirrors the sysbox rollout).
+    # Compared as a dotted version tuple against the executor's reported gpu.driver
+    # (e.g. "580.95.05"). 580.65.06 is the r580 floor that ships CUDA 13.0. An executor
+    # below this is penalised before MIN_DRIVER_CUTOFF and fully gated on/after it.
+    MIN_NVIDIA_DRIVER_VERSION: str = Field(env="MIN_NVIDIA_DRIVER_VERSION", default="580.65.06")
+    PORTION_FOR_MIN_DRIVER_BEFORE: float = 0.2  # soft penalty before the cutoff (1 - 0.2 = 0.8x)
+    PORTION_FOR_MIN_DRIVER_AFTER: float = 1  # full gate on/after the cutoff (1 - 1 = 0x)
+    MIN_DRIVER_CUTOFF: datetime = datetime(2026, 7, 15, 12, 0, 0)
+
     TIME_DELTA_FOR_EMISSION: float = 0.01
 
     # Read version from version.txt

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -136,7 +136,7 @@ class Settings(BaseSettings):
     # on/after the cutoff, non-compliant unrented executors are fully gated (multiplier 0).
     # Currently-rented executors are always exempt.
     MIN_NVIDIA_DRIVER_VERSION: str = Field(env="MIN_NVIDIA_DRIVER_VERSION", default="580.65.06")
-    MIN_DRIVER_CUTOFF: datetime = datetime(2026, 6, 19, 12, 0, 0)
+    MIN_DRIVER_CUTOFF: datetime = datetime(2026, 6, 16, 12, 0, 0)
 
     TIME_DELTA_FOR_EMISSION: float = 0.01
 

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -130,14 +130,11 @@ class Settings(BaseSettings):
     SYSBOX_RENTED_CUTOFF: datetime = datetime(2026, 4, 3, 12, 0, 0)
     DISCORD_INCENTIVE_CUTOFF: datetime = datetime(2026, 6, 15, 12, 0, 0)
 
-    # Minimum NVIDIA driver requirement (phased gate, mirrors the sysbox rollout).
-    # Compared as a dotted version tuple against the executor's reported gpu.driver
-    # (e.g. "580.95.05"). 580.65.06 is the r580 floor that ships CUDA 13.0. An executor
-    # below this is penalised before MIN_DRIVER_CUTOFF and fully gated on/after it.
+    # Minimum NVIDIA driver requirement. Compared as a dotted version tuple against the
+    # executor's reported gpu.driver (e.g. "580.95.05"). 580.65.06 is the r580 floor that
+    # ships CUDA 13.0. Non-compliant unrented executors are fully gated (multiplier 0);
+    # currently-rented executors are exempt.
     MIN_NVIDIA_DRIVER_VERSION: str = Field(env="MIN_NVIDIA_DRIVER_VERSION", default="580.65.06")
-    PORTION_FOR_MIN_DRIVER_BEFORE: float = 0.2  # soft penalty before the cutoff (1 - 0.2 = 0.8x)
-    PORTION_FOR_MIN_DRIVER_AFTER: float = 1  # full gate on/after the cutoff (1 - 1 = 0x)
-    MIN_DRIVER_CUTOFF: datetime = datetime(2026, 7, 15, 12, 0, 0)
 
     TIME_DELTA_FOR_EMISSION: float = 0.01
 

--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -4,8 +4,6 @@ This implementation extracts the original score calculation and weight distribut
 logic to maintain backward compatibility with the existing system.
 """
 
-from datetime import UTC, datetime
-
 import bittensor
 
 from core.config import settings
@@ -28,23 +26,15 @@ def _parse_driver_version(value: str) -> tuple[int, ...] | None:
         return None
 
 
-def get_min_driver_multiplier(
-    driver_version: str,
-    is_rented: bool = False,
-    reference_time: datetime | None = None,
-) -> float:
-    """Phased minimum NVIDIA driver multiplier (mirrors the sysbox gate).
+def get_min_driver_multiplier(driver_version: str, is_rented: bool = False) -> float:
+    """Minimum NVIDIA driver multiplier — hard gate at 0 for non-compliant unrented executors.
 
     An executor whose reported driver is at least ``settings.MIN_NVIDIA_DRIVER_VERSION``
-    (compared as a dotted version tuple) is unaffected (multiplier 1.0). Otherwise a soft
-    penalty (``PORTION_FOR_MIN_DRIVER_BEFORE``) applies until ``MIN_DRIVER_CUTOFF`` and a
-    full gate (``PORTION_FOR_MIN_DRIVER_AFTER``, default 1.0 → multiplier 0.0) after it.
+    (compared as a dotted version tuple) is unaffected (multiplier 1.0). A non-compliant
+    unrented executor is fully gated (multiplier 0.0).
 
-    Currently-rented executors are exempt from the gate — an active customer must not be
-    penalised because their miner has not yet upgraded the host driver.
-
-    ``reference_time`` is normalised to naive-UTC so it can be compared with the naive
-    cutoff (same convention as ``SYSBOX_RENTED_CUTOFF``); tests may inject it.
+    Currently-rented executors are exempt — an active customer must not be penalised
+    because their miner has not yet upgraded the host driver.
 
     A missing or unparseable ``driver_version`` means the value was not reported (a real
     GPU always reports a driver string), so the gate fails open rather than penalising an
@@ -56,15 +46,7 @@ def get_min_driver_multiplier(
     required = _parse_driver_version(settings.MIN_NVIDIA_DRIVER_VERSION)
     if reported is None or required is None or reported >= required:
         return 1.0
-    now = reference_time or datetime.now(UTC)
-    if now.tzinfo is not None:
-        now = now.astimezone(UTC).replace(tzinfo=None)
-    portion = (
-        settings.PORTION_FOR_MIN_DRIVER_AFTER
-        if now >= settings.MIN_DRIVER_CUTOFF
-        else settings.PORTION_FOR_MIN_DRIVER_BEFORE
-    )
-    return 1 - portion
+    return 0.0
 
 
 class DefaultIncentive(BaseIncentive):

--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -4,6 +4,8 @@ This implementation extracts the original score calculation and weight distribut
 logic to maintain backward compatibility with the existing system.
 """
 
+from datetime import UTC, datetime
+
 import bittensor
 
 from core.config import settings
@@ -26,25 +28,38 @@ def _parse_driver_version(value: str) -> tuple[int, ...] | None:
         return None
 
 
-def get_min_driver_multiplier(driver_version: str, is_rented: bool = False) -> float:
-    """Minimum NVIDIA driver multiplier — hard gate at 0 for non-compliant unrented executors.
+def get_min_driver_multiplier(
+    driver_version: str,
+    is_rented: bool = False,
+    reference_time: datetime | None = None,
+) -> float:
+    """Minimum NVIDIA driver multiplier with a grace period.
 
     An executor whose reported driver is at least ``settings.MIN_NVIDIA_DRIVER_VERSION``
     (compared as a dotted version tuple) is unaffected (multiplier 1.0). A non-compliant
-    unrented executor is fully gated (multiplier 0.0).
+    unrented executor gets a grace period until ``settings.MIN_DRIVER_CUTOFF`` (multiplier
+    1.0) and is fully gated on/after it (multiplier 0.0).
 
-    Currently-rented executors are exempt — an active customer must not be penalised
-    because their miner has not yet upgraded the host driver.
+    Currently-rented executors are always exempt — an active customer must not be
+    penalised because their miner has not yet upgraded the host driver.
 
     A missing or unparseable ``driver_version`` means the value was not reported (a real
     GPU always reports a driver string), so the gate fails open rather than penalising an
     unknown reading.
+
+    ``reference_time`` is normalised to naive-UTC so it can be compared with the naive
+    cutoff (same convention as ``SYSBOX_RENTED_CUTOFF``); tests may inject it.
     """
     if is_rented:
         return 1.0
     reported = _parse_driver_version(driver_version)
     required = _parse_driver_version(settings.MIN_NVIDIA_DRIVER_VERSION)
     if reported is None or required is None or reported >= required:
+        return 1.0
+    now = reference_time or datetime.now(UTC)
+    if now.tzinfo is not None:
+        now = now.astimezone(UTC).replace(tzinfo=None)
+    if now < settings.MIN_DRIVER_CUTOFF:
         return 1.0
     return 0.0
 

--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -4,6 +4,8 @@ This implementation extracts the original score calculation and weight distribut
 logic to maintain backward compatibility with the existing system.
 """
 
+from datetime import UTC, datetime
+
 import bittensor
 
 from core.config import settings
@@ -13,6 +15,56 @@ from services.const import TOTAL_BURN_EMISSION
 from services.task_service import JobResult
 
 logger = get_logger(__name__)
+
+
+def _parse_driver_version(value: str) -> tuple[int, ...] | None:
+    """Parse a dotted NVIDIA driver version (e.g. "580.95.05") into an int tuple for
+    ordering. Returns None when the value is missing or non-numeric."""
+    if not value:
+        return None
+    try:
+        return tuple(int(part) for part in str(value).strip().split("."))
+    except (TypeError, ValueError):
+        return None
+
+
+def get_min_driver_multiplier(
+    driver_version: str,
+    is_rented: bool = False,
+    reference_time: datetime | None = None,
+) -> float:
+    """Phased minimum NVIDIA driver multiplier (mirrors the sysbox gate).
+
+    An executor whose reported driver is at least ``settings.MIN_NVIDIA_DRIVER_VERSION``
+    (compared as a dotted version tuple) is unaffected (multiplier 1.0). Otherwise a soft
+    penalty (``PORTION_FOR_MIN_DRIVER_BEFORE``) applies until ``MIN_DRIVER_CUTOFF`` and a
+    full gate (``PORTION_FOR_MIN_DRIVER_AFTER``, default 1.0 → multiplier 0.0) after it.
+
+    Currently-rented executors are exempt from the gate — an active customer must not be
+    penalised because their miner has not yet upgraded the host driver.
+
+    ``reference_time`` is normalised to naive-UTC so it can be compared with the naive
+    cutoff (same convention as ``SYSBOX_RENTED_CUTOFF``); tests may inject it.
+
+    A missing or unparseable ``driver_version`` means the value was not reported (a real
+    GPU always reports a driver string), so the gate fails open rather than penalising an
+    unknown reading.
+    """
+    if is_rented:
+        return 1.0
+    reported = _parse_driver_version(driver_version)
+    required = _parse_driver_version(settings.MIN_NVIDIA_DRIVER_VERSION)
+    if reported is None or required is None or reported >= required:
+        return 1.0
+    now = reference_time or datetime.now(UTC)
+    if now.tzinfo is not None:
+        now = now.astimezone(UTC).replace(tzinfo=None)
+    portion = (
+        settings.PORTION_FOR_MIN_DRIVER_AFTER
+        if now >= settings.MIN_DRIVER_CUTOFF
+        else settings.PORTION_FOR_MIN_DRIVER_BEFORE
+    )
+    return 1 - portion
 
 
 class DefaultIncentive(BaseIncentive):
@@ -159,6 +211,11 @@ class DefaultIncentive(BaseIncentive):
 
             job_result.sysbox_multiplier = 1 - portion
 
+        # Minimum NVIDIA driver multiplier (phased gate); rented executors are exempt.
+        job_result.driver_multiplier = get_min_driver_multiplier(
+            job_result.nvidia_driver_version, is_rented=job_result.is_rented
+        )
+
         # Uptime multiplier
         if settings.SKIP_COLLATERAL_PENALTY or job_result.collateral_deposited:
             job_result.uptime_multiplier = 1
@@ -172,15 +229,19 @@ class DefaultIncentive(BaseIncentive):
             )
 
         # Apply multiplier
-        job_result.mining_score *= job_result.sysbox_multiplier * job_result.uptime_multiplier
+        job_result.mining_score *= (
+            job_result.sysbox_multiplier * job_result.uptime_multiplier * job_result.driver_multiplier
+        )
         log = _m(
-            "Mining score is calculated successfully. Formula: score * gpu_portion * gpu_count / total_gpu_count * sysbox_multiplier * uptime_multiplier",
+            "Mining score is calculated successfully. Formula: score * gpu_portion * gpu_count / total_gpu_count * sysbox_multiplier * uptime_multiplier * driver_multiplier",
             extra=get_extra_info(
                 {
                     "executor_id": str(job_result.executor_info.uuid),
                     "gpu_model": job_result.gpu_model,
                     "gpu_count": job_result.gpu_count,
                     "sysbox_multiplier": job_result.sysbox_multiplier,
+                    "driver_multiplier": job_result.driver_multiplier,
+                    "nvidia_driver_version": job_result.nvidia_driver_version,
                     "uptime_multiplier": job_result.uptime_multiplier,
                     "mining_score": job_result.mining_score,
                     "gpu_portion": job_result.gpu_portion,

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from incentive.config import IncentiveConfig
     from services.redis_service import RedisService
 from incentive.utils import get_hourly_rate
-from incentive.default import DefaultIncentive
+from incentive.default import DefaultIncentive, get_min_driver_multiplier
 from incentive.price_provider import PriceProvider
 from services.const import TEMPO, SECONDS_PER_BLOCK, FIXED_RATIO, TOTAL_BURN_EMISSION
 from services.task_service import JobResult
@@ -222,6 +222,9 @@ class RentalPriceIncentive(DefaultIncentive):
             # Sysbox penalty is applied later via effective_rate, not baked into hourly_rate
             result.sysbox_multiplier = 1.0 if result.sysbox_runtime else 1 - settings.PORTION_FOR_SYSBOX_UNRENTED
 
+            # Minimum NVIDIA driver penalty: applied later via effective_rate
+            result.driver_multiplier = get_min_driver_multiplier(result.nvidia_driver_version)
+
             cap_spec = self.config.max_unrented_gpus.get(base_model, {})
             bucket = self._resolve_bucket(result, cap_spec)
             max_cap = cap_spec.get(bucket, 0)
@@ -239,6 +242,7 @@ class RentalPriceIncentive(DefaultIncentive):
                     + result.gpu_count
                     * result.hourly_rate
                     * result.sysbox_multiplier
+                    * result.driver_multiplier
                 )
 
     async def _on_finish_pre_process(self) -> None:
@@ -320,6 +324,7 @@ class RentalPriceIncentive(DefaultIncentive):
             result.hourly_rate
             * result.unrented_cap_multiplier
             * result.sysbox_multiplier
+            * result.driver_multiplier
         )
 
         # calculate incentive score
@@ -341,6 +346,8 @@ class RentalPriceIncentive(DefaultIncentive):
                     "sysbox_runtime": result.sysbox_runtime,
                     "sysbox_multiplier": result.sysbox_multiplier,
                     "provider_discord_connected": result.provider_discord_connected,
+                    "nvidia_driver_version": result.nvidia_driver_version,
+                    "driver_multiplier": result.driver_multiplier,
                     "unrented_cap_multiplier": result.unrented_cap_multiplier,
                     "effective_rate": result.effective_rate,
                     "total_unrented_by_gpu_type": result.total_unrented_by_gpu_type,
@@ -528,6 +535,8 @@ class RentalPriceIncentive(DefaultIncentive):
             gpu_splitting_min_count=params.gpu_splitting_min_count,
             collateral_deposited=params.collateral_deposited,
             sysbox_runtime=params.sysbox_runtime,
+            # Price estimates assume a compliant driver (no requirement penalty).
+            nvidia_driver_version=settings.MIN_NVIDIA_DRIVER_VERSION,
         )
 
         await self._pre_process_job_result("estimate", fake_result)

--- a/neurons/validators/src/services/task/models.py
+++ b/neurons/validators/src/services/task/models.py
@@ -19,6 +19,7 @@ class JobResult(BaseModel):
     gpu_model: str | None = None
     gpu_count: int = 0
     sysbox_runtime: bool = False
+    nvidia_driver_version: str = ""  # reported gpu.driver string, e.g. "580.95.05"
     supports_gpu_splitting: bool = False
     gpu_splitting_min_count: int | None = None
     ssh_pub_keys: list[str] | None = None
@@ -36,6 +37,7 @@ class JobResult(BaseModel):
     # Incentive relevant fields 
     mining_score: float | None = None                   # Score for mining pool for scoring logic
     sysbox_multiplier: float | None = None              # Multiplier for sysbox runtime for scoring logic
+    driver_multiplier: float | None = None              # Multiplier for the minimum NVIDIA driver requirement
     uptime_multiplier: float | None = None              # Multiplier for uptime
     gpu_portion: float | None = None                    # Portion of the GPU model for scoring logic
     total_gpu_count: int | None = None                  # Total number of GPUs of the same model

--- a/neurons/validators/src/services/task/result_handler.py
+++ b/neurons/validators/src/services/task/result_handler.py
@@ -122,6 +122,10 @@ class ResultHandler:
         if context.state.gpu_metrics is not None:
             specs["gpu_metrics"] = context.state.gpu_metrics
 
+        # NVIDIA driver version string reported by NVML (e.g. "580.95.05"). Used by the
+        # minimum-driver requirement gate.
+        nvidia_driver_version = str(specs.get("gpu", {}).get("driver") or "")
+
         # Build and return JobResult
         return JobResult(
             spec=specs,
@@ -135,6 +139,7 @@ class ResultHandler:
             gpu_model=gpu_model,
             gpu_count=gpu_count,
             sysbox_runtime=context.state.sysbox_runtime,
+            nvidia_driver_version=nvidia_driver_version,
             supports_gpu_splitting=context.state.supports_gpu_splitting,
             gpu_splitting_min_count=context.state.gpu_splitting_min_count,
             ssh_pub_keys=context.ssh_pub_keys,

--- a/neurons/validators/tests/test_min_driver_gate.py
+++ b/neurons/validators/tests/test_min_driver_gate.py
@@ -1,55 +1,36 @@
-"""Tests for the phased minimum NVIDIA driver gate (mirrors the sysbox gate)."""
+"""Tests for the minimum NVIDIA driver gate."""
 
-from datetime import UTC, timedelta
-
-from core.config import settings
 from incentive.default import get_min_driver_multiplier
-
-BEFORE_CUTOFF = settings.MIN_DRIVER_CUTOFF - timedelta(days=1)
-AFTER_CUTOFF = settings.MIN_DRIVER_CUTOFF + timedelta(days=1)
 
 
 def test_compliant_driver_is_unaffected():
     # Default floor is 580.65.06 (r580, ships CUDA 13.0).
-    assert get_min_driver_multiplier("580.95.05", reference_time=BEFORE_CUTOFF) == 1.0
-    assert get_min_driver_multiplier("595.45.04", reference_time=AFTER_CUTOFF) == 1.0
+    assert get_min_driver_multiplier("580.95.05") == 1.0
+    assert get_min_driver_multiplier("595.45.04") == 1.0
     # Exactly at the floor is compliant.
-    assert get_min_driver_multiplier("580.65.06", reference_time=AFTER_CUTOFF) == 1.0
+    assert get_min_driver_multiplier("580.65.06") == 1.0
 
 
 def test_unknown_driver_fails_open():
     # A real GPU always reports a driver string; missing/garbage means "not reported".
-    assert get_min_driver_multiplier("", reference_time=AFTER_CUTOFF) == 1.0
-    assert get_min_driver_multiplier("unknown", reference_time=AFTER_CUTOFF) == 1.0
+    assert get_min_driver_multiplier("") == 1.0
+    assert get_min_driver_multiplier("unknown") == 1.0
 
 
-def test_old_driver_soft_penalty_before_cutoff():
-    # 570.211.01 (CUDA 12.8) before the cutoff → soft penalty, not a full gate.
-    expected = 1 - settings.PORTION_FOR_MIN_DRIVER_BEFORE
-    assert get_min_driver_multiplier("570.211.01", reference_time=BEFORE_CUTOFF) == expected
-
-
-def test_old_driver_full_gate_after_cutoff():
-    expected = 1 - settings.PORTION_FOR_MIN_DRIVER_AFTER
-    assert get_min_driver_multiplier("570.211.01", reference_time=AFTER_CUTOFF) == expected
+def test_old_driver_is_fully_gated():
+    # 570.211.01 (CUDA 12.8) is below the 580.65.06 floor — no incentive.
+    assert get_min_driver_multiplier("570.211.01") == 0.0
 
 
 def test_version_compared_numerically_not_lexically():
     # "580.40" < "580.65.06" numerically even though it could mislead a string compare,
     # and 580.211 (hypothetical) must beat the floor on the second component.
-    assert get_min_driver_multiplier("580.40.00", reference_time=AFTER_CUTOFF) == 1 - settings.PORTION_FOR_MIN_DRIVER_AFTER
-    assert get_min_driver_multiplier("580.211.01", reference_time=AFTER_CUTOFF) == 1.0
-
-
-def test_tz_aware_reference_time_is_normalised():
-    aware_after = AFTER_CUTOFF.replace(tzinfo=UTC)
-    assert get_min_driver_multiplier("570.211.01", reference_time=aware_after) == 1 - settings.PORTION_FOR_MIN_DRIVER_AFTER
+    assert get_min_driver_multiplier("580.40.00") == 0.0
+    assert get_min_driver_multiplier("580.211.01") == 1.0
 
 
 def test_rented_executor_is_exempt():
     # An active customer must not be penalised because the miner has not upgraded yet.
-    # Both the soft-penalty window and the post-cutoff full gate are skipped when rented.
-    assert get_min_driver_multiplier("570.211.01", is_rented=True, reference_time=BEFORE_CUTOFF) == 1.0
-    assert get_min_driver_multiplier("570.211.01", is_rented=True, reference_time=AFTER_CUTOFF) == 1.0
-    # Unrented stays gated for parity with the existing behaviour.
-    assert get_min_driver_multiplier("570.211.01", is_rented=False, reference_time=AFTER_CUTOFF) == 1 - settings.PORTION_FOR_MIN_DRIVER_AFTER
+    assert get_min_driver_multiplier("570.211.01", is_rented=True) == 1.0
+    # Unrented stays gated for parity with the unrented behaviour.
+    assert get_min_driver_multiplier("570.211.01", is_rented=False) == 0.0

--- a/neurons/validators/tests/test_min_driver_gate.py
+++ b/neurons/validators/tests/test_min_driver_gate.py
@@ -1,0 +1,55 @@
+"""Tests for the phased minimum NVIDIA driver gate (mirrors the sysbox gate)."""
+
+from datetime import UTC, timedelta
+
+from core.config import settings
+from incentive.default import get_min_driver_multiplier
+
+BEFORE_CUTOFF = settings.MIN_DRIVER_CUTOFF - timedelta(days=1)
+AFTER_CUTOFF = settings.MIN_DRIVER_CUTOFF + timedelta(days=1)
+
+
+def test_compliant_driver_is_unaffected():
+    # Default floor is 580.65.06 (r580, ships CUDA 13.0).
+    assert get_min_driver_multiplier("580.95.05", reference_time=BEFORE_CUTOFF) == 1.0
+    assert get_min_driver_multiplier("595.45.04", reference_time=AFTER_CUTOFF) == 1.0
+    # Exactly at the floor is compliant.
+    assert get_min_driver_multiplier("580.65.06", reference_time=AFTER_CUTOFF) == 1.0
+
+
+def test_unknown_driver_fails_open():
+    # A real GPU always reports a driver string; missing/garbage means "not reported".
+    assert get_min_driver_multiplier("", reference_time=AFTER_CUTOFF) == 1.0
+    assert get_min_driver_multiplier("unknown", reference_time=AFTER_CUTOFF) == 1.0
+
+
+def test_old_driver_soft_penalty_before_cutoff():
+    # 570.211.01 (CUDA 12.8) before the cutoff → soft penalty, not a full gate.
+    expected = 1 - settings.PORTION_FOR_MIN_DRIVER_BEFORE
+    assert get_min_driver_multiplier("570.211.01", reference_time=BEFORE_CUTOFF) == expected
+
+
+def test_old_driver_full_gate_after_cutoff():
+    expected = 1 - settings.PORTION_FOR_MIN_DRIVER_AFTER
+    assert get_min_driver_multiplier("570.211.01", reference_time=AFTER_CUTOFF) == expected
+
+
+def test_version_compared_numerically_not_lexically():
+    # "580.40" < "580.65.06" numerically even though it could mislead a string compare,
+    # and 580.211 (hypothetical) must beat the floor on the second component.
+    assert get_min_driver_multiplier("580.40.00", reference_time=AFTER_CUTOFF) == 1 - settings.PORTION_FOR_MIN_DRIVER_AFTER
+    assert get_min_driver_multiplier("580.211.01", reference_time=AFTER_CUTOFF) == 1.0
+
+
+def test_tz_aware_reference_time_is_normalised():
+    aware_after = AFTER_CUTOFF.replace(tzinfo=UTC)
+    assert get_min_driver_multiplier("570.211.01", reference_time=aware_after) == 1 - settings.PORTION_FOR_MIN_DRIVER_AFTER
+
+
+def test_rented_executor_is_exempt():
+    # An active customer must not be penalised because the miner has not upgraded yet.
+    # Both the soft-penalty window and the post-cutoff full gate are skipped when rented.
+    assert get_min_driver_multiplier("570.211.01", is_rented=True, reference_time=BEFORE_CUTOFF) == 1.0
+    assert get_min_driver_multiplier("570.211.01", is_rented=True, reference_time=AFTER_CUTOFF) == 1.0
+    # Unrented stays gated for parity with the existing behaviour.
+    assert get_min_driver_multiplier("570.211.01", is_rented=False, reference_time=AFTER_CUTOFF) == 1 - settings.PORTION_FOR_MIN_DRIVER_AFTER

--- a/neurons/validators/tests/test_min_driver_gate.py
+++ b/neurons/validators/tests/test_min_driver_gate.py
@@ -1,36 +1,52 @@
 """Tests for the minimum NVIDIA driver gate."""
 
+from datetime import UTC, timedelta
+
+from core.config import settings
 from incentive.default import get_min_driver_multiplier
+
+BEFORE_CUTOFF = settings.MIN_DRIVER_CUTOFF - timedelta(days=1)
+AFTER_CUTOFF = settings.MIN_DRIVER_CUTOFF + timedelta(days=1)
 
 
 def test_compliant_driver_is_unaffected():
     # Default floor is 580.65.06 (r580, ships CUDA 13.0).
-    assert get_min_driver_multiplier("580.95.05") == 1.0
-    assert get_min_driver_multiplier("595.45.04") == 1.0
+    assert get_min_driver_multiplier("580.95.05", reference_time=AFTER_CUTOFF) == 1.0
+    assert get_min_driver_multiplier("595.45.04", reference_time=AFTER_CUTOFF) == 1.0
     # Exactly at the floor is compliant.
-    assert get_min_driver_multiplier("580.65.06") == 1.0
+    assert get_min_driver_multiplier("580.65.06", reference_time=AFTER_CUTOFF) == 1.0
 
 
 def test_unknown_driver_fails_open():
     # A real GPU always reports a driver string; missing/garbage means "not reported".
-    assert get_min_driver_multiplier("") == 1.0
-    assert get_min_driver_multiplier("unknown") == 1.0
+    assert get_min_driver_multiplier("", reference_time=AFTER_CUTOFF) == 1.0
+    assert get_min_driver_multiplier("unknown", reference_time=AFTER_CUTOFF) == 1.0
 
 
-def test_old_driver_is_fully_gated():
-    # 570.211.01 (CUDA 12.8) is below the 580.65.06 floor — no incentive.
-    assert get_min_driver_multiplier("570.211.01") == 0.0
+def test_old_driver_in_grace_period_is_unaffected():
+    # Before the cutoff providers still have time to upgrade — no penalty yet.
+    assert get_min_driver_multiplier("570.211.01", reference_time=BEFORE_CUTOFF) == 1.0
+
+
+def test_old_driver_is_fully_gated_after_cutoff():
+    # On/after the cutoff a non-compliant unrented executor earns nothing.
+    assert get_min_driver_multiplier("570.211.01", reference_time=AFTER_CUTOFF) == 0.0
 
 
 def test_version_compared_numerically_not_lexically():
     # "580.40" < "580.65.06" numerically even though it could mislead a string compare,
     # and 580.211 (hypothetical) must beat the floor on the second component.
-    assert get_min_driver_multiplier("580.40.00") == 0.0
-    assert get_min_driver_multiplier("580.211.01") == 1.0
+    assert get_min_driver_multiplier("580.40.00", reference_time=AFTER_CUTOFF) == 0.0
+    assert get_min_driver_multiplier("580.211.01", reference_time=AFTER_CUTOFF) == 1.0
 
 
 def test_rented_executor_is_exempt():
-    # An active customer must not be penalised because the miner has not upgraded yet.
-    assert get_min_driver_multiplier("570.211.01", is_rented=True) == 1.0
-    # Unrented stays gated for parity with the unrented behaviour.
-    assert get_min_driver_multiplier("570.211.01", is_rented=False) == 0.0
+    # An active customer must not be penalised, even after the cutoff.
+    assert get_min_driver_multiplier("570.211.01", is_rented=True, reference_time=AFTER_CUTOFF) == 1.0
+    # Unrented stays gated after the cutoff.
+    assert get_min_driver_multiplier("570.211.01", is_rented=False, reference_time=AFTER_CUTOFF) == 0.0
+
+
+def test_tz_aware_reference_time_is_normalised():
+    aware_after = AFTER_CUTOFF.replace(tzinfo=UTC)
+    assert get_min_driver_multiplier("570.211.01", reference_time=aware_after) == 0.0


### PR DESCRIPTION
## Describe your changes

Adds a phased gate that penalises executors below `MIN_NVIDIA_DRIVER_VERSION` (default `580.65.06`, the r580 floor that ships CUDA 13.0). Mirrors the sysbox rollout: soft penalty (`PORTION_FOR_MIN_DRIVER_BEFORE = 0.2`) before `MIN_DRIVER_CUTOFF` (2026-07-15), full gate after.

Currently-rented executors are exempt from the gate — an active customer must not lose score because the miner has not yet upgraded the host driver. The exemption lives inside `get_min_driver_multiplier(..., is_rented=...)` so it's the single source of truth.

Driver version is read from `specs["gpu"]["driver"]` in the result handler and threaded through `JobResult.nvidia_driver_version`. The multiplier is logged and surfaced in `JobResult.driver_multiplier` for both the default and rental-price incentive paths.

Tests in `neurons/validators/tests/test_min_driver_gate.py` cover: compliant driver, unknown/missing driver fails open, soft-penalty window, full gate after cutoff, numeric (not lexical) version compare, tz-aware reference time normalisation, and the rented-exemption skip in both windows.

## Issue ticket number and link

[DAH-2200](https://www.notion.so/Compute-SN-c27d35dd084e4c4d92374f55cdd293f2?p=f9b26856f1a6406892b5db46446260da&pm=s)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?