### PR TITLE
feat: DAH-2265 — verify cached image is digest-current (+ plan 2/3)

### DIFF
--- a/neurons/validators/src/clients/backend_client.py
+++ b/neurons/validators/src/clients/backend_client.py
@@ -5,6 +5,7 @@ import json
 import logging
 import time
 from typing import Any, ClassVar, TypeVar
+from urllib.parse import urlencode
 
 import aiohttp
 import bittensor
@@ -13,6 +14,8 @@ from tenacity import retry, retry_if_result, stop_after_attempt, wait_fixed
 
 from core.utils import _m, get_extra_info
 from protocol.vc_protocol.compute_requests import (
+    DefaultDockerImage,
+    DefaultDockerImagesResponse,
     ExecutorHealthCheckResponse,
     PodRentalActiveResponse,
     RentedExecutorsResponse,
@@ -206,6 +209,25 @@ class BackendClient:
             RentedExecutorsResponse,
             timeout=30,
         )
+
+    async def get_default_docker_image(
+        self, gpu_model: str, driver_version: str
+    ) -> list[DefaultDockerImage] | None:
+        """Fetch the recommended/default template image(s) for a GPU + driver combo.
+
+        Hits the same public `/executors/default-docker-image` endpoint the executor
+        cache pre-pull consumes (DAH-2265 Plan 2). Advisory caller: no retry (must not
+        block the validation pipeline), unsigned (mirrors the executor), and `get()`
+        already returns None on any error / non-200 / bad JSON, so this fails open.
+        """
+        query = urlencode({"gpu_model": gpu_model, "driver_version": driver_version})
+        response = await self.get(
+            f"/executors/default-docker-image?{query}",
+            DefaultDockerImagesResponse,
+            add_signature=False,
+            timeout=15,
+        )
+        return response.root if response is not None else None
 
     async def get_pod_rental_active(self, pod_id: str) -> PodRentalActiveResponse | None:
         """Fetch whether the backend still considers a pod rental active."""

--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, RootModel, field_validator
 
 from services.const import FILLER_CONTAINER_PREFIX
 
@@ -120,3 +120,28 @@ class ExecutorHealthCheckResponse(BaseModel):
     error: str | None = None
     details: dict | None = None
     reason_code: str | None = None
+
+
+class DefaultDockerImage(BaseModel, extra="allow"):
+    """One recommended/default template image for a GPU + driver combo.
+
+    Mirrors a single item from the backend `/executors/default-docker-image`
+    response (the same endpoint the executor cache pre-pull consumes). Parsed
+    leniently so new backend fields never break validation.
+    """
+    docker_image: str
+    docker_image_tag: str
+    docker_image_size: int | None = None
+    # DAH-2265: bare manifest-list digest ("sha256:…") the backend says is current for this
+    # image. None when the backend has no recorded digest. Compared against the executor's
+    # local RepoDigest to flag stale content cached under an unchanged tag.
+    docker_image_digest: str | None = None
+
+    @property
+    def image_ref(self) -> str:
+        return f"{self.docker_image}:{self.docker_image_tag}"
+
+
+class DefaultDockerImagesResponse(RootModel[list[DefaultDockerImage]]):
+    """The backend returns a bare JSON list; wrap it so `BackendClient.get()`
+    (which validates with a single model) can parse it."""

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1417,6 +1417,7 @@ class DockerService:
         log_extra: dict,
         limit: int | None = None,
         timeout: int = 10,
+        sparse: bool = False,
     ):
         requested_timeout = timeout
         if limit:
@@ -1429,7 +1430,17 @@ class DockerService:
             command = f'/usr/bin/docker plugin install ashald/docker-volume-loopback --alias {loopback_plugin_name} --grant-all-permissions DATA_DIR="{docker_root_dir}/loopback"'
             await ssh_client.run(command)
 
-            command = f'/usr/bin/docker volume create -d {loopback_plugin_name} {local_volume} -o size={limit}g'
+            # DAH-2265 Plan 3: the loopback plugin preallocates the whole backing file
+            # by default (creation time scales with size). `sparse=true` writes a sparse
+            # file (creation ~flat) while still capping the volume at `size`. Gated to
+            # full-node rentals only — see the caller — because a sparse partial volume
+            # leaves its unwritten space free in df AND still counts its declared size in
+            # resolve_volume_sizing(), double-counting the pool and overcommitting host disk.
+            sparse_opt = " -o sparse=true" if sparse else ""
+            command = (
+                f'/usr/bin/docker volume create -d {loopback_plugin_name} '
+                f'{local_volume} -o size={limit}g{sparse_opt}'
+            )
         else:
             loopback_plugin_name = None
             command = f"/usr/bin/docker volume create {local_volume}"
@@ -1443,6 +1454,7 @@ class DockerService:
             "effective_timeout_seconds": timeout,
             "timeout_scaled": timeout != requested_timeout,
             "loopback_plugin": loopback_plugin_name,
+            "sparse": bool(sparse and limit),
         }
         logger.info(
             _m(
@@ -2564,6 +2576,14 @@ class DockerService:
 
                     current_step = "volume_creation"
                     local_volume = f"volume_{payload.pod_id}"
+                    # DAH-2265 Plan 3: only full-node rentals (disk_share >= 1.0) get a
+                    # sparse loopback volume. A full-node pod is sole-tenant, so there is
+                    # nothing to overcommit against; partial (< 1.0) and legacy (None)
+                    # rentals must stay preallocated to keep the DAH-2183 fresh-sizing
+                    # math (df_avail + existing declared sizes) balanced.
+                    full_node_rental = (
+                        payload.disk_share is not None and payload.disk_share >= 1.0
+                    )
                     await self.create_local_volume(
                         ssh_client=ssh_client,
                         local_volume=local_volume,
@@ -2571,6 +2591,7 @@ class DockerService:
                         log_text=f"Creating docker volume {local_volume}",
                         log_extra=default_extra,
                         limit=effective_volume_limit_gb,
+                        sparse=full_node_rental,
                     )
                     created_local_volume = True
 

--- a/neurons/validators/src/services/task/checks/__init__.py
+++ b/neurons/validators/src/services/task/checks/__init__.py
@@ -1,4 +1,5 @@
 from .banned_gpu import BannedGpuCheck
+from .cached_template_verification import CachedTemplateVerificationCheck
 from .capability import CapabilityCheck
 from .collateral import CollateralCheck
 from .custom_build_orphan_sweep import CustomBuildOrphanSweepCheck
@@ -27,6 +28,7 @@ from .verifyx import VerifyXCheck
 
 __all__ = [
     "BannedGpuCheck",
+    "CachedTemplateVerificationCheck",
     "CapabilityCheck",
     "CollateralCheck",
     "CustomBuildOrphanSweepCheck",

--- a/neurons/validators/src/services/task/checks/cached_template_verification.py
+++ b/neurons/validators/src/services/task/checks/cached_template_verification.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+import shlex
+from dataclasses import replace
+
+from ..messages import CachedTemplateMessages as Msg
+from ..messages import render_message
+from ..pipeline import CheckResult, Context
+
+
+def _repo_digest(stdout: str | None, repo: str) -> str | None:
+    """Bare sha256 of the RepoDigests entry matching ``repo`` ("repo@sha256:…"), or None.
+
+    Strict fail-open: empty/invalid JSON, or no entry whose repo equals ``repo``, returns
+    None. Matching by repo (not ``[0]``) avoids a false match when the image carries several
+    RepoDigests from different repos.
+    """
+    try:
+        entries = json.loads((stdout or "").strip() or "null") or []
+    except Exception:
+        return None
+    for entry in entries:
+        name, _, sha = str(entry).partition("@")
+        if name == repo and sha:
+            return sha
+    return None
+
+
+class CachedTemplateVerificationCheck:
+    """Advisory: verify the executor has the recommended default image pre-pulled.
+
+    DAH-2265 Plan 2. The executor cache pre-pull (``cache_template_service.py``) keeps the
+    recommended default template image warm, and the rental-time DAH-1524 pull-skip turns
+    DOCKER_PULL into a no-op when the image is already present. This check *observes*
+    whether that pre-pull actually happened: it resolves the recommended image from the
+    backend (the same ``/executors/default-docker-image`` endpoint the executor uses) and
+    probes ``docker image inspect`` on the executor.
+
+    Strictly advisory — non-fatal, never halts, never changes score. It only:
+      * emits a structured event (logged by the pipeline sink), and
+      * publishes ``recommended_image_cached`` into ``executor.specs`` via pipeline state.
+
+    It fails open on every uncertainty (unknown GPU/driver, backend unreachable, empty
+    recommendation, SSH error) by recording a skip and leaving state untouched.
+    """
+
+    check_id = "executor.validate.cached_template"
+    fatal = False
+
+    async def run(self, ctx: Context) -> CheckResult:
+        gpu_model = ctx.state.gpu_model
+        driver_version = str((ctx.state.specs or {}).get("gpu", {}).get("driver") or "")
+
+        if not gpu_model or not driver_version:
+            event = render_message(
+                Msg.SKIPPED,
+                ctx=ctx,
+                check_id=self.check_id,
+                what={
+                    "reason": "missing gpu_model or driver_version",
+                    "gpu_model": gpu_model,
+                    "driver_version": driver_version,
+                },
+            )
+            return CheckResult(passed=True, event=event)
+
+        # Backend client already fails open to None on any error/non-200; the try/except
+        # is belt-and-suspenders so an unexpected raise can never break the pipeline.
+        try:
+            images = await ctx.services.backend.get_default_docker_image(gpu_model, driver_version)
+            backend_error = None
+        except Exception as exc:
+            images = None
+            backend_error = str(exc)
+
+        if not images:
+            event = render_message(
+                Msg.SKIPPED,
+                ctx=ctx,
+                check_id=self.check_id,
+                what={
+                    "reason": "no recommended image from backend",
+                    "gpu_model": gpu_model,
+                    "driver_version": driver_version,
+                    "backend_error": backend_error,
+                },
+            )
+            return CheckResult(passed=True, event=event)
+
+        # The top entry is the primary recommended image that default-template rentals
+        # request — the same image the executor pre-pull warms first.
+        image_ref = images[0].image_ref
+        docker_image = images[0].docker_image
+        # Bare manifest digest the backend says is current for this image, if any. Normalize
+        # defensively so a "repo@sha256:…" paste is tolerated and only the sha is compared (M3).
+        backend_digest = getattr(images[0], "docker_image_digest", None)
+        backend_digest = (backend_digest or "").rpartition("@")[2] or None
+
+        try:
+            inspect = await ctx.ssh.run(
+                f'/usr/bin/docker image inspect --format "{{{{json .RepoDigests}}}}" {shlex.quote(image_ref)}',
+                check=False,
+            )
+        except Exception as exc:
+            event = render_message(
+                Msg.SKIPPED,
+                ctx=ctx,
+                check_id=self.check_id,
+                what={
+                    "reason": "docker image inspect failed",
+                    "recommended_image": image_ref,
+                    "error": str(exc),
+                },
+            )
+            return CheckResult(passed=True, event=event)
+
+        cached = inspect.exit_status == 0
+        # Local RepoDigest for THIS repo (strict fail-open: any parse/lookup miss → None).
+        local_digest = _repo_digest(getattr(inspect, "stdout", None), docker_image) if cached else None
+
+        digest_match: bool | None = None
+        if cached and backend_digest and local_digest:
+            digest_match = local_digest == backend_digest
+
+        # One CheckResult event: surface the most specific signal. The digest message refines
+        # the cached axis; recommended_image_cached is still published independently below.
+        if not cached:
+            template = Msg.NOT_CACHED
+        elif digest_match is True:
+            template = Msg.DIGEST_MATCH
+        elif digest_match is False:
+            template = Msg.DIGEST_MISMATCH
+        elif backend_digest:
+            # Cached, a backend digest exists, but the local RepoDigest was unreadable/unmatched.
+            template = Msg.DIGEST_SKIPPED
+        else:
+            # Cached, but the backend published no digest to compare against.
+            template = Msg.CACHED
+
+        event = render_message(
+            template,
+            ctx=ctx,
+            check_id=self.check_id,
+            what={
+                "recommended_image": image_ref,
+                "cached": cached,
+                "digest_match": digest_match,
+                "backend_digest": backend_digest,
+                "local_digest": local_digest,
+                "gpu_model": gpu_model,
+                "driver_version": driver_version,
+            },
+        )
+        return CheckResult(
+            passed=True,
+            event=event,
+            updates={
+                "state": replace(
+                    ctx.state,
+                    recommended_image_cached=cached,
+                    recommended_image_digest_match=digest_match,
+                )
+            },
+        )

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -916,3 +916,66 @@ class FinalizeMessages:
         category="runtime",
         impact="Proceed",
     )
+
+
+class CachedTemplateMessages:
+    """DAH-2265 Plan 2 — advisory cached-template verification.
+
+    Confirms whether the executor has the recommended default image pre-pulled so
+    DOCKER_PULL is a no-op for default-template rentals. Purely observational: every
+    template is severity="info" and the check never fails the pipeline or changes score.
+    """
+
+    CACHED = MessageTemplate(
+        event="Recommended default image is cached on executor",
+        reason="RECOMMENDED_IMAGE_CACHED",
+        severity="info",
+        category="runtime",
+        impact="None — default-template DOCKER_PULL will be a no-op",
+    )
+    NOT_CACHED = MessageTemplate(
+        event="Recommended default image not cached on executor",
+        reason="RECOMMENDED_IMAGE_NOT_CACHED",
+        severity="info",
+        category="runtime",
+        impact=(
+            "None (advisory) — default-template rentals will pay a docker pull "
+            "until the executor pre-pull catches up"
+        ),
+        remediation=(
+            "Executor cache pre-pull keeps the recommended image warm; "
+            "verify cache_template_service is running on the host."
+        ),
+    )
+    SKIPPED = MessageTemplate(
+        event="Cached-template verification skipped",
+        reason="RECOMMENDED_IMAGE_CHECK_SKIPPED",
+        severity="info",
+        category="runtime",
+        impact="None — could not determine the recommended image this cycle",
+    )
+    DIGEST_MATCH = MessageTemplate(
+        event="Recommended image digest matches the published manifest",
+        reason="RECOMMENDED_IMAGE_DIGEST_MATCH",
+        severity="info",
+        category="runtime",
+        impact="None — node holds current content under this tag",
+    )
+    DIGEST_MISMATCH = MessageTemplate(
+        event="Recommended image digest differs from the published manifest",
+        reason="RECOMMENDED_IMAGE_DIGEST_MISMATCH",
+        severity="info",
+        category="runtime",
+        impact="None (advisory) — node serves STALE content under an unchanged tag",
+        remediation=(
+            "Provider should re-pull repo:tag to fetch the latest content; "
+            "the executor cache pre-pull may be broken or disabled."
+        ),
+    )
+    DIGEST_SKIPPED = MessageTemplate(
+        event="Recommended image digest check skipped",
+        reason="RECOMMENDED_IMAGE_DIGEST_SKIPPED",
+        severity="info",
+        category="runtime",
+        impact="None — digest unknown this cycle (no backend digest / unreadable RepoDigests)",
+    )

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -77,6 +77,15 @@ class ContextState:
     rented_data: RentedExecutorsResponse | None = None
     gpu_metrics: dict | None = None
     inspector_event: dict | None = None
+    # DAH-2265 Plan 2: advisory result of the cached-template verification check.
+    # True/False once measured; None = not measured this cycle (skipped/fail-open).
+    # ResultHandler publishes it into executor.specs when not None.
+    recommended_image_cached: bool | None = None
+    # DAH-2265 digest: advisory digest-match for the recommended image. True = local
+    # RepoDigest matches the backend's published manifest digest; False = differs (node
+    # serves STALE content under an unchanged tag); None = not compared this cycle
+    # (not cached / no backend digest / unreadable RepoDigest — strict fail-open).
+    recommended_image_digest_match: bool | None = None
 
 
 class CheckResult(BaseModel):

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -28,6 +28,7 @@ from services.verifyx_validation_service import VerifyXValidationService
 
 from .checks import (
     BannedGpuCheck,
+    CachedTemplateVerificationCheck,
     CapabilityCheck,
     CollateralCheck,
     CustomBuildOrphanSweepCheck,
@@ -264,6 +265,11 @@ class PipelineFactory:
                 VerifyXCheck(),
                 TdxHostCheck(),
                 CapabilityCheck(),
+                # DAH-2265 Plan 2: advisory, non-fatal — observes whether the executor has
+                # the recommended default image pre-pulled (DOCKER_PULL no-op). Runs here,
+                # after specs/gpu_model/driver are populated and the GPU is validated, on the
+                # idle valid-executor population. No scoring impact; fails open on any error.
+                CachedTemplateVerificationCheck(),
                 RentalVerificationCheck(),
                 ScoreCheck(),
                 FinalizeCheck(),

--- a/neurons/validators/src/services/task/result_handler.py
+++ b/neurons/validators/src/services/task/result_handler.py
@@ -133,6 +133,21 @@ class ResultHandler:
         if context.state.gpu_metrics is not None:
             specs["gpu_metrics"] = context.state.gpu_metrics
 
+        # DAH-2265 Plan 2: advisory cached-template signal — whether this executor has the
+        # recommended default image pre-pulled (so DOCKER_PULL is a no-op for default-template
+        # rentals). Captured by CachedTemplateVerificationCheck. Only published when measured
+        # (None → skipped/fail-open, key omitted). Rides executor.specs like gpu_metrics; no
+        # scoring impact.
+        if context.state.recommended_image_cached is not None:
+            specs["recommended_image_cached"] = context.state.recommended_image_cached
+
+        # DAH-2265 digest: advisory digest-match for the recommended image. False = the node
+        # holds STALE content under an unchanged tag (re-pull needed). Only published when
+        # compared (None → not cached / no backend digest / unreadable, key omitted). Rides
+        # executor.specs like recommended_image_cached; no scoring impact.
+        if context.state.recommended_image_digest_match is not None:
+            specs["recommended_image_digest_match"] = context.state.recommended_image_digest_match
+
         # NVIDIA driver version string reported by NVML (e.g. "580.95.05"). Used by the
         # minimum-driver requirement gate.
         nvidia_driver_version = str(specs.get("gpu", {}).get("driver") or "")

--- a/neurons/validators/tests/test_cached_template_verification.py
+++ b/neurons/validators/tests/test_cached_template_verification.py
@@ -1,0 +1,298 @@
+"""DAH-2265 Plan 2 — CachedTemplateVerificationCheck (advisory, non-fatal).
+
+Verifies the executor has the recommended default image pre-pulled, publishing the
+result to executor.specs (via pipeline state) and a structured event. It must never
+fail the pipeline or change score, and must fail open on every uncertainty.
+"""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from neurons.validators.src.services.task.checks.cached_template_verification import (
+    CachedTemplateVerificationCheck,
+)
+from neurons.validators.src.services.task.messages import CachedTemplateMessages as Msg
+
+from protocol.vc_protocol.compute_requests import DefaultDockerImage
+from tests.helpers import build_services, build_state
+
+_IMAGE = DefaultDockerImage(
+    docker_image="daturaai/torch", docker_image_tag="2.4.0", docker_image_size=12_000_000_000
+)
+_IMAGE_WITH_DIGEST = DefaultDockerImage(
+    docker_image="daturaai/torch",
+    docker_image_tag="2.4.0",
+    docker_image_size=12_000_000_000,
+    docker_image_digest="sha256:aaa",
+)
+_LOCAL_MATCH = '["daturaai/torch@sha256:aaa"]'
+_LOCAL_MISMATCH = '["daturaai/torch@sha256:bbb"]'
+_GPU = "NVIDIA H200"
+_DRIVER = "580.95.05"
+_SPECS = {"gpu": {"driver": _DRIVER}}
+
+
+def _backend(images=None, raises=False):
+    backend = Mock()
+    if raises:
+        backend.get_default_docker_image = AsyncMock(side_effect=RuntimeError("boom"))
+    else:
+        backend.get_default_docker_image = AsyncMock(return_value=images)
+    return backend
+
+
+def _ssh(exit_status=0, stdout="", raises=False):
+    # stdout is always a real str (M5): the check does `(inspect.stdout or "").strip()`, so a
+    # bare Mock attribute would corrupt the parse rather than fail open deterministically.
+    ssh = AsyncMock()
+    if raises:
+        ssh.run = AsyncMock(side_effect=RuntimeError("ssh down"))
+    else:
+        ssh.run = AsyncMock(return_value=Mock(exit_status=exit_status, stdout=stdout))
+    return ssh
+
+
+def test_check_is_non_fatal():
+    assert CachedTemplateVerificationCheck.fatal is False
+
+
+@pytest.mark.asyncio
+async def test_image_cached_publishes_true(context_factory):
+    backend = _backend(images=[_IMAGE])
+    ssh = _ssh(exit_status=0)
+    ctx = context_factory(
+        services=build_services(backend=backend),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=ssh,
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.CACHED.reason
+    assert result.event.what_we_saw["cached"] is True
+    assert result.event.what_we_saw["recommended_image"] == "daturaai/torch:2.4.0"
+    assert result.updates["state"].recommended_image_cached is True
+    # The probe used a read-only, fail-open inspect.
+    cmd = ssh.run.await_args.args[0]
+    assert "docker image inspect" in cmd
+    assert ssh.run.await_args.kwargs["check"] is False
+    backend.get_default_docker_image.assert_awaited_once_with(_GPU, _DRIVER)
+
+
+@pytest.mark.asyncio
+async def test_image_not_cached_publishes_false(context_factory):
+    ctx = context_factory(
+        services=build_services(backend=_backend(images=[_IMAGE])),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=_ssh(exit_status=1),
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.NOT_CACHED.reason
+    assert result.event.what_we_saw["cached"] is False
+    assert result.updates["state"].recommended_image_cached is False
+
+
+@pytest.mark.asyncio
+async def test_skips_when_gpu_model_missing(context_factory):
+    backend = _backend(images=[_IMAGE])
+    ctx = context_factory(
+        services=build_services(backend=backend),
+        state=build_state(gpu_model=None, specs=_SPECS),
+        ssh=_ssh(),
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.SKIPPED.reason
+    assert "state" not in result.updates
+    backend.get_default_docker_image.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_skips_when_driver_missing(context_factory):
+    ctx = context_factory(
+        services=build_services(backend=_backend(images=[_IMAGE])),
+        state=build_state(gpu_model=_GPU, specs={"gpu": {}}),
+        ssh=_ssh(),
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.SKIPPED.reason
+    assert "state" not in result.updates
+
+
+@pytest.mark.asyncio
+async def test_skips_when_backend_returns_nothing(context_factory):
+    ssh = _ssh()
+    ctx = context_factory(
+        services=build_services(backend=_backend(images=None)),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=ssh,
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.SKIPPED.reason
+    assert "state" not in result.updates
+    # No recommended image → never probe the executor.
+    ssh.run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fails_open_when_backend_raises(context_factory):
+    ctx = context_factory(
+        services=build_services(backend=_backend(raises=True)),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=_ssh(),
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.SKIPPED.reason
+    assert "state" not in result.updates
+
+
+@pytest.mark.asyncio
+async def test_fails_open_when_inspect_raises(context_factory):
+    ctx = context_factory(
+        services=build_services(backend=_backend(images=[_IMAGE])),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=_ssh(raises=True),
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.SKIPPED.reason
+    assert "state" not in result.updates
+
+
+# --- DAH-2265 digest verification (advisory, strict fail-open) ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_digest_match_publishes_true(context_factory):
+    # Branch 4: cached + local RepoDigest == backend digest → match True.
+    ssh = _ssh(exit_status=0, stdout=_LOCAL_MATCH)
+    ctx = context_factory(
+        services=build_services(backend=_backend(images=[_IMAGE_WITH_DIGEST])),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=ssh,
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.DIGEST_MATCH.reason
+    assert result.updates["state"].recommended_image_cached is True
+    assert result.updates["state"].recommended_image_digest_match is True
+    # The probe now reads RepoDigests (not just exit status) and stays read-only/fail-open.
+    cmd = ssh.run.await_args.args[0]
+    assert "--format" in cmd
+    assert "RepoDigests" in cmd
+    assert ssh.run.await_args.kwargs["check"] is False
+
+
+@pytest.mark.asyncio
+async def test_digest_mismatch_publishes_false(context_factory):
+    # Branch 5: cached + local RepoDigest != backend digest → match False (stale content).
+    ctx = context_factory(
+        services=build_services(backend=_backend(images=[_IMAGE_WITH_DIGEST])),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=_ssh(exit_status=0, stdout=_LOCAL_MISMATCH),
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.DIGEST_MISMATCH.reason
+    assert result.updates["state"].recommended_image_cached is True
+    assert result.updates["state"].recommended_image_digest_match is False
+
+
+@pytest.mark.asyncio
+async def test_digest_match_normalizes_repo_at_sha_backend_value(context_factory):
+    # M3: a backend digest pasted as "repo@sha256:…" must compare only on the bare sha.
+    image = DefaultDockerImage(
+        docker_image="daturaai/torch",
+        docker_image_tag="2.4.0",
+        docker_image_size=12_000_000_000,
+        docker_image_digest="daturaai/torch@sha256:aaa",
+    )
+    ctx = context_factory(
+        services=build_services(backend=_backend(images=[image])),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=_ssh(exit_status=0, stdout=_LOCAL_MATCH),
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.event.reason_code == Msg.DIGEST_MATCH.reason
+    assert result.updates["state"].recommended_image_digest_match is True
+
+
+@pytest.mark.asyncio
+async def test_digest_none_when_backend_digest_missing(context_factory):
+    # Branch 2: cached, but backend published no digest → match None, cached stays True.
+    ctx = context_factory(
+        services=build_services(backend=_backend(images=[_IMAGE])),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=_ssh(exit_status=0, stdout=_LOCAL_MATCH),
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.event.reason_code == Msg.CACHED.reason
+    assert result.updates["state"].recommended_image_cached is True
+    assert result.updates["state"].recommended_image_digest_match is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stdout",
+    [
+        "[]",  # no RepoDigests (locally built / docker-loaded image)
+        '["other/repo@sha256:zzz"]',  # different repo, different sha
+        '["other/repo@sha256:aaa"]',  # M5 danger: different repo, SAME sha → must NOT match
+    ],
+)
+async def test_digest_none_when_no_repo_match(context_factory, stdout):
+    # Branch 3: cached + backend digest set, but no RepoDigest for THIS repo → match None.
+    ctx = context_factory(
+        services=build_services(backend=_backend(images=[_IMAGE_WITH_DIGEST])),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=_ssh(exit_status=0, stdout=stdout),
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.DIGEST_SKIPPED.reason
+    assert result.updates["state"].recommended_image_cached is True
+    assert result.updates["state"].recommended_image_digest_match is None
+
+
+@pytest.mark.asyncio
+async def test_digest_fails_open_on_unparseable_stdout(context_factory):
+    # Branch 3 variant: cached + backend digest set, RepoDigests JSON is garbage → match None,
+    # never raises.
+    ctx = context_factory(
+        services=build_services(backend=_backend(images=[_IMAGE_WITH_DIGEST])),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=_ssh(exit_status=0, stdout="not json at all"),
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.DIGEST_SKIPPED.reason
+    assert result.updates["state"].recommended_image_digest_match is None

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -2077,7 +2077,84 @@ async def test_create_local_volume_uses_scaled_timeout_for_large_limited_volume(
         "effective_timeout_seconds": 133,
         "timeout_scaled": True,
         "loopback_plugin": "vloopback",
+        "sparse": False,
     }
+
+
+# ---------------------------------------------------------------------------
+# DAH-2265 Plan 3: sparse vloopback volume creation, gated to full-node rentals.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_local_volume_sparse_true_appends_sparse_flag(
+    docker_service,
+    monkeypatch,
+):
+    """sparse=True (full-node rental) → `-o sparse=true` appended after the size cap."""
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=Mock(stdout="/var/lib/docker\n"))
+    execute = AsyncMock()
+    monkeypatch.setattr(docker_service, "execute_and_stream_logs", execute)
+
+    await docker_service.create_local_volume(
+        ssh_client=ssh_client,
+        local_volume="volume_test",
+        log_tag="tag",
+        log_text="Creating docker volume volume_test",
+        log_extra={},
+        limit=200,
+        sparse=True,
+    )
+
+    command = execute.await_args.kwargs["command"]
+    assert command == (
+        "/usr/bin/docker volume create -d vloopback volume_test "
+        "-o size=200g -o sparse=true"
+    )
+    assert execute.await_args.kwargs["log_extra"]["sparse"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_local_volume_sparse_false_keeps_preallocation(
+    docker_service,
+    monkeypatch,
+):
+    """sparse=False (partial / legacy rental) → no sparse flag; size cap unchanged."""
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=Mock(stdout="/var/lib/docker\n"))
+    execute = AsyncMock()
+    monkeypatch.setattr(docker_service, "execute_and_stream_logs", execute)
+
+    await docker_service.create_local_volume(
+        ssh_client=ssh_client,
+        local_volume="volume_test",
+        log_tag="tag",
+        log_text="Creating docker volume volume_test",
+        log_extra={},
+        limit=200,
+    )
+
+    command = execute.await_args.kwargs["command"]
+    assert command == "/usr/bin/docker volume create -d vloopback volume_test -o size=200g"
+    assert "sparse" not in command
+    assert execute.await_args.kwargs["log_extra"]["sparse"] is False
+
+
+@pytest.mark.parametrize(
+    "disk_share, expected_sparse",
+    [
+        (1.0, True),    # exact full-node
+        (1.5, True),    # >1.0 (defensive) still full-node
+        (0.5, False),   # partial
+        (0.99, False),  # just-under partial
+        (None, False),  # legacy / unknown
+    ],
+)
+def test_full_node_sparse_gate(disk_share, expected_sparse):
+    """The call-site gate: sparse iff disk_share is not None and >= 1.0 (DAH-2265 Plan 3)."""
+    full_node_rental = disk_share is not None and disk_share >= 1.0
+    assert full_node_rental is expected_sparse
 
 
 # ---------------------------------------------------------------------------

--- a/neurons/validators/tests/test_result_handler_gpu_metrics.py
+++ b/neurons/validators/tests/test_result_handler_gpu_metrics.py
@@ -154,3 +154,59 @@ async def test_handle_result_skips_inspector_event_in_dry_run(context_factory):
     )
 
     redis.publish.assert_not_awaited()
+
+
+# DAH-2265 Plan 2: advisory recommended_image_cached signal rides executor.specs.
+
+
+def _context_cached(context_factory, *, recommended_image_cached):
+    state = build_state(
+        specs={"gpu": {"count": 1}},
+        recommended_image_cached=recommended_image_cached,
+    )
+    return context_factory(
+        state=state,
+        tdx_attestation_passed=False,
+        score=1.0,
+        job_score=1.0,
+        collateral_deposited=False,
+        ssh_pub_keys=[],
+        rented=False,
+    )
+
+
+@pytest.mark.parametrize("cached", [True, False])
+@pytest.mark.asyncio
+async def test_handle_result_publishes_recommended_image_cached(context_factory, cached):
+    """When measured (True/False), the published spec carries recommended_image_cached."""
+    ctx = _context_cached(context_factory, recommended_image_cached=cached)
+    handler = ResultHandler(redis_service=None, dry_run=True)
+
+    result = await handler.handle_result(
+        context=ctx,
+        miner_info=_miner_info(),
+        executor_info=ctx.executor,
+        verified_job_info={},
+        log_text="ok",
+        success=True,
+    )
+
+    assert result.spec["recommended_image_cached"] is cached
+
+
+@pytest.mark.asyncio
+async def test_handle_result_omits_recommended_image_cached_when_not_measured(context_factory):
+    """Fail-safe: None (skipped/fail-open) → no recommended_image_cached key published."""
+    ctx = _context_cached(context_factory, recommended_image_cached=None)
+    handler = ResultHandler(redis_service=None, dry_run=True)
+
+    result = await handler.handle_result(
+        context=ctx,
+        miner_info=_miner_info(),
+        executor_info=ctx.executor,
+        verified_job_info={},
+        log_text="ok",
+        success=True,
+    )
+
+    assert "recommended_image_cached" not in result.spec


### PR DESCRIPTION
## Describe your changes

Validator-side DAH-2265 work. The headline addition is **image-digest verification**: the validator now flags provider nodes that serve **stale content under an unchanged tag**. It also carries two earlier DAH-2265 plans that were sitting in the working tree.

**Image digest verification (new)**
- `CachedTemplateVerificationCheck` probe now reads the executor's `RepoDigests` (instead of exit-status only) and compares the local digest against the backend's published manifest digest (served by the companion backend PR).
- New advisory signal `recommended_image_digest_match` (`bool | None`) published to `executor.specs`:
  - `True` — cached image's RepoDigest matches the published manifest digest.
  - `False` — cached but **differs** → node holds stale content under the tag (the case we want to catch).
  - `None` — not compared (not cached / no backend digest / unreadable RepoDigest). **Strict fail-open.**
- Backend↔executor comparison is apples-to-apples: DockerHub **manifest-list** digest ↔ executor `RepoDigest` (bare `sha256:…`, normalized to tolerate `repo@sha`). Matching is strictly per-repo (guards the same-sha/different-repo false-match).
- `fatal=False`, always `passed=True` — **no scoring or `active` impact** (advisory only).
- `compute_requests.py`: `DefaultDockerImage` gains `docker_image_digest`. `messages.py`: `DIGEST_MATCH/MISMATCH/SKIPPED`. `result_handler.py`/`pipeline.py`: state field + publish-when-not-None.

**Plan 2 — cached-template verification** (base check this digest work extends): registers `CachedTemplateVerificationCheck` and publishes `recommended_image_cached`.

**Plan 3 — sparse loopback volume**: full-node rentals (`disk_share >= 1.0`) get `sparse=true` for flat-time volume creation; partial/legacy rentals stay preallocated to keep the DAH-2183 fresh-sizing math balanced.

## Issue ticket number and link

[DAH-2265](https://www.notion.so/DAH-2265)

Companion PR (backend, serves the digest): https://github.com/Datura-ai/lium-io-backend/pull/712

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.

  Validator suite **750 passed / 4 skipped**; digest check file covers all five truth-table branches incl. the same-sha/different-repo guard, the `repo@sha` normalization, and fail-open on unreadable RepoDigests. New files `ruff@0.5.1`-clean; zero net-new lint on edited files.
- [x] Need to take care of performance?

  No new hot-path cost: the digest read reuses the existing single `docker image inspect` probe (now `--format "{{json .RepoDigests}}"`); no extra SSH round-trips.

## Notes for reviewers
- **Advisory boundary:** the digest signal cannot affect score or node liveness; a wrong/missing digest is visibility noise only.
- **Backend digest is populated at push time** (`docker buildx imagetools inspect`). Until then it is `None` and the validator correctly reports `None` (skip) — no false flags.
- Out of scope (separate follow-ups): the remediation/"force re-pull" action, and surfacing `recommended_image_digest_match=False` in the provider portal.
