### PR TITLE
DAH-2272 - Add SSH connect phase-timing instrumentation and asyncssh debug toggle

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -162,12 +162,13 @@ class Settings(BaseSettings):
     CONTAINER_CLEANUP_DRY_RUN: bool = Field(env="CONTAINER_CLEANUP_DRY_RUN", default=False, description="Dry run mode for stale container cleanup")
 
     # DAH-2272: raise the asyncssh logger to DEBUG (debug level 2) so the SSH
-    # handshake (banner / key exchange / auth) is logged per connection. Off by
-    # default — verbose; flip on briefly in staging/prod to deep-dive a slow
-    # connect below the always-on ssh_connect_phase_timing split. Lives on the
+    # handshake (banner / key exchange / auth) is logged per connection. Enabled
+    # by default while DAH-2272 is under investigation, so the handshake trace is
+    # captured whenever the rare slow-connect transient hits; set
+    # SSH_DEBUG_LOGGING=false (env) to silence it without a deploy. Lives on the
     # main settings (not DebugSettings, which is local-dev only) so it is
-    # configurable where the real slow connects happen.
-    SSH_DEBUG_LOGGING: bool = Field(env="SSH_DEBUG_LOGGING", default=False, description="Enable verbose asyncssh SSH handshake debug logging")
+    # configurable in staging/prod where the real slow connects happen.
+    SSH_DEBUG_LOGGING: bool = Field(env="SSH_DEBUG_LOGGING", default=True, description="Enable verbose asyncssh SSH handshake debug logging")
 
     # DAH-2250 — unrented incentive soft price limit. When True, an unrented executor
     # whose price_per_gpu exceeds market p90 * SOFT_LIMIT_PRICE_RATE loses the unrented

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -81,14 +81,6 @@ class DebugSettings(BaseSettings):
 
     SKIP_STORAGE_CHECK: bool = Field(default=False, description="Skip storage check")
 
-    # DAH-2272: raise the asyncssh logger to DEBUG (debug level 2) so the SSH
-    # handshake (banner / key exchange / auth) is logged per connection. Off by
-    # default — it is verbose; enable per-deploy to break down a slow connect
-    # below the tcp/login split that ssh_connect_timing already emits.
-    SSH_DEBUG_LOGGING: bool = Field(
-        default=False, description="Enable verbose asyncssh SSH handshake debug logging"
-    )
-
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
@@ -168,6 +160,14 @@ class Settings(BaseSettings):
     SKIP_COLLATERAL_PENALTY: bool = Field(env="SKIP_COLLATERAL_PENALTY", default=True)
     DRY_RUN: bool = Field(env="DRY_RUN", default=False, description="Run validation without publishing scores/weights")
     CONTAINER_CLEANUP_DRY_RUN: bool = Field(env="CONTAINER_CLEANUP_DRY_RUN", default=False, description="Dry run mode for stale container cleanup")
+
+    # DAH-2272: raise the asyncssh logger to DEBUG (debug level 2) so the SSH
+    # handshake (banner / key exchange / auth) is logged per connection. Off by
+    # default — verbose; flip on briefly in staging/prod to deep-dive a slow
+    # connect below the always-on ssh_connect_phase_timing split. Lives on the
+    # main settings (not DebugSettings, which is local-dev only) so it is
+    # configurable where the real slow connects happen.
+    SSH_DEBUG_LOGGING: bool = Field(env="SSH_DEBUG_LOGGING", default=False, description="Enable verbose asyncssh SSH handshake debug logging")
 
     # DAH-2250 — unrented incentive soft price limit. When True, an unrented executor
     # whose price_per_gpu exceeds market p90 * SOFT_LIMIT_PRICE_RATE loses the unrented

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -81,6 +81,14 @@ class DebugSettings(BaseSettings):
 
     SKIP_STORAGE_CHECK: bool = Field(default=False, description="Skip storage check")
 
+    # DAH-2272: raise the asyncssh logger to DEBUG (debug level 2) so the SSH
+    # handshake (banner / key exchange / auth) is logged per connection. Off by
+    # default — it is verbose; enable per-deploy to break down a slow connect
+    # below the tcp/login split that ssh_connect_timing already emits.
+    SSH_DEBUG_LOGGING: bool = Field(
+        default=False, description="Enable verbose asyncssh SSH handshake debug logging"
+    )
+
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -168,6 +168,9 @@ class Settings(BaseSettings):
     # SSH_DEBUG_LOGGING=false (env) to silence it without a deploy. Lives on the
     # main settings (not DebugSettings, which is local-dev only) so it is
     # configurable in staging/prod where the real slow connects happen.
+    # TODO(DAH-2272): flip default back to False once the slow-connect
+    # investigation is closed — debug-level handshake logging shouldn't ship on
+    # by default long-term.
     SSH_DEBUG_LOGGING: bool = Field(env="SSH_DEBUG_LOGGING", default=True, description="Enable verbose asyncssh SSH handshake debug logging")
 
     # DAH-2250 — unrented incentive soft price limit. When True, an unrented executor

--- a/neurons/validators/src/core/utils.py
+++ b/neurons/validators/src/core/utils.py
@@ -128,6 +128,23 @@ def get_extra_info(extra: dict) -> dict:
     return extra_info
 
 
+def _apply_asyncssh_log_level(asyncssh_logger: logging.Logger | None = None) -> int:
+    """Set the asyncssh logger level from the ``DEBUG_SSH_DEBUG_LOGGING`` flag.
+
+    DAH-2272: defaults to WARNING (asyncssh is quiet); when the flag is on, raise
+    it to DEBUG and request debug level 2 (full handshake, no packet dumps — 3
+    can leak the private key) so the banner / key-exchange / auth phases are
+    logged per connection.
+    """
+    level = logging.DEBUG if settings.debug.SSH_DEBUG_LOGGING else logging.WARNING
+    lg = asyncssh_logger or logging.getLogger("asyncssh")
+    lg.setLevel(level)
+    if settings.debug.SSH_DEBUG_LOGGING:
+        # Level 2 = full debug logging; level 3 would dump packets (key material).
+        asyncssh.set_debug_level(2)
+    return level
+
+
 def configure_logs_of_other_modules():
     # Configure root logger with JSON formatter
     root_logger = logging.getLogger()
@@ -155,7 +172,7 @@ def configure_logs_of_other_modules():
             return True
 
     asyncssh_logger = logging.getLogger("asyncssh")
-    asyncssh_logger.setLevel(logging.WARNING)
+    _apply_asyncssh_log_level(asyncssh_logger)
 
     # Add the filter to the logger
     asyncssh_logger.addFilter(ContextFilter())
@@ -187,7 +204,8 @@ def get_logger(name: str):
                 "propagate": False,
             },
             "asyncssh": {
-                "level": "WARNING",
+                # DAH-2272: DEBUG when DEBUG_SSH_DEBUG_LOGGING is set, else quiet.
+                "level": "DEBUG" if settings.debug.SSH_DEBUG_LOGGING else "WARNING",
                 "propagate": True,
             },
         },

--- a/neurons/validators/src/core/utils.py
+++ b/neurons/validators/src/core/utils.py
@@ -129,17 +129,17 @@ def get_extra_info(extra: dict) -> dict:
 
 
 def _apply_asyncssh_log_level(asyncssh_logger: logging.Logger | None = None) -> int:
-    """Set the asyncssh logger level from the ``DEBUG_SSH_DEBUG_LOGGING`` flag.
+    """Set the asyncssh logger level from the ``SSH_DEBUG_LOGGING`` setting.
 
     DAH-2272: defaults to WARNING (asyncssh is quiet); when the flag is on, raise
     it to DEBUG and request debug level 2 (full handshake, no packet dumps — 3
     can leak the private key) so the banner / key-exchange / auth phases are
     logged per connection.
     """
-    level = logging.DEBUG if settings.debug.SSH_DEBUG_LOGGING else logging.WARNING
+    level = logging.DEBUG if settings.SSH_DEBUG_LOGGING else logging.WARNING
     lg = asyncssh_logger or logging.getLogger("asyncssh")
     lg.setLevel(level)
-    if settings.debug.SSH_DEBUG_LOGGING:
+    if settings.SSH_DEBUG_LOGGING:
         # Level 2 = full debug logging; level 3 would dump packets (key material).
         asyncssh.set_debug_level(2)
     return level
@@ -204,8 +204,8 @@ def get_logger(name: str):
                 "propagate": False,
             },
             "asyncssh": {
-                # DAH-2272: DEBUG when DEBUG_SSH_DEBUG_LOGGING is set, else quiet.
-                "level": "DEBUG" if settings.debug.SSH_DEBUG_LOGGING else "WARNING",
+                # DAH-2272: DEBUG when SSH_DEBUG_LOGGING is set, else quiet.
+                "level": "DEBUG" if settings.SSH_DEBUG_LOGGING else "WARNING",
                 "propagate": True,
             },
         },

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -51,6 +51,7 @@ from protocol.vc_protocol.compute_requests import RentedMachine
 
 from core.config import settings
 from core.utils import _m, get_extra_info, retry_ssh_command
+from services.ssh_connect_timing import connect_with_phase_timing
 from services.const import (
     FILLER_CONTAINER_PREFIX,
     POD_CONTAINER_PREFIX,
@@ -1138,7 +1139,15 @@ class DockerService:
         decrypted_key = self.ssh_service.decrypt_payload(keypair.ss58_address, private_key)
         pkey = asyncssh.import_private_key(decrypted_key)
         try:
-            async with asyncssh.connect(
+            # DAH-2272: this early port-check connect is the one whose stall got
+            # absorbed into "Started in subnet"; phase-time it so a future stall
+            # is attributable to network (TCP) vs. remote sshd (login).
+            async with connect_with_phase_timing(
+                log_extra={
+                    "miner_hotkey": miner_hotkey,
+                    "executor_ip_address": executor_info.address,
+                    "context": "wait_for_port_check_containers",
+                },
                 host=executor_info.address,
                 port=executor_info.ssh_port,
                 username=executor_info.ssh_username,
@@ -2868,8 +2877,12 @@ class DockerService:
             require_rental_docker_ssh_host_key(executor_info)
 
             current_step = "ssh_connect"
+            # DAH-2272: connect_with_phase_timing logs the TCP-vs-SSH-login
+            # split for this connect (host/network vs. remote sshd) without
+            # changing how the connection is established.
             async with (
-                asyncssh.connect(
+                connect_with_phase_timing(
+                    log_extra=default_extra,
                     host=executor_info.address,
                     port=executor_info.ssh_port,
                     username=executor_info.ssh_username,

--- a/neurons/validators/src/services/ssh_connect_timing.py
+++ b/neurons/validators/src/services/ssh_connect_timing.py
@@ -32,7 +32,7 @@ Reading the split: a large ``tcp_connect_ms`` (with an IP host, so no DNS) →
 network path / host uplink; a large ``ssh_handshake_ms`` → remote sshd slow to
 emit its banner / KEX; a large value across *all* hosts in the same window →
 validator-side (event-loop) rather than remote. For a finer banner-vs-KEX
-split, enable ``DEBUG_SSH_DEBUG_LOGGING`` (see ``core.utils``).
+split, enable ``SSH_DEBUG_LOGGING`` (see ``core.utils``).
 
 Only the *notification* callbacks (all return ``None``) are overridden; the
 credential/host-key request callbacks are left to the base ``SSHClient`` so auth

--- a/neurons/validators/src/services/ssh_connect_timing.py
+++ b/neurons/validators/src/services/ssh_connect_timing.py
@@ -1,0 +1,119 @@
+"""SSH connect phase timing (DAH-2272).
+
+Splits a single ``asyncssh.connect`` into its two coarse legs **without changing
+how the connection is established** — so we can attribute a slow connect to the
+remote host/network vs. the remote sshd:
+
+* ``tcp_connect_ms`` — DNS resolution + TCP handshake (network / remote-host
+  reachability). Measured from just before ``asyncssh.connect`` to asyncssh's
+  ``SSHClient.connection_made`` callback, which fires "as soon as the TCP
+  connection completes".
+* ``ssh_login_ms`` — SSH banner exchange + key exchange + authentication
+  (sshd-side + crypto). Measured from ``connection_made`` to
+  ``SSHClient.auth_completed`` ("authentication completed successfully").
+
+Reading the split:
+
+* large ``tcp_connect_ms`` → the network path / remote host is slow or lossy
+  (the validator's event loop is fine — see the same-window comparison in the
+  DAH-2272 RCA).
+* large ``ssh_login_ms`` → the remote sshd is slow to respond (classic
+  ``UseDNS yes`` reverse-lookup stall, PAM) or KEX/auth is expensive.
+
+For a finer banner-vs-KEX-vs-auth breakdown, enable the asyncssh debug log
+(``DEBUG_SSH_DEBUG_LOGGING=true``); see ``core.utils.configure_logs_of_other_modules``.
+
+This is observation-only: it attaches a timing ``client_factory`` (a documented
+asyncssh extension point) to the real connect and emits one structured log
+line. It never alters the socket, the connect options, or the failure behaviour
+of the underlying connect, and on any internal error it degrades to a plain
+``asyncssh.connect``.
+"""
+
+import logging
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+import asyncssh
+
+from core.utils import _m, get_extra_info
+from payload_models.payloads import now_ms
+
+logger = logging.getLogger(__name__)
+
+
+class _PhaseTimingSSHClient(asyncssh.SSHClient):
+    """Records TCP-complete and auth-complete wall-clock marks for one connect.
+
+    asyncssh constructs one of these per connection via ``client_factory`` and
+    invokes the callbacks on the connection's own task, so the marks line up
+    with the exact connect being measured.
+    """
+
+    def __init__(self, marks: dict):
+        self._marks = marks
+
+    def connection_made(self, conn: asyncssh.SSHClientConnection) -> None:
+        # Fired as soon as the TCP connection completes (pre-handshake).
+        self._marks["tcp_done_ms"] = now_ms()
+
+    def auth_completed(self) -> None:
+        # Fired once banner + KEX + auth have all succeeded.
+        self._marks["auth_done_ms"] = now_ms()
+
+
+@asynccontextmanager
+async def connect_with_phase_timing(
+    *,
+    log_extra: dict | None = None,
+    **connect_kwargs,
+) -> AsyncIterator[asyncssh.SSHClientConnection]:
+    """``asyncssh.connect`` wrapper that logs the TCP-vs-SSH-login split.
+
+    Drop-in replacement for ``async with asyncssh.connect(...) as ssh_client:``.
+    All keyword arguments are forwarded verbatim to ``asyncssh.connect``; an
+    internal ``client_factory`` is injected to capture phase marks. On exit the
+    connection is closed exactly as the plain async-context-manager form would.
+
+    A caller-supplied ``client_factory`` is not supported (no callsite passes
+    one); doing so raises ``ValueError`` rather than silently dropping it.
+    """
+    if connect_kwargs.get("client_factory") is not None:
+        raise ValueError("connect_with_phase_timing does not support a custom client_factory")
+
+    log_extra = log_extra or {}
+    marks: dict = {}
+    t0 = now_ms()
+
+    # Use the `async with` form so cleanup (close + wait_closed) is identical to
+    # a plain `asyncssh.connect`. By the time `__aenter__` returns, the connect
+    # has resolved and both phase callbacks have fired, so the marks are set.
+    async with asyncssh.connect(
+        client_factory=lambda: _PhaseTimingSSHClient(marks),
+        **connect_kwargs,
+    ) as conn:
+        tcp_done = marks.get("tcp_done_ms")
+        auth_done = marks.get("auth_done_ms")
+        end = now_ms()
+        tcp_ms = (tcp_done - t0) if tcp_done is not None else None
+        login_ms = (
+            (auth_done - tcp_done)
+            if (auth_done is not None and tcp_done is not None)
+            else None
+        )
+        logger.info(
+            _m(
+                "ssh_connect_phase_timing",
+                extra=get_extra_info(
+                    {
+                        **log_extra,
+                        "host": connect_kwargs.get("host"),
+                        "port": connect_kwargs.get("port"),
+                        "tcp_connect_ms": tcp_ms,
+                        "ssh_login_ms": login_ms,
+                        "total_connect_ms": end - t0,
+                    }
+                ),
+            )
+        )
+        yield conn

--- a/neurons/validators/src/services/ssh_connect_timing.py
+++ b/neurons/validators/src/services/ssh_connect_timing.py
@@ -1,35 +1,45 @@
 """SSH connect phase timing (DAH-2272).
 
-Splits a single ``asyncssh.connect`` into its two coarse legs **without changing
-how the connection is established** — so we can attribute a slow connect to the
-remote host/network vs. the remote sshd:
+Splits a single ``asyncssh.connect`` into its phases **without changing how the
+connection is established** — so we can attribute a slow connect to the network,
+the remote sshd, or the validator. It does this by attaching an observation-only
+``SSHClient`` (a documented asyncssh extension point) that timestamps the
+connection lifecycle callbacks, then emits one structured
+``ssh_connect_phase_timing`` log line per connect.
 
-* ``tcp_connect_ms`` — DNS resolution + TCP handshake (network / remote-host
-  reachability). Measured from just before ``asyncssh.connect`` to asyncssh's
-  ``SSHClient.connection_made`` callback, which fires "as soon as the TCP
-  connection completes".
-* ``ssh_login_ms`` — SSH banner exchange + key exchange + authentication
-  (sshd-side + crypto). Measured from ``connection_made`` to
-  ``SSHClient.auth_completed`` ("authentication completed successfully").
+Phases (each the gap between two asyncssh ``SSHClient`` callbacks):
 
-Reading the split:
+* ``tcp_connect_ms`` — start → ``connection_made`` ("as soon as the TCP
+  connection completes"). DNS resolution + TCP handshake → **network /
+  remote-host reachability**.
+* ``ssh_handshake_ms`` — ``connection_made`` → ``begin_auth`` ("authentication
+  is about to begin"). Version-banner exchange + key exchange → the **remote
+  sshd** (a ``UseDNS`` reverse-lookup banner stall lands here) + KEX crypto.
+* ``ssh_auth_ms`` — ``begin_auth`` → ``auth_completed``. Authentication
+  round-trips.
+* ``ssh_login_ms`` — ``connection_made`` → ``auth_completed``. The whole
+  post-TCP leg; always available even if ``begin_auth`` was skipped, so it is
+  the robust fallback for ``ssh_handshake_ms + ssh_auth_ms``.
+* ``total_connect_ms`` — start → connect returned.
 
-* large ``tcp_connect_ms`` → the network path / remote host is slow or lossy
-  (the validator's event loop is fine — see the same-window comparison in the
-  DAH-2272 RCA).
-* large ``ssh_login_ms`` → the remote sshd is slow to respond (classic
-  ``UseDNS yes`` reverse-lookup stall, PAM) or KEX/auth is expensive.
+Plus negotiated metadata read off the connection once it is up:
+``server_version`` (the remote sshd's identification banner — e.g.
+``SSH-2.0-OpenSSH_8.9p1``, the single most useful clue for a banner stall),
+``cipher``/``mac``, any pre-auth ``auth_banner`` the server displayed, and any
+server SSH ``DEBUG`` messages.
 
-For a finer banner-vs-KEX-vs-auth breakdown, enable the asyncssh debug log
-(``DEBUG_SSH_DEBUG_LOGGING=true``); see ``core.utils.configure_logs_of_other_modules``.
+Reading the split: a large ``tcp_connect_ms`` (with an IP host, so no DNS) →
+network path / host uplink; a large ``ssh_handshake_ms`` → remote sshd slow to
+emit its banner / KEX; a large value across *all* hosts in the same window →
+validator-side (event-loop) rather than remote. For a finer banner-vs-KEX
+split, enable ``DEBUG_SSH_DEBUG_LOGGING`` (see ``core.utils``).
 
-This is observation-only: it attaches a timing ``client_factory`` (a documented
-asyncssh extension point) to the real connect and emits one structured log
-line. It never alters the socket, the connect options, or the failure behaviour
-of the underlying connect, and on any internal error it degrades to a plain
-``asyncssh.connect``.
+Only the *notification* callbacks (all return ``None``) are overridden; the
+credential/host-key request callbacks are left to the base ``SSHClient`` so auth
+behaviour is untouched.
 """
 
+import inspect
 import logging
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
@@ -41,25 +51,74 @@ from payload_models.payloads import now_ms
 
 logger = logging.getLogger(__name__)
 
+_BANNER_MAX = 200
+
 
 class _PhaseTimingSSHClient(asyncssh.SSHClient):
-    """Records TCP-complete and auth-complete wall-clock marks for one connect.
+    """Observation-only client that records connect-phase marks.
 
     asyncssh constructs one of these per connection via ``client_factory`` and
     invokes the callbacks on the connection's own task, so the marks line up
-    with the exact connect being measured.
+    with the exact connect being measured. Every method here is a pure
+    notification (returns ``None``); nothing influences the handshake or auth.
     """
 
-    def __init__(self, marks: dict):
+    def __init__(self, marks: dict, log_extra: dict, host: object):
         self._marks = marks
+        self._log_extra = log_extra
+        self._host = host
 
     def connection_made(self, conn: asyncssh.SSHClientConnection) -> None:
         # Fired as soon as the TCP connection completes (pre-handshake).
         self._marks["tcp_done_ms"] = now_ms()
 
+    def begin_auth(self, username: str) -> None:
+        # Fired once version exchange + KEX are done and auth is about to start.
+        self._marks["auth_begin_ms"] = now_ms()
+
+    def auth_banner_received(self, msg: str, lang: str) -> None:
+        # Optional server-sent pre-auth banner (many hosts send none).
+        self._marks["auth_banner_ms"] = now_ms()
+        self._marks["auth_banner"] = (msg or "")[:_BANNER_MAX]
+
     def auth_completed(self) -> None:
-        # Fired once banner + KEX + auth have all succeeded.
+        # Fired once authentication has succeeded.
         self._marks["auth_done_ms"] = now_ms()
+
+    def debug_msg_received(self, msg: str, lang: str, always_display: bool) -> None:
+        # Rare: an SSH DEBUG message from the server. Capture for diagnostics.
+        self._marks.setdefault("server_debug_msgs", []).append((msg or "")[:_BANNER_MAX])
+
+    def connection_lost(self, exc: "Exception | None") -> None:
+        # Fires at close — after the wrapper's summary line — so it is logged
+        # on its own. Only surface abnormal drops (keepalive timeout, mid-deploy
+        # reset); a clean close (exc is None) stays silent to avoid noise.
+        if exc is not None:
+            logger.warning(
+                _m(
+                    "ssh_connection_lost",
+                    extra=get_extra_info(
+                        {**self._log_extra, "host": self._host, "error": str(exc)}
+                    ),
+                )
+            )
+
+
+def _safe_extra(conn: object, key: str):
+    """Read a negotiated value off the connection, tolerating absence/mocks.
+
+    The real ``SSHClientConnection.get_extra_info`` returns a plain value; the
+    coroutine guard only matters for mock connections, so an async-shaped result
+    is discarded (and closed) rather than logged.
+    """
+    try:
+        value = conn.get_extra_info(key)
+    except Exception:
+        return None
+    if inspect.iscoroutine(value):
+        value.close()
+        return None
+    return value
 
 
 @asynccontextmanager
@@ -68,7 +127,7 @@ async def connect_with_phase_timing(
     log_extra: dict | None = None,
     **connect_kwargs,
 ) -> AsyncIterator[asyncssh.SSHClientConnection]:
-    """``asyncssh.connect`` wrapper that logs the TCP-vs-SSH-login split.
+    """``asyncssh.connect`` wrapper that logs the connect-phase breakdown.
 
     Drop-in replacement for ``async with asyncssh.connect(...) as ssh_client:``.
     All keyword arguments are forwarded verbatim to ``asyncssh.connect``; an
@@ -83,37 +142,41 @@ async def connect_with_phase_timing(
 
     log_extra = log_extra or {}
     marks: dict = {}
+    host = connect_kwargs.get("host")
     t0 = now_ms()
 
     # Use the `async with` form so cleanup (close + wait_closed) is identical to
     # a plain `asyncssh.connect`. By the time `__aenter__` returns, the connect
-    # has resolved and both phase callbacks have fired, so the marks are set.
+    # has resolved and the phase callbacks have fired, so the marks are set.
     async with asyncssh.connect(
-        client_factory=lambda: _PhaseTimingSSHClient(marks),
+        client_factory=lambda: _PhaseTimingSSHClient(marks, log_extra, host),
         **connect_kwargs,
     ) as conn:
-        tcp_done = marks.get("tcp_done_ms")
-        auth_done = marks.get("auth_done_ms")
         end = now_ms()
-        tcp_ms = (tcp_done - t0) if tcp_done is not None else None
-        login_ms = (
-            (auth_done - tcp_done)
-            if (auth_done is not None and tcp_done is not None)
-            else None
-        )
-        logger.info(
-            _m(
-                "ssh_connect_phase_timing",
-                extra=get_extra_info(
-                    {
-                        **log_extra,
-                        "host": connect_kwargs.get("host"),
-                        "port": connect_kwargs.get("port"),
-                        "tcp_connect_ms": tcp_ms,
-                        "ssh_login_ms": login_ms,
-                        "total_connect_ms": end - t0,
-                    }
-                ),
-            )
-        )
+        tcp_done = marks.get("tcp_done_ms")
+        auth_begin = marks.get("auth_begin_ms")
+        auth_done = marks.get("auth_done_ms")
+
+        def _delta(a, b):
+            return (b - a) if (a is not None and b is not None) else None
+
+        extra = {
+            **log_extra,
+            "host": host,
+            "port": connect_kwargs.get("port"),
+            "tcp_connect_ms": _delta(t0, tcp_done),
+            "ssh_handshake_ms": _delta(tcp_done, auth_begin),  # banner + KEX
+            "ssh_auth_ms": _delta(auth_begin, auth_done),      # authentication
+            "ssh_login_ms": _delta(tcp_done, auth_done),       # robust combined
+            "total_connect_ms": end - t0,
+            "server_version": _safe_extra(conn, "server_version"),
+            "cipher": _safe_extra(conn, "recv_cipher"),
+            "mac": _safe_extra(conn, "recv_mac"),
+        }
+        if marks.get("auth_banner"):
+            extra["auth_banner"] = marks["auth_banner"]
+        if marks.get("server_debug_msgs"):
+            extra["server_debug_msgs"] = marks["server_debug_msgs"]
+
+        logger.info(_m("ssh_connect_phase_timing", extra=get_extra_info(extra)))
         yield conn

--- a/neurons/validators/tests/test_ssh_connect_timing.py
+++ b/neurons/validators/tests/test_ssh_connect_timing.py
@@ -1,0 +1,185 @@
+"""Tests for the SSH connect phase-timing instrumentation (DAH-2272)."""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import services.ssh_connect_timing as sct
+from services.ssh_connect_timing import connect_with_phase_timing
+
+MODULE_LOGGER = "services.ssh_connect_timing"
+
+
+def _fake_conn():
+    conn = MagicMock(name="ssh_conn")
+    conn.close = MagicMock()
+    conn.wait_closed = AsyncMock()
+    return conn
+
+
+class _FakeConnectCM:
+    """Stand-in for asyncssh.connect()'s return (an async context manager).
+
+    On enter it optionally drives the phase callbacks on the injected client so
+    the wrapper sees realistic marks; on exit it mirrors asyncssh cleanup.
+    """
+
+    def __init__(self, conn, client, fire_callbacks=True):
+        self._conn = conn
+        self._client = client
+        self._fire = fire_callbacks
+
+    async def __aenter__(self):
+        if self._fire:
+            self._client.connection_made(object())  # TCP done
+            self._client.auth_completed()            # banner+kex+auth done
+        return self._conn
+
+    async def __aexit__(self, *_):
+        self._conn.close()
+        await self._conn.wait_closed()
+        return False
+
+
+def _connect_returning(conn, *, fire_callbacks=True, capture=None):
+    """Build a sync fake for asyncssh.connect that returns a _FakeConnectCM."""
+
+    def fake_connect(*, client_factory, **kwargs):
+        if capture is not None:
+            capture.update(kwargs)
+        client = client_factory()
+        return _FakeConnectCM(conn, client, fire_callbacks=fire_callbacks)
+
+    return fake_connect
+
+
+def _clock(monkeypatch, ticks):
+    """Make ``now_ms`` return ``ticks`` in order."""
+    it = iter(ticks)
+    monkeypatch.setattr(sct, "now_ms", lambda: next(it))
+
+
+def _phase_record(caplog):
+    for rec in caplog.records:
+        msg = getattr(rec, "msg", None)
+        if getattr(msg, "message", None) == "ssh_connect_phase_timing":
+            return msg
+    return None
+
+
+@pytest.mark.asyncio
+async def test_logs_tcp_and_login_split(monkeypatch, caplog):
+    """connection_made/auth_completed marks become tcp_connect_ms / ssh_login_ms."""
+    conn = _fake_conn()
+    # now_ms() order: t0, (connection_made), (auth_completed), end
+    _clock(monkeypatch, [1000, 1100, 1400, 1450])
+    captured = {}
+    monkeypatch.setattr(sct.asyncssh, "connect", _connect_returning(conn, capture=captured))
+
+    with caplog.at_level(logging.INFO, logger=MODULE_LOGGER):
+        async with connect_with_phase_timing(
+            log_extra={"miner_hotkey": "5Fabc"},
+            host="1.2.3.4",
+            port=2222,
+        ) as client:
+            assert client is conn
+
+    rec = _phase_record(caplog)
+    assert rec is not None, "phase-timing log line not emitted"
+    assert rec.extra["tcp_connect_ms"] == 100
+    assert rec.extra["ssh_login_ms"] == 300
+    assert rec.extra["total_connect_ms"] == 450
+    assert rec.extra["host"] == "1.2.3.4"
+    assert rec.extra["port"] == 2222
+    assert rec.extra["miner_hotkey"] == "5Fabc"
+
+    # host/port were forwarded verbatim to asyncssh.connect.
+    assert captured["host"] == "1.2.3.4"
+    assert captured["port"] == 2222
+    # Connection is closed on context exit, exactly like `async with asyncssh.connect`.
+    conn.close.assert_called_once()
+    conn.wait_closed.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_missing_marks_log_none_without_crashing(monkeypatch, caplog):
+    """If the callbacks never fire, the split fields are None (not an error)."""
+    conn = _fake_conn()
+    _clock(monkeypatch, [1000, 1500])  # t0, end only
+    monkeypatch.setattr(
+        sct.asyncssh, "connect", _connect_returning(conn, fire_callbacks=False)
+    )
+
+    with caplog.at_level(logging.INFO, logger=MODULE_LOGGER):
+        async with connect_with_phase_timing(host="h", port=22):
+            pass
+
+    rec = _phase_record(caplog)
+    assert rec is not None
+    assert rec.extra["tcp_connect_ms"] is None
+    assert rec.extra["ssh_login_ms"] is None
+    assert rec.extra["total_connect_ms"] == 500
+    conn.wait_closed.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_custom_client_factory_rejected(monkeypatch):
+    """A caller-supplied client_factory is rejected rather than silently dropped."""
+    # asyncssh.connect must not even be reached.
+    monkeypatch.setattr(
+        sct.asyncssh, "connect", AsyncMock(side_effect=AssertionError("must not connect"))
+    )
+    with pytest.raises(ValueError, match="custom client_factory"):
+        async with connect_with_phase_timing(host="h", client_factory=lambda: None):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_connect_failure_propagates_and_does_not_log(monkeypatch, caplog):
+    """If asyncssh.connect raises, the error propagates and nothing is logged/closed."""
+    _clock(monkeypatch, [1000])  # only t0 is consumed
+
+    def boom(*, client_factory, **kwargs):
+        raise ConnectionResetError("network")
+
+    monkeypatch.setattr(sct.asyncssh, "connect", boom)
+
+    with caplog.at_level(logging.INFO, logger=MODULE_LOGGER):
+        with pytest.raises(ConnectionResetError):
+            async with connect_with_phase_timing(host="h", port=22):
+                pass
+
+    assert _phase_record(caplog) is None
+
+
+def test_apply_asyncssh_log_level_off(monkeypatch):
+    """Flag off -> asyncssh logger WARNING, debug level not raised."""
+    from core import utils
+
+    monkeypatch.setattr(utils.settings.debug, "SSH_DEBUG_LOGGING", False)
+    set_debug = MagicMock()
+    monkeypatch.setattr(utils.asyncssh, "set_debug_level", set_debug)
+
+    lg = logging.getLogger("asyncssh-test-off")
+    level = utils._apply_asyncssh_log_level(lg)
+
+    assert level == logging.WARNING
+    assert lg.level == logging.WARNING
+    set_debug.assert_not_called()
+
+
+def test_apply_asyncssh_log_level_on(monkeypatch):
+    """Flag on -> asyncssh logger DEBUG, debug level 2 (handshake, no packet dumps)."""
+    from core import utils
+
+    monkeypatch.setattr(utils.settings.debug, "SSH_DEBUG_LOGGING", True)
+    set_debug = MagicMock()
+    monkeypatch.setattr(utils.asyncssh, "set_debug_level", set_debug)
+
+    lg = logging.getLogger("asyncssh-test-on")
+    level = utils._apply_asyncssh_log_level(lg)
+
+    assert level == logging.DEBUG
+    assert lg.level == logging.DEBUG
+    set_debug.assert_called_once_with(2)

--- a/neurons/validators/tests/test_ssh_connect_timing.py
+++ b/neurons/validators/tests/test_ssh_connect_timing.py
@@ -10,46 +10,62 @@ from services.ssh_connect_timing import connect_with_phase_timing
 
 MODULE_LOGGER = "services.ssh_connect_timing"
 
+_DEFAULT_EXTRA_INFO = {
+    "server_version": "SSH-2.0-OpenSSH_8.9p1 Ubuntu",
+    "recv_cipher": "aes256-gcm@openssh.com",
+    "recv_mac": "",
+}
 
-def _fake_conn():
+
+def _fake_conn(extra_info=None):
+    info = dict(_DEFAULT_EXTRA_INFO if extra_info is None else extra_info)
     conn = MagicMock(name="ssh_conn")
     conn.close = MagicMock()
     conn.wait_closed = AsyncMock()
+    conn.get_extra_info = MagicMock(side_effect=lambda k, default=None: info.get(k, default))
     return conn
 
 
 class _FakeConnectCM:
     """Stand-in for asyncssh.connect()'s return (an async context manager).
 
-    On enter it optionally drives the phase callbacks on the injected client so
-    the wrapper sees realistic marks; on exit it mirrors asyncssh cleanup.
+    On enter it drives the SSHClient phase callbacks so the wrapper sees
+    realistic marks; on exit it mirrors asyncssh cleanup (and an optional
+    abnormal connection_lost).
     """
 
-    def __init__(self, conn, client, fire_callbacks=True):
+    def __init__(self, conn, client, *, fire=True, banner=None, lost_exc=None):
         self._conn = conn
         self._client = client
-        self._fire = fire_callbacks
+        self._fire = fire
+        self._banner = banner
+        self._lost_exc = lost_exc
 
     async def __aenter__(self):
         if self._fire:
             self._client.connection_made(object())  # TCP done
-            self._client.auth_completed()            # banner+kex+auth done
+            self._client.begin_auth("root")          # KEX done, auth starting
+            if self._banner is not None:
+                self._client.auth_banner_received(self._banner, "")
+            self._client.auth_completed()            # auth done
         return self._conn
 
     async def __aexit__(self, *_):
+        if self._lost_exc is not None:
+            self._client.connection_lost(self._lost_exc)
         self._conn.close()
         await self._conn.wait_closed()
         return False
 
 
-def _connect_returning(conn, *, fire_callbacks=True, capture=None):
+def _connect_returning(conn, *, fire=True, banner=None, lost_exc=None, capture=None):
     """Build a sync fake for asyncssh.connect that returns a _FakeConnectCM."""
 
     def fake_connect(*, client_factory, **kwargs):
         if capture is not None:
             capture.update(kwargs)
         client = client_factory()
-        return _FakeConnectCM(conn, client, fire_callbacks=fire_callbacks)
+        return _FakeConnectCM(conn, client, fire=fire, banner=banner, lost_exc=lost_exc)
 
     return fake_connect
 
@@ -60,46 +76,63 @@ def _clock(monkeypatch, ticks):
     monkeypatch.setattr(sct, "now_ms", lambda: next(it))
 
 
-def _phase_record(caplog):
+def _record(caplog, message):
     for rec in caplog.records:
-        msg = getattr(rec, "msg", None)
-        if getattr(msg, "message", None) == "ssh_connect_phase_timing":
-            return msg
+        if getattr(getattr(rec, "msg", None), "message", None) == message:
+            return rec.msg
     return None
 
 
 @pytest.mark.asyncio
-async def test_logs_tcp_and_login_split(monkeypatch, caplog):
-    """connection_made/auth_completed marks become tcp_connect_ms / ssh_login_ms."""
+async def test_logs_three_way_phase_split(monkeypatch, caplog):
+    """connection_made/begin_auth/auth_completed → tcp / handshake / auth split."""
     conn = _fake_conn()
-    # now_ms() order: t0, (connection_made), (auth_completed), end
-    _clock(monkeypatch, [1000, 1100, 1400, 1450])
+    # now_ms() order: t0, connection_made, begin_auth, auth_completed, end
+    _clock(monkeypatch, [1000, 1100, 1300, 1400, 1450])
     captured = {}
     monkeypatch.setattr(sct.asyncssh, "connect", _connect_returning(conn, capture=captured))
 
     with caplog.at_level(logging.INFO, logger=MODULE_LOGGER):
         async with connect_with_phase_timing(
-            log_extra={"miner_hotkey": "5Fabc"},
-            host="1.2.3.4",
-            port=2222,
+            log_extra={"miner_hotkey": "5Fabc"}, host="1.2.3.4", port=2222
         ) as client:
             assert client is conn
 
-    rec = _phase_record(caplog)
+    rec = _record(caplog, "ssh_connect_phase_timing")
     assert rec is not None, "phase-timing log line not emitted"
-    assert rec.extra["tcp_connect_ms"] == 100
-    assert rec.extra["ssh_login_ms"] == 300
+    assert rec.extra["tcp_connect_ms"] == 100      # t0 -> connection_made
+    assert rec.extra["ssh_handshake_ms"] == 200    # connection_made -> begin_auth
+    assert rec.extra["ssh_auth_ms"] == 100         # begin_auth -> auth_completed
+    assert rec.extra["ssh_login_ms"] == 300        # connection_made -> auth_completed
     assert rec.extra["total_connect_ms"] == 450
     assert rec.extra["host"] == "1.2.3.4"
     assert rec.extra["port"] == 2222
     assert rec.extra["miner_hotkey"] == "5Fabc"
+    # Negotiated metadata read off the connection.
+    assert rec.extra["server_version"] == "SSH-2.0-OpenSSH_8.9p1 Ubuntu"
+    assert rec.extra["cipher"] == "aes256-gcm@openssh.com"
 
-    # host/port were forwarded verbatim to asyncssh.connect.
     assert captured["host"] == "1.2.3.4"
-    assert captured["port"] == 2222
-    # Connection is closed on context exit, exactly like `async with asyncssh.connect`.
     conn.close.assert_called_once()
     conn.wait_closed.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_auth_banner_captured(monkeypatch, caplog):
+    """A server pre-auth banner is recorded; absent it, the field is omitted."""
+    conn = _fake_conn()
+    # extra tick for auth_banner_received between begin_auth and auth_completed
+    _clock(monkeypatch, [1000, 1100, 1300, 1350, 1400, 1450])
+    monkeypatch.setattr(
+        sct.asyncssh, "connect", _connect_returning(conn, banner="Authorized users only")
+    )
+
+    with caplog.at_level(logging.INFO, logger=MODULE_LOGGER):
+        async with connect_with_phase_timing(host="h", port=22):
+            pass
+
+    rec = _record(caplog, "ssh_connect_phase_timing")
+    assert rec.extra["auth_banner"] == "Authorized users only"
 
 
 @pytest.mark.asyncio
@@ -107,26 +140,58 @@ async def test_missing_marks_log_none_without_crashing(monkeypatch, caplog):
     """If the callbacks never fire, the split fields are None (not an error)."""
     conn = _fake_conn()
     _clock(monkeypatch, [1000, 1500])  # t0, end only
-    monkeypatch.setattr(
-        sct.asyncssh, "connect", _connect_returning(conn, fire_callbacks=False)
-    )
+    monkeypatch.setattr(sct.asyncssh, "connect", _connect_returning(conn, fire=False))
 
     with caplog.at_level(logging.INFO, logger=MODULE_LOGGER):
         async with connect_with_phase_timing(host="h", port=22):
             pass
 
-    rec = _phase_record(caplog)
+    rec = _record(caplog, "ssh_connect_phase_timing")
     assert rec is not None
     assert rec.extra["tcp_connect_ms"] is None
+    assert rec.extra["ssh_handshake_ms"] is None
+    assert rec.extra["ssh_auth_ms"] is None
     assert rec.extra["ssh_login_ms"] is None
     assert rec.extra["total_connect_ms"] == 500
     conn.wait_closed.assert_awaited_once()
 
 
 @pytest.mark.asyncio
+async def test_abnormal_connection_lost_warns(monkeypatch, caplog):
+    """An abnormal connection_lost (exc set) emits a separate warning."""
+    conn = _fake_conn()
+    _clock(monkeypatch, [1000, 1100, 1300, 1400, 1450])
+    exc = ConnectionResetError("keepalive timeout")
+    monkeypatch.setattr(sct.asyncssh, "connect", _connect_returning(conn, lost_exc=exc))
+
+    with caplog.at_level(logging.INFO, logger=MODULE_LOGGER):
+        async with connect_with_phase_timing(log_extra={"x": 1}, host="9.9.9.9", port=22):
+            pass
+
+    lost = _record(caplog, "ssh_connection_lost")
+    assert lost is not None
+    assert "keepalive timeout" in lost.extra["error"]
+    assert lost.extra["host"] == "9.9.9.9"
+
+
+@pytest.mark.asyncio
+async def test_clean_connection_lost_is_silent(monkeypatch, caplog):
+    """A clean close (exc=None) must NOT emit an ssh_connection_lost line."""
+    conn = _fake_conn()
+    _clock(monkeypatch, [1000, 1100, 1300, 1400, 1450])
+    # lost_exc stays None -> connection_lost not fired by the fake on exit
+    monkeypatch.setattr(sct.asyncssh, "connect", _connect_returning(conn))
+
+    with caplog.at_level(logging.INFO, logger=MODULE_LOGGER):
+        async with connect_with_phase_timing(host="h", port=22):
+            pass
+
+    assert _record(caplog, "ssh_connection_lost") is None
+
+
+@pytest.mark.asyncio
 async def test_custom_client_factory_rejected(monkeypatch):
     """A caller-supplied client_factory is rejected rather than silently dropped."""
-    # asyncssh.connect must not even be reached.
     monkeypatch.setattr(
         sct.asyncssh, "connect", AsyncMock(side_effect=AssertionError("must not connect"))
     )
@@ -137,7 +202,7 @@ async def test_custom_client_factory_rejected(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_connect_failure_propagates_and_does_not_log(monkeypatch, caplog):
-    """If asyncssh.connect raises, the error propagates and nothing is logged/closed."""
+    """If asyncssh.connect raises, the error propagates and nothing is logged."""
     _clock(monkeypatch, [1000])  # only t0 is consumed
 
     def boom(*, client_factory, **kwargs):
@@ -150,7 +215,7 @@ async def test_connect_failure_propagates_and_does_not_log(monkeypatch, caplog):
             async with connect_with_phase_timing(host="h", port=22):
                 pass
 
-    assert _phase_record(caplog) is None
+    assert _record(caplog, "ssh_connect_phase_timing") is None
 
 
 def test_apply_asyncssh_log_level_off(monkeypatch):

--- a/neurons/validators/tests/test_ssh_connect_timing.py
+++ b/neurons/validators/tests/test_ssh_connect_timing.py
@@ -222,7 +222,7 @@ def test_apply_asyncssh_log_level_off(monkeypatch):
     """Flag off -> asyncssh logger WARNING, debug level not raised."""
     from core import utils
 
-    monkeypatch.setattr(utils.settings.debug, "SSH_DEBUG_LOGGING", False)
+    monkeypatch.setattr(utils.settings, "SSH_DEBUG_LOGGING", False)
     set_debug = MagicMock()
     monkeypatch.setattr(utils.asyncssh, "set_debug_level", set_debug)
 
@@ -238,7 +238,7 @@ def test_apply_asyncssh_log_level_on(monkeypatch):
     """Flag on -> asyncssh logger DEBUG, debug level 2 (handshake, no packet dumps)."""
     from core import utils
 
-    monkeypatch.setattr(utils.settings.debug, "SSH_DEBUG_LOGGING", True)
+    monkeypatch.setattr(utils.settings, "SSH_DEBUG_LOGGING", True)
     set_debug = MagicMock()
     monkeypatch.setattr(utils.asyncssh, "set_debug_level", set_debug)
 


### PR DESCRIPTION
## Describe your changes

Diagnostic instrumentation for DAH-2272. The RCA found that a slow cached deploy
(~165s total) was dominated by un-instrumented SSH **establishment** to a provider
host (110s in the early port-check connect + 33.5s in the create_container connect),
but the current logs emit nothing during a connect, so we can't tell whether a stall
is the network leg or the remote sshd. This change makes that attributable.

**1. TCP-vs-SSH-login split (always-on).** New `connect_with_phase_timing` wraps the
two rental-path `asyncssh.connect` calls — `create_container` and the early
`wait_for_port_check_containers`. Using asyncssh's `client_factory` callbacks
(`connection_made` = TCP complete, `auth_completed` = login complete) it emits one
structured `ssh_connect_phase_timing` log line per connect:
- `tcp_connect_ms` — DNS + TCP handshake → network / remote-host reachability
- `ssh_login_ms` — banner + KEX + auth → remote sshd (e.g. `UseDNS` stall) / crypto
- `total_connect_ms`

It does **not** change how the connection is established (same `async with` cleanup,
options, and failure behaviour) — it only observes.

**2. asyncssh debug toggle (opt-in).** New `DEBUG_SSH_DEBUG_LOGGING` flag raises the
`asyncssh` logger to DEBUG at debug level 2 (full handshake; not level 3, which dumps
packets/key material) for a finer banner-vs-KEX-vs-auth breakdown on demand. Off by
default; gated in both logging-config paths.

Query in Loki with `{namespace="subnet"} |= "ssh_connect_phase_timing"`.

Diagnostic only — no behaviour change to the deploy path.

## Issue ticket number and link

[DAH-2272 — Investigate Cache Templates Deployment Latency](https://www.notion.so/38ab8bfdbde98184b747e537fd323494)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [x] Need to take care of performance? — Negligible: per connect it adds one
  lightweight `SSHClient` subclass and one log line; the debug toggle is off by
  default. No extra connections or round-trips.
