### PR TITLE
DAH-2233 - Sandbox custom-Dockerfile pod builds in isolated sysbox DinD with egress firewall

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -188,6 +188,36 @@ class Settings(BaseSettings):
         env="CUSTOM_DOCKERFILE_MAX_BYTES", default=65_536,
         description="Defense-in-depth cap on dockerfile_content size; route is authoritative.",
     )
+    # DAH-2211 — internet-enabled custom builds run inside a throwaway sysbox
+    # Docker-in-Docker container (NOT on the host daemon) so the build can
+    # `--network` out for deps while a build-time escape stays confined to an
+    # unprivileged-on-host (user-namespaced) container. Egress is firewalled
+    # host-side to block cloud metadata + RFC1918. See the DAH-2211 build flow.
+    CUSTOM_DOCKERFILE_DIND_IMAGE: str = Field(
+        env="CUSTOM_DOCKERFILE_DIND_IMAGE", default="daturaai/dind:0.0.1",
+        description="Sysbox DinD image used to build custom-dockerfile pods in isolation.",
+    )
+    CUSTOM_DOCKERFILE_DIND_CPUS: str = Field(
+        env="CUSTOM_DOCKERFILE_DIND_CPUS", default="4",
+        description="--cpus limit for the throwaway DinD build container.",
+    )
+    CUSTOM_DOCKERFILE_DIND_MEMORY: str = Field(
+        env="CUSTOM_DOCKERFILE_DIND_MEMORY", default="8g",
+        description="--memory limit for the throwaway DinD build container.",
+    )
+    CUSTOM_DOCKERFILE_DIND_READY_TIMEOUT_SECONDS: int = Field(
+        env="CUSTOM_DOCKERFILE_DIND_READY_TIMEOUT_SECONDS", default=60,
+        description="Max seconds to wait for the inner DinD dockerd to become ready.",
+    )
+    CUSTOM_DOCKERFILE_EGRESS_BLOCK_CIDRS: str = Field(
+        env="CUSTOM_DOCKERFILE_EGRESS_BLOCK_CIDRS",
+        default="169.254.0.0/16,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16",
+        description=(
+            "Comma-separated CIDRs the custom build must NOT reach (cloud metadata + "
+            "RFC1918). Enforced host-side in the DOCKER-USER chain, scoped to the DinD "
+            "container IP. Build still has full public-internet egress."
+        ),
+    )
 
     DEPLOY_ENV: Literal["PROD", "LOCAL", "STAGE"] = Field(env="DEPLOY_ENV", default="PROD")
 

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import ipaddress
 import math
 import random
 from dataclasses import dataclass
@@ -1650,26 +1651,101 @@ class DockerService:
     def _custom_build_scratch_dir(pod_id: str) -> str:
         return f"/tmp/lium-build-{pod_id}"
 
-    async def _write_dockerfile_via_heredoc(
+    @staticmethod
+    def _dind_container_name(pod_id: str) -> str:
+        return f"lium-dind-build-{pod_id}"
+
+    # Build context written inside the throwaway DinD container.
+    _DIND_BUILD_CONTEXT = "/build"
+
+    async def _write_dockerfile_into_dind(
         self,
         ssh_client: asyncssh.SSHClientConnection,
-        scratch_dir: str,
+        dind_name: str,
         dockerfile_content: str,
     ) -> None:
-        """Write a Dockerfile to the executor without ever putting it on argv.
+        """Write the Dockerfile *inside* the DinD container without argv exposure.
 
-        We pipe via stdin to `tee` so arbitrary user content (including `EOF`
-        markers, backticks, `$(...)`) cannot escape into the shell.
+        Streams user content via stdin into `cat` (through `docker exec -i`) so
+        arbitrary content (`EOF` markers, backticks, `$(...)`) cannot escape into
+        the shell. Only the controlled container name reaches argv.
         """
-        # `tee` writes stdin verbatim. shlex-quote the destination path only.
-        dest = f"{scratch_dir}/Dockerfile"
-        command = f"/usr/bin/tee {shlex.quote(dest)} > /dev/null"
+        ctx = self._DIND_BUILD_CONTEXT
+        inner = f"mkdir -p {ctx} && cat > {ctx}/Dockerfile"
+        command = (
+            f"/usr/bin/docker exec -i {shlex.quote(dind_name)} "
+            f"sh -c {shlex.quote(inner)}"
+        )
         result = await ssh_client.run(command, input=dockerfile_content, check=False)
         if result.exit_status != 0:
             stderr = (result.stderr or "").strip()
             raise RuntimeError(
-                f"Failed to write Dockerfile to {dest!r}: exit={result.exit_status} stderr={stderr!r}"
+                f"Failed to write Dockerfile into {dind_name!r}: "
+                f"exit={result.exit_status} stderr={stderr!r}"
             )
+
+    @staticmethod
+    def _parse_egress_block_cidrs(raw: str) -> list[str]:
+        """Validate the configured egress-block CIDRs into shell-safe strings.
+
+        Invalid entries are dropped with a warning. 169.254.0.0/16 (cloud
+        metadata) is always included so a misconfiguration can never silently
+        re-expose the credential-theft vector.
+        """
+        cidrs: list[str] = []
+        for part in (raw or "").split(","):
+            part = part.strip()
+            if not part:
+                continue
+            try:
+                cidrs.append(str(ipaddress.ip_network(part, strict=False)))
+            except ValueError:
+                logger.warning(
+                    _m(
+                        "Ignoring invalid CUSTOM_DOCKERFILE_EGRESS_BLOCK_CIDRS entry",
+                        extra=get_extra_info({"entry": part}),
+                    )
+                )
+        metadata = "169.254.0.0/16"
+        if metadata not in cidrs:
+            cidrs.insert(0, metadata)
+        return cidrs
+
+    @staticmethod
+    def _egress_filter_script(dind_ip: str, cidrs: list[str], apply: bool) -> str:
+        """Backend-agnostic iptables script for the host DOCKER-USER chain.
+
+        Runs inside a `--network=host --cap-add=NET_ADMIN` helper container so it
+        edits the *host* netns regardless of where the validator SSH lands. The
+        fleet is mixed nft/legacy, so we pick whichever backend actually owns the
+        DOCKER-USER chain. Rules are scoped to the DinD container's source IP so
+        DinD-internal docker networking (172.x bridges) is never affected.
+
+        `dind_ip` and `cidrs` are pre-validated via `ipaddress`, so they are
+        shell-safe to interpolate.
+        """
+        lines = [
+            "IPT=iptables-nft",
+            "$IPT -L DOCKER-USER -n >/dev/null 2>&1 || IPT=iptables-legacy",
+        ]
+        if apply:
+            # No DOCKER-USER chain => egress filtering cannot be guaranteed. Fail
+            # loudly so the caller aborts rather than running the build open.
+            lines.append(
+                '$IPT -L DOCKER-USER -n >/dev/null 2>&1 || '
+                '{ echo "DOCKER-USER chain not found" >&2; exit 3; }'
+            )
+            for c in cidrs:
+                lines.append(
+                    f"$IPT -C DOCKER-USER -s {dind_ip} -d {c} -j DROP 2>/dev/null || "
+                    f"$IPT -I DOCKER-USER -s {dind_ip} -d {c} -j DROP"
+                )
+        else:
+            for c in cidrs:
+                lines.append(
+                    f"$IPT -D DOCKER-USER -s {dind_ip} -d {c} -j DROP 2>/dev/null || true"
+                )
+        return "; ".join(lines)
 
     async def _custom_build_image(
         self,
@@ -1688,9 +1764,13 @@ class DockerService:
         from core.config import settings
 
         pod_id = payload.pod_id
-        scratch_dir = self._custom_build_scratch_dir(pod_id)
         image_tag = self._custom_build_image_tag(pod_id)
+        dind_name = self._dind_container_name(pod_id)
+        ctx = self._DIND_BUILD_CONTEXT
         timeout_s = int(settings.CUSTOM_DOCKERFILE_BUILD_TIMEOUT_SECONDS)
+        ready_timeout_s = int(settings.CUSTOM_DOCKERFILE_DIND_READY_TIMEOUT_SECONDS)
+        dind_image = settings.CUSTOM_DOCKERFILE_DIND_IMAGE
+        cidrs = self._parse_egress_block_cidrs(settings.CUSTOM_DOCKERFILE_EGRESS_BLOCK_CIDRS)
 
         # Defense-in-depth size cap. Route is authoritative; this is a wire-trust guard.
         max_bytes = int(settings.CUSTOM_DOCKERFILE_MAX_BYTES)
@@ -1707,112 +1787,265 @@ class DockerService:
             )
             return False, "build_input_oversize"
 
-        # 1. mkdir scratch dir
-        await self.stream_log(
-            f"Preparing custom build scratch dir {scratch_dir}", "success", log_tag
-        )
-        mkdir_cmd = f"/usr/bin/mkdir -p {shlex.quote(scratch_dir)}"
+        # 1. Preflight: sysbox-runc MUST be available. Never fall back to runc —
+        #    a silent fallback would run an internet-enabled build on the host
+        #    daemon with no user-namespace containment, defeating the design.
         try:
-            mkdir_res = await ssh_client.run(mkdir_cmd, check=False)
-            if mkdir_res.exit_status != 0:
-                raise RuntimeError(
-                    f"mkdir failed exit={mkdir_res.exit_status} stderr={(mkdir_res.stderr or '').strip()!r}"
+            info = await ssh_client.run(
+                "/usr/bin/docker info --format '{{json .Runtimes}}'", check=False
+            )
+            if info.exit_status != 0 or "sysbox-runc" not in (info.stdout or ""):
+                await self.stream_log(
+                    "sysbox-runc runtime unavailable on executor", "error", log_tag
                 )
+                logger.error(
+                    _m(
+                        "Custom build aborted: sysbox-runc unavailable",
+                        extra=get_extra_info(
+                            {**default_extra, "runtimes": (info.stdout or "").strip()}
+                        ),
+                    )
+                )
+                return False, "build_sysbox_unavailable"
         except Exception as exc:
             logger.error(
                 _m(
-                    "Custom build mkdir failed",
+                    "Custom build sysbox preflight failed",
                     extra=get_extra_info({**default_extra, "error": str(exc)}),
                 ),
                 exc_info=True,
             )
-            return False, "build_setup"
+            return False, "build_sysbox_unavailable"
 
-        # 2. write Dockerfile via stdin/tee
+        dind_ip: str | None = None
+        egress_applied = False
         try:
-            await self._write_dockerfile_via_heredoc(ssh_client, scratch_dir, content)
-        except Exception as exc:
-            logger.error(
-                _m(
-                    "Custom build Dockerfile write failed",
-                    extra=get_extra_info({**default_extra, "error": str(exc)}),
-                ),
-                exc_info=True,
+            # 2. Launch the throwaway DinD build container under sysbox-runc.
+            await self.stream_log(
+                f"Starting isolated build container {dind_name}", "success", log_tag
             )
-            return False, "build_setup"
-
-        # No explicit pre-build disk check — see DAH-2211 v1 decision.
-        # The 2026-06-12 staging incident (validator SSH lands inside the
-        # executor container, host /var/lib/docker invisible) showed a guard
-        # here is more likely to false-reject than to catch a real exhaustion
-        # case. Real disk failures surface from `docker build` itself as a
-        # docker_build CCF, which routes through the same accident-analysis
-        # bucket. v1.1 follow-up: per-build cgroup disk quota.
-
-        # 3. docker build (network=none, hard timeout)
-        # Use whatever builder the daemon defaults to: legacy hosts reject
-        # `--progress=plain` (BuildKit-only), and BuildKit hosts without the
-        # `buildx` plugin reject `DOCKER_BUILDKIT=1`. Letting Docker decide is
-        # the only setting that works across the heterogeneous executor fleet.
-        #
-        # Executor-runner images that ship Docker CLI without the `buildx`
-        # plugin emit a multi-line DEPRECATED notice on stderr when the CLI
-        # falls back to the legacy builder. `_stream_process_output` flips
-        # status=False on any stderr line — including the trailing blank line
-        # that follows the notice — so a successful build was being misread as
-        # `docker_build` failure. Drop the three DEPRECATED content lines AND
-        # any whitespace-only stderr lines. Real build errors (RUN failures,
-        # network-blocked, etc.) are non-blank content and still reach stderr;
-        # exit code is preserved by bash.
-        build_cmd = (
-            "bash -c " + shlex.quote(
-                '/usr/bin/docker build --network=none --pull -t "$1" "$2" '
-                '2> >(grep -vE '
-                r'"^(DEPRECATED:|[[:space:]]+Install the buildx component|'
-                r'[[:space:]]+https://docs\.docker\.com/go/buildx/|'
-                r'[[:space:]]*$)" '
-                '>&2)'
+            run_dind = (
+                f"/usr/bin/docker run -d --runtime=sysbox-runc "
+                f"--name {shlex.quote(dind_name)} "
+                f"--cpus={shlex.quote(str(settings.CUSTOM_DOCKERFILE_DIND_CPUS))} "
+                f"--memory={shlex.quote(str(settings.CUSTOM_DOCKERFILE_DIND_MEMORY))} "
+                f"{shlex.quote(dind_image)}"
             )
-            + f" _ {shlex.quote(image_tag)} {shlex.quote(scratch_dir)}"
-        )
-        try:
+            start_res = await ssh_client.run(run_dind, check=False)
+            if start_res.exit_status != 0:
+                logger.error(
+                    _m(
+                        "Custom build DinD start failed",
+                        extra=get_extra_info(
+                            {**default_extra, "stderr": (start_res.stderr or "").strip()}
+                        ),
+                    )
+                )
+                return False, "build_dind_start"
+
+            # 3. Wait for the inner dockerd to accept connections.
+            ready = False
+            for _ in range(max(1, ready_timeout_s)):
+                probe = await ssh_client.run(
+                    f"/usr/bin/docker exec {shlex.quote(dind_name)} docker info",
+                    check=False,
+                )
+                if probe.exit_status == 0:
+                    ready = True
+                    break
+                await asyncio.sleep(1)
+            if not ready:
+                logger.error(
+                    _m(
+                        "Custom build DinD dockerd not ready",
+                        extra=get_extra_info(
+                            {**default_extra, "ready_timeout_s": ready_timeout_s}
+                        ),
+                    )
+                )
+                return False, "build_dind_unready"
+
+            # 4. Resolve the DinD container IP and firewall its egress host-side
+            #    (block cloud metadata + RFC1918; full public internet stays open).
+            ip_res = await ssh_client.run(
+                "/usr/bin/docker inspect -f "
+                "'{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "
+                f"{shlex.quote(dind_name)}",
+                check=False,
+            )
+            raw_ip = (ip_res.stdout or "").strip()
+            try:
+                dind_ip = str(ipaddress.ip_address(raw_ip))
+            except ValueError:
+                logger.error(
+                    _m(
+                        "Custom build could not resolve DinD container IP",
+                        extra=get_extra_info({**default_extra, "raw_ip": raw_ip}),
+                    )
+                )
+                return False, "build_egress_setup"
+
+            apply_script = self._egress_filter_script(dind_ip, cidrs, apply=True)
+            egress_cmd = (
+                f"/usr/bin/docker run --rm --network=host --cap-add=NET_ADMIN "
+                f"--entrypoint /bin/sh {shlex.quote(dind_image)} "
+                f"-c {shlex.quote(apply_script)}"
+            )
             ok, err = await self.execute_and_stream_logs(
                 ssh_client=ssh_client,
-                command=build_cmd,
+                command=egress_cmd,
                 log_tag=log_tag,
-                log_text=f"Building custom image {image_tag}",
+                log_text="Applying build egress firewall",
+                log_extra={**default_extra, "dind_ip": dind_ip},
+                raise_exception=False,
+            )
+            if not ok:
+                # Cannot guarantee egress filtering -> never run the build open.
+                logger.error(
+                    _m(
+                        "Custom build egress firewall failed",
+                        extra=get_extra_info({**default_extra, "error": err}),
+                    )
+                )
+                return False, "build_egress_setup"
+            egress_applied = True
+
+            # 5. Write the Dockerfile into the DinD container (stdin, not argv).
+            await self.stream_log(
+                f"Preparing build context in {dind_name}", "success", log_tag
+            )
+            try:
+                await self._write_dockerfile_into_dind(ssh_client, dind_name, content)
+            except Exception as exc:
+                logger.error(
+                    _m(
+                        "Custom build Dockerfile write failed",
+                        extra=get_extra_info({**default_extra, "error": str(exc)}),
+                    ),
+                    exc_info=True,
+                )
+                return False, "build_setup"
+
+            # 6. Build INSIDE the DinD container WITH network enabled (no
+            #    --network=none). BuildKit streams progress to stderr and
+            #    `execute_and_stream_logs` treats any stderr as failure, so we
+            #    redirect build output to stdout (streamed as success logs) and
+            #    emit to stderr ONLY on non-zero exit — the streamer's signal.
+            inner_build = (
+                f"docker build --progress=plain --pull "
+                f"-t {shlex.quote(image_tag)} {shlex.quote(ctx)} 2>&1; "
+                f"rc=$?; [ $rc -ne 0 ] && echo BUILD_FAILED_RC=$rc >&2; exit $rc"
+            )
+            build_cmd = (
+                f"/usr/bin/docker exec {shlex.quote(dind_name)} "
+                f"sh -c {shlex.quote(inner_build)}"
+            )
+            try:
+                ok, err = await self.execute_and_stream_logs(
+                    ssh_client=ssh_client,
+                    command=build_cmd,
+                    log_tag=log_tag,
+                    log_text=f"Building custom image {image_tag}",
+                    log_extra={**default_extra, "build_image_tag": image_tag},
+                    timeout=timeout_s,
+                    raise_exception=False,
+                )
+            except Exception as exc:
+                logger.error(
+                    _m(
+                        "Custom build invocation failed",
+                        extra=get_extra_info({**default_extra, "error": str(exc)}),
+                    ),
+                    exc_info=True,
+                )
+                return False, "docker_build"
+            if not ok:
+                if "process timed out" in (err or "").lower():
+                    return False, "build_timeout"
+                return False, "docker_build"
+
+            # 7. Export the image from DinD and load it onto the host daemon so
+            #    the rental `docker run` (host-side) can use it.
+            await self.stream_log(
+                f"Loading built image {image_tag} onto host", "success", log_tag
+            )
+            export_cmd = (
+                f"/usr/bin/docker exec {shlex.quote(dind_name)} "
+                f"docker save {shlex.quote(image_tag)} | /usr/bin/docker load"
+            )
+            ok, err = await self.execute_and_stream_logs(
+                ssh_client=ssh_client,
+                command=export_cmd,
+                log_tag=log_tag,
+                log_text=f"Exporting custom image {image_tag}",
                 log_extra={**default_extra, "build_image_tag": image_tag},
                 timeout=timeout_s,
                 raise_exception=False,
             )
-        except Exception as exc:
-            logger.error(
+            if not ok:
+                if "process timed out" in (err or "").lower():
+                    return False, "build_timeout"
+                return False, "build_export"
+
+            return True, None
+        finally:
+            # Always tear down the throwaway container + its egress rules. The
+            # host-loaded image is removed later by _cleanup_custom_build_artifacts.
+            await self._teardown_dind_build(
+                ssh_client=ssh_client,
+                dind_name=dind_name,
+                dind_image=dind_image,
+                dind_ip=dind_ip if egress_applied else None,
+                cidrs=cidrs,
+                default_extra=default_extra,
+            )
+
+    async def _teardown_dind_build(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        dind_name: str,
+        dind_image: str,
+        dind_ip: str | None,
+        cidrs: list[str],
+        default_extra: dict,
+    ) -> None:
+        """Best-effort teardown of the throwaway DinD container + its egress rules.
+
+        Always called from `_custom_build_image`'s finally. Failures are logged,
+        never raised — the rental flow must not break on cleanup.
+        """
+        if dind_ip:
+            try:
+                remove_script = self._egress_filter_script(dind_ip, cidrs, apply=False)
+                await ssh_client.run(
+                    f"/usr/bin/docker run --rm --network=host --cap-add=NET_ADMIN "
+                    f"--entrypoint /bin/sh {shlex.quote(dind_image)} "
+                    f"-c {shlex.quote(remove_script)}",
+                    check=False,
+                )
+            except Exception as exc:  # noqa: BLE001 — best-effort
+                logger.warning(
+                    _m(
+                        "Custom build egress rule teardown failed (non-fatal)",
+                        extra=get_extra_info(
+                            {**default_extra, "error": str(exc), "dind_ip": dind_ip}
+                        ),
+                    )
+                )
+        try:
+            await ssh_client.run(
+                f"/usr/bin/docker rm -f {shlex.quote(dind_name)} 2>/dev/null || true",
+                check=False,
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            logger.warning(
                 _m(
-                    "Custom build invocation failed",
-                    extra=get_extra_info({**default_extra, "error": str(exc)}),
-                ),
-                exc_info=True,
+                    "Custom build DinD container teardown failed (non-fatal)",
+                    extra=get_extra_info(
+                        {**default_extra, "error": str(exc), "dind_name": dind_name}
+                    ),
+                )
             )
-            return False, "docker_build"
-
-        if not ok:
-            # Distinguish timeout / network-blocked vs generic build failure.
-            err_lc = (err or "").lower()
-            if "process timed out" in err_lc:
-                return False, "build_timeout"
-            # `--network=none` causes name-resolution / unreachable host messages.
-            network_markers = (
-                "could not resolve host",
-                "temporary failure in name resolution",
-                "network is unreachable",
-                "no route to host",
-                "name or service not known",
-            )
-            if any(m in err_lc for m in network_markers):
-                return False, "build_network_blocked"
-            return False, "docker_build"
-
-        return True, None
 
     async def _cleanup_custom_build_artifacts(
         self,

--- a/neurons/validators/src/services/task/checks/custom_build_orphan_sweep.py
+++ b/neurons/validators/src/services/task/checks/custom_build_orphan_sweep.py
@@ -42,6 +42,11 @@ SWEEP_INTERVAL_SECONDS = 6 * 60 * 60
 # ``docker_service._custom_build_image_tag`` / ``_custom_build_scratch_dir``.
 BUILD_IMAGE_PREFIX = "lium-build-"
 BUILD_SCRATCH_PREFIX = "/tmp/lium-build-"
+# DAH-2211 — internet-enabled builds run in a throwaway sysbox DinD container
+# named ``lium-dind-build-{pod_id}`` (see ``docker_service._dind_container_name``).
+# Inline teardown removes it; this sweep mops up the validator-crashed-mid-build
+# leftover so a stale container does not pin CPU/mem/disk on the executor host.
+BUILD_DIND_PREFIX = "lium-dind-build-"
 
 
 class CustomBuildOrphanSweepCheck:
@@ -122,6 +127,42 @@ class CustomBuildOrphanSweepCheck:
             orphans.append(path)
         return orphans
 
+    async def _list_orphan_dind_containers(self, ssh, active_pod_ids: set[str]) -> list[str]:
+        """Return `lium-dind-build-*` container names whose pod_id is not active."""
+        cmd = (
+            f'/usr/bin/docker ps -a --filter "name={BUILD_DIND_PREFIX}" '
+            f'--format "{{{{.Names}}}}" 2>/dev/null || true'
+        )
+        try:
+            result = await ssh.run(cmd, check=False)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Custom build orphan sweep: docker ps failed: %s", exc)
+            return []
+        orphans: list[str] = []
+        for raw in (result.stdout or "").splitlines():
+            name = raw.strip()
+            if not name.startswith(BUILD_DIND_PREFIX):
+                continue
+            pod_id = name[len(BUILD_DIND_PREFIX):]
+            if not pod_id or pod_id in active_pod_ids:
+                continue
+            orphans.append(name)
+        return orphans
+
+    async def _remove_dind_container(self, ssh, name: str) -> bool:
+        # Defensive — only act on names matching our prefix.
+        if not name.startswith(BUILD_DIND_PREFIX):
+            return False
+        cmd = f'/usr/bin/docker rm -f {name} 2>/dev/null || true'
+        try:
+            await ssh.run(cmd, check=False)
+            return True
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Custom build orphan sweep: dind rm failed (%s): %s", name, exc
+            )
+            return False
+
     async def _remove_image(self, ssh, image_ref: str) -> bool:
         cmd = f'/usr/bin/docker image rm {image_ref} 2>/dev/null || true'
         try:
@@ -162,9 +203,10 @@ class CustomBuildOrphanSweepCheck:
 
         active_pod_ids = self._active_pod_ids(ctx)
         try:
-            orphan_images, orphan_scratch = await asyncio.gather(
+            orphan_images, orphan_scratch, orphan_dind = await asyncio.gather(
                 self._list_orphan_images(ctx.ssh, active_pod_ids),
                 self._list_orphan_scratch_dirs(ctx.ssh, active_pod_ids),
+                self._list_orphan_dind_containers(ctx.ssh, active_pod_ids),
             )
         except Exception as exc:  # noqa: BLE001 — non-fatal
             logger.warning(
@@ -177,18 +219,27 @@ class CustomBuildOrphanSweepCheck:
                 Msg.SWEPT,
                 ctx=ctx,
                 check_id=self.check_id,
-                what={"removed_image_count": 0, "removed_scratch_count": 0, "error": str(exc)},
+                what={
+                    "removed_image_count": 0,
+                    "removed_scratch_count": 0,
+                    "removed_dind_count": 0,
+                    "error": str(exc),
+                },
             )
             return CheckResult(passed=True, event=event)
 
         removed_images = 0
         removed_scratch = 0
+        removed_dind = 0
         for image_ref in orphan_images:
             if await self._remove_image(ctx.ssh, image_ref):
                 removed_images += 1
         for path in orphan_scratch:
             if await self._remove_scratch(ctx.ssh, path):
                 removed_scratch += 1
+        for name in orphan_dind:
+            if await self._remove_dind_container(ctx.ssh, name):
+                removed_dind += 1
 
         # Only update cadence timestamp on a successful run end-to-end; this way
         # a transient SSH failure (which we logged above and turned into an
@@ -202,8 +253,10 @@ class CustomBuildOrphanSweepCheck:
             what={
                 "removed_image_count": removed_images,
                 "removed_scratch_count": removed_scratch,
+                "removed_dind_count": removed_dind,
                 "removed_images": orphan_images,
                 "removed_scratch_paths": orphan_scratch,
+                "removed_dind_containers": orphan_dind,
                 "active_pod_ids": sorted(active_pod_ids),
             },
         )

--- a/neurons/validators/tests/test_custom_build_orphan_sweep.py
+++ b/neurons/validators/tests/test_custom_build_orphan_sweep.py
@@ -72,6 +72,34 @@ async def test_sweep_removes_orphan_image_and_scratch():
 
 
 @pytest.mark.asyncio
+async def test_sweep_removes_orphan_dind_container():
+    """DAH-2211: a leftover `lium-dind-build-*` container (validator crashed
+    mid-build) is force-removed unless its pod is still active."""
+    check = CustomBuildOrphanSweepCheck(interval_seconds=0)
+
+    ssh = AsyncMock()
+    calls: list[str] = []
+
+    async def _run(cmd, **kw):
+        calls.append(cmd)
+        if "docker ps -a" in cmd:
+            return _result(
+                stdout="lium-dind-build-POD-DEAD\nlium-dind-build-POD-ALIVE\n"
+            )
+        return _result()
+
+    ssh.run = _run
+    ctx = _make_ctx(executor_uuid="exec-1", active_pod_ids={"POD-ALIVE"}, ssh=ssh)
+
+    result = await check.run(ctx)
+    assert result.passed is True
+
+    dind_rm_calls = [c for c in calls if "docker rm -f lium-dind-build-" in c]
+    assert any("lium-dind-build-POD-DEAD" in c for c in dind_rm_calls)
+    assert not any("lium-dind-build-POD-ALIVE" in c for c in dind_rm_calls)
+
+
+@pytest.mark.asyncio
 async def test_sweep_respects_cadence():
     """Second invocation within the cadence window must NOT re-list / remove."""
     check = CustomBuildOrphanSweepCheck(interval_seconds=6 * 60 * 60)

--- a/neurons/validators/tests/test_custom_dockerfile_build.py
+++ b/neurons/validators/tests/test_custom_dockerfile_build.py
@@ -1,16 +1,19 @@
 """DAH-2211 — validator-owned subset of §3.A and §3.B tests for
 custom-dockerfile pod deployment.
 
-Covers (from the plan):
+Covers (from the plan + DAH-2211 isolated-build flow):
 - A.1 Golden-snapshot regression — image-pull JSON byte-identical
 - A.2 Build success path
 - A.4 Build failure (bad RUN)
-- A.5 Unreachable base image
+- A.5 Unreachable base image (network ON → generic docker_build)
 - A.6 Hard timeout
-- A.9 `--network=none` enforced during build
+- A.9 Build runs in a sysbox DinD container WITH network (no --network=none)
 - A.11 Empty dockerfile_content guard (validator-level, no SSH issued)
+- A.12 sysbox-runc unavailable → build_sysbox_unavailable (never builds)
+- A.13 egress firewall failure → build_egress_setup (never builds)
+- A.14 DinD container always torn down (finally)
+- A.15 image export (save|load) failure → build_export
 - B.1 SSE latency p95 ≤ 2000 ms (stubbed redis consumer)
-- B.3 Pre-build `df` rejection
 """
 
 from __future__ import annotations
@@ -77,6 +80,63 @@ def _ssh_result(exit_status: int = 0, stdout: str = "", stderr: str = ""):
     r.stdout = stdout
     r.stderr = stderr
     return r
+
+
+def _make_dind_ssh(
+    *,
+    sysbox: bool = True,
+    dind_start_exit: int = 0,
+    ready_exit: int = 0,
+    dind_ip: str = "172.20.0.2",
+):
+    """An `ssh.run` router emulating the DAH-2211 DinD build control commands.
+
+    Routes by command substring: sysbox preflight, DinD `run -d`, the
+    readiness `docker exec ... docker info` probe, IP inspect, and everything
+    else (Dockerfile write, teardown) → exit 0. The build / egress / export
+    steps go through `execute_and_stream_logs`, not `ssh.run`.
+    """
+    calls: list[str] = []
+
+    async def _run(cmd, **kw):
+        calls.append(cmd)
+        if "info --format" in cmd and "Runtimes" in cmd:
+            runtimes = '{"runc":{"path":"runc"}'
+            if sysbox:
+                runtimes += ',"sysbox-runc":{"path":"/usr/bin/sysbox-runc"}'
+            runtimes += "}"
+            return _ssh_result(stdout=runtimes)
+        if "run -d --runtime=sysbox-runc" in cmd:
+            return _ssh_result(exit_status=dind_start_exit, stdout="dind-cid")
+        if "docker exec" in cmd and cmd.rstrip().endswith("docker info"):
+            return _ssh_result(exit_status=ready_exit)
+        if "docker inspect -f" in cmd:
+            return _ssh_result(stdout=dind_ip)
+        return _ssh_result(exit_status=0)
+
+    ssh = AsyncMock()
+    ssh.run = _run
+    ssh.calls = calls
+    return ssh
+
+
+def _make_esl(*, egress=(True, ""), build=(True, ""), export=(True, "")):
+    """Stub `execute_and_stream_logs`, routing by the step it serves."""
+    seen: list[str] = []
+
+    async def _esl(**kwargs):
+        cmd = kwargs.get("command", "")
+        seen.append(cmd)
+        if "--network=host" in cmd:  # egress firewall helper
+            return egress
+        if "docker save" in cmd:  # export (save | load)
+            return export
+        if "docker build" in cmd:  # the build itself
+            return build
+        return (True, "")
+
+    _esl.seen = seen
+    return _esl
 
 
 def _base_payload(*, dockerfile_content: str | None = None, docker_image: str = "daturaai/pytorch:test") -> ContainerCreateRequest:
@@ -339,30 +399,22 @@ async def test_A4_build_failure_returns_ccf_unknown_error(svc, monkeypatch):
 
 
 # ------------------------------------------------------------------
-# A.5 — Unreachable base classifies identically (UnknownError) with
-#       distinguishing failure_step
+# A.5 — Unreachable base image. Network is ON now, so a resolve failure is a
+#       genuine build error (no dedicated network-blocked step).
 # ------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_A5_unreachable_base_image_ccf_classification(svc, monkeypatch):
-    ssh_client = AsyncMock()
-    ssh_client.run = AsyncMock(return_value=_ssh_result())
+    ssh_client = _make_dind_ssh()
     _patch_create_container_happy(svc, monkeypatch, ssh_client)
-
-    # _custom_build_image internally classifies via the docker build stderr
-    # markers. Here we route through the real subroutine to assert the
-    # classification logic by stubbing execute_and_stream_logs to return a
-    # registry-resolution failure.
     monkeypatch.setattr(svc, "_cleanup_custom_build_artifacts", AsyncMock())
-    # df returns plenty of space
-    async def _ssh_run(cmd, **kw):
-        return _ssh_result(stdout=str(1024 * 1024 * 100))
-    ssh_client.run = _ssh_run
 
-    async def _exec_emulate_pull_failure(**kwargs):
-        return (False, "ERROR: failed to pull image: could not resolve host gcr.io")
-    monkeypatch.setattr(svc, "execute_and_stream_logs", _exec_emulate_pull_failure)
+    # Egress applies fine; the build step fails resolving an unreachable base.
+    monkeypatch.setattr(
+        svc, "execute_and_stream_logs",
+        _make_esl(build=(False, "ERROR: failed to solve: could not resolve host gcr.io")),
+    )
 
     payload = _base_payload(dockerfile_content="FROM gcr.io/this-does-not-exist:latest\n")
     result = await svc.create_container(
@@ -374,8 +426,8 @@ async def test_A5_unreachable_base_image_ccf_classification(svc, monkeypatch):
 
     assert isinstance(result, FailedContainerRequest)
     assert result.error_code == FailedContainerErrorCodes.UnknownError
-    # Network resolution failures classify as `build_network_blocked`.
-    assert result.failure_step == "build_network_blocked"
+    # With network enabled there is no special network-blocked step anymore.
+    assert result.failure_step == "docker_build"
 
 
 # ------------------------------------------------------------------
@@ -385,16 +437,14 @@ async def test_A5_unreachable_base_image_ccf_classification(svc, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_A6_build_hard_timeout(svc, monkeypatch):
-    ssh_client = AsyncMock()
-    # df: plenty of space
-    async def _ssh_run(cmd, **kw):
-        return _ssh_result(stdout=str(1024 * 1024 * 100))
-    ssh_client.run = _ssh_run
+    ssh_client = _make_dind_ssh()
     _patch_create_container_happy(svc, monkeypatch, ssh_client)
 
-    async def _exec_timeout(**kwargs):
-        return (False, "Process timed out")
-    monkeypatch.setattr(svc, "execute_and_stream_logs", _exec_timeout)
+    # Egress applies fine; the build step times out.
+    monkeypatch.setattr(
+        svc, "execute_and_stream_logs",
+        _make_esl(build=(False, "Process timed out")),
+    )
     monkeypatch.setattr(svc, "_cleanup_custom_build_artifacts", AsyncMock())
 
     payload = _base_payload(dockerfile_content="FROM scratch\nRUN sleep 99999\n")
@@ -411,22 +461,18 @@ async def test_A6_build_hard_timeout(svc, monkeypatch):
 
 
 # ------------------------------------------------------------------
-# A.9 — `--network=none` enforced during build
+# A.9 — Build runs inside a sysbox DinD container WITH network (no
+#       --network=none), then the image is exported to the host.
 # ------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_A9_network_none_used_in_build_command(svc, monkeypatch):
-    """The docker build command emitted by `_custom_build_image` carries
-    `--network=none`, so `RUN curl ...` can't egress at build time."""
-    ssh_client = AsyncMock()
-    ssh_client.run = AsyncMock(return_value=_ssh_result())
-
-    captured: list[str] = []
-    async def _exec(**kwargs):
-        captured.append(kwargs.get("command", ""))
-        return (True, "")
-    monkeypatch.setattr(svc, "execute_and_stream_logs", _exec)
+async def test_A9_build_runs_in_sysbox_dind_with_network(svc, monkeypatch):
+    """`_custom_build_image` launches a sysbox DinD container, builds inside it
+    WITHOUT `--network=none`, firewalls egress, and exports the image."""
+    ssh_client = _make_dind_ssh()
+    esl = _make_esl()
+    monkeypatch.setattr(svc, "execute_and_stream_logs", esl)
     monkeypatch.setattr(svc, "stream_log", AsyncMock())
 
     payload = _base_payload(dockerfile_content="FROM alpine\nRUN curl -m 2 http://example.com\n")
@@ -437,9 +483,121 @@ async def test_A9_network_none_used_in_build_command(svc, monkeypatch):
         default_extra={"pod_id": payload.pod_id},
     )
     assert ok is True and step is None
-    # Must call docker build with --network=none
-    assert any("--network=none" in c for c in captured), captured
-    assert any(f"lium-build-{payload.pod_id}" in c for c in captured), captured
+
+    all_run = "\n".join(ssh_client.calls)
+    all_esl = "\n".join(esl.seen)
+    # DinD launched under sysbox-runc with the per-pod name.
+    assert "run -d --runtime=sysbox-runc" in all_run
+    assert f"lium-dind-build-{payload.pod_id}" in all_run
+    # Build happens inside the DinD container and NEVER with --network=none.
+    assert any("docker build" in c for c in esl.seen)
+    assert "--network=none" not in all_esl
+    # Egress firewall applied + image exported (save | load) onto the host.
+    assert any("--network=host" in c and "DOCKER-USER" in c for c in esl.seen)
+    assert any("docker save" in c and "docker load" in c for c in esl.seen)
+    assert any(f"lium-build-{payload.pod_id}" in c for c in esl.seen)
+
+
+# ------------------------------------------------------------------
+# A.12 — sysbox-runc unavailable → build_sysbox_unavailable, NO build attempted
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_A12_sysbox_unavailable_aborts_before_build(svc, monkeypatch):
+    ssh_client = _make_dind_ssh(sysbox=False)
+    esl = _make_esl()
+    monkeypatch.setattr(svc, "execute_and_stream_logs", esl)
+    monkeypatch.setattr(svc, "stream_log", AsyncMock())
+
+    payload = _base_payload(dockerfile_content="FROM alpine\nRUN echo hi\n")
+    ok, step = await svc._custom_build_image(
+        ssh_client=ssh_client,
+        payload=payload,
+        log_tag="t",
+        default_extra={"pod_id": payload.pod_id},
+    )
+    assert ok is False
+    assert step == "build_sysbox_unavailable"
+    # Never started a DinD container, never built (no runc fallback).
+    assert not any("run -d --runtime=sysbox-runc" in c for c in ssh_client.calls)
+    assert not any("docker build" in c for c in esl.seen)
+
+
+# ------------------------------------------------------------------
+# A.13 — egress firewall failure → build_egress_setup, NO build attempted
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_A13_egress_failure_aborts_before_build(svc, monkeypatch):
+    ssh_client = _make_dind_ssh()
+    esl = _make_esl(egress=(False, "DOCKER-USER chain not found"))
+    monkeypatch.setattr(svc, "execute_and_stream_logs", esl)
+    monkeypatch.setattr(svc, "stream_log", AsyncMock())
+
+    payload = _base_payload(dockerfile_content="FROM alpine\nRUN echo hi\n")
+    ok, step = await svc._custom_build_image(
+        ssh_client=ssh_client,
+        payload=payload,
+        log_tag="t",
+        default_extra={"pod_id": payload.pod_id},
+    )
+    assert ok is False
+    assert step == "build_egress_setup"
+    # The build must NOT run when egress filtering can't be guaranteed.
+    assert not any("docker build" in c for c in esl.seen)
+    # But the DinD container is still torn down.
+    assert any(f"docker rm -f" in c and f"lium-dind-build-{payload.pod_id}" in c
+               for c in ssh_client.calls)
+
+
+# ------------------------------------------------------------------
+# A.14 — DinD container is always torn down (finally), even on success
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_A14_dind_container_always_torn_down(svc, monkeypatch):
+    ssh_client = _make_dind_ssh()
+    monkeypatch.setattr(svc, "execute_and_stream_logs", _make_esl())
+    monkeypatch.setattr(svc, "stream_log", AsyncMock())
+
+    payload = _base_payload(dockerfile_content="FROM alpine\nRUN echo hi\n")
+    ok, step = await svc._custom_build_image(
+        ssh_client=ssh_client,
+        payload=payload,
+        log_tag="t",
+        default_extra={"pod_id": payload.pod_id},
+    )
+    assert ok is True and step is None
+    assert any(
+        "docker rm -f" in c and f"lium-dind-build-{payload.pod_id}" in c
+        for c in ssh_client.calls
+    ), ssh_client.calls
+
+
+# ------------------------------------------------------------------
+# A.15 — image export (save | load) failure → build_export
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_A15_export_failure_classifies_build_export(svc, monkeypatch):
+    ssh_client = _make_dind_ssh()
+    esl = _make_esl(export=(False, "Error: no space left on device"))
+    monkeypatch.setattr(svc, "execute_and_stream_logs", esl)
+    monkeypatch.setattr(svc, "stream_log", AsyncMock())
+
+    payload = _base_payload(dockerfile_content="FROM alpine\nRUN echo hi\n")
+    ok, step = await svc._custom_build_image(
+        ssh_client=ssh_client,
+        payload=payload,
+        log_tag="t",
+        default_extra={"pod_id": payload.pod_id},
+    )
+    assert ok is False
+    assert step == "build_export"
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Describe your changes

Custom-dockerfile pods previously built with `docker build --network=none` directly on the executor **host daemon**, so `RUN` steps could not fetch dependencies. This moves the build into a **throwaway sysbox Docker-in-Docker container with network enabled**, then exports the image and loads it onto the host for the rental `docker run`.

**Isolation / security (both threats from the review):**
- **Host-escape blast radius** — the build runs under `--runtime=sysbox-runc` (user-namespaced: root inside maps to an unprivileged host UID). Preflight hard-fails with `build_sysbox_unavailable` if `sysbox-runc` is absent — it never silently falls back to `runc`.
- **Network egress abuse** — a host-side egress firewall (`DOCKER-USER`, backend-aware nft/legacy helper, scoped to the DinD container IP) blocks cloud metadata (`169.254.0.0/16`) and RFC1918 while leaving public internet open. If the firewall cannot be applied the build is aborted (`build_egress_setup`) — it never runs open.
- The DinD container and its egress rules are always torn down (`finally`); the orphan sweep now also reaps leftover `lium-dind-build-*` containers.

**Build success/failure detection:** BuildKit streams progress to stderr, which `execute_and_stream_logs` reads as failure, so the inner build redirects output to stdout and emits a stderr marker only on non-zero exit.

**Changes**
- `docker_service.py` — rewrote `_custom_build_image` for the DinD flow; added `_dind_container_name`, `_write_dockerfile_into_dind`, `_parse_egress_block_cidrs`, `_egress_filter_script`, `_teardown_dind_build`.
- `config.py` — new tunables: DinD image / cpus / memory, ready timeout, egress block CIDRs.
- `custom_build_orphan_sweep.py` — sweep leftover `lium-dind-build-*` containers.
- Tests — updated A.5/A.6/A.9 for the new flow; added A.12–A.15 (sysbox-unavailable, egress failure, always-teardown, export failure) and a DinD orphan-sweep case.

**Verification**
- Full validator suite: **690 passed, 4 skipped**.
- The exact generated command sequence was run end-to-end on a live sysbox executor: internet works during build (`pypi=200`), metadata blocked (`169.254.169.254` → blocked), image loaded and ran on host, teardown left zero rules.

**Rollout note:** every executor host must have `sysbox-runc` installed and the `daturaai/dind` image present. The preflight fails safe (custom builds error cleanly) on hosts that lack either, until they are provisioned.

## Issue ticket number and link

[DAH-2233 - Sandbox custom-Dockerfile pod builds (sysbox/rootless-BuildKit) instead of host docker build --network=none](https://app.notion.com/p/Sandbox-custom-Dockerfile-pod-builds-sysbox-rootless-BuildKit-instead-of-host-docker-build-netwo-382b8bfdbde981b89210f5acde98015e)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance? Build now adds DinD startup + image save/load (seconds–minutes + transient 2x image disk for large CUDA images); bounded by existing build timeout and new `--cpus`/`--memory` limits.