### PR TITLE
DAH-2313: require sysbox for unrented executors (validator check)

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -11,8 +11,8 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 if TYPE_CHECKING:
     from bittensor import Wallet
 
-from lium_core.shared_config import DEFAULT_SHARED_CONFIG, SharedConfigClient
 from incentive.config import IncentiveConfig
+from lium_core.shared_config import DEFAULT_SHARED_CONFIG, SharedConfigClient
 
 
 class FeatureFlag(str, Enum):
@@ -129,6 +129,8 @@ class Settings(BaseSettings):
     PORTION_FOR_SYSBOX_UNRENTED: float = 1
     PORTION_FOR_SYSBOX_RENTED: float = 1
     SYSBOX_RENTED_CUTOFF: datetime = datetime(2026, 4, 3, 12, 0, 0)
+    # DAH-2313: reject unrented executors without sysbox so they never appear on the network.
+    REQUIRE_SYSBOX_FOR_UNRENTED: bool = Field(env="REQUIRE_SYSBOX_FOR_UNRENTED", default=True)
     DISCORD_INCENTIVE_CUTOFF: datetime = datetime(2026, 6, 15, 12, 0, 0)
 
     # Minimum NVIDIA driver requirement. Compared as a dotted version tuple against the

--- a/neurons/validators/src/services/task/checks/__init__.py
+++ b/neurons/validators/src/services/task/checks/__init__.py
@@ -22,6 +22,7 @@ from .score import ScoreCheck
 from .spec_change import SpecChangeCheck
 from .stale_container_cleanup import StaleContainerCleanupCheck
 from .start_gpu_monitor import StartGPUMonitorCheck
+from .sysbox_required import SysboxRequiredCheck
 from .tdx_host import TdxHostCheck
 from .upload_files import UploadFilesCheck
 from .verifyx import VerifyXCheck
@@ -51,6 +52,7 @@ __all__ = [
     "ScoreCheck",
     "StaleContainerCleanupCheck",
     "StartGPUMonitorCheck",
+    "SysboxRequiredCheck",
     "SpecChangeCheck",
     "UploadFilesCheck",
     "VerifyXCheck",

--- a/neurons/validators/src/services/task/checks/sysbox_required.py
+++ b/neurons/validators/src/services/task/checks/sysbox_required.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from core.config import settings
+
+from ..messages import SysboxRequiredMessages as Msg
+from ..messages import render_message
+from ..pipeline import CheckResult, Context
+
+
+class SysboxRequiredCheck:
+    """Ban unrented executors that lack the sysbox runtime from appearing on the network.
+
+    DAH-2313: sysbox is required to be allowed on the network. A machine that has no sysbox
+    AND is not currently rented is rejected here (fatal) so the pipeline halts before scoring
+    and the executor is reported with a zero score / cleared verification. Already-rented
+    no-sysbox machines are left untouched so live rentals are never disrupted.
+    """
+
+    check_id = "executor.validate.sysbox_required"
+    fatal = True
+
+    async def run(self, ctx: Context) -> CheckResult:
+        if not settings.REQUIRE_SYSBOX_FOR_UNRENTED:
+            event = render_message(Msg.DISABLED, ctx=ctx, check_id=self.check_id)
+            return CheckResult(passed=True, event=event)
+
+        # Determine rental status the same way as port_count.py / rented_machine.py.
+        rented_data = ctx.state.rented_data
+        rented_executor = rented_data.executors.get(ctx.executor.uuid) if rented_data else None
+        is_rented = rented_executor is not None and len(rented_executor.pods) > 0
+
+        if not ctx.state.sysbox_runtime and not is_rented:
+            event = render_message(
+                Msg.SYSBOX_MISSING,
+                ctx=ctx,
+                check_id=self.check_id,
+                what={"sysbox_runtime": ctx.state.sysbox_runtime, "is_rented": is_rented},
+            )
+            return CheckResult(
+                passed=False,
+                event=event,
+                updates={"clear_verified_job_info": True},
+            )
+
+        event = render_message(
+            Msg.SYSBOX_OK,
+            ctx=ctx,
+            check_id=self.check_id,
+            what={"sysbox_runtime": ctx.state.sysbox_runtime, "is_rented": is_rented},
+        )
+        return CheckResult(passed=True, event=event)

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -364,6 +364,31 @@ class BannedGpuMessages:
     )
 
 
+class SysboxRequiredMessages:
+    SYSBOX_MISSING = MessageTemplate(
+        event="Sysbox required for unrented executor",
+        reason="SYSBOX_REQUIRED_MISSING",
+        severity="warning",
+        category="policy",
+        impact="Score set to 0; verification cleared; executor kept off the network",
+        remediation="Install the sysbox runtime; unrented machines without sysbox are not allowed on the network.",
+    )
+    SYSBOX_OK = MessageTemplate(
+        event="Sysbox requirement satisfied",
+        reason="SYSBOX_REQUIRED_OK",
+        severity="info",
+        category="policy",
+        impact="Proceed",
+    )
+    DISABLED = MessageTemplate(
+        event="Sysbox requirement disabled",
+        reason="SYSBOX_REQUIRED_DISABLED",
+        severity="info",
+        category="policy",
+        impact="Proceed",
+    )
+
+
 class DuplicateExecutorMessages:
     DUPLICATE = MessageTemplate(
         event="Duplicate executor registration",

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -9,11 +9,9 @@ import uuid
 from typing import cast
 
 import bittensor
+from clients.backend_client import BackendClient
 from datura.requests.miner_requests import ExecutorSSHInfo
 from payload_models.payloads import MinerJobEnryptedFiles, MinerJobRequestPayload
-
-from clients.backend_client import BackendClient
-from core.config import settings
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.collateral_contract_service import CollateralContractService
 from services.const import GPU_MODEL_RATES, LIB_NVIDIA_ML_DIGESTS, MAX_GPU_COUNT
@@ -23,8 +21,10 @@ from services.inspector_validation_service import InspectorValidationService
 from services.interactive_shell_service import InteractiveShellService
 from services.matrix_validation_service import ValidationService
 from services.redis_service import RENTAL_SUCCEED_MACHINE_SET, RedisService
-from services.ssh_service import SSHService
 from services.verifyx_validation_service import VerifyXValidationService
+
+from core.config import settings
+from services.ssh_service import SSHService
 
 from .checks import (
     BannedGpuCheck,
@@ -50,6 +50,7 @@ from .checks import (
     SpecChangeCheck,
     StaleContainerCleanupCheck,
     StartGPUMonitorCheck,
+    SysboxRequiredCheck,
     TdxHostCheck,
     TenantEnforcementCheck,
     UploadFilesCheck,
@@ -241,6 +242,8 @@ class PipelineFactory:
                 SpecChangeCheck(),
                 GpuFingerprintCheck(),
                 BannedGpuCheck(),
+                # DAH-2313: require sysbox before an unrented executor is allowed on the network.
+                SysboxRequiredCheck(),
                 DuplicateExecutorCheck(),
                 CollateralCheck(),
                 # Reap orphaned (non-rented) rental containers BEFORE the port checks.
@@ -303,6 +306,8 @@ class PipelineFactory:
                 SpecChangeCheck(),
                 GpuFingerprintCheck(),
                 BannedGpuCheck(),
+                # DAH-2313: require sysbox before an unrented executor is allowed on the network.
+                SysboxRequiredCheck(),
                 DuplicateExecutorCheck(),
                 CollateralCheck(),
                 # StaleContainerCleanupCheck(),  # SKIP: removes containers on the executor

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -242,8 +242,6 @@ class PipelineFactory:
                 SpecChangeCheck(),
                 GpuFingerprintCheck(),
                 BannedGpuCheck(),
-                # DAH-2313: require sysbox before an unrented executor is allowed on the network.
-                SysboxRequiredCheck(),
                 DuplicateExecutorCheck(),
                 CollateralCheck(),
                 # Reap orphaned (non-rented) rental containers BEFORE the port checks.
@@ -262,6 +260,10 @@ class PipelineFactory:
                 _CUSTOM_BUILD_ORPHAN_SWEEP_SINGLETON,
                 PortConnectivityCheck(),
                 PortCountCheck(),
+                # DAH-2313: require sysbox before an unrented executor is allowed on the network.
+                # Runs after PortConnectivityCheck, which overwrites ctx.state.sysbox_runtime with
+                # the authoritative probe result used for scoring (not the earlier scrape hint).
+                SysboxRequiredCheck(),
                 InspectorRentedCheck(),
                 TenantEnforcementCheck(),
                 GpuUsageCheck(),
@@ -306,13 +308,15 @@ class PipelineFactory:
                 SpecChangeCheck(),
                 GpuFingerprintCheck(),
                 BannedGpuCheck(),
-                # DAH-2313: require sysbox before an unrented executor is allowed on the network.
-                SysboxRequiredCheck(),
                 DuplicateExecutorCheck(),
                 CollateralCheck(),
                 # StaleContainerCleanupCheck(),  # SKIP: removes containers on the executor
                 PortConnectivityCheck(),
                 PortCountCheck(),
+                # DAH-2313: require sysbox before an unrented executor is allowed on the network.
+                # Runs after PortConnectivityCheck, which overwrites ctx.state.sysbox_runtime with
+                # the authoritative probe result used for scoring (not the earlier scrape hint).
+                SysboxRequiredCheck(),
                 TenantEnforcementCheck(),
                 GpuUsageCheck(),
                 # VerifyXCheck(),

--- a/neurons/validators/tests/test_sysbox_required_check.py
+++ b/neurons/validators/tests/test_sysbox_required_check.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+from neurons.validators.src.services.task.checks.sysbox_required import SysboxRequiredCheck
+from neurons.validators.src.services.task.messages import SysboxRequiredMessages as Msg
+from protocol.vc_protocol.compute_requests import (
+    RentedExecutor,
+    RentedExecutorsResponse,
+    RentedPod,
+)
+
+from core.config import settings
+from tests.helpers import build_state
+
+
+def _rented_data() -> RentedExecutorsResponse:
+    return RentedExecutorsResponse(
+        executors={
+            "executor-123": RentedExecutor(
+                miner_hotkey="test-miner",
+                executor_ip_address="127.0.0.1",
+                executor_ip_port="22",
+                pods=[RentedPod(pod_id="pod-1", container_name="container_test", rented_ports=[8080, 8081])],
+            )
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_sysbox_unrented_fails(context_factory):
+    """Unrented executor without sysbox is rejected and its verification is cleared."""
+    ctx = context_factory(state=build_state(sysbox_runtime=False))
+
+    result = await SysboxRequiredCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.SYSBOX_MISSING.reason
+    assert result.updates["clear_verified_job_info"] is True
+
+
+@pytest.mark.asyncio
+async def test_no_sysbox_rented_passes(context_factory):
+    """Rented executor without sysbox is left untouched so live rentals are not disrupted."""
+    ctx = context_factory(state=build_state(sysbox_runtime=False, rented_data=_rented_data()))
+
+    result = await SysboxRequiredCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.SYSBOX_OK.reason
+
+
+@pytest.mark.asyncio
+async def test_sysbox_present_passes(context_factory):
+    """Executor with sysbox passes regardless of rental status."""
+    ctx = context_factory(state=build_state(sysbox_runtime=True))
+
+    result = await SysboxRequiredCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.SYSBOX_OK.reason
+
+
+@pytest.mark.asyncio
+async def test_disabled_flag_skips_enforcement(context_factory, monkeypatch):
+    """With the kill-switch off, no-sysbox unrented executors are not rejected."""
+    monkeypatch.setattr(settings, "REQUIRE_SYSBOX_FOR_UNRENTED", False)
+    ctx = context_factory(state=build_state(sysbox_runtime=False))
+
+    result = await SysboxRequiredCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.DISABLED.reason


### PR DESCRIPTION
## Task
Notion: https://app.notion.com/p/Require-sysbox-before-a-node-is-allowed-on-the-network-ban-no-sysbox-for-unrented-machines-390b8bfdbde98177b96ae9d6c3d0b5b8

Sysbox must be required before a node is allowed on the network. Today a machine without sysbox already earns 0 incentive, but it still appears as an active/rentable node. Goal: an executor that has **no sysbox AND is not currently rented** must be kept off the network. Already-rented no-sysbox machines must be untouched (no live-rental disruption). Affects ~9 machines (~3%).

## What / how
New validator-side fatal check `SysboxRequiredCheck` (`neurons/validators/src/services/task/checks/sysbox_required.py`), mirroring `BannedGpuCheck`:

- If `not ctx.state.sysbox_runtime AND not is_rented` -> `passed=False` + `clear_verified_job_info=True`. The pipeline halts before `ScoreCheck`, so `score`/`job_score` stay `0.0`. The executor is then published to the backend with a zero score; the backend skips saving it (new machines never appear), and an already-active one goes stale and is marked inactive after ~1h.
- `is_rented` is recomputed locally from `ctx.state.rented_data` (same pattern as `port_count.py`), so a currently-rented no-sysbox executor passes untouched.
- Inserted right after `BannedGpuCheck()` in both the normal and dry-run pipelines (`pipeline_factory.py`).
- Kill-switch setting `REQUIRE_SYSBOX_FOR_UNRENTED` (default `True`, env-overridable) — set to `False` to disable enforcement instantly.

## Test plan

Pre-deploy (already green locally):
- [x] `pdm run pytest tests/test_sysbox_required_check.py -v` — 4 cases: no-sysbox+unrented -> fail (+ `clear_verified_job_info`), no-sysbox+rented -> pass, sysbox -> pass, flag off -> pass.
- [x] Full validator suite: 864 passed (5 pre-existing `test_rental_docker_sdk.py` failures unrelated to this change), `ruff check` clean, `prod_snapshot` unaffected.

Post-deploy (staging):
- [ ] In validator logs, confirm event `SYSBOX_REQUIRED_MISSING` fires for a no-sysbox unrented executor.
- [ ] Confirm such executors drop off the active/rentable list (score/synthetic_job_score = 0 -> backend skip -> inactive after ~1h).
- [ ] Confirm a rented no-sysbox executor stays active (no disruption).
- [ ] Confirm setting `REQUIRE_SYSBOX_FOR_UNRENTED=False` disables the behavior.