### PR TITLE
DAH-2250, unrented incentive soft price limit (market p90 * 1.1)

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -165,7 +165,7 @@ class Settings(BaseSettings):
     # whose price_per_gpu exceeds market p90 * SOFT_LIMIT_PRICE_RATE loses the unrented
     # rental incentive while staying active. When False, the breach is only logged
     # (shadow mode) so prod impact can be observed before enforcing.
-    ENABLE_UNRENTED_SOFT_PRICE_LIMIT: bool = Field(env="ENABLE_UNRENTED_SOFT_PRICE_LIMIT", default=False)
+    ENABLE_UNRENTED_SOFT_PRICE_LIMIT: bool = Field(env="ENABLE_UNRENTED_SOFT_PRICE_LIMIT", default=True)
 
     COLLATERAL_CONTRACT_ADDRESS: str = Field(
         env='COLLATERAL_CONTRACT_ADDRESS', default='0x8A4023FdD1eaA7b242F3723a7d096B6CC693c7C6'

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -165,7 +165,7 @@ class Settings(BaseSettings):
     # whose price_per_gpu exceeds market p90 * SOFT_LIMIT_PRICE_RATE loses the unrented
     # rental incentive while staying active. When False, the breach is only logged
     # (shadow mode) so prod impact can be observed before enforcing.
-    ENABLE_UNRENTED_SOFT_PRICE_LIMIT: bool = Field(env="ENABLE_UNRENTED_SOFT_PRICE_LIMIT", default=True)
+    ENABLE_UNRENTED_SOFT_PRICE_LIMIT: bool = Field(env="ENABLE_UNRENTED_SOFT_PRICE_LIMIT", default=False)
 
     COLLATERAL_CONTRACT_ADDRESS: str = Field(
         env='COLLATERAL_CONTRACT_ADDRESS', default='0x8A4023FdD1eaA7b242F3723a7d096B6CC693c7C6'

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -161,6 +161,12 @@ class Settings(BaseSettings):
     DRY_RUN: bool = Field(env="DRY_RUN", default=False, description="Run validation without publishing scores/weights")
     CONTAINER_CLEANUP_DRY_RUN: bool = Field(env="CONTAINER_CLEANUP_DRY_RUN", default=False, description="Dry run mode for stale container cleanup")
 
+    # DAH-2250 — unrented incentive soft price limit. When True, an unrented executor
+    # whose price_per_gpu exceeds market p90 * SOFT_LIMIT_PRICE_RATE loses the unrented
+    # rental incentive while staying active. When False, the breach is only logged
+    # (shadow mode) so prod impact can be observed before enforcing.
+    ENABLE_UNRENTED_SOFT_PRICE_LIMIT: bool = Field(env="ENABLE_UNRENTED_SOFT_PRICE_LIMIT", default=False)
+
     COLLATERAL_CONTRACT_ADDRESS: str = Field(
         env='COLLATERAL_CONTRACT_ADDRESS', default='0x8A4023FdD1eaA7b242F3723a7d096B6CC693c7C6'
     )

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 import bittensor
 from pydantic import BaseModel, Field
 
-from core.config import settings
+from core.config import settings, shared_client
 from core.utils import _m, get_extra_info, get_logger
 from incentive.config import BASE_GPU_MAP
 from incentive.eligibility import is_missing_discord_after_cutoff
@@ -31,6 +31,11 @@ from services.const import TEMPO, SECONDS_PER_BLOCK, FIXED_RATIO, TOTAL_BURN_EMI
 from services.task_service import JobResult
 
 logger = get_logger(__name__)
+
+# DAH-2250 — unrented incentive soft price limit (section 3 of the market-pricing
+# proposal). An unrented executor whose price_per_gpu exceeds the market p90 times
+# this multiplier forfeits the unrented rental incentive but stays active.
+SOFT_LIMIT_PRICE_RATE = 1.1
 
 
 # ── Snapshot models ──────────────────────────────────────────────────────────
@@ -169,6 +174,40 @@ class RentalPriceIncentive(DefaultIncentive):
     def get_base_model_for_gpu(self, gpu_model: str) -> str:
         base_model = BASE_GPU_MAP[gpu_model]
         return base_model
+
+    def _is_over_soft_price_limit(self, result: JobResult) -> bool:
+        # miner price_per_gpu above the market p90 ceiling (p90 * SOFT_LIMIT_PRICE_RATE)
+        price_per_gpu = result.executor_info.price_per_gpu
+        if not price_per_gpu:
+            return False
+        # machine_prices_p90 is partial: GPUs without market data keep full incentive
+        p90 = shared_client.config.machine_prices_p90.get(result.gpu_model)
+        if not p90:
+            return False
+        return price_per_gpu > p90 * SOFT_LIMIT_PRICE_RATE
+
+    def _log_soft_price_limit(self, result: JobResult) -> None:
+        # structured log for every unrented executor over the p90 soft ceiling
+        enforced = settings.ENABLE_UNRENTED_SOFT_PRICE_LIMIT
+        p90 = shared_client.config.machine_prices_p90.get(result.gpu_model)
+        logger.info(
+            _m(
+                "Unrented executor over market p90 soft price limit"
+                + ("" if enforced else " (shadow only - flag off)"),
+                extra={
+                    "executor_id": str(result.executor_info.uuid),
+                    "gpu_model": result.gpu_model,
+                    "gpu_count": result.gpu_count,
+                    "price_per_gpu": result.executor_info.price_per_gpu,
+                    "machine_price_p90": p90,
+                    "soft_limit_rate": SOFT_LIMIT_PRICE_RATE,
+                    "soft_limit_threshold": p90 * SOFT_LIMIT_PRICE_RATE if p90 else None,
+                    "enforced": enforced,
+                    "reason": "price_above_market_p90_soft_limit",
+                    "pool": "rental_excluded" if enforced else "rental_kept_shadow",
+                },
+            )
+        )
 
     @staticmethod
     def _resolve_bucket(result: JobResult, cap_spec: dict[int, int]) -> int:
@@ -459,11 +498,21 @@ class RentalPriceIncentive(DefaultIncentive):
 
         # Check if GPU is unrented and eligible (has positive cap in max_unrented_gpus)
         base_model = self.get_base_model_for_gpu(job_result.gpu_model)
-        job_result.eligible_for_rental_share = (
+        eligible_for_rental_share = (
             not job_result.is_rented
             and (base_model in self.config.rental_incentive_gpu_types)
             and (job_result.score > 0 or job_result.job_score > 0)
         )
+
+        # DAH-2250 soft price limit: an otherwise-eligible unrented executor priced
+        # above the market p90 ceiling forfeits the unrented incentive (node stays
+        # active). While the flag is off we only log the would-be exclusion (shadow).
+        if eligible_for_rental_share and self._is_over_soft_price_limit(job_result):
+            self._log_soft_price_limit(job_result)
+            if settings.ENABLE_UNRENTED_SOFT_PRICE_LIMIT:
+                eligible_for_rental_share = False
+
+        job_result.eligible_for_rental_share = eligible_for_rental_share
         if job_result.eligible_for_rental_share:
             logger.info(
                 _m(

--- a/neurons/validators/tests/test_unrented_soft_price_limit.py
+++ b/neurons/validators/tests/test_unrented_soft_price_limit.py
@@ -107,6 +107,15 @@ def test_is_over_soft_price_limit_no_price(monkeypatch):
     assert over is False
 
 
+def test_enforcement_defaults_to_shadow_mode():
+    # Arrange / Act — rollout contract: first deploy must be shadow-only, so the
+    # flag default (not the env-resolved value) must stay False.
+    default = type(settings).model_fields["ENABLE_UNRENTED_SOFT_PRICE_LIMIT"].default
+
+    # Assert
+    assert default is False
+
+
 @pytest.mark.asyncio
 async def test_shadow_mode_keeps_rental_eligibility(monkeypatch):
     # Arrange — over the limit but flag off → shadow only

--- a/neurons/validators/tests/test_unrented_soft_price_limit.py
+++ b/neurons/validators/tests/test_unrented_soft_price_limit.py
@@ -1,0 +1,150 @@
+"""DAH-2250 — unrented incentive soft price limit.
+
+An unrented executor priced above the market p90 ceiling
+(machine_prices_p90[gpu] * SOFT_LIMIT_PRICE_RATE) forfeits the unrented rental
+incentive while staying active. Enforcement is gated by
+ENABLE_UNRENTED_SOFT_PRICE_LIMIT; while the flag is off the breach is only
+logged (shadow mode) and the payout is unchanged.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from datura.requests.miner_requests import ExecutorSSHInfo
+
+from core.config import settings, shared_client
+from incentive.config import IncentiveConfig
+from incentive.rental_price import RentalPriceIncentive
+from services.task_service import JobResult
+
+H200 = "NVIDIA H200"  # base model H200 is rental-eligible by default
+
+
+def _build_incentive() -> RentalPriceIncentive:
+    return RentalPriceIncentive(IncentiveConfig(), AsyncMock(), {}, {})
+
+
+def _make_job(
+    price_per_gpu: float | None,
+    *,
+    gpu_model: str = H200,
+    is_rented: bool = False,
+) -> JobResult:
+    return JobResult(
+        executor_info=ExecutorSSHInfo(
+            uuid="exec-1",
+            address="10.0.0.1",
+            port=8080,
+            ssh_username="root",
+            ssh_port=22,
+            python_path="/usr/bin/python3",
+            root_dir="/tmp",
+            price_per_gpu=price_per_gpu,
+        ),
+        score=1.0,
+        job_score=1.0,
+        job_batch_id="batch",
+        log_status="success",
+        log_text="ok",
+        gpu_model=gpu_model,
+        gpu_count=1,
+        is_rented=is_rented,
+        collateral_deposited=True,
+        sysbox_runtime=True,
+    )
+
+
+def _set_p90(monkeypatch, mapping: dict[str, float]) -> None:
+    new_cfg = shared_client.config.model_copy(update={"machine_prices_p90": mapping})
+    monkeypatch.setattr(shared_client, "_config", new_cfg)
+
+
+def test_is_over_soft_price_limit_above_threshold(monkeypatch):
+    # Arrange — threshold = 2.0 * 1.1 = 2.2
+    _set_p90(monkeypatch, {H200: 2.0})
+    incentive = _build_incentive()
+
+    # Act
+    over = incentive._is_over_soft_price_limit(_make_job(2.3))
+
+    # Assert
+    assert over is True
+
+
+def test_is_over_soft_price_limit_at_threshold_is_not_over(monkeypatch):
+    # Arrange — exactly at the threshold (2.2) is allowed
+    _set_p90(monkeypatch, {H200: 2.0})
+    incentive = _build_incentive()
+
+    # Act
+    over = incentive._is_over_soft_price_limit(_make_job(2.2))
+
+    # Assert
+    assert over is False
+
+
+def test_is_over_soft_price_limit_no_market_data(monkeypatch):
+    # Arrange — H200 absent from p90 map → cannot gate
+    _set_p90(monkeypatch, {})
+    incentive = _build_incentive()
+
+    # Act
+    over = incentive._is_over_soft_price_limit(_make_job(99.0))
+
+    # Assert
+    assert over is False
+
+
+def test_is_over_soft_price_limit_no_price(monkeypatch):
+    # Arrange — miner price unknown → cannot gate
+    _set_p90(monkeypatch, {H200: 2.0})
+    incentive = _build_incentive()
+
+    # Act
+    over = incentive._is_over_soft_price_limit(_make_job(None))
+
+    # Assert
+    assert over is False
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_keeps_rental_eligibility(monkeypatch):
+    # Arrange — over the limit but flag off → shadow only
+    _set_p90(monkeypatch, {H200: 2.0})
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_SOFT_PRICE_LIMIT", False)
+    incentive = _build_incentive()
+
+    # Act
+    result = await incentive.calculate_executor_score(_make_job(2.3))
+
+    # Assert — still eligible for the unrented rental pool
+    assert result.eligible_for_rental_share is True
+
+
+@pytest.mark.asyncio
+async def test_enforced_drops_rental_eligibility(monkeypatch):
+    # Arrange — over the limit and flag on
+    _set_p90(monkeypatch, {H200: 2.0})
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_SOFT_PRICE_LIMIT", True)
+    incentive = _build_incentive()
+
+    # Act
+    result = await incentive.calculate_executor_score(_make_job(2.3))
+
+    # Assert — excluded from rental pool, no mining either (active but no incentive)
+    assert result.eligible_for_rental_share is False
+    assert result.mining_score == 0
+
+
+@pytest.mark.asyncio
+async def test_enforced_under_threshold_keeps_eligibility(monkeypatch):
+    # Arrange — flag on but price within the p90 ceiling (2.1 < 2.2)
+    _set_p90(monkeypatch, {H200: 2.0})
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_SOFT_PRICE_LIMIT", True)
+    incentive = _build_incentive()
+
+    # Act
+    result = await incentive.calculate_executor_score(_make_job(2.1))
+
+    # Assert
+    assert result.eligible_for_rental_share is True


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2250 — Market-based pricing: anchor GPU defaults to 30d Lium median + soft/hard limits](https://www.notion.so/Market-based-pricing-anchor-GPU-defaults-to-30d-Lium-median-soft-hard-limits-388b8bfdbde98174a4d2f81118604c3a)

---

## Problem

Section 3 (soft limit / incentive cutoff) of the market-based pricing proposal: an unrented executor priced far above the market should not earn the unrented rental incentive. Today any unrented, eligible GPU gets a share of the rental emission pool regardless of how overpriced it is versus the market p90.

## Solution

Gate the unrented rental incentive on the market p90 price. An unrented executor whose `price_per_gpu` exceeds `machine_prices_p90[gpu] * 1.1` forfeits the unrented rental incentive but **stays active** (still responsive, no penalty, no score wipe). This mirrors the existing hard limit (`score_calculator.py`, `price > machine_prices[gpu] * machine_max_price_rate`) but at the incentive layer instead of zeroing the score.

Rollout is gated by `ENABLE_UNRENTED_SOFT_PRICE_LIMIT` (default `False`). While the flag is off the breach is only logged (shadow mode), so prod impact can be observed before enforcing — same pattern as `PENALTY_TRIGGERS_DRY_RUN`.

`machine_prices_p90` is a SharedConfig field that exists only in **lium-core 0.1.3**; the validator was pinned to 0.1.2 (which lacks it), so the dependency is bumped to `>=0.1.3` to avoid an `AttributeError` at runtime.

## Changes

- `core/config.py`: add `ENABLE_UNRENTED_SOFT_PRICE_LIMIT` env flag (default `False`).
- `incentive/rental_price.py`: add `SOFT_LIMIT_PRICE_RATE = 1.1`, helpers `_is_over_soft_price_limit` / `_log_soft_price_limit`, and gate `eligible_for_rental_share` in `calculate_executor_score`.
- `pyproject.toml` + `pdm.lock`: bump `lium-core` 0.1.2 → **0.1.3** (provides `machine_prices_p90`).
- `tests/test_unrented_soft_price_limit.py`: 7 tests (threshold boundary, missing market data, missing price, shadow vs enforced).

## Deployment Steps

Use GitHub Action. After deploy the rule stays dormant until prod SharedConfig serves `machine_prices_p90` AND `ENABLE_UNRENTED_SOFT_PRICE_LIMIT=true`. Recommended rollout: deploy with flag off, watch shadow logs, then flip the flag.

## Review Request

- [x] Just code review

## Other PRs

- lium-core: `machine_prices_p90` was added in lium-core 0.1.3 (PR Datura-ai/lium-core#2, already merged + published to PyPI). This PR only bumps the consumer pin; no lium-core code change here.

## Risks

- Affects real rental emissions only when the flag is ON. With the flag off (default) payout is unchanged — only a structured log line per over-limit executor.
- Change is monotonic: it can only **remove** rental eligibility, never grant it. Cannot increase anyone's emission.
- GPUs absent from `machine_prices_p90` (partial map) or with unknown price keep full incentive — no accidental exclusion on missing data.
- Estimate path unaffected (fake executor has `price_per_gpu=None`).
- `prod_snapshot` incentive baselines unchanged (flag off + empty default p90 + no price in snapshot).
- lium-core bump is additive (0.1.2 → 0.1.3 adds one optional field); without it, `shared_client.config.machine_prices_p90` would `AttributeError` on priced unrented executors.

## Test Cases

### Test Case 1 — shadow mode (flag off)

**Actions**: unrented H200 at `2.3`, p90 `2.0` (threshold `2.2`), `ENABLE_UNRENTED_SOFT_PRICE_LIMIT=false`.

**Expected Output**: `eligible_for_rental_share` stays `True`; a shadow log line is emitted (`enforced=false`, `pool=rental_kept_shadow`).

### Test Case 2 — enforced (flag on)

**Actions**: same executor, `ENABLE_UNRENTED_SOFT_PRICE_LIMIT=true`.

**Expected Output**: `eligible_for_rental_share` becomes `False`, `mining_score == 0` (active node, no incentive).

### Test Case 3 — boundaries

**Actions**: price exactly at threshold (`2.2`), price under (`2.1`), GPU missing from p90 map, `price_per_gpu=None`.

**Expected Output**: not over the limit in every case → full incentive kept. Full validator suite: 744 passed, 4 skipped (against lium-core 0.1.3).

## Checklist

- [x] Proper labels added (`ready-review`)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
