### PR TITLE
feat: DAH-2311 — whitelist rebuilt dstack OS image and repoint image downloads to private-ml-sdk release

### DIFF
--- a/neurons/executor/dstacktee/lium-cvm.sh
+++ b/neurons/executor/dstacktee/lium-cvm.sh
@@ -14,7 +14,9 @@ NC='\033[0m' # No Color
 
 # Configuration
 OS_IMAGE_NAME=${OS:-dstack-nvidia-0.5.5}
-OS_IMAGE_URL="https://download.dstack.org/os-images/$OS_IMAGE_NAME.tar.gz"
+# DAH-2311: serve the Lium-built image (NVIDIA driver 595.71.05) from the private-ml-sdk
+# release; override OS_IMAGE_URL to point elsewhere (e.g. staging mirror).
+OS_IMAGE_URL="${OS_IMAGE_URL:-https://github.com/Datura-ai/private-ml-sdk/releases/download/v0.5.5/$OS_IMAGE_NAME.tar.gz}"
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 KEY_PROVIDER_DIR="$THIS_DIR/key-provider"
 SCRIPTS_DIR="$THIS_DIR/scripts"

--- a/neurons/validators/docker-compose.app.dstacktee.dev.yml
+++ b/neurons/validators/docker-compose.app.dstacktee.dev.yml
@@ -26,6 +26,10 @@ services:
   dstack-verifier:
     image: dstacktee/dstack-verifier@sha256:3f36162ca8dd2d4207601a6302881de6b497e610eb44050bb0874776fc8ded07
     restart: unless-stopped
+    environment:
+      # DAH-2311: fetch the Lium-built OS image measurements (NVIDIA 595.71.05) from the
+      # private-ml-sdk release. {OS_IMAGE_HASH} is substituted by the verifier, not compose.
+      - DSTACK_VERIFIER_IMAGE_DOWNLOAD_URL=https://github.com/Datura-ai/private-ml-sdk/releases/download/v0.5.5/mr_{OS_IMAGE_HASH}.tar.gz
 
   validator:
     image: daturaai/compute-subnet-validator:dev

--- a/neurons/validators/docker-compose.app.dstacktee.yml
+++ b/neurons/validators/docker-compose.app.dstacktee.yml
@@ -26,6 +26,10 @@ services:
   dstack-verifier:
     image: dstacktee/dstack-verifier@sha256:3f36162ca8dd2d4207601a6302881de6b497e610eb44050bb0874776fc8ded07
     restart: unless-stopped
+    environment:
+      # DAH-2311: fetch the Lium-built OS image measurements (NVIDIA 595.71.05) from the
+      # private-ml-sdk release. {OS_IMAGE_HASH} is substituted by the verifier, not compose.
+      - DSTACK_VERIFIER_IMAGE_DOWNLOAD_URL=https://github.com/Datura-ai/private-ml-sdk/releases/download/v0.5.5/mr_{OS_IMAGE_HASH}.tar.gz
 
   validator:
     image: daturaai/compute-subnet-validator:latest

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -232,7 +232,11 @@ RENTAL_CONTAINER_PREFIXES = ("pod_", "filler_", "container_", "health_check_")
 TDX_WHITELIST = {
     "OS_IMAGE_HASH": set(
         [
+            # dstack-nvidia 0.5.5 — upstream download.dstack.org build
             "9b69bb1698bacbb6985409a2c272bcb892e09cdcea63d5399c6768b67d3ff677",
+            # DAH-2311 — dstack-nvidia 0.5.5 rebuilt with NVIDIA driver 595.71.05
+            # (private-ml-sdk git_revision 0a1dcf7, prod/non-dev image)
+            "dbfde5432af2762da24d2ee3f39dcb7fdb676064fce1891edab3f6d924e8dc3d",
         ]
     ),
     "COMPOSE_HASH": { # compose file hash will be vary depending on the environment (depends on lium-watchtower)


### PR DESCRIPTION
## Describe your changes

Registers the rebuilt dstack TDX guest (CVM OS) image in the validator TDX attestation whitelist and repoints image distribution at the private-ml-sdk release.

The image was rebuilt from private-ml-sdk (branch `bump/nvidia-595.71.05`, `git_revision 0a1dcf7`) to bundle **NVIDIA driver 595.71.05** (ties to DAH-2115). Its `os_image_hash` (`digest.txt`) differs from the upstream 0.5.5 build, so CVM executors running it would otherwise be rejected at attestation.

**Changes**
- **validator** — add the new prod digest `dbfde5432af2762da24d2ee3f39dcb7fdb676064fce1891edab3f6d924e8dc3d` to `TDX_WHITELIST["OS_IMAGE_HASH"]` (`const.py`), **alongside** the existing upstream `9b69bb…` for a zero-downtime cutover. The dev image digest is intentionally **not** whitelisted (it ships `sshd`/`strace`, which would break the CVM confidentiality guarantee; `OS_IMAGE_HASH` is env-agnostic).
- **executor** — `lium-cvm.sh` `OS_IMAGE_URL` now points at the private-ml-sdk `v0.5.5` release (env-overridable) so providers boot the Lium-built image.
- **validator (deploy)** — `dstack-verifier` `IMAGE_DOWNLOAD_URL` points at the release `mr_{OS_IMAGE_HASH}.tar.gz` in both dstacktee compose files, so the verifier can recompute the measurements it needs to validate the quote.

**Why the whitelisted digest is a real trust anchor (verified in the verifier source):** the executor's TDX quote carries the claimed `os_image_hash`; the verifier downloads the matching image files, re-checks they hash back to the digest, recomputes MRTD/RTMR0-2 via `dstack-mr`, and asserts they equal the hardware-measured values in the signed quote. A forged `os_image_hash` fails this check.

**Deploy notes**
- Release assets already published on `fortunelucky777/private-ml-sdk` `v0.5.5`: `dstack-nvidia-0.5.5.tar.gz` (provider, full image) and `mr_dbfde5….tar.gz` (verifier, flat measurement tarball).
- The verifier URL override resolves images from the fork release. `9b69bb…` stays whitelisted but the verifier no longer fetches it — acceptable because no prod CVM providers run the old image yet. When CVM goes multi-image, mirror both `mr_` tarballs under one host.
- Suggested staging gate: boot the custom image on a TDX node, capture a real quote, POST to the pinned verifier, confirm `is_valid=true` and `app_info.os_image_hash == dbfde5…`.

## Issue ticket number and link

DAH-2311

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I wrote tests. — n/a: the change is a whitelist data entry + deploy config; the existing attestation test mocks the verifier and disables the whitelist.
- [ ] Need to take care of performance? — no.
