### PR TITLE
DAH-2217, exclude miner default job from unrented incentive

### DIFF
--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 from incentive.utils import get_hourly_rate
 from incentive.default import DefaultIncentive
 from incentive.price_provider import PriceProvider
-from services.const import TEMPO, SECONDS_PER_BLOCK, FIXED_RATIO, TOTAL_BURN_EMISSION
+from services.const import TEMPO, SECONDS_PER_BLOCK, FIXED_RATIO, TOTAL_BURN_EMISSION, DEFAULT_JOB_OWNER_MINER
 from services.task_service import JobResult
 
 logger = get_logger(__name__)
@@ -423,6 +423,24 @@ class RentalPriceIncentive(DefaultIncentive):
                         "gpu_model": job_result.gpu_model,
                         "gpu_count": job_result.gpu_count,
                         "reason": "new_rentals_paused",
+                        "score": 0,
+                        "pool": "none",
+                    },
+                )
+            )
+            job_result.mining_score = 0
+            job_result.eligible_for_rental_share = False
+            return job_result
+
+        if job_result.default_job_owner == DEFAULT_JOB_OWNER_MINER and not job_result.is_rented:
+            logger.info(
+                _m(
+                    "Executor excluded from both pools - running miner's own default job",
+                    extra={
+                        "executor_id": str(job_result.executor_info.uuid),
+                        "gpu_model": job_result.gpu_model,
+                        "gpu_count": job_result.gpu_count,
+                        "reason": "miner_default_job",
                         "score": 0,
                         "pool": "none",
                     },

--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -79,6 +79,9 @@ class RentedExecutorsResponse(BaseModel):
     spot_executor_ids: list[str] = []  # executor_ids in spot tier (no incentive, no penalty)
     new_rentals_paused_executor_ids: list[str] = []  # executor_ids paused from unrented incentives
     provider_discord_connected_executor_ids: list[str] | None = None  # executor_ids whose provider has connected Discord
+    # executor_id → "miner" | "lium"; absent = no default job. Parsed leniently as str for
+    # forward-compatibility (a future owner value must not break parsing of the whole response).
+    default_job_owner_by_executor: dict[str, str] = {}
 
     @field_validator("filler_containers_by_executor")
     @classmethod
@@ -91,6 +94,9 @@ class RentedExecutorsResponse(BaseModel):
 
     def get_filler_container(self, executor_uuid: str) -> str | None:
         return self.filler_containers_by_executor.get(str(executor_uuid))
+
+    def get_default_job_owner(self, executor_uuid: str) -> str | None:
+        return self.default_job_owner_by_executor.get(str(executor_uuid))
 
 
 class PodRentalActiveResponse(BaseModel):

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -382,6 +382,10 @@ POD_CONTAINER_PREFIX = "pod_"
 FILLER_CONTAINER_PREFIX = "filler_"
 FILLER_CONTAINER_GRACE_MINUTES = 15
 
+# Owner of an executor's active default job, as reported by compute-app.
+# An executor running the miner's OWN default job earns no unrented incentive.
+DEFAULT_JOB_OWNER_MINER = "miner"
+
 # Container name prefixes that count as "rental-related" on an executor.
 # All producers of short-lived containers competing for the 9100-9130 port range
 # MUST be listed here so that container_cleanup and wait_for_port_check_containers

--- a/neurons/validators/src/services/task/models.py
+++ b/neurons/validators/src/services/task/models.py
@@ -27,6 +27,7 @@ class JobResult(BaseModel):
     is_new_rentals_paused: bool = False
     provider_discord_connected: bool = True
     rental_created_at: datetime | None = None
+    default_job_owner: str | None = None  # "miner" | "lium" | None; miner default job is excluded from unrented incentive
 
     # tdx attestation relevant fields
     attestation_digest: str | None = None

--- a/neurons/validators/src/services/task/result_handler.py
+++ b/neurons/validators/src/services/task/result_handler.py
@@ -107,6 +107,11 @@ class ResultHandler:
             context.state.rented_data
             and executor_info.uuid in context.state.rented_data.new_rentals_paused_executor_ids
         )
+        default_job_owner = (
+            context.state.rented_data.get_default_job_owner(executor_info.uuid)
+            if context.state.rented_data
+            else None
+        )
         provider_discord_connected = self._get_provider_discord_connected(context)
 
         # add TDX attestation and spot tier to specs (propagated to compute-app
@@ -143,6 +148,7 @@ class ResultHandler:
             is_new_rentals_paused=is_new_rentals_paused,
             provider_discord_connected=provider_discord_connected,
             rental_created_at=self._get_rental_created_at(context),
+            default_job_owner=default_job_owner,
             tdx_attestation_passed=context.tdx_attestation_passed,
         )
 

--- a/neurons/validators/tests/prod_snapshot/test_prod_snapshot_incentive.py
+++ b/neurons/validators/tests/prod_snapshot/test_prod_snapshot_incentive.py
@@ -170,6 +170,7 @@ def _build_job_results(prod_snapshot: dict) -> dict[str, list[JobResult]]:
                 supports_gpu_splitting=r.get("supports_gpu_splitting", False),
                 gpu_splitting_min_count=r.get("gpu_splitting_min_count"),
                 is_spot=r.get("is_spot", False),
+                default_job_owner=r.get("default_job_owner"),
             )
             job_results[hotkey].append(job_result)
     return job_results

--- a/neurons/validators/tests/test_new_rentals_pause_filter.py
+++ b/neurons/validators/tests/test_new_rentals_pause_filter.py
@@ -159,6 +159,44 @@ def test_rented_executors_response_parses_provider_discord_connected_executor_id
     assert result.provider_discord_connected_executor_ids == ["discord-executor"]
 
 
+def test_rented_executors_response_defaults_default_job_owner_by_executor():
+    """Older backend responses without default-job owners remain compatible."""
+    result = RentedExecutorsResponse.model_validate({"executors": {}})
+
+    assert result.default_job_owner_by_executor == {}
+
+
+def test_rented_executors_response_parses_default_job_owner_by_executor():
+    """Default-job owners are parsed leniently so an unknown future value cannot break the whole response."""
+    result = RentedExecutorsResponse.model_validate(
+        {
+            "executors": {},
+            "default_job_owner_by_executor": {
+                "miner-executor": "miner",
+                "lium-executor": "lium",
+                "future-executor": "partner",
+            },
+        }
+    )
+
+    assert result.default_job_owner_by_executor == {
+        "miner-executor": "miner",
+        "lium-executor": "lium",
+        "future-executor": "partner",
+    }
+
+
+def test_get_default_job_owner_returns_owner_or_none():
+    """The accessor used by ResultHandler returns the owner for a known executor, None otherwise."""
+    result = RentedExecutorsResponse(
+        executors={},
+        default_job_owner_by_executor={"miner-executor": "miner"},
+    )
+
+    assert result.get_default_job_owner("miner-executor") == "miner"
+    assert result.get_default_job_owner("unknown-executor") is None
+
+
 def test_result_handler_treats_missing_provider_discord_list_as_connected():
     """Missing backend field means unknown, so do not penalize during rollout."""
     context = SimpleNamespace(

--- a/neurons/validators/tests/test_rental_price_incentive_flow.py
+++ b/neurons/validators/tests/test_rental_price_incentive_flow.py
@@ -142,6 +142,7 @@ def _make_rented_data(
     spot_executor_ids: list[str] | None = None,
     new_rentals_paused_executor_ids: list[str] | None = None,
     provider_discord_connected_executor_ids: list[str] | None = None,
+    default_job_owner_by_executor: dict[str, str] | None = None,
 ) -> RentedExecutorsResponse:
     executors = {}
     for executor_id in rented_executor_ids or []:
@@ -158,6 +159,7 @@ def _make_rented_data(
         spot_executor_ids=spot_executor_ids or [],
         new_rentals_paused_executor_ids=new_rentals_paused_executor_ids or [],
         provider_discord_connected_executor_ids=provider_discord_connected_executor_ids,
+        default_job_owner_by_executor=default_job_owner_by_executor or {},
     )
 
 
@@ -2809,3 +2811,82 @@ async def test_rental_price_paused_unrented_excluded_from_incentives_but_still_v
     assert secure_rented.is_rented is True
     assert secure_rented.total_gpu_count == 16
     assert validator.miner_scores["miner_secure_rented"] > 0
+
+
+@pytest.mark.asyncio
+async def test_rental_price_miner_default_job_unrented_earns_nothing(
+    validator_with_rental_price,
+    mock_subtensor_client,
+    mock_settings,
+    create_job_result,
+    create_neuron_info,
+    mock_price_provider,
+):
+    """An unrented executor running the MINER'S OWN default job earns nothing:
+    - it is excluded from both pools (mining + rental)
+    - it does not dilute the unrented bucket caps of legitimate executors
+    A Lium-owned default job (or no default job) keeps the unrented incentive.
+    """
+    validator = validator_with_rental_price
+    validator.miner_scores = {}
+
+    miners = [
+        create_neuron_info(uid=100, hotkey="burner1"),
+        create_neuron_info(uid=101, hotkey="burner2"),
+        create_neuron_info(uid=2, hotkey="miner_plain"),
+        create_neuron_info(uid=3, hotkey="miner_lium_job"),
+        create_neuron_info(uid=4, hotkey="miner_own_job"),
+    ]
+
+    plain = _job(
+        create_job_result, executor_id="exec-plain",
+        gpu_model="H100", gpu_count=8, is_rented=False,
+    )
+    lium_job = _job(
+        create_job_result, executor_id="exec-lium-job",
+        gpu_model="H100", gpu_count=8, is_rented=False,
+    )
+    own_job = _job(
+        create_job_result, executor_id="exec-own-job",
+        gpu_model="H100", gpu_count=8, is_rented=False,
+    )
+    lium_job.default_job_owner = "lium"
+    own_job.default_job_owner = "miner"
+
+    all_job_results = {
+        "miner_plain": [plain],
+        "miner_lium_job": [lium_job],
+        "miner_own_job": [own_job],
+    }
+
+    validator.backend_client.get_all_rented_executors = AsyncMock(
+        return_value=_make_rented_data(
+            default_job_owner_by_executor={
+                "exec-lium-job": "lium",
+                "exec-own-job": "miner",
+            },
+        )
+    )
+
+    await _run_sync_with_jobs(validator, miners, all_job_results)
+
+    # Miner's own default job -> excluded from both pools, earns nothing
+    assert own_job.default_job_owner == "miner"
+    assert own_job.mining_score == 0
+    assert own_job.eligible_for_rental_share is False
+    assert (own_job.incentive or 0.0) == 0.0
+    assert validator.miner_scores.get("miner_own_job", 0.0) == pytest.approx(0.0, abs=0.0001)
+
+    # Lium-owned default job -> still earns the unrented incentive
+    assert lium_job.default_job_owner == "lium"
+    assert lium_job.eligible_for_rental_share is True
+    assert (lium_job.incentive or 0.0) > 0.0
+
+    # No default job -> still earns the unrented incentive
+    assert plain.default_job_owner is None
+    assert plain.eligible_for_rental_share is True
+    assert (plain.incentive or 0.0) > 0.0
+
+    # The miner's own job must not dilute the legitimate unrented bucket (only plain + lium_job count)
+    assert lium_job.total_unrented_by_gpu_type == 16
+    assert plain.total_unrented_by_gpu_type == 16


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2217](https://www.notion.so/37db8bfdbde981e793b8ecd39168dbe0)

---

## Problem

A miner can run its **own** default job (`MINER_DEFAULT_JOB`) on an unrented executor and still
collect the unrented incentive. That incentive is meant to reward capacity Lium can serve to
customers, not a miner running its own workload on its own hardware. Such executors should earn
**zero** unrented incentive, while executors running a Lium-owned default job (`DPHN`/`PEARL`) or
nothing at all keep it.

## Solution

The validator already receives per-executor filler signals from compute-app on
`/executors/rented`. This PR consumes one new additive field on that response,
`default_job_owner_by_executor: dict[str, str]` (`executor_id → "miner" | "lium"`; absent = no
default job), and uses it in incentive scoring:

- `RentedExecutorsResponse` parses the new field leniently as `str` (an unknown future owner value
  must not break parsing of the whole response) and exposes `get_default_job_owner(executor_uuid)`.
- `ResultHandler` threads the owner onto `JobResult.default_job_owner`.
- `RentalPriceIncentive` adds an explicit early-exit gate (mirroring the existing
  `new_rentals_paused` gate): an **unrented** executor whose default-job owner is `"miner"` is
  excluded from **both** pools (mining + rental share) and returns early — so it earns nothing and
  does not dilute the unrented bucket caps of legitimate executors. The `rented` flag and
  tenant-enforcement are left untouched (Path A — see task for why Path B / `rented=True` was
  rejected).

## Changes

- `protocol/vc_protocol/compute_requests.py`: add `default_job_owner_by_executor` field +
  `get_default_job_owner()` accessor.
- `services/task/models.py`: add `JobResult.default_job_owner: str | None`.
- `services/task/result_handler.py`: extract owner from `rented_data` onto the `JobResult`.
- `services/const.py`: add `DEFAULT_JOB_OWNER_MINER = "miner"`.
- `incentive/rental_price.py`: exclude unrented miner-default-job executors from both pools.
- Tests: flow test (miner-own-job earns nothing; Lium-job / no-job still earn; no bucket
  dilution), response-parse tests, prod_snapshot factory field.

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review

## Other PRs

- compute-app (sender): https://github.com/Datura-ai/lium-io-backend/pull/693

## Risks

- **Backward-compatible / deploy-order independent.** The gate only fires when
  `default_job_owner == "miner"` AND the executor is not rented. `default_job_owner` defaults to
  `None`, so behavior is unchanged until the backend starts sending the field — validator and
  backend can deploy in any order.
- Lenient `str` parsing means a future owner value (e.g. `"partner"`) won't break response parsing.
- `prod_snapshot` baselines are unchanged: the new field defaults to `None`, so scoring output is
  identical in normal mode (no baseline regeneration needed).

## Test Cases

### Test Case 1 — miner's own default job earns nothing

**Actions**: three unrented H100x8 executors — one with no default job, one with a Lium-owned
default job (`owner="lium"`), one with the miner's own default job (`owner="miner"`).

**Expected Output**: the miner-own-job executor has `mining_score == 0`,
`eligible_for_rental_share is False`, `incentive == 0`, and contributes nothing to the miner
score; the Lium-job and no-job executors keep a positive unrented incentive; the miner-own-job
executor does not dilute the unrented bucket (`total_unrented_by_gpu_type == 16`).

### Test Case 2 — response parsing

**Actions**: parse a `RentedExecutorsResponse` with and without `default_job_owner_by_executor`,
including an unknown owner value.

**Expected Output**: missing field → `{}`; known/unknown values parse without error;
`get_default_job_owner()` returns the owner or `None`.

Full validator suite: **673 passed, 4 skipped** (includes prod_snapshot in normal mode).

## Checklist

- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
