### PR TITLE
Hotfix follow-up: preserve non-cached SSH bootstrap behavior

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -2733,7 +2733,7 @@ class DockerService:
                         log_tag=log_tag,
                         log_extra=default_extra,
                     )
-                    if not ssh_bootstrap_ok:
+                    if payload.ships_sshd and not ssh_bootstrap_ok:
                         raise RuntimeError("SSH bootstrap failed")
 
                     jupyter_url = None

--- a/neurons/validators/tests/test_deploy_optimizations.py
+++ b/neurons/validators/tests/test_deploy_optimizations.py
@@ -301,6 +301,18 @@ async def test_ships_sshd_false_runs_install(svc, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_ships_sshd_false_preserves_lenient_bootstrap_failure(svc, monkeypatch):
+    ssh_client = _ssh_client(inspect_exit=0)
+    _patch_happy(svc, monkeypatch, ssh_client)
+    svc.install_open_ssh_server_and_start_ssh_service.return_value = False
+
+    result = await _run(svc, _payload(ships_sshd=False))
+
+    assert isinstance(result, ContainerCreated)
+    svc.install_open_ssh_server_and_start_ssh_service.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_ships_sshd_true_with_jupyter(svc, monkeypatch):
     ssh_client = _ssh_client(inspect_exit=0)
     _patch_happy(svc, monkeypatch, ssh_client)


### PR DESCRIPTION
## Summary
- Keep the merged shipped-sshd hotfix fail-closed only for `ships_sshd=true`.
- Preserve previous non-cached/custom-image behavior when the bootstrap helper reports false.
- Add a regression test for `ships_sshd=false` bootstrap failures.

## Why
While staging the merged hotfix, a true non-cached Ubuntu image hit `ships_sshd=false` and returned a bootstrap false result. The merged PR would convert that existing lenient path into `CREATION_FAILED`, which is broader than the intended emergency fix for cached templates.

## Validation
- `pdm run pytest tests/test_deploy_optimizations.py tests/test_docker_service.py -q` from `neurons/validators`
- `git diff --check`