### PR TITLE
DAH-2291 - Fix alpha price query after finney Swap pallet migration

### DIFF
--- a/neurons/validators/src/clients/subtensor_client.py
+++ b/neurons/validators/src/clients/subtensor_client.py
@@ -661,5 +661,13 @@ class SubtensorClient:
         return cls._subtensor
 
     def get_alpha_rate(self) -> float:
-        price = self.subtensor.get_subnet_price(netuid=self.netuid)
-        return price.tao
+        # `subtensor.get_subnet_price()` reads the `Swap.AlphaSqrtPrice` storage item,
+        # which the finney runtime removed when the `Swap` pallet was migrated to a new
+        # AMM — querying it now raises `Storage function "Swap.AlphaSqrtPrice" not found`.
+        # `subtensor.subnet()` is resilient: it attempts `get_subnet_price()` and, on that
+        # failure, falls back to the `tao_in / alpha_in` reserve ratio, yielding the same
+        # alpha price in TAO. This keeps the query working without a bittensor SDK upgrade.
+        subnet = self.subtensor.subnet(netuid=self.netuid)
+        if subnet is None or subnet.price is None:
+            raise RuntimeError(f"No subnet price available for netuid {self.netuid}")
+        return subnet.price.tao

--- a/neurons/validators/tests/test_subtensor_client_alpha_rate.py
+++ b/neurons/validators/tests/test_subtensor_client_alpha_rate.py
@@ -1,0 +1,59 @@
+"""Regression tests for SubtensorClient.get_alpha_rate.
+
+Background: the finney runtime migrated its `Swap` pallet to a new AMM and removed the
+`Swap.AlphaSqrtPrice` storage item. `subtensor.get_subnet_price()` reads that item directly
+and started raising `Storage function "Swap.AlphaSqrtPrice" not found` in production. The fix
+routes through `subtensor.subnet()`, which falls back to the `tao_in / alpha_in` reserve ratio
+when the storage query fails. These tests exercise the method against a mocked subtensor so the
+heavy SubtensorClient init is bypassed.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from clients.subtensor_client import SubtensorClient
+
+
+def _client_with_subnet(price_obj):
+    """Build a stand-in `self` whose `.subtensor.subnet()` returns a configured object."""
+    fake_self = MagicMock()
+    fake_self.netuid = 51
+    fake_self.subtensor.subnet.return_value = price_obj
+    return fake_self
+
+
+def test_get_alpha_rate_returns_subnet_price_tao():
+    # Arrange: subnet() returns a DynamicInfo-like object with a Balance price
+    price = MagicMock()
+    price.tao = 0.054316
+    subnet = MagicMock()
+    subnet.price = price
+    fake_self = _client_with_subnet(subnet)
+
+    # Act
+    result = SubtensorClient.get_alpha_rate(fake_self)
+
+    # Assert: reads the alpha price in TAO and queries the configured netuid
+    assert result == 0.054316
+    fake_self.subtensor.subnet.assert_called_once_with(netuid=51)
+
+
+def test_get_alpha_rate_raises_when_subnet_missing():
+    # Arrange: subnet() returns None (subnet not found / decode failure)
+    fake_self = _client_with_subnet(None)
+
+    # Act / Assert: surfaces an error so the caller's retry+fallback path engages
+    with pytest.raises(RuntimeError):
+        SubtensorClient.get_alpha_rate(fake_self)
+
+
+def test_get_alpha_rate_raises_when_price_missing():
+    # Arrange: subnet() returns an object without a usable price
+    subnet = MagicMock()
+    subnet.price = None
+    fake_self = _client_with_subnet(subnet)
+
+    # Act / Assert
+    with pytest.raises(RuntimeError):
+        SubtensorClient.get_alpha_rate(fake_self)


### PR DESCRIPTION
## Describe your changes

**Production incident:** the validator's alpha-token-price query was failing with
`Storage function "Swap.AlphaSqrtPrice" not found`.

**Root cause:** this is a chain-runtime schema change, not a code or network bug. `bittensor==9.10.1`'s `subtensor.get_subnet_price(netuid)` reads the `Swap.AlphaSqrtPrice` storage item directly. The finney runtime upgraded and migrated its `Swap` pallet to a new AMM, removing `AlphaSqrtPrice`. On the current finney runtime the `Swap` pallet now only exposes: `FeeRate`, `HasMigrationRun`, `PalSwapInitialized`, `ScrapReservoirAlpha`, `SwapBalancer`. Newer SDKs (9.12.x) confirm the diagnosis — they rewrote `get_subnet_price` to use the `SwapRuntimeApi.current_alpha_price` runtime API.

**Fix:** route `SubtensorClient.get_alpha_rate()` through `subtensor.subnet(netuid)` instead of `get_subnet_price()`. In 9.10.1, `subnet()` attempts `get_subnet_price()` and, when that storage query raises, **falls back internally to the `tao_in / alpha_in` reserve ratio** — returning the same alpha price in TAO. This restores the query on the current runtime **without a bittensor SDK upgrade** and is more resilient (built-in fallback rather than one hardcoded storage path).

- `get_alpha_rate()` returns the identical value the old path produced, so the downstream `epoch_subnet_emission = TEMPO * tao_price * alpha_rate` math is unchanged.
- Scope is exactly two files: the one-method fix + a regression test. No unrelated changes.

### Local verification

Reproduced and verified live against finney with the production-pinned stack (`bittensor==9.10.1`, `async-substrate-interface==1.6.3`, `scalecodec==1.2.11`, `bt-decode==0.8.0`, `websockets==16.0`, per `pdm.lock`):

```
BEFORE (old code path):  subtensor.get_subnet_price(51).tao
  -> ERROR: SubstrateRequestException: Storage function "Swap.AlphaSqrtPrice" not found
AFTER  (fixed code path): subtensor.subnet(51).price.tao
  -> 0.0543... TAO per alpha  (agrees with SwapRuntimeApi.current_alpha_price and SubnetTAO/SubnetAlphaIn)
```

Tests: `test_subtensor_client_alpha_rate.py` (3 new) + `test_price_provider.py` (47) pass; full incentive-flow suite green.

## Issue ticket number and link

[DAH-2291](https://www.notion.so/DAH-2291)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?
