### PR TITLE
Extend min NVIDIA driver cutoff date to 2026-06-30

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -136,7 +136,7 @@ class Settings(BaseSettings):
     # on/after the cutoff, non-compliant unrented executors are fully gated (multiplier 0).
     # Currently-rented executors are always exempt.
     MIN_NVIDIA_DRIVER_VERSION: str = Field(env="MIN_NVIDIA_DRIVER_VERSION", default="580.65.06")
-    MIN_DRIVER_CUTOFF: datetime = datetime(2026, 6, 24, 12, 0, 0)
+    MIN_DRIVER_CUTOFF: datetime = datetime(2026, 6, 30, 12, 0, 0)
 
     TIME_DELTA_FOR_EMISSION: float = 0.01
 


### PR DESCRIPTION
## Describe your changes

Extend the validator `MIN_DRIVER_CUTOFF` grace period for the minimum NVIDIA driver requirement from 2026-06-24 to 2026-06-30 (noon UTC). Unrented executors below `MIN_NVIDIA_DRIVER_VERSION` (580.65.06) remain fully gated only on/after the cutoff; currently-rented executors stay exempt.

## Issue ticket number and link

[DAH-2200](https://www.notion.so/Compute-SN-c27d35dd084e4c4d92374f55cdd293f2?p=f9b26856f1a6406892b5db46446260da&pm=s)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I wrote tests.
- [ ] Need to take care of performance?


Made with [Cursor](https://cursor.com)