### PR TITLE
raise GPU power-limit floor from 80% to 90% (DAH-2227)

### DIFF
--- a/neurons/validators/src/services/task/checks/gpu_power_limit.py
+++ b/neurons/validators/src/services/task/checks/gpu_power_limit.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from ..messages import GpuPowerLimitMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
 
-MIN_POWER_LIMIT_RATIO = 0.8
+MIN_POWER_LIMIT_RATIO = 0.9
 
 
 def _to_float(value) -> float | None:
@@ -69,7 +69,7 @@ class GpuPowerLimitCheck:
                     "score": 0.0,
                     "job_score": 0.0,
                     "score_warning": (
-                        " WARNING: GPU power limit is below 80% of the default power limit"
+                        " WARNING: GPU power limit is below 90% of the default power limit"
                     ),
                 },
             )

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -255,7 +255,7 @@ class GpuPowerLimitMessages:
         category="policy",
         impact="Job skipped; score set to 0",
         remediation=(
-            "Restore the GPU power limit to at least 80% of the default limit "
+            "Restore the GPU power limit to at least 90% of the default limit "
             "reported by NVML."
         ),
     )

--- a/neurons/validators/tests/test_gpu_power_limit_check.py
+++ b/neurons/validators/tests/test_gpu_power_limit_check.py
@@ -45,10 +45,19 @@ async def test_power_limit_rejects_below_threshold(context_factory):
 
 @pytest.mark.asyncio
 async def test_power_limit_allows_exact_threshold(context_factory):
-    ctx = context_factory(state=_state(current_limit=280, default_limit=350))
+    ctx = context_factory(state=_state(current_limit=315, default_limit=350))
     result = await GpuPowerLimitCheck().run(ctx)
     assert result.passed is True
     assert result.event.reason_code == "GPU_POWER_LIMIT_OK"
+
+
+@pytest.mark.asyncio
+async def test_power_limit_rejects_between_old_and_new_floor(context_factory):
+    ctx = context_factory(state=_state(current_limit=300, default_limit=350))
+    result = await GpuPowerLimitCheck().run(ctx)
+    assert result.passed is False
+    assert result.event.reason_code == "GPU_POWER_LIMIT_BELOW_DEFAULT"
+    assert result.updates["score"] == 0.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Raise the validator's minimum GPU power-limit floor from **80% → 90%** of the NVML default power limit. Miners cut PL for stability under Pearl, but a 20% reduction measurably degrades renter performance. Per Fish, only allow a 10% reduction.

## Changes

- `MIN_POWER_LIMIT_RATIO` `0.8 → 0.9` in `checks/gpu_power_limit.py` (the sole enforcement point — executor scored 0 when `current_limit / default_limit < ratio`).
- Update the operator-facing remediation message and the `score_warning` string (`80% → 90%`).
- Tests: the exact-threshold case now uses `315/350 = 0.9`; added `test_power_limit_rejects_between_old_and_new_floor` (`300/350 ≈ 0.857`) to lock the tightened band that previously passed.

## Test

```
pdm run pytest tests/test_gpu_power_limit_check.py -v   # 5 passed
```

Notion: DAH-2227. Follows DAH-2168, which introduced the 0.8 floor.
