### PR TITLE
DAH-2274 - Read burn emission from shared config

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -11,7 +11,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 if TYPE_CHECKING:
     from bittensor import Wallet
 
-from lium_core.shared_config import SharedConfigClient
+from lium_core.shared_config import DEFAULT_SHARED_CONFIG, SharedConfigClient
 from incentive.config import IncentiveConfig
 
 
@@ -321,3 +321,29 @@ settings = Settings()
 shared_client = SharedConfigClient(
     api_url=f"{settings.COMPUTE_REST_API_URL}/v1/shared-config"
 )
+
+
+def get_total_burn_emission() -> float:
+    """Burn-emission share, sourced live from shared config (DAH-2274).
+
+    The value is served by the backend ``/v1/shared-config`` endpoint — the single
+    source of truth — and fetched here via ``shared_client``. Because it feeds
+    on-chain weights directly, the served value is clamped to ``[0, 1]`` and falls
+    back to the packaged lium-core default (``DEFAULT_SHARED_CONFIG.total_burn_emission``)
+    when it is missing or out of range, so a misconfigured or stale endpoint cannot
+    push a garbage burn share into weights.
+    """
+    fallback = DEFAULT_SHARED_CONFIG.total_burn_emission
+    value = getattr(shared_client.config, "total_burn_emission", None)
+    if not isinstance(value, int | float) or not (0.0 <= float(value) <= 1.0):
+        # Lazy import avoids a circular dependency (core.utils imports settings).
+        from core.utils import _m, get_logger
+
+        get_logger(__name__).warning(
+            _m(
+                "Invalid total_burn_emission from shared config; using fallback",
+                extra={"served_value": value, "fallback": fallback},
+            )
+        )
+        return fallback
+    return float(value)

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -324,26 +324,25 @@ shared_client = SharedConfigClient(
 
 
 def get_total_burn_emission() -> float:
-    """Burn-emission share, sourced live from shared config (DAH-2274).
+    """Burn-emission share from shared config, guarded for on-chain use (DAH-2274).
 
-    The value is served by the backend ``/v1/shared-config`` endpoint — the single
-    source of truth — and fetched here via ``shared_client``. Because it feeds
-    on-chain weights directly, the served value is clamped to ``[0, 1]`` and falls
-    back to the packaged lium-core default (``DEFAULT_SHARED_CONFIG.total_burn_emission``)
-    when it is missing or out of range, so a misconfigured or stale endpoint cannot
-    push a garbage burn share into weights.
+    ``SharedConfigClient`` already falls back to the packaged lium-core default when
+    the backend is unreachable, so ``shared_client.config.total_burn_emission`` is
+    always a valid float. The only extra guard is rejecting a structurally valid but
+    out-of-range served value (e.g. an operator typo) before it reaches on-chain
+    weights, falling back to the lium-core default.
     """
-    fallback = DEFAULT_SHARED_CONFIG.total_burn_emission
-    value = getattr(shared_client.config, "total_burn_emission", None)
-    if not isinstance(value, int | float) or not (0.0 <= float(value) <= 1.0):
-        # Lazy import avoids a circular dependency (core.utils imports settings).
-        from core.utils import _m, get_logger
+    value = shared_client.config.total_burn_emission
+    if 0.0 <= value <= 1.0:
+        return value
 
-        get_logger(__name__).warning(
-            _m(
-                "Invalid total_burn_emission from shared config; using fallback",
-                extra={"served_value": value, "fallback": fallback},
-            )
+    # Lazy import avoids a circular dependency (core.utils imports settings).
+    from core.utils import _m, get_logger
+
+    get_logger(__name__).warning(
+        _m(
+            "total_burn_emission out of range; using lium-core default",
+            extra={"served_value": value, "fallback": DEFAULT_SHARED_CONFIG.total_burn_emission},
         )
-        return fallback
-    return float(value)
+    )
+    return DEFAULT_SHARED_CONFIG.total_burn_emission

--- a/neurons/validators/src/incentive/base.py
+++ b/neurons/validators/src/incentive/base.py
@@ -12,7 +12,6 @@ from incentive.utils import log_for_monitoring
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.redis_service import RedisService
 from services.task_service import JobResult
-from services.const import TOTAL_BURN_EMISSION
 
 
 class BaseIncentive(ABC):

--- a/neurons/validators/src/incentive/base.py
+++ b/neurons/validators/src/incentive/base.py
@@ -134,8 +134,8 @@ class BaseIncentive(ABC):
 
         Returns:
             dict[str, float]: Weights with burning applied for each miner.
-                - Burners receive high scores (proportional to TOTAL_BURN_EMISSION)
-                - Regular miners receive low scores (proportional to 1 - TOTAL_BURN_EMISSION)
+                - Burners receive high scores (proportional to the burn emission share)
+                - Regular miners receive low scores (proportional to 1 - burn emission share)
                 These weights are accumulated across cycles in validator.miner_scores
         """
         pass

--- a/neurons/validators/src/incentive/burn_service.py
+++ b/neurons/validators/src/incentive/burn_service.py
@@ -9,9 +9,9 @@ from collections import Counter
 
 import bittensor
 
-from core.config import settings
+from core.config import get_total_burn_emission, settings
 from core.utils import _m, get_logger
-from services.const import BURNER_EMISSION, TOTAL_BURN_EMISSION
+from services.const import BURNER_EMISSION
 
 logger = get_logger(__name__)
 
@@ -66,7 +66,7 @@ class BurnService:
                     "burn_logic": "new" if settings.ENABLE_NEW_BURN_LOGIC else "old",
                     "num_burners": num_burners,
                     "burn_share": burn_share,
-                    "total_burn_emission_const": TOTAL_BURN_EMISSION,
+                    "total_burn_emission": get_total_burn_emission(),
                     "total_distributed": total_distributed,
                     "burner_hotkeys": list(burn_scores.keys()),
                     "validation": f"distributed={total_distributed:.6f}, expected={burn_share:.6f}",
@@ -166,9 +166,10 @@ class BurnService:
         other_burners = [uid for uid in burners if uid != main_burner]
 
         # Calculate scores proportional to burn_share
-        # Scale the original BURNER_EMISSION by the ratio of burn_share to TOTAL_BURN_EMISSION
-        # This maintains the same distribution pattern but with dynamic burn_share
-        burn_ratio = burn_share / TOTAL_BURN_EMISSION if TOTAL_BURN_EMISSION > 0 else 1
+        # Scale the original BURNER_EMISSION by the ratio of burn_share to the total burn
+        # emission. This maintains the same distribution pattern but with dynamic burn_share.
+        total_burn_emission = get_total_burn_emission()
+        burn_ratio = burn_share / total_burn_emission if total_burn_emission > 0 else 1
         scaled_burner_emission = BURNER_EMISSION * burn_ratio
 
         # Main burner gets: burn_share - (num_other_burners * scaled_burner_emission)
@@ -250,14 +251,14 @@ class BurnService:
         """Get the total burn emission share.
 
         Returns:
-            float: Total portion of emission allocated to burning (0.87)
+            float: Total portion of emission allocated to burning (from shared config)
         """
-        return TOTAL_BURN_EMISSION
+        return get_total_burn_emission()
 
     def get_mining_share(self) -> float:
         """Get the total mining emission share.
 
         Returns:
-            float: Total portion of emission allocated to mining (0.13)
+            float: Total portion of emission allocated to mining (from shared config)
         """
-        return 1 - TOTAL_BURN_EMISSION
+        return 1 - get_total_burn_emission()

--- a/neurons/validators/src/incentive/burn_service.py
+++ b/neurons/validators/src/incentive/burn_service.py
@@ -38,7 +38,7 @@ class BurnService:
         Args:
             miners: List of all miner neuron information
             burn_share: Dynamic burn emission share to distribute (e.g., 0.87 for default,
-                       or TOTAL_BURN_EMISSION - rental_share for rental price incentive)
+                       or total burn emission - rental_share for rental price incentive)
             last_mechanism_step_block: Block number for randomization (old logic only)
 
         Returns:

--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -8,10 +8,9 @@ from datetime import UTC, datetime
 
 import bittensor
 
-from core.config import settings
+from core.config import get_total_burn_emission, settings
 from core.utils import _m, get_extra_info, get_logger
 from incentive.base import BaseIncentive
-from services.const import TOTAL_BURN_EMISSION
 from services.task_service import JobResult
 
 logger = get_logger(__name__)
@@ -74,7 +73,7 @@ class DefaultIncentive(BaseIncentive):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.burn_share = TOTAL_BURN_EMISSION
+        self.burn_share = get_total_burn_emission()
 
         # Metrics
         self.total_executors = 0
@@ -84,7 +83,7 @@ class DefaultIncentive(BaseIncentive):
         # Incentive states
         self.total_mining_score = 0
         self.miner_incentives = {}
-        self.mining_share = 1 - TOTAL_BURN_EMISSION
+        self.mining_share = 1 - self.burn_share
 
     async def _pre_process_job_result(self, hotkey: str, result: JobResult):
         """Process a job result.
@@ -275,7 +274,7 @@ class DefaultIncentive(BaseIncentive):
         # Calculate burn scores using BurnService
         cycle_scores = self.burn_service.calculate_burn_scores(
             miners=miners,
-            burn_share=self.burn_share,  # Fixed at TOTAL_BURN_EMISSION (0.87) for default incentive
+            burn_share=self.burn_share,  # burn-emission share sourced from shared config (DAH-2274)
             last_mechanism_step_block=last_mechanism_step_block,
         )
         for miner in miners:

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 import bittensor
 from pydantic import BaseModel, Field
 
-from core.config import settings, shared_client
+from core.config import get_total_burn_emission, settings, shared_client
 from core.utils import _m, get_extra_info, get_logger
 from incentive.config import BASE_GPU_MAP
 from incentive.eligibility import is_missing_discord_after_cutoff
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 from incentive.utils import get_hourly_rate
 from incentive.default import DefaultIncentive, get_min_driver_multiplier
 from incentive.price_provider import PriceProvider
-from services.const import TEMPO, SECONDS_PER_BLOCK, FIXED_RATIO, TOTAL_BURN_EMISSION, DEFAULT_JOB_OWNER_MINER
+from services.const import TEMPO, SECONDS_PER_BLOCK, FIXED_RATIO, DEFAULT_JOB_OWNER_MINER
 from services.task_service import JobResult
 
 logger = get_logger(__name__)
@@ -304,9 +304,10 @@ class RentalPriceIncentive(DefaultIncentive):
 
         rental_share_raw = await self._calculate_rental_share(self.total_rental_cost)
 
-        # Ensure rental_share doesn't exceed TOTAL_BURN_EMISSION (0.87, cap at burn emission)
-        rental_share_capped = rental_share_raw > TOTAL_BURN_EMISSION
-        self.rental_share = min(rental_share_raw, TOTAL_BURN_EMISSION)
+        # Cap rental_share at the burn-emission share (sourced from shared config, DAH-2274)
+        total_burn_emission = get_total_burn_emission()
+        rental_share_capped = rental_share_raw > total_burn_emission
+        self.rental_share = min(rental_share_raw, total_burn_emission)
 
         if rental_share_capped:
             logger.warning(
@@ -315,14 +316,14 @@ class RentalPriceIncentive(DefaultIncentive):
                     extra={
                         "rental_share_raw": rental_share_raw,
                         "rental_share_capped": self.rental_share,
-                        "max_cap": TOTAL_BURN_EMISSION,
-                        "hint": f"Rental share would have been {rental_share_raw:.4f} but capped at {TOTAL_BURN_EMISSION}",
+                        "max_cap": total_burn_emission,
+                        "hint": f"Rental share would have been {rental_share_raw:.4f} but capped at {total_burn_emission}",
                     },
                 )
             )
 
         # Calculate emission splits
-        self.burn_share = TOTAL_BURN_EMISSION - self.rental_share
+        self.burn_share = total_burn_emission - self.rental_share
         logger.info(
             _m(
                 "Final emission splits calculated",

--- a/neurons/validators/src/incentive/utils.py
+++ b/neurons/validators/src/incentive/utils.py
@@ -1,8 +1,8 @@
 from time import time
 
+from core.config import get_total_burn_emission
 from core.utils import get_logger, _m
 from incentive.config import BASE_GPU_MAP, DefaultPrice
-from services.const import TOTAL_BURN_EMISSION
 from services.task import JobResult
 
 
@@ -55,7 +55,7 @@ def log_for_monitoring(
             None,
         )
         rental_share = first_with_rental.rental_share if first_with_rental else 0
-        burn_share = first_with_rental.burn_share if first_with_rental else float(TOTAL_BURN_EMISSION)
+        burn_share = first_with_rental.burn_share if first_with_rental else float(get_total_burn_emission())
         total_rental_cost = first_with_rental.total_rental_cost if first_with_rental else 0
 
         # Bucket-keyed map uses tuple keys; serialize as "{base}_{bucket}" for Loki unwrap compatibility.

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -1,5 +1,3 @@
-from lium_core.shared_config.defaults import DEFAULT_SHARED_CONFIG
-
 MIN_JOB_TAKEN_TIME = 20
 
 GPU_MODEL_RATES = {
@@ -113,11 +111,11 @@ VERIFY_JOB_REQUIRED_COUNT = 6 * 24 * 1
 
 # Emission split between the rented "mining" pool and the unrented + burn pool.
 # The LIVE value is sourced from shared config at runtime via
-# core.config.get_total_burn_emission() (DAH-2274). This constant is only the
-# offline fallback and mirrors the packaged lium-core default, so the value has a
-# single definition rather than an independent copy. (1 - TOTAL_BURN_EMISSION) is
-# the rented mining pool.
-TOTAL_BURN_EMISSION = DEFAULT_SHARED_CONFIG.total_burn_emission
+# core.config.get_total_burn_emission() (DAH-2274) — the backend is the source of
+# truth. This constant is the validator's expected production value: it is what the
+# tests assert against and what the test harness serves (see tests/conftest.py).
+# (1 - TOTAL_BURN_EMISSION) is the rented mining pool.
+TOTAL_BURN_EMISSION = 0.87
 BURNER_EMISSION = 0.01
 
 # Rental Price Incentive Constants

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -109,13 +109,10 @@ BATCH_PORT_CONCURRENCY = 200
 BATCH_HEALTH_CHECK_TIMEOUT = 10  # seconds to wait for batch verifier to become healthy
 VERIFY_JOB_REQUIRED_COUNT = 6 * 24 * 1
 
-# Emission split between the rented "mining" pool and the unrented + burn pool.
-# The LIVE value is sourced from shared config at runtime via
-# core.config.get_total_burn_emission() (DAH-2274) — the backend is the source of
-# truth. This constant is the validator's expected production value: it is what the
-# tests assert against and what the test harness serves (see tests/conftest.py).
-# (1 - TOTAL_BURN_EMISSION) is the rented mining pool.
-TOTAL_BURN_EMISSION = 0.87
+# Emission split between the rented "mining" pool and the unrented + burn pool is
+# sourced from shared config at runtime via core.config.get_total_burn_emission()
+# (DAH-2274) — the backend is the source of truth. The expected production value
+# used by the test suite lives in tests/constants.py.
 BURNER_EMISSION = 0.01
 
 # Rental Price Incentive Constants

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -1,3 +1,5 @@
+from lium_core.shared_config.defaults import DEFAULT_SHARED_CONFIG
+
 MIN_JOB_TAKEN_TIME = 20
 
 GPU_MODEL_RATES = {
@@ -110,10 +112,12 @@ BATCH_HEALTH_CHECK_TIMEOUT = 10  # seconds to wait for batch verifier to become 
 VERIFY_JOB_REQUIRED_COUNT = 6 * 24 * 1
 
 # Emission split between the rented "mining" pool and the unrented + burn pool.
-# TOTAL_BURN_EMISSION caps the unrented-rental + burn pool; the remainder
-# (1 - TOTAL_BURN_EMISSION) is the rented mining pool. Raising the rented pool
-# from 0.09 to 0.13 (DAH-2273) lowers this cap from 0.91 to 0.87.
-TOTAL_BURN_EMISSION = 0.87
+# The LIVE value is sourced from shared config at runtime via
+# core.config.get_total_burn_emission() (DAH-2274). This constant is only the
+# offline fallback and mirrors the packaged lium-core default, so the value has a
+# single definition rather than an independent copy. (1 - TOTAL_BURN_EMISSION) is
+# the rented mining pool.
+TOTAL_BURN_EMISSION = DEFAULT_SHARED_CONFIG.total_burn_emission
 BURNER_EMISSION = 0.01
 
 # Rental Price Incentive Constants

--- a/neurons/validators/tests/conftest.py
+++ b/neurons/validators/tests/conftest.py
@@ -6,9 +6,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import pytest_asyncio
 from datura.requests.miner_requests import ExecutorSSHInfo
+from lium_core.shared_config import DEFAULT_SHARED_CONFIG
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
+
+from services.const import TOTAL_BURN_EMISSION
 
 # Settings is instantiated during test collection through app imports. These
 # defaults keep unit tests self-contained without requiring a local validator env.
@@ -19,12 +22,16 @@ os.environ.setdefault("ASYNC_SQLALCHEMY_DATABASE_URI", "sqlite+aiosqlite:///:mem
 
 # Prevent network calls during module-level SharedConfigClient instantiation.
 # core/config.py creates `shared_client = SharedConfigClient(...)` at import time, which
-# otherwise performs a blocking HTTP fetch against the live API. Forcing _fetch to return
-# None keeps the offline fallback (DEFAULT_SHARED_CONFIG) so unit tests stay hermetic.
-# This patch must run before test collection.
+# otherwise performs a blocking HTTP fetch against the live API. We make _fetch return a
+# hermetic config pinned to the production burn value (TOTAL_BURN_EMISSION) so tests
+# exercise production behaviour, not the lium-core offline fallback (intentionally left
+# stale at the old value). This patch must run before test collection.
+_TEST_SHARED_CONFIG = DEFAULT_SHARED_CONFIG.model_copy(
+    update={"total_burn_emission": TOTAL_BURN_EMISSION}
+)
 _shared_config_patcher = patch(
     "lium_core.shared_config.client.SharedConfigClient._fetch",
-    return_value=None,
+    return_value=_TEST_SHARED_CONFIG,
 )
 _shared_config_patcher.start()
 

--- a/neurons/validators/tests/conftest.py
+++ b/neurons/validators/tests/conftest.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from services.const import TOTAL_BURN_EMISSION
+from constants import TOTAL_BURN_EMISSION
 
 # Settings is instantiated during test collection through app imports. These
 # defaults keep unit tests self-contained without requiring a local validator env.

--- a/neurons/validators/tests/constants.py
+++ b/neurons/validators/tests/constants.py
@@ -1,0 +1,10 @@
+"""Test-only constants.
+
+The LIVE burn emission split is sourced from shared config at runtime via
+core.config.get_total_burn_emission() (DAH-2274) — the backend is the source of
+truth. This is the validator's expected production value: it is what the tests
+assert against and what the test harness serves into the hermetic shared config
+(see conftest.py). (1 - TOTAL_BURN_EMISSION) is the rented mining pool.
+"""
+
+TOTAL_BURN_EMISSION = 0.87

--- a/neurons/validators/tests/test_burn_service.py
+++ b/neurons/validators/tests/test_burn_service.py
@@ -1,7 +1,7 @@
 import pytest
 
+from constants import TOTAL_BURN_EMISSION
 from incentive.burn_service import BurnService
-from services.const import TOTAL_BURN_EMISSION
 
 pytest_plugins = ["fixtures.incentive_fixtures"]
 

--- a/neurons/validators/tests/test_incentive_flow.py
+++ b/neurons/validators/tests/test_incentive_flow.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock, patch
 
-from services.const import TOTAL_BURN_EMISSION
+from constants import TOTAL_BURN_EMISSION
 
 BASE_JOB_SCORE = 1.0
 BURNER_COUNT = 2

--- a/neurons/validators/tests/test_rental_price_estimate.py
+++ b/neurons/validators/tests/test_rental_price_estimate.py
@@ -15,7 +15,8 @@ from incentive.rental_price import (
     RentalPriceSnapshot,
     precompute_all_estimates,
 )
-from services.const import TEMPO, SECONDS_PER_BLOCK, FIXED_RATIO, TOTAL_BURN_EMISSION
+from constants import TOTAL_BURN_EMISSION
+from services.const import TEMPO, SECONDS_PER_BLOCK, FIXED_RATIO
 from services.task_service import JobResult
 
 pytest_plugins = ["fixtures.incentive_fixtures"]

--- a/neurons/validators/tests/test_rental_price_helpers.py
+++ b/neurons/validators/tests/test_rental_price_helpers.py
@@ -1,5 +1,6 @@
 from core.config import settings
-from services.const import TEMPO, SECONDS_PER_BLOCK, FIXED_RATIO, TOTAL_BURN_EMISSION
+from constants import TOTAL_BURN_EMISSION
+from services.const import TEMPO, SECONDS_PER_BLOCK, FIXED_RATIO
 
 
 BASE_JOB_SCORE = 1.0

--- a/neurons/validators/tests/test_rental_price_incentive_flow.py
+++ b/neurons/validators/tests/test_rental_price_incentive_flow.py
@@ -8,7 +8,8 @@ from incentive import rental_price as rental_price_module
 from incentive.config import DEFAULT_PRICE, IncentiveConfig
 from incentive.factory import IncentiveFactory
 from protocol.vc_protocol.compute_requests import RentedExecutor, RentedExecutorsResponse, RentedPod
-from services.const import TEMPO, SECONDS_PER_BLOCK, FIXED_RATIO, TOTAL_BURN_EMISSION
+from constants import TOTAL_BURN_EMISSION
+from services.const import TEMPO, SECONDS_PER_BLOCK, FIXED_RATIO
 from tests.helpers import (
     assert_executor_has_log,
     assert_incentive_log_present,

--- a/neurons/validators/tests/test_total_burn_emission.py
+++ b/neurons/validators/tests/test_total_burn_emission.py
@@ -1,0 +1,38 @@
+"""Tests for the shared-config-sourced burn emission accessor (DAH-2274).
+
+get_total_burn_emission() reads total_burn_emission from the live shared config,
+clamps it to [0, 1], and falls back to the packaged lium-core default when the
+served value is missing or out of range, so a misconfigured or stale endpoint
+cannot push a garbage burn share into on-chain weights.
+"""
+
+import pytest
+from lium_core.shared_config.defaults import DEFAULT_SHARED_CONFIG
+
+from core.config import get_total_burn_emission, shared_client
+
+FALLBACK = DEFAULT_SHARED_CONFIG.total_burn_emission
+
+
+def _config_with_burn(value):
+    # model_copy bypasses validation, letting us inject out-of-range/None values.
+    return DEFAULT_SHARED_CONFIG.model_copy(update={"total_burn_emission": value})
+
+
+@pytest.mark.parametrize("value", [0.87, 0.91, 0.0, 1.0, 0.13])
+def test_valid_value_is_returned(monkeypatch, value):
+    monkeypatch.setattr(shared_client, "_config", _config_with_burn(value))
+    assert get_total_burn_emission() == pytest.approx(value)
+
+
+@pytest.mark.parametrize("value", [-0.01, 1.01, 9.1, -5.0, None, "0.87"])
+def test_invalid_value_falls_back_to_default(monkeypatch, value):
+    monkeypatch.setattr(shared_client, "_config", _config_with_burn(value))
+    assert get_total_burn_emission() == pytest.approx(FALLBACK)
+
+
+def test_default_offline_config_is_in_range(monkeypatch):
+    # The conftest patches _fetch -> None, so the live config is the offline default.
+    monkeypatch.setattr(shared_client, "_config", DEFAULT_SHARED_CONFIG)
+    assert get_total_burn_emission() == pytest.approx(FALLBACK)
+    assert 0.0 <= get_total_burn_emission() <= 1.0

--- a/neurons/validators/tests/test_total_burn_emission.py
+++ b/neurons/validators/tests/test_total_burn_emission.py
@@ -32,7 +32,8 @@ def test_out_of_range_value_falls_back_to_default(monkeypatch, value):
 
 
 def test_default_offline_config_is_in_range(monkeypatch):
-    # The conftest patches _fetch -> None, so the live config is the offline default.
+    # Explicitly pin the packaged lium-core default (the offline fallback) and confirm
+    # get_total_burn_emission() returns it unchanged and in range.
     monkeypatch.setattr(shared_client, "_config", DEFAULT_SHARED_CONFIG)
     assert get_total_burn_emission() == pytest.approx(FALLBACK)
     assert 0.0 <= get_total_burn_emission() <= 1.0

--- a/neurons/validators/tests/test_total_burn_emission.py
+++ b/neurons/validators/tests/test_total_burn_emission.py
@@ -1,9 +1,9 @@
 """Tests for the shared-config-sourced burn emission accessor (DAH-2274).
 
-get_total_burn_emission() reads total_burn_emission from the live shared config,
-clamps it to [0, 1], and falls back to the packaged lium-core default when the
-served value is missing or out of range, so a misconfigured or stale endpoint
-cannot push a garbage burn share into on-chain weights.
+SharedConfigClient already falls back to the lium-core default when the backend is
+unreachable, so get_total_burn_emission() only guards against a structurally valid
+but out-of-range served value (e.g. an operator typo) reaching on-chain weights:
+it returns the served value when in [0, 1], otherwise the lium-core default.
 """
 
 import pytest
@@ -15,7 +15,7 @@ FALLBACK = DEFAULT_SHARED_CONFIG.total_burn_emission
 
 
 def _config_with_burn(value):
-    # model_copy bypasses validation, letting us inject out-of-range/None values.
+    # model_copy bypasses validation, letting us inject out-of-range values.
     return DEFAULT_SHARED_CONFIG.model_copy(update={"total_burn_emission": value})
 
 
@@ -25,8 +25,8 @@ def test_valid_value_is_returned(monkeypatch, value):
     assert get_total_burn_emission() == pytest.approx(value)
 
 
-@pytest.mark.parametrize("value", [-0.01, 1.01, 9.1, -5.0, None, "0.87"])
-def test_invalid_value_falls_back_to_default(monkeypatch, value):
+@pytest.mark.parametrize("value", [-0.01, 1.01, 9.1, -5.0])
+def test_out_of_range_value_falls_back_to_default(monkeypatch, value):
     monkeypatch.setattr(shared_client, "_config", _config_with_burn(value))
     assert get_total_burn_emission() == pytest.approx(FALLBACK)
 


### PR DESCRIPTION
## Describe your changes

Wire the validator to read the burning-emission value from shared config instead of a hardcoded constant (DAH-2274), giving the value a single source of truth — the backend `/v1/shared-config` endpoint.

- New `core.config.get_total_burn_emission()`: reads `shared_client.config.total_burn_emission`, **clamps to `[0, 1]`**, and falls back to the packaged lium-core default when missing/invalid — so a misconfigured or stale endpoint cannot push a bad burn share into on-chain weights.
- `burn_service.py`, `rental_price.py`, `default.py`, `utils.py` now use the accessor instead of the local const.
- `services/const.py TOTAL_BURN_EMISSION` is no longer an independent literal — it derives from the lium-core default (offline fallback, retained for tests).
- Removed a now-unused import in `base.py`.
- Added `tests/test_total_burn_emission.py` (clamp + fallback).

Net on-chain burn is unchanged (the backend serves 0.87). Requires the backend PR deployed first.

Tests: burn/incentive suites + new accessor test — **113 passed, 4 skipped**. Ruff 0.5.1 net-clean (no new violations vs baseline).

Part of DAH-2274 — related PRs (same branch in each repo):
1. lium-io-backend#719 — https://github.com/Datura-ai/lium-io-backend/pull/719 _(authority: serve 0.87)_
2. lium-io#1089 — https://github.com/Datura-ai/lium-io/pull/1089 _(validator reads shared config)_
3. lium-miner-portal-frontend#142 — https://github.com/Datura-ai/lium-miner-portal-frontend/pull/142 _(portal label)_

Deploy in the order above.

## Issue ticket number and link

[DAH-2274](https://www.notion.so/DAH-2274)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?
