### PR TITLE
validator: clarify NVML_DRIVER_UNKNOWN remediation to prevent blind whitelisting

### DIFF
--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -291,7 +291,13 @@ class NvmlDigestMessages:
         severity="error",
         category="env",
         impact="Score set to 0; previous verification cleared",
-        remediation="Update to a supported NVIDIA driver version. Your current driver version is not recognized.",
+        remediation=(
+            "Do not blindly add this hash to LIB_NVIDIA_ML_DIGESTS. An unrecognized "
+            "version can mean a tampered/spoofed NVML, e.g. a Windows GeForce version "
+            "like 591.86 that has no Linux driver. Only whitelist after confirming it "
+            "is a real NVIDIA Linux release and taking the digest from a clean install, "
+            "never from the reported value."
+        ),
     )
     DIGEST_OK = MessageTemplate(
         event="NVML library digest verified",


### PR DESCRIPTION
## What & why

A prod validator fired `NVML_DRIVER_UNKNOWN` for driver **`591.86`** reported by a Linux executor (subnet executor_id `b9ae1bfe-3788-4998-ad32-71f75a5e9f80`, miner `5EvTSGTCZKgBHKCw2T9jynZVfBQQqx3u1XuVqYjURbD69ZEx`).

`591.86` is a **Windows-only GeForce Game Ready** driver version — there is no such NVIDIA Linux driver (the Linux equivalent of that branch is `590.48.01`). A Linux executor reporting `591.86` through NVML is a hallmark of a **tampered/spoofed `libnvidia-ml`**, which is exactly what `NvmlDigestCheck` exists to catch. The check did its job: score set to 0, executor never onboarded.

The problem is operational: the old remediation text (`"Update to a supported NVIDIA driver version..."`) plus the Grafana alert nudge operators toward **blindly adding the reported hash to `LIB_NVIDIA_ML_DIGESTS`** — which would whitelist a spoofed NVML and defeat the anti-spoofing guard.

## Change

Single string: rewrite the `NVML_DRIVER_UNKNOWN` remediation in `neurons/validators/src/services/task/messages.py` to warn operators **not** to whitelist blindly — verify the version is a real NVIDIA Linux release and take the digest from a clean install, not from the reported value. `591.86` is named as an example, **not** encoded as a format rule (legit Linux drivers like `550.120` / `570.144` are also two-component, so "format" is not a reliable spoofing signal).

No logic change, no behavior change — only the message text.

## Test plan

- [x] `pdm run pytest tests/test_nvml_digest_check.py` → 7 passed (asserts `reason_code`, unaffected by text)
- [x] `pdm run ruff check neurons/validators/src/services/task/messages.py` → clean
- Note: the operator-facing alert summary ("Add the new driver hash to const.py") lives in **Grafana**, not this repo — not changed here.