### PR TITLE
DAH-2265 - Fail verification for uncached recommended template after cutoff

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -137,7 +137,7 @@ class Settings(BaseSettings):
     # unrented executor that has not pre-pulled the recommended default image, or holds stale
     # content under the same tag, fails verification early (score 0, reason surfaced to the
     # provider). Fails open: an unmeasured signal (None) is never penalised.
-    CACHED_TEMPLATE_CUTOFF: datetime = datetime(2026, 7, 8, 12, 0, 0)
+    CACHED_TEMPLATE_CUTOFF: datetime = datetime(2026, 7, 9, 12, 0, 0)
 
     # Minimum NVIDIA driver requirement. Compared as a dotted version tuple against the
     # executor's reported gpu.driver (e.g. "580.95.05"). 580.65.06 is the r580 floor that

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -131,6 +131,14 @@ class Settings(BaseSettings):
     SYSBOX_RENTED_CUTOFF: datetime = datetime(2026, 4, 3, 12, 0, 0)
     DISCORD_INCENTIVE_CUTOFF: datetime = datetime(2026, 6, 15, 12, 0, 0)
 
+    # DAH-2265: cached-template requirement. Before the cutoff the CachedTemplateVerificationCheck
+    # is purely advisory (publishes recommended_image_cached / recommended_image_digest_match to
+    # executor.specs, never changes score). On/after the cutoff that check turns critical: an
+    # unrented executor that has not pre-pulled the recommended default image, or holds stale
+    # content under the same tag, fails verification early (score 0, reason surfaced to the
+    # provider). Fails open: an unmeasured signal (None) is never penalised.
+    CACHED_TEMPLATE_CUTOFF: datetime = datetime(2026, 7, 15, 12, 0, 0)
+
     # Minimum NVIDIA driver requirement. Compared as a dotted version tuple against the
     # executor's reported gpu.driver (e.g. "580.95.05"). 580.65.06 is the r580 floor that
     # ships CUDA 13.0. Before MIN_DRIVER_CUTOFF providers get a grace period (no penalty);

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -137,7 +137,7 @@ class Settings(BaseSettings):
     # unrented executor that has not pre-pulled the recommended default image, or holds stale
     # content under the same tag, fails verification early (score 0, reason surfaced to the
     # provider). Fails open: an unmeasured signal (None) is never penalised.
-    CACHED_TEMPLATE_CUTOFF: datetime = datetime(2026, 7, 15, 12, 0, 0)
+    CACHED_TEMPLATE_CUTOFF: datetime = datetime(2026, 7, 8, 12, 0, 0)
 
     # Minimum NVIDIA driver requirement. Compared as a dotted version tuple against the
     # executor's reported gpu.driver (e.g. "580.95.05"). 580.65.06 is the r580 floor that

--- a/neurons/validators/src/services/task/checks/cached_template_verification.py
+++ b/neurons/validators/src/services/task/checks/cached_template_verification.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import json
 import shlex
 from dataclasses import replace
+from datetime import datetime
+
+from core.config import settings
 
 from ..messages import CachedTemplateMessages as Msg
 from ..messages import render_message
@@ -28,25 +31,31 @@ def _repo_digest(stdout: str | None, repo: str) -> str | None:
 
 
 class CachedTemplateVerificationCheck:
-    """Advisory: verify the executor has the recommended default image pre-pulled.
+    """Verify the executor has the recommended default image pre-pulled (DAH-2265).
 
-    DAH-2265 Plan 2. The executor cache pre-pull (``cache_template_service.py``) keeps the
-    recommended default template image warm, and the rental-time DAH-1524 pull-skip turns
-    DOCKER_PULL into a no-op when the image is already present. This check *observes*
-    whether that pre-pull actually happened: it resolves the recommended image from the
+    The executor cache pre-pull (``cache_template_service.py``) keeps the recommended default
+    template image warm, and the rental-time DAH-1524 pull-skip turns DOCKER_PULL into a no-op
+    when the image is already present. This check resolves the recommended image from the
     backend (the same ``/executors/default-docker-image`` endpoint the executor uses) and
     probes ``docker image inspect`` on the executor.
 
-    Strictly advisory — non-fatal, never halts, never changes score. It only:
-      * emits a structured event (logged by the pipeline sink), and
-      * publishes ``recommended_image_cached`` into ``executor.specs`` via pipeline state.
+    Two-phase by ``settings.CACHED_TEMPLATE_CUTOFF``:
+      * Before the cutoff — advisory only: emits a structured event and publishes
+        ``recommended_image_cached`` / ``recommended_image_digest_match`` into
+        ``executor.specs`` via pipeline state. Never changes score.
+      * On/after the cutoff — critical (``fatal``): the two bad signals (image not pre-pulled,
+        or stale content under an unchanged tag) return ``passed=False`` so the pipeline halts
+        early, the executor scores 0, and the failure reason reaches the provider via
+        ``log_text``. This check sits after ``TenantEnforcementCheck`` (the rented
+        short-circuit), so it only ever gates *unrented* executors — an active customer rental
+        is never failed by it.
 
-    It fails open on every uncertainty (unknown GPU/driver, backend unreachable, empty
-    recommendation, SSH error) by recording a skip and leaving state untouched.
+    Fails open on every uncertainty (unknown GPU/driver, backend unreachable, empty
+    recommendation, SSH error) by recording a skip and leaving score untouched.
     """
 
     check_id = "executor.validate.cached_template"
-    fatal = False
+    fatal = True
 
     async def run(self, ctx: Context) -> CheckResult:
         gpu_model = ctx.state.gpu_model
@@ -138,10 +147,25 @@ class CachedTemplateVerificationCheck:
             # Cached, but the backend published no digest to compare against.
             template = Msg.CACHED
 
+        # DAH-2265: on/after the cutoff this check turns critical. The two "bad" signals —
+        # image not pre-pulled (NOT_CACHED) or stale content under an unchanged tag
+        # (DIGEST_MISMATCH) — fail verification early, so the executor scores 0 and the reason
+        # reaches the provider via log_text (the pipeline surfaces the last event). Before the
+        # cutoff (and on every fail-open None path above) the check stays advisory: passed=True,
+        # score untouched. The cached/digest signals are published to specs either way.
+        after_cutoff = datetime.utcnow() >= settings.CACHED_TEMPLATE_CUTOFF
+        should_fail = after_cutoff and template in (Msg.NOT_CACHED, Msg.DIGEST_MISMATCH)
+
         event = render_message(
             template,
             ctx=ctx,
             check_id=self.check_id,
+            severity="error" if should_fail else None,
+            impact=(
+                "Score set to 0 — recommended default image must be pre-pulled and current"
+                if should_fail
+                else None
+            ),
             what={
                 "recommended_image": image_ref,
                 "cached": cached,
@@ -150,10 +174,11 @@ class CachedTemplateVerificationCheck:
                 "local_digest": local_digest,
                 "gpu_model": gpu_model,
                 "driver_version": driver_version,
+                "after_cutoff": after_cutoff,
             },
         )
         return CheckResult(
-            passed=True,
+            passed=not should_fail,
             event=event,
             updates={
                 "state": replace(

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -919,11 +919,14 @@ class FinalizeMessages:
 
 
 class CachedTemplateMessages:
-    """DAH-2265 Plan 2 — advisory cached-template verification.
+    """DAH-2265 — cached-template verification.
 
     Confirms whether the executor has the recommended default image pre-pulled so
-    DOCKER_PULL is a no-op for default-template rentals. Purely observational: every
-    template is severity="info" and the check never fails the pipeline or changes score.
+    DOCKER_PULL is a no-op for default-template rentals. Templates carry severity="info"
+    (advisory) by default; before ``settings.CACHED_TEMPLATE_CUTOFF`` the check is purely
+    observational. On/after the cutoff the check renders the two bad signals (NOT_CACHED,
+    DIGEST_MISMATCH) with a severity="error" override and fails verification — see
+    ``CachedTemplateVerificationCheck``.
     """
 
     CACHED = MessageTemplate(

--- a/neurons/validators/tests/test_cached_template_verification.py
+++ b/neurons/validators/tests/test_cached_template_verification.py
@@ -1,13 +1,21 @@
-"""DAH-2265 Plan 2 — CachedTemplateVerificationCheck (advisory, non-fatal).
+"""DAH-2265 — CachedTemplateVerificationCheck.
 
 Verifies the executor has the recommended default image pre-pulled, publishing the
-result to executor.specs (via pipeline state) and a structured event. It must never
-fail the pipeline or change score, and must fail open on every uncertainty.
+result to executor.specs (via pipeline state) and a structured event. Before
+``settings.CACHED_TEMPLATE_CUTOFF`` it is advisory (never fails / changes score); on/after
+the cutoff the two bad signals (not cached, stale digest) fail verification. It must fail
+open on every uncertainty regardless of the cutoff.
+
+An autouse fixture pins the cutoff to the future by default so the advisory-mode assertions
+are wall-clock-independent; cutoff-enforcement tests opt in with ``_set_cutoff(active=True)``.
 """
 
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+
+from core.config import settings
 from neurons.validators.src.services.task.checks.cached_template_verification import (
     CachedTemplateVerificationCheck,
 )
@@ -52,8 +60,23 @@ def _ssh(exit_status=0, stdout="", raises=False):
     return ssh
 
 
-def test_check_is_non_fatal():
-    assert CachedTemplateVerificationCheck.fatal is False
+@pytest.fixture(autouse=True)
+def _advisory_by_default(monkeypatch):
+    # Pin every test to BEFORE the cutoff (advisory mode) so assertions are independent of the
+    # wall clock. Cutoff-enforcement tests opt in with _set_cutoff(active=True).
+    monkeypatch.setattr(
+        settings, "CACHED_TEMPLATE_CUTOFF", datetime.utcnow() + timedelta(days=365)
+    )
+
+
+def _set_cutoff(monkeypatch, *, active: bool) -> None:
+    cutoff = datetime.utcnow() - timedelta(days=1) if active else datetime.utcnow() + timedelta(days=1)
+    monkeypatch.setattr(settings, "CACHED_TEMPLATE_CUTOFF", cutoff)
+
+
+def test_check_is_fatal():
+    # DAH-2265: the check is fatal-capable; run() only returns passed=False after the cutoff.
+    assert CachedTemplateVerificationCheck.fatal is True
 
 
 @pytest.mark.asyncio
@@ -296,3 +319,127 @@ async def test_digest_fails_open_on_unparseable_stdout(context_factory):
     assert result.passed is True
     assert result.event.reason_code == Msg.DIGEST_SKIPPED.reason
     assert result.updates["state"].recommended_image_digest_match is None
+
+
+# --- DAH-2265 cutoff enforcement (critical on/after the cutoff) --------------------------
+
+
+@pytest.mark.asyncio
+async def test_not_cached_fails_after_cutoff(context_factory, monkeypatch):
+    # Image not pre-pulled + after cutoff → fatal fail. The reason rides the event (and thus
+    # log_text → provider), the cached signal is still published to specs.
+    _set_cutoff(monkeypatch, active=True)
+    ctx = context_factory(
+        services=build_services(backend=_backend(images=[_IMAGE])),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=_ssh(exit_status=1),
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.NOT_CACHED.reason
+    assert result.event.severity == "error"
+    assert result.updates["state"].recommended_image_cached is False
+
+
+@pytest.mark.asyncio
+async def test_digest_mismatch_fails_after_cutoff(context_factory, monkeypatch):
+    # Stale content under the same tag + after cutoff → fatal fail.
+    _set_cutoff(monkeypatch, active=True)
+    ctx = context_factory(
+        services=build_services(backend=_backend(images=[_IMAGE_WITH_DIGEST])),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=_ssh(exit_status=0, stdout=_LOCAL_MISMATCH),
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.DIGEST_MISMATCH.reason
+    assert result.event.severity == "error"
+    assert result.updates["state"].recommended_image_cached is True
+    assert result.updates["state"].recommended_image_digest_match is False
+
+
+@pytest.mark.asyncio
+async def test_cached_passes_after_cutoff(context_factory, monkeypatch):
+    # Pre-pulled, no backend digest to compare → CACHED, never a fatal fail.
+    _set_cutoff(monkeypatch, active=True)
+    ctx = context_factory(
+        services=build_services(backend=_backend(images=[_IMAGE])),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=_ssh(exit_status=0),
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.CACHED.reason
+
+
+@pytest.mark.asyncio
+async def test_digest_match_passes_after_cutoff(context_factory, monkeypatch):
+    _set_cutoff(monkeypatch, active=True)
+    ctx = context_factory(
+        services=build_services(backend=_backend(images=[_IMAGE_WITH_DIGEST])),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=_ssh(exit_status=0, stdout=_LOCAL_MATCH),
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.DIGEST_MATCH.reason
+
+
+@pytest.mark.asyncio
+async def test_uncertainty_fails_open_after_cutoff(context_factory, monkeypatch):
+    # No recommended image from backend → SKIPPED, stays advisory even after the cutoff.
+    _set_cutoff(monkeypatch, active=True)
+    ssh = _ssh()
+    ctx = context_factory(
+        services=build_services(backend=_backend(images=None)),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=ssh,
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.SKIPPED.reason
+    ssh.run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_digest_skipped_passes_after_cutoff(context_factory, monkeypatch):
+    # Cached but RepoDigest unreadable for this repo → DIGEST_SKIPPED, never a fatal fail.
+    _set_cutoff(monkeypatch, active=True)
+    ctx = context_factory(
+        services=build_services(backend=_backend(images=[_IMAGE_WITH_DIGEST])),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=_ssh(exit_status=0, stdout="[]"),
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.DIGEST_SKIPPED.reason
+
+
+@pytest.mark.asyncio
+async def test_not_cached_stays_advisory_before_cutoff(context_factory, monkeypatch):
+    # Same bad signal as the fatal test, but before the cutoff → advisory pass, info severity.
+    _set_cutoff(monkeypatch, active=False)
+    ctx = context_factory(
+        services=build_services(backend=_backend(images=[_IMAGE])),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=_ssh(exit_status=1),
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.NOT_CACHED.reason
+    assert result.event.severity != "error"
+    assert result.updates["state"].recommended_image_cached is False


### PR DESCRIPTION
## Describe your changes

Makes `CachedTemplateVerificationCheck` **conditionally critical** so that, after a cutoff, an executor that hasn't pre-pulled the recommended default image fails verification early — and the provider sees the reason.

Before `CACHED_TEMPLATE_CUTOFF` (default `2026-07-15 12:00 UTC`) the check stays **advisory**: it publishes `recommended_image_cached` / `recommended_image_digest_match` to `executor.specs` and never changes score (unchanged behavior). On/after the cutoff, the two bad signals — image not pre-pulled (`NOT_CACHED`) or stale content under an unchanged tag (`DIGEST_MISMATCH`) — return `passed=False`. Since the check is `fatal`, the pipeline halts early: the executor scores 0, and the failure event becomes `log_text`, which is published to the provider via `full_log_text`. It still **fails open** on every uncertainty (`None` — unknown GPU/driver, backend unreachable, unreadable digest), regardless of the cutoff.

**Why a fatal check instead of an incentive-layer gate:** an earlier revision gated this in the incentive layer (mirroring the Discord cutoff). The fatal-check approach is simpler and, crucially, **surfaces the reason to the provider** — the incentive gate only logged it validator-side. It's also naturally safe for active rentals: the check runs *after* `TenantEnforcementCheck`, which halts the pipeline for rented executors, so only **unrented** executors are ever gated. A customer's active rental can't be failed by this.

**Changes**
- `core/config.py` — new `CACHED_TEMPLATE_CUTOFF` constant.
- `services/task/checks/cached_template_verification.py` — `fatal=True`; `run()` returns `passed=False` only when after the cutoff AND the signal is `NOT_CACHED`/`DIGEST_MISMATCH`, rendering the event with a `severity="error"` override. Advisory specs are still published either way.
- `services/task/messages.py` — updated `CachedTemplateMessages` docstring.

**Tests** (`tests/test_cached_template_verification.py`)
- Autouse fixture pins the cutoff to advisory mode by default, so the existing 16 advisory tests are wall-clock-independent.
- New tests: fatal `NOT_CACHED` / `DIGEST_MISMATCH` after cutoff (incl. `severity == "error"` and that specs are still published), `CACHED` / `DIGEST_MATCH` pass after cutoff, fail-open uncertainty after cutoff, `DIGEST_SKIPPED` pass after cutoff, and advisory-before-cutoff.

Verification suite: 23 passed. Full validators suite (excluding the pre-existing-flaky `prod_snapshot`): 809 passed, 4 skipped.

## Issue ticket number and link

DAH-2265

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?
