### PR TITLE
DAH-2213, revive duplicate-executor detection: fix redis key, observe mode

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -146,6 +146,7 @@ class Settings(BaseSettings):
     SKIP_COLLATERAL_PENALTY: bool = Field(env="SKIP_COLLATERAL_PENALTY", default=True)
     DRY_RUN: bool = Field(env="DRY_RUN", default=False, description="Run validation without publishing scores/weights")
     CONTAINER_CLEANUP_DRY_RUN: bool = Field(env="CONTAINER_CLEANUP_DRY_RUN", default=False, description="Dry run mode for stale container cleanup")
+    DUPLICATE_EXECUTOR_DRY_RUN: bool = Field(env="DUPLICATE_EXECUTOR_DRY_RUN", default=True, description="Observe mode: detect duplicate executors but don't penalize")
 
     COLLATERAL_CONTRACT_ADDRESS: str = Field(
         env='COLLATERAL_CONTRACT_ADDRESS', default='0x8A4023FdD1eaA7b242F3723a7d096B6CC693c7C6'

--- a/neurons/validators/src/services/task/checks/duplicate_executor.py
+++ b/neurons/validators/src/services/task/checks/duplicate_executor.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from core.config import settings
+from services.redis_service import DUPLICATED_MACHINE_SET
+
 from ..messages import DuplicateExecutorMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
 
-DUPLICATED_MACHINE_SET = "duplicated_machine:set"
 
 class DuplicateExecutorCheck:
     """Ensure a miner is not registering the same executor UUID multiple times.
@@ -23,14 +25,24 @@ class DuplicateExecutorCheck:
         )
 
         if is_duplicate:
+            what = {
+                "executor_uuid": ctx.executor.uuid,
+                "miner_hotkey": ctx.miner_hotkey,
+            }
+            if settings.DUPLICATE_EXECUTOR_DRY_RUN:
+                event = render_message(
+                    Msg.DUPLICATE_OBSERVED,
+                    ctx=ctx,
+                    check_id=self.check_id,
+                    what=what,
+                )
+                return CheckResult(passed=True, event=event)
+
             event = render_message(
                 Msg.DUPLICATE,
                 ctx=ctx,
                 check_id=self.check_id,
-                what={
-                    "executor_uuid": ctx.executor.uuid,
-                    "miner_hotkey": ctx.miner_hotkey,
-                },
+                what=what,
             )
             return CheckResult(
                 passed=False,

--- a/neurons/validators/src/services/task/checks/duplicate_executor.py
+++ b/neurons/validators/src/services/task/checks/duplicate_executor.py
@@ -25,7 +25,7 @@ class DuplicateExecutorCheck:
         )
 
         if is_duplicate:
-            what = {
+            what: dict[str, str] = {
                 "executor_uuid": ctx.executor.uuid,
                 "miner_hotkey": ctx.miner_hotkey,
             }

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -373,6 +373,14 @@ class DuplicateExecutorMessages:
         impact="Score set to 0; verification cleared",
         remediation="Ensure every executor has a unique UUID and deregister duplicates before retrying.",
     )
+    DUPLICATE_OBSERVED = MessageTemplate(
+        event="Duplicate executor registration (observe mode)",
+        reason="EXECUTOR_DUPLICATE_OBSERVED",
+        severity="warning",
+        category="policy",
+        impact="Detected; no score impact (observe mode)",
+        remediation="Ensure every executor has a unique UUID and deregister duplicates before retrying.",
+    )
     UNIQUE = MessageTemplate(
         event="Executor registration unique",
         reason="EXECUTOR_NOT_DUPLICATE",

--- a/neurons/validators/tests/test_duplicate_executor_check.py
+++ b/neurons/validators/tests/test_duplicate_executor_check.py
@@ -1,45 +1,100 @@
 import pytest
 
+from core.config import settings
+
+from neurons.validators.src.services.redis_service import DUPLICATED_MACHINE_SET
 from neurons.validators.src.services.task.checks.duplicate_executor import DuplicateExecutorCheck
 from neurons.validators.src.services.task.messages import DuplicateExecutorMessages as Msg
 
 from tests.helpers import build_context_config, build_services, build_state
 
 
-class DummyRedis:
-    def __init__(self, duplicates: set[str]):
-        self.duplicates = duplicates
+class FakeRedis:
+    """Redis double backed by per-key sets.
+
+    Mirrors how compute_client writes duplicate pairs under DUPLICATED_MACHINE_SET
+    and how the check reads them back, so a key-name divergence between writer and
+    reader makes the dual-registration test fail.
+    """
+
+    def __init__(self) -> None:
+        self.sets: dict[str, set[str]] = {}
         self.calls: list[tuple[str, str]] = []
+
+    async def sadd(self, key: str, elem: str) -> None:
+        self.sets.setdefault(key, set()).add(elem)
 
     async def is_elem_exists_in_set(self, key: str, elem: str) -> bool:
         self.calls.append((key, elem))
-        return elem in self.duplicates
+        return elem in self.sets.get(key, set())
 
 
-@pytest.mark.parametrize(
-    "duplicates,expected_pass,expected_reason,expect_clear",
-    [
-        (set(), True, Msg.UNIQUE.reason, False),
-        ({"miner-hotkey:executor-123"}, False, Msg.DUPLICATE.reason, True),
-    ],
-)
+def _make_ctx(redis_service, context_factory, miner_hotkey: str = "miner-hotkey"):
+    return context_factory(
+        services=build_services(redis=redis_service),
+        config=build_context_config(),
+        state=build_state(),
+        miner_hotkey=miner_hotkey,
+    )
+
+
 @pytest.mark.asyncio
-async def test_duplicate_executor_check(duplicates, expected_pass, expected_reason, expect_clear, context_factory):
-    redis_service = DummyRedis(duplicates)
-    services = build_services(redis=redis_service)
-    config = build_context_config()
-    state = build_state()
+async def test_unique_executor_passes(context_factory):
+    redis_service = FakeRedis()
+    ctx = _make_ctx(redis_service, context_factory)
 
-    ctx = context_factory(services=services, config=config, state=state)
     result = await DuplicateExecutorCheck().run(ctx)
 
-    assert result.passed is expected_pass
-    assert result.event.reason_code == expected_reason
+    assert result.passed is True
+    assert result.event.reason_code == Msg.UNIQUE.reason
+    assert "clear_verified_job_info" not in result.updates
 
-    expected_elem = f"{ctx.miner_hotkey}:{ctx.executor.uuid}"
-    assert redis_service.calls == [("duplicated_machine:set", expected_elem)]
 
-    if expect_clear:
-        assert result.updates.get("clear_verified_job_info") is True
-    else:
-        assert "clear_verified_job_info" not in result.updates
+@pytest.mark.asyncio
+async def test_duplicate_observe_mode_passes_without_penalty(context_factory, monkeypatch):
+    monkeypatch.setattr(settings, "DUPLICATE_EXECUTOR_DRY_RUN", True)
+    redis_service = FakeRedis()
+    ctx = _make_ctx(redis_service, context_factory)
+    await redis_service.sadd(DUPLICATED_MACHINE_SET, f"{ctx.miner_hotkey}:{ctx.executor.uuid}")
+
+    result = await DuplicateExecutorCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.DUPLICATE_OBSERVED.reason
+    assert "clear_verified_job_info" not in result.updates
+
+
+@pytest.mark.asyncio
+async def test_duplicate_enforce_mode_fails_and_clears(context_factory, monkeypatch):
+    monkeypatch.setattr(settings, "DUPLICATE_EXECUTOR_DRY_RUN", False)
+    redis_service = FakeRedis()
+    ctx = _make_ctx(redis_service, context_factory)
+    elem = f"{ctx.miner_hotkey}:{ctx.executor.uuid}"
+    await redis_service.sadd(DUPLICATED_MACHINE_SET, elem)
+
+    result = await DuplicateExecutorCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.DUPLICATE.reason
+    assert result.updates.get("clear_verified_job_info") is True
+    # the check must read the same Redis key the writer (compute_client) populates
+    assert redis_service.calls == [(DUPLICATED_MACHINE_SET, elem)]
+
+
+@pytest.mark.asyncio
+async def test_dual_registration_both_fail_in_enforce_mode(context_factory, monkeypatch):
+    # writer side: one executor announced by two hotkeys -> both pairs land in the set
+    monkeypatch.setattr(settings, "DUPLICATE_EXECUTOR_DRY_RUN", False)
+    redis_service = FakeRedis()
+    ctx_a = _make_ctx(redis_service, context_factory, miner_hotkey="hotkey-a")
+    ctx_b = _make_ctx(redis_service, context_factory, miner_hotkey="hotkey-b")
+    await redis_service.sadd(DUPLICATED_MACHINE_SET, f"hotkey-a:{ctx_a.executor.uuid}")
+    await redis_service.sadd(DUPLICATED_MACHINE_SET, f"hotkey-b:{ctx_b.executor.uuid}")
+
+    result_a = await DuplicateExecutorCheck().run(ctx_a)
+    result_b = await DuplicateExecutorCheck().run(ctx_b)
+
+    assert result_a.passed is False
+    assert result_b.passed is False
+    assert result_a.event.reason_code == Msg.DUPLICATE.reason
+    assert result_b.event.reason_code == Msg.DUPLICATE.reason


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2213 — Revive duplicate-executor detection in the validator](https://app.notion.com/p/Revive-duplicate-executor-detection-in-the-validator-37db8bfdbde98192a821fee08af0be16)

---

## Problem

`DuplicateExecutorCheck` has been a no-op since 2025-10-29 (commit `24bb8652`). The check reads the Redis set `duplicated_machine:set` — a constant re-declared locally inside the check — while the writer (`compute_client`) populates `duplicated_machines` (the shared constant in `redis_service`). The reader's key is never written, so `is_elem_exists_in_set` always returns `False` and the check always passes.

Result: the same executor can be announced by two miner hotkeys and both get scored. Confirmed in prod on 2026-06-17 (executor `bf6d4d9a-a7d7-4e6b-8fe3-ae741b185167` passed as "unique" under `5GivXCUF5pPSHZnRHupmgLTvRT6Q24iNZyxMvzFGwgAuz1HH` and `5DcgzqMmpRTdm6ajx4NbutvRGe257PRFgSavP8np6jqAEpDr` in the same batch). Earlier Jun 9-12 incident caused double emission and miner payouts landing on the wrong wallet.

## Solution

Import the shared `DUPLICATED_MACHINE_SET` from `redis_service` and remove the divergent local constant, so the reader and writer use the same key again — restoring the pre-`24bb8652` behavior (all copies of a duplicated machine fail the check).

To de-risk re-enabling a long-dead check, it ships behind an observe-mode flag `DUPLICATE_EXECUTOR_DRY_RUN` (default `true`). In observe mode the check logs a distinct event `EXECUTOR_DUPLICATE_OBSERVED` and does **not** change score. Setting the flag to `false` enforces (duplicate fails with score 0 and clears verified job info).

## Changes

- `core/config.py`: add `DUPLICATE_EXECUTOR_DRY_RUN` env flag (default `true` = observe).
- `checks/duplicate_executor.py`: read the shared `DUPLICATED_MACHINE_SET`; drop the local `duplicated_machine:set`; add observe branch (log + pass) vs enforce branch (fail + clear).
- `task/messages.py`: add `DUPLICATE_OBSERVED` template (`EXECUTOR_DUPLICATE_OBSERVED`, severity `warning`).
- `tests/test_duplicate_executor_check.py`: fix the assertion that hardcoded the wrong key; add observe-mode, enforce-mode, and a writer→reader dual-registration regression test.

## Deployment Steps

Use GitHub Action. Ships in observe mode (`DUPLICATE_EXECUTOR_DRY_RUN=true`). After a clean observe window (no false positives), flip `DUPLICATE_EXECUTOR_DRY_RUN=false` in prod env to enforce.

## Review Request

- [x] Just code review

## Other PRs

None. (Backend `get_executors_with_duplicate_gpu_uuids` already returns all copies — no compute-app change needed.)

## Risks

- When flipped to enforce, **all** copies of a duplicated machine fail (no canonical-keep) — a legit provider migration that briefly announces one machine under two hotkeys gets score 0 on both until the conflict clears. Mitigated by the observe-mode default and a shadow window before enforcing.
- If the observe flag is left on indefinitely, dedup stays disabled (same as the original bug). Tracked in the task's post-deploy checklist.
- Scope limited to the validator's duplicate check; no change to how the duplicate set is built.

## Test Cases

### Test Case 1 — Observe mode (default)
**Actions**: duplicate pair present in `duplicated_machines`, `DUPLICATE_EXECUTOR_DRY_RUN=true`.
**Expected Output**: `passed=True`, event `EXECUTOR_DUPLICATE_OBSERVED`, no `clear_verified_job_info`.

### Test Case 2 — Enforce mode
**Actions**: same setup, `DUPLICATE_EXECUTOR_DRY_RUN=false`.
**Expected Output**: `passed=False`, event `EXECUTOR_DUPLICATE`, `clear_verified_job_info=True`; the check reads key `duplicated_machines`.

### Test Case 3 — Dual registration (regression guard)
**Actions**: one executor announced by two hotkeys → both pairs written under `duplicated_machines`; enforce mode.
**Expected Output**: both registrations fail. Guards against the reader/writer key diverging again.

Full validator suite: **687 passed, 4 skipped**.

## Checklist

- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
