### PR TITLE
DAH-2327, explain zero unrented incentive in customer-facing log

### DIFF
--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -86,7 +86,7 @@ class DefaultIncentive(BaseIncentive):
         self.miner_incentives = {}
         self.mining_share = 1 - self.burn_share
 
-    async def _pre_process_job_result(self, hotkey: str, result: JobResult):
+    async def _pre_process_job_result(self, hotkey: str, result: JobResult) -> JobResult:
         """Process a job result.
 
         Args:
@@ -101,7 +101,7 @@ class DefaultIncentive(BaseIncentive):
             self.failed_executors += 1
         return result
 
-    async def _post_process_job_result(self, hotkey: str, result: JobResult):
+    async def _post_process_job_result(self, hotkey: str, result: JobResult) -> JobResult:
         """Process a job result.
 
         Args:

--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -108,13 +108,13 @@ class DefaultIncentive(BaseIncentive):
             result: Job execution result to process
         """
         if result.mining_score is None:
-            error_report = MinerLogLine.mining_score_missing(hotkey, result)
+            error_report: MinerLogLine = MinerLogLine.mining_score_missing(hotkey, result)
             result.incentive_logs.append(error_report.to_log_line())
             return result
 
         result.incentive = (self.mining_share * result.mining_score / self.total_mining_score) if self.total_mining_score > 0 else 0.0
         self.miner_incentives[hotkey] = self.miner_incentives.get(hotkey, 0.0) + result.incentive
-        report = MinerLogLine.mining_incentive_calculated(
+        report: MinerLogLine = MinerLogLine.mining_incentive_calculated(
             hotkey, result, self.total_mining_score, self.mining_share
         )
         result.incentive_logs.append(report.to_log_line())
@@ -207,7 +207,7 @@ class DefaultIncentive(BaseIncentive):
         job_result.mining_score *= (
             job_result.sysbox_multiplier * job_result.uptime_multiplier * job_result.driver_multiplier
         )
-        line = MinerLogLine.mining_score_calculated(job_result, is_rented_after_cutoff)
+        line: MinerLogLine = MinerLogLine.mining_score_calculated(job_result, is_rented_after_cutoff)
         job_result.incentive_logs.append(line.to_log_line())
         logger.info(line.as_internal_log())
         return job_result

--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -108,16 +108,16 @@ class DefaultIncentive(BaseIncentive):
             result: Job execution result to process
         """
         if result.mining_score is None:
-            result.incentive_logs.append(miner_log.mining_score_missing(hotkey, result).to_log_line())
+            error_report = miner_log.mining_score_missing(hotkey, result)
+            result.incentive_logs.append(error_report.to_log_line())
             return result
 
         result.incentive = (self.mining_share * result.mining_score / self.total_mining_score) if self.total_mining_score > 0 else 0.0
         self.miner_incentives[hotkey] = self.miner_incentives.get(hotkey, 0.0) + result.incentive
-        result.incentive_logs.append(
-            miner_log.mining_incentive_calculated(
-                hotkey, result, self.total_mining_score, self.mining_share
-            ).to_log_line()
+        report = miner_log.mining_incentive_calculated(
+            hotkey, result, self.total_mining_score, self.mining_share
         )
+        result.incentive_logs.append(report.to_log_line())
         return result
 
     async def calculate_executor_score(

--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -108,14 +108,16 @@ class DefaultIncentive(BaseIncentive):
             result: Job execution result to process
         """
         if result.mining_score is None:
-            miner_log.mining_score_missing(hotkey, result).write_to_miner_log(result)
+            result.incentive_logs.append(miner_log.mining_score_missing(hotkey, result).to_log_line())
             return result
 
         result.incentive = (self.mining_share * result.mining_score / self.total_mining_score) if self.total_mining_score > 0 else 0.0
         self.miner_incentives[hotkey] = self.miner_incentives.get(hotkey, 0.0) + result.incentive
-        miner_log.mining_incentive_calculated(
-            hotkey, result, self.total_mining_score, self.mining_share
-        ).write_to_miner_log(result)
+        result.incentive_logs.append(
+            miner_log.mining_incentive_calculated(
+                hotkey, result, self.total_mining_score, self.mining_share
+            ).to_log_line()
+        )
         return result
 
     async def calculate_executor_score(
@@ -206,7 +208,7 @@ class DefaultIncentive(BaseIncentive):
             job_result.sysbox_multiplier * job_result.uptime_multiplier * job_result.driver_multiplier
         )
         line = miner_log.mining_score_calculated(job_result, is_rented_after_cutoff)
-        line.write_to_miner_log(job_result)
+        job_result.incentive_logs.append(line.to_log_line())
         logger.info(line.as_internal_log())
         return job_result
 

--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -10,6 +10,7 @@ import bittensor
 
 from core.config import get_total_burn_emission, settings
 from core.utils import _m, get_extra_info, get_logger
+from incentive import miner_incentive_log as miner_log
 from incentive.base import BaseIncentive
 from services.task_service import JobResult
 
@@ -107,38 +108,14 @@ class DefaultIncentive(BaseIncentive):
             result: Job execution result to process
         """
         if result.mining_score is None:
-            result.incentive_logs.append(
-                _m(
-                    "Mining score is not set for job result. This should not happen.",
-                    extra=get_extra_info({
-                        "hotkey": hotkey,
-                        "executor_id": str(result.executor_info.uuid),
-                        "score": result.score,
-                        "job_score": result.job_score,
-                        "gpu_model": result.gpu_model,
-                        "gpu_count": result.gpu_count,
-                    }),
-                ).to_full_string()
-            )
+            miner_log.mining_score_missing(hotkey, result).write_to_miner_log(result)
             return result
 
         result.incentive = (self.mining_share * result.mining_score / self.total_mining_score) if self.total_mining_score > 0 else 0.0
         self.miner_incentives[hotkey] = self.miner_incentives.get(hotkey, 0.0) + result.incentive
-        result.incentive_logs.append(
-            _m(
-                "Incentive score is calculated successfully. Formula: mining_share * mining_score / total_mining_score",
-                extra=get_extra_info({
-                    "hotkey": hotkey,
-                    "executor_id": str(result.executor_info.uuid),
-                    "mining_score": result.mining_score,
-                    "total_mining_score": self.total_mining_score,
-                    "mining_share": self.mining_share,
-                    "gpu_model": result.gpu_model,
-                    "gpu_count": result.gpu_count,
-                    "incentive": result.incentive,
-                }),
-            ).to_full_string()
-        )
+        miner_log.mining_incentive_calculated(
+            hotkey, result, self.total_mining_score, self.mining_share
+        ).write_to_miner_log(result)
         return result
 
     async def calculate_executor_score(
@@ -228,29 +205,9 @@ class DefaultIncentive(BaseIncentive):
         job_result.mining_score *= (
             job_result.sysbox_multiplier * job_result.uptime_multiplier * job_result.driver_multiplier
         )
-        log = _m(
-            "Mining score is calculated successfully. Formula: score * gpu_portion * gpu_count / total_gpu_count * sysbox_multiplier * uptime_multiplier * driver_multiplier",
-            extra=get_extra_info(
-                {
-                    "executor_id": str(job_result.executor_info.uuid),
-                    "gpu_model": job_result.gpu_model,
-                    "gpu_count": job_result.gpu_count,
-                    "sysbox_multiplier": job_result.sysbox_multiplier,
-                    "driver_multiplier": job_result.driver_multiplier,
-                    "nvidia_driver_version": job_result.nvidia_driver_version,
-                    "uptime_multiplier": job_result.uptime_multiplier,
-                    "mining_score": job_result.mining_score,
-                    "gpu_portion": job_result.gpu_portion,
-                    "total_gpu_count": job_result.total_gpu_count,
-                    "rental_created": job_result.rental_created_at,
-                    "is_rented_after_cutoff": is_rented_after_cutoff,
-                }
-            ),
-        )
-        job_result.incentive_logs.append(
-            log.to_full_string()
-        )
-        logger.info(log)
+        line = miner_log.mining_score_calculated(job_result, is_rented_after_cutoff)
+        line.write_to_miner_log(job_result)
+        logger.info(line.as_internal_log())
         return job_result
 
     async def calculate_final_weights(

--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -10,7 +10,7 @@ import bittensor
 
 from core.config import get_total_burn_emission, settings
 from core.utils import _m, get_extra_info, get_logger
-from incentive import miner_incentive_log as miner_log
+from incentive.miner_incentive_log import MinerLogLine
 from incentive.base import BaseIncentive
 from services.task_service import JobResult
 
@@ -108,13 +108,13 @@ class DefaultIncentive(BaseIncentive):
             result: Job execution result to process
         """
         if result.mining_score is None:
-            error_report = miner_log.mining_score_missing(hotkey, result)
+            error_report = MinerLogLine.mining_score_missing(hotkey, result)
             result.incentive_logs.append(error_report.to_log_line())
             return result
 
         result.incentive = (self.mining_share * result.mining_score / self.total_mining_score) if self.total_mining_score > 0 else 0.0
         self.miner_incentives[hotkey] = self.miner_incentives.get(hotkey, 0.0) + result.incentive
-        report = miner_log.mining_incentive_calculated(
+        report = MinerLogLine.mining_incentive_calculated(
             hotkey, result, self.total_mining_score, self.mining_share
         )
         result.incentive_logs.append(report.to_log_line())
@@ -207,7 +207,7 @@ class DefaultIncentive(BaseIncentive):
         job_result.mining_score *= (
             job_result.sysbox_multiplier * job_result.uptime_multiplier * job_result.driver_multiplier
         )
-        line = miner_log.mining_score_calculated(job_result, is_rented_after_cutoff)
+        line = MinerLogLine.mining_score_calculated(job_result, is_rented_after_cutoff)
         job_result.incentive_logs.append(line.to_log_line())
         logger.info(line.as_internal_log())
         return job_result

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -85,7 +85,7 @@ class MinerLogLine(BaseModel):
 
     def to_log_line(self) -> str:
         """Render as one string; the caller appends it to result.incentive_logs."""
-        return _m(self.message, extra=get_extra_info(self.fields)).to_full_string()
+        return self.as_internal_log().to_full_string()
 
     def as_internal_log(self) -> _StructuredMessage:
         """The same line as an `_m` object, for mirroring into the internal logger."""

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -81,7 +81,7 @@ class MinerLogLine(BaseModel):
     fields: dict[str, Any] = Field(default_factory=dict)           # structured payload next to the message
     reason: ZeroIncentiveReason | None = None                      # machine-readable zero-incentive code; None for reports
     internal_message: str | None = None                            # separate internal-log wording (both-pools exclusions only)
-    internal_fields: dict[str, Any] = Field(default_factory=dict)  # extra fields for that internal log
+    internal_fields: dict[str, Any] = Field(default_factory=dict)  # full extra dict for that internal log
 
     def to_log_line(self) -> str:
         """Render as one string; the caller appends it to result.incentive_logs."""
@@ -91,6 +91,14 @@ class MinerLogLine(BaseModel):
         """The same line as an `_m` object, for mirroring into the internal logger."""
         return _m(self.message, extra=get_extra_info(self.fields))
 
+    def to_internal_log(self) -> _StructuredMessage:
+        """The separate internal observability log (both-pools exclusions only).
+
+        Uses `internal_message`/`internal_fields` baked in by `_no_payout`; the caller
+        just does `logger.info(exclusion.to_internal_log())`.
+        """
+        return _m(self.internal_message, extra=self.internal_fields)
+
     @staticmethod
     def _no_payout(
         result: JobResult,
@@ -98,7 +106,7 @@ class MinerLogLine(BaseModel):
         message: str,
         extra_fields: dict[str, Any] | None = None,
         internal_message: str | None = None,
-        internal_fields: dict[str, Any] | None = None,
+        internal_extra_fields: dict[str, Any] | None = None,
     ) -> MinerLogLine:
         """Shared shape of every zero-incentive reason: executor identity + reason + incentive 0."""
         fields: dict[str, Any] = {
@@ -109,12 +117,23 @@ class MinerLogLine(BaseModel):
             "incentive": 0.0,
             **(extra_fields or {}),
         }
+        internal_fields: dict[str, Any] = {}
+        if internal_message is not None:
+            internal_fields = {
+                "executor_id": str(result.executor_info.uuid),
+                "gpu_model": result.gpu_model,
+                "gpu_count": result.gpu_count,
+                "reason": reason,
+                "score": 0,
+                "pool": "none",
+                **(internal_extra_fields or {}),
+            }
         return MinerLogLine(
             message=message,
             fields=fields,
             reason=reason,
             internal_message=internal_message,
-            internal_fields=internal_fields or {},
+            internal_fields=internal_fields,
         )
 
     # ── Group A: excluded from BOTH pools (mining + unrented) — earns nothing ─
@@ -141,7 +160,7 @@ class MinerLogLine(BaseModel):
                 "provider Discord for this executor to start earning incentive."
             ),
             internal_message="Executor excluded from both pools - provider Discord not connected",
-            internal_fields={"provider_discord_connected": result.provider_discord_connected},
+            internal_extra_fields={"provider_discord_connected": result.provider_discord_connected},
         )
 
     @staticmethod

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -73,7 +73,7 @@ class MinerLogLine(BaseModel):
     Built ONLY via the named constructors below (the catalog). The constructor bakes
     every field in; rendering takes no arguments:
 
-        line = MinerLogLine.no_payout_because_spot_tier(result)
+        line: MinerLogLine = MinerLogLine.no_payout_because_spot_tier(result)
         result.incentive_logs.append(line.to_log_line())
     """
 
@@ -101,7 +101,7 @@ class MinerLogLine(BaseModel):
         internal_fields: dict[str, Any] | None = None,
     ) -> MinerLogLine:
         """Shared shape of every zero-incentive reason: executor identity + reason + incentive 0."""
-        fields = {
+        fields: dict[str, Any] = {
             "executor_id": str(result.executor_info.uuid),
             "gpu_model": result.gpu_model,
             "gpu_count": result.gpu_count,
@@ -186,8 +186,8 @@ class MinerLogLine(BaseModel):
     def no_payout_because_price_above_market_soft_limit(
         result: JobResult, market_p90: float, rate: float
     ) -> MinerLogLine:
-        price_per_gpu = result.executor_info.price_per_gpu
-        soft_limit = round(market_p90 * rate, 4)
+        price_per_gpu: float | None = result.executor_info.price_per_gpu
+        soft_limit: float = round(market_p90 * rate, 4)
         return MinerLogLine._no_payout(
             result,
             reason=ZeroIncentiveReason.PRICE_ABOVE_MARKET_P90_SOFT_LIMIT,

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -11,26 +11,27 @@ HOW A NODE PICKS A POOL:
   idle AND model in program AND price ok AND capacity? -> unrented pool (earns)
   otherwise                                            -> 0 incentive (reason below)
 
-WHAT THIS CATALOG HOLDS (the miner-facing log block, JobResult.incentive_logs,
-delivered via MACHINE_SPEC_CHANNEL):
+WHAT THIS CATALOG HOLDS — every `MinerLogLine` the miner-facing log block
+(JobResult.incentive_logs, delivered via MACHINE_SPEC_CHANNEL) can contain:
 
 1. ZERO-INCENTIVE REASONS — each records the fact "this executor gets NO payout
-   because <reason>" in the miner's log (`no_payout_because_*` builders):
+   because <reason>" (`MinerLogLine.no_payout_because_*` constructors):
    Group A — earns nothing in EITHER pool (built by `_reason_excluded_from_both_pools`):
      spot tier, Discord not connected, paused for new rentals, running own default job
    Group B — idle but does not qualify for the unrented pool:
      GPU model not in the unrented program (earns only when rented),
      price above the market soft limit (lower the price to earn),
-     no unrented capacity for that GPU-count tier this cycle
+     no unrented capacity for that GPU-count tier this cycle,
+     NVIDIA driver below the minimum, sysbox runtime not enabled
 
 2. CALCULATION REPORTS — the per-cycle score/incentive lines every scored node gets:
      mining_score_calculated, mining_incentive_calculated,
      rental_incentive_calculated, mining_score_missing (internal-error case)
 
 The scoring code (rental_price.py / default.py) detects each condition where its
-data naturally lives (some per-executor upfront, some only after cohort aggregation)
-and appends the matching builder's `.to_log_line(...)` to result.incentive_logs. Open
-THIS file to see everything a miner can be told and exactly how each message reads.
+data naturally lives (some per-executor upfront, some only after cohort aggregation),
+builds the matching line and appends `line.to_log_line()` to result.incentive_logs.
+Open THIS file to see everything a miner can be told and exactly how each message reads.
 """
 
 from __future__ import annotations
@@ -45,265 +46,280 @@ if TYPE_CHECKING:
     from services.task_service import JobResult
 
 
-class ZeroIncentiveReason(BaseModel):
-    """One reason a validated executor earns 0 subnet incentive."""
-
-    reason: str                                                    # machine-readable code, e.g. "spot_tier"
-    message_for_miner: str                                         # plain-English, shown to the miner
-    miner_log_fields: dict[str, Any] = Field(default_factory=dict)
-    internal_log_message: str | None = None                        # set only for both-pools exclusions
-    internal_log_fields: dict[str, Any] = Field(default_factory=dict)
-
-    def to_log_line(self, result: JobResult) -> str:
-        """Render this reason as one line for the customer-facing incentive log.
-
-        The caller appends the returned string to JobResult.incentive_logs (the
-        "Incentive Scores Calculation Logs" block delivered to the miner via
-        MACHINE_SPEC_CHANNEL, DAH-2327).
-        """
-        info = {
-            "executor_id": str(result.executor_info.uuid),
-            "gpu_model": result.gpu_model,
-            "gpu_count": result.gpu_count,
-            "reason": self.reason,
-            "incentive": 0.0,
-            **self.miner_log_fields,
-        }
-        return _m(self.message_for_miner, extra=get_extra_info(info)).to_full_string()
-
-
-# ── Group A: excluded from BOTH pools (mining + unrented) — earns nothing ─────
-
-def no_payout_because_spot_tier() -> ZeroIncentiveReason:
-    return ZeroIncentiveReason(
-        reason="spot_tier",
-        message_for_miner=(
-            "No subnet incentive: this executor is on the spot tier, and spot-tier "
-            "executors do not earn subnet incentive."
-        ),
-        internal_log_message="Executor excluded from both pools - spot tier",
-    )
-
-
-def no_payout_because_discord_not_connected(is_connected: bool) -> ZeroIncentiveReason:
-    return ZeroIncentiveReason(
-        reason="provider_discord_not_connected",
-        message_for_miner=(
-            "No subnet incentive: provider Discord is not connected. Connect your "
-            "provider Discord for this executor to start earning incentive."
-        ),
-        internal_log_message="Executor excluded from both pools - provider Discord not connected",
-        internal_log_fields={"provider_discord_connected": is_connected},
-    )
-
-
-def no_payout_because_paused_for_new_rentals() -> ZeroIncentiveReason:
-    return ZeroIncentiveReason(
-        reason="new_rentals_paused",
-        message_for_miner=(
-            "No subnet incentive: this executor is paused for new rentals and earns "
-            "nothing while paused. Resume new rentals to start earning again."
-        ),
-        internal_log_message="Executor excluded from both pools - paused for new rentals",
-    )
-
-
-def no_payout_because_running_own_default_job() -> ZeroIncentiveReason:
-    return ZeroIncentiveReason(
-        reason="miner_default_job",
-        message_for_miner=(
-            "No subnet incentive: this executor is running your own default job instead "
-            "of a Lium job, and executors on your own job do not earn subnet incentive."
-        ),
-        internal_log_message="Executor excluded from both pools - running miner's own default job",
-    )
-
-
-# ── Group B: idle but not qualified for the unrented pool ─────────────────────
-
-def no_payout_because_gpu_model_not_in_unrented_program(gpu_model: str) -> ZeroIncentiveReason:
-    return ZeroIncentiveReason(
-        reason="gpu_model_not_eligible_for_unrented_incentive",
-        message_for_miner=(
-            f"No subnet incentive while idle: GPU model {gpu_model} is not part of the "
-            "unrented (idle-node) incentive program, so this executor earns nothing "
-            "unless rented. Rent it out to earn."
-        ),
-    )
-
-
-def no_payout_because_price_above_market_soft_limit(price_per_gpu: float, market_p90: float, rate: float) -> ZeroIncentiveReason:
-    soft_limit = round(market_p90 * rate, 4)
-    return ZeroIncentiveReason(
-        reason="price_above_market_p90_soft_limit",
-        message_for_miner=(
-            f"No unrented incentive: your price ${price_per_gpu}/GPU/h is above the market "
-            f"soft price limit ${soft_limit} (90th-percentile market rate ${market_p90} x "
-            f"{rate}). Lower the price to ${soft_limit} or below to earn the unrented incentive."
-        ),
-        miner_log_fields={
-            "price_per_gpu": price_per_gpu,
-            "machine_price_p90": market_p90,
-            "soft_limit_rate": rate,
-            "soft_limit_threshold": soft_limit,
-        },
-    )
-
-
-def no_payout_because_no_unrented_capacity_for_gpu_count(
-    gpu_count: int,
-    gpu_model: str,
-    count_bucket: int | None,
-    max_cap: int | None,
-    cap_multiplier: float | None,
-    total_rental_cost: float,
-) -> ZeroIncentiveReason:
-    return ZeroIncentiveReason(
-        reason="no_unrented_capacity_for_gpu_count",
-        message_for_miner=(
-            f"No unrented incentive: there is currently no unrented-incentive capacity for "
-            f"{gpu_count}x {gpu_model} (its GPU-count tier has no cap this cycle). Rent this "
-            f"executor out to earn."
-        ),
-        miner_log_fields={
-            "count_bucket": count_bucket,
-            "max_cap": max_cap,
-            "unrented_cap_multiplier": cap_multiplier,
-            "total_rental_cost": total_rental_cost,
-        },
-    )
-
-
-# ── Calculation reports: the per-cycle lines every scored node gets ───────────
-
 class MinerLogLine(BaseModel):
-    """One fully-built line for the miner-facing incentive log."""
+    """One line of the miner-facing incentive log.
 
-    message: str
-    fields: dict[str, Any] = Field(default_factory=dict)
+    Built ONLY via the named constructors below (the catalog). The constructor bakes
+    every field in; rendering takes no arguments:
+
+        line = MinerLogLine.no_payout_because_spot_tier(result)
+        result.incentive_logs.append(line.to_log_line())
+    """
+
+    message: str                                                   # plain-English, shown to the miner
+    fields: dict[str, Any] = Field(default_factory=dict)           # structured payload next to the message
+    reason: str | None = None                                      # machine-readable zero-incentive code; None for reports
+    internal_message: str | None = None                            # separate internal-log wording (both-pools exclusions only)
+    internal_fields: dict[str, Any] = Field(default_factory=dict)  # extra fields for that internal log
+
+    def to_log_line(self) -> str:
+        """Render as one string; the caller appends it to result.incentive_logs."""
+        return _m(self.message, extra=get_extra_info(self.fields)).to_full_string()
 
     def as_internal_log(self):
         """The same line as an `_m` object, for mirroring into the internal logger."""
         return _m(self.message, extra=get_extra_info(self.fields))
 
-    def to_log_line(self) -> str:
-        """Render this line as a string; the caller appends it to incentive_logs."""
-        return self.as_internal_log().to_full_string()
-
-
-def mining_score_calculated(result: JobResult, is_rented_after_cutoff: bool) -> MinerLogLine:
-    return MinerLogLine(
-        message=(
-            "Mining score is calculated successfully. Formula: score * gpu_portion * gpu_count "
-            "/ total_gpu_count * sysbox_multiplier * uptime_multiplier * driver_multiplier"
-        ),
-        fields={
+    @classmethod
+    def _no_payout(
+        cls,
+        result: JobResult,
+        reason: str,
+        message: str,
+        extra_fields: dict[str, Any] | None = None,
+        internal_message: str | None = None,
+        internal_fields: dict[str, Any] | None = None,
+    ) -> MinerLogLine:
+        """Shared shape of every zero-incentive reason: executor identity + reason + incentive 0."""
+        fields = {
             "executor_id": str(result.executor_info.uuid),
             "gpu_model": result.gpu_model,
             "gpu_count": result.gpu_count,
-            "sysbox_multiplier": result.sysbox_multiplier,
-            "driver_multiplier": result.driver_multiplier,
-            "nvidia_driver_version": result.nvidia_driver_version,
-            "uptime_multiplier": result.uptime_multiplier,
-            "mining_score": result.mining_score,
-            "gpu_portion": result.gpu_portion,
-            "total_gpu_count": result.total_gpu_count,
-            "rental_created": result.rental_created_at,
-            "is_rented_after_cutoff": is_rented_after_cutoff,
-        },
-    )
+            "reason": reason,
+            "incentive": 0.0,
+            **(extra_fields or {}),
+        }
+        return cls(
+            message=message,
+            fields=fields,
+            reason=reason,
+            internal_message=internal_message,
+            internal_fields=internal_fields or {},
+        )
 
+    # ── Group A: excluded from BOTH pools (mining + unrented) — earns nothing ─
 
-def mining_incentive_calculated(
-    hotkey: str, result: JobResult, total_mining_score: float, mining_share: float
-) -> MinerLogLine:
-    return MinerLogLine(
-        message=(
-            "Incentive score is calculated successfully. Formula: mining_share * mining_score "
-            "/ total_mining_score"
-        ),
-        fields={
-            "hotkey": hotkey,
-            "executor_id": str(result.executor_info.uuid),
-            "mining_score": result.mining_score,
-            "total_mining_score": total_mining_score,
-            "mining_share": mining_share,
-            "gpu_model": result.gpu_model,
-            "gpu_count": result.gpu_count,
-            "incentive": result.incentive,
-        },
-    )
+    @classmethod
+    def no_payout_because_spot_tier(cls, result: JobResult) -> MinerLogLine:
+        return cls._no_payout(
+            result,
+            reason="spot_tier",
+            message=(
+                "No subnet incentive: this executor is on the spot tier, and spot-tier "
+                "executors do not earn subnet incentive."
+            ),
+            internal_message="Executor excluded from both pools - spot tier",
+        )
 
+    @classmethod
+    def no_payout_because_discord_not_connected(cls, result: JobResult) -> MinerLogLine:
+        return cls._no_payout(
+            result,
+            reason="provider_discord_not_connected",
+            message=(
+                "No subnet incentive: provider Discord is not connected. Connect your "
+                "provider Discord for this executor to start earning incentive."
+            ),
+            internal_message="Executor excluded from both pools - provider Discord not connected",
+            internal_fields={"provider_discord_connected": result.provider_discord_connected},
+        )
 
-def rental_incentive_calculated(hotkey: str, result: JobResult, bucket: int) -> MinerLogLine:
-    return MinerLogLine(
-        message=(
-            "Rental price incentive for executor is calculated successfully. Formula: "
-            "rental_share * gpu_count * effective_rate / total_rental_cost"
-        ),
-        fields={
-            "hotkey": hotkey,
-            "executor_id": str(result.executor_info.uuid),
-            "gpu_model": result.gpu_model,
-            "gpu_count": result.gpu_count,
-            "hourly_rate": result.hourly_rate,
-            "sysbox_runtime": result.sysbox_runtime,
-            "sysbox_multiplier": result.sysbox_multiplier,
-            "provider_discord_connected": result.provider_discord_connected,
-            "nvidia_driver_version": result.nvidia_driver_version,
-            "driver_multiplier": result.driver_multiplier,
-            "unrented_cap_multiplier": result.unrented_cap_multiplier,
-            "effective_rate": result.effective_rate,
-            "total_unrented_by_gpu_type": result.total_unrented_by_gpu_type,
-            "count_bucket": bucket,
-            "max_cap": result.max_cap,
-            "cap_dilution_applied": result.cap_dilution_applied,
-            "rental_share": result.rental_share,
-            "burn_share": result.burn_share,
-            "incentive": result.incentive,
-            "total_rental_cost": result.total_rental_cost,
-        },
-    )
+    @classmethod
+    def no_payout_because_paused_for_new_rentals(cls, result: JobResult) -> MinerLogLine:
+        return cls._no_payout(
+            result,
+            reason="new_rentals_paused",
+            message=(
+                "No subnet incentive: this executor is paused for new rentals and earns "
+                "nothing while paused. Resume new rentals to start earning again."
+            ),
+            internal_message="Executor excluded from both pools - paused for new rentals",
+        )
 
+    @classmethod
+    def no_payout_because_running_own_default_job(cls, result: JobResult) -> MinerLogLine:
+        return cls._no_payout(
+            result,
+            reason="miner_default_job",
+            message=(
+                "No subnet incentive: this executor is running your own default job instead "
+                "of a Lium job, and executors on your own job do not earn subnet incentive."
+            ),
+            internal_message="Executor excluded from both pools - running miner's own default job",
+        )
 
-def mining_score_missing(hotkey: str, result: JobResult) -> MinerLogLine:
-    # Internal-error case: scoring finished without a mining score. Should not happen.
-    return MinerLogLine(
-        message="Mining score is not set for job result. This should not happen.",
-        fields={
-            "hotkey": hotkey,
-            "executor_id": str(result.executor_info.uuid),
-            "score": result.score,
-            "job_score": result.job_score,
-            "gpu_model": result.gpu_model,
-            "gpu_count": result.gpu_count,
-        },
-    )
+    # ── Group B: idle but not qualified for the unrented pool ─────────────────
 
+    @classmethod
+    def no_payout_because_gpu_model_not_in_unrented_program(cls, result: JobResult) -> MinerLogLine:
+        return cls._no_payout(
+            result,
+            reason="gpu_model_not_eligible_for_unrented_incentive",
+            message=(
+                f"No subnet incentive while idle: GPU model {result.gpu_model} is not part of "
+                "the unrented (idle-node) incentive program, so this executor earns nothing "
+                "unless rented. Rent it out to earn."
+            ),
+        )
 
-def no_payout_because_nvidia_driver_below_minimum(
-    nvidia_driver_version: str, driver_multiplier: float | None
-) -> ZeroIncentiveReason:
-    return ZeroIncentiveReason(
-        reason="nvidia_driver_below_minimum",
-        message_for_miner=(
-            f"No unrented incentive: NVIDIA driver {nvidia_driver_version} is below the "
-            "minimum version required by the network. Upgrade the NVIDIA driver on this "
-            "executor to earn the unrented incentive."
-        ),
-        miner_log_fields={
-            "nvidia_driver_version": nvidia_driver_version,
-            "driver_multiplier": driver_multiplier,
-        },
-    )
+    @classmethod
+    def no_payout_because_price_above_market_soft_limit(
+        cls, result: JobResult, market_p90: float, rate: float
+    ) -> MinerLogLine:
+        price_per_gpu = result.executor_info.price_per_gpu
+        soft_limit = round(market_p90 * rate, 4)
+        return cls._no_payout(
+            result,
+            reason="price_above_market_p90_soft_limit",
+            message=(
+                f"No unrented incentive: your price ${price_per_gpu}/GPU/h is above the market "
+                f"soft price limit ${soft_limit} (90th-percentile market rate ${market_p90} x "
+                f"{rate}). Lower the price to ${soft_limit} or below to earn the unrented incentive."
+            ),
+            extra_fields={
+                "price_per_gpu": price_per_gpu,
+                "machine_price_p90": market_p90,
+                "soft_limit_rate": rate,
+                "soft_limit_threshold": soft_limit,
+            },
+        )
 
+    @classmethod
+    def no_payout_because_no_unrented_capacity_for_gpu_count(
+        cls, result: JobResult, count_bucket: int | None
+    ) -> MinerLogLine:
+        return cls._no_payout(
+            result,
+            reason="no_unrented_capacity_for_gpu_count",
+            message=(
+                f"No unrented incentive: there is currently no unrented-incentive capacity for "
+                f"{result.gpu_count}x {result.gpu_model} (its GPU-count tier has no cap this "
+                f"cycle). Rent this executor out to earn."
+            ),
+            extra_fields={
+                "count_bucket": count_bucket,
+                "max_cap": result.max_cap,
+                "unrented_cap_multiplier": result.unrented_cap_multiplier,
+                "total_rental_cost": result.total_rental_cost,
+            },
+        )
 
-def no_payout_because_sysbox_not_enabled(sysbox_runtime: bool) -> ZeroIncentiveReason:
-    return ZeroIncentiveReason(
-        reason="sysbox_not_enabled",
-        message_for_miner=(
-            "No unrented incentive: this executor does not run the sysbox runtime, which is "
-            "required for unrented incentive. Enable sysbox on this executor to earn."
-        ),
-        miner_log_fields={"sysbox_runtime": sysbox_runtime},
-    )
+    @classmethod
+    def no_payout_because_nvidia_driver_below_minimum(cls, result: JobResult) -> MinerLogLine:
+        return cls._no_payout(
+            result,
+            reason="nvidia_driver_below_minimum",
+            message=(
+                f"No unrented incentive: NVIDIA driver {result.nvidia_driver_version} is below "
+                "the minimum version required by the network. Upgrade the NVIDIA driver on this "
+                "executor to earn the unrented incentive."
+            ),
+            extra_fields={
+                "nvidia_driver_version": result.nvidia_driver_version,
+                "driver_multiplier": result.driver_multiplier,
+            },
+        )
+
+    @classmethod
+    def no_payout_because_sysbox_not_enabled(cls, result: JobResult) -> MinerLogLine:
+        return cls._no_payout(
+            result,
+            reason="sysbox_not_enabled",
+            message=(
+                "No unrented incentive: this executor does not run the sysbox runtime, which is "
+                "required for unrented incentive. Enable sysbox on this executor to earn."
+            ),
+            extra_fields={"sysbox_runtime": result.sysbox_runtime},
+        )
+
+    # ── Calculation reports: the per-cycle lines every scored node gets ───────
+
+    @classmethod
+    def mining_score_calculated(cls, result: JobResult, is_rented_after_cutoff: bool) -> MinerLogLine:
+        return cls(
+            message=(
+                "Mining score is calculated successfully. Formula: score * gpu_portion * gpu_count "
+                "/ total_gpu_count * sysbox_multiplier * uptime_multiplier * driver_multiplier"
+            ),
+            fields={
+                "executor_id": str(result.executor_info.uuid),
+                "gpu_model": result.gpu_model,
+                "gpu_count": result.gpu_count,
+                "sysbox_multiplier": result.sysbox_multiplier,
+                "driver_multiplier": result.driver_multiplier,
+                "nvidia_driver_version": result.nvidia_driver_version,
+                "uptime_multiplier": result.uptime_multiplier,
+                "mining_score": result.mining_score,
+                "gpu_portion": result.gpu_portion,
+                "total_gpu_count": result.total_gpu_count,
+                "rental_created": result.rental_created_at,
+                "is_rented_after_cutoff": is_rented_after_cutoff,
+            },
+        )
+
+    @classmethod
+    def mining_incentive_calculated(
+        cls, hotkey: str, result: JobResult, total_mining_score: float, mining_share: float
+    ) -> MinerLogLine:
+        return cls(
+            message=(
+                "Incentive score is calculated successfully. Formula: mining_share * mining_score "
+                "/ total_mining_score"
+            ),
+            fields={
+                "hotkey": hotkey,
+                "executor_id": str(result.executor_info.uuid),
+                "mining_score": result.mining_score,
+                "total_mining_score": total_mining_score,
+                "mining_share": mining_share,
+                "gpu_model": result.gpu_model,
+                "gpu_count": result.gpu_count,
+                "incentive": result.incentive,
+            },
+        )
+
+    @classmethod
+    def rental_incentive_calculated(cls, hotkey: str, result: JobResult, count_bucket: int) -> MinerLogLine:
+        return cls(
+            message=(
+                "Rental price incentive for executor is calculated successfully. Formula: "
+                "rental_share * gpu_count * effective_rate / total_rental_cost"
+            ),
+            fields={
+                "hotkey": hotkey,
+                "executor_id": str(result.executor_info.uuid),
+                "gpu_model": result.gpu_model,
+                "gpu_count": result.gpu_count,
+                "hourly_rate": result.hourly_rate,
+                "sysbox_runtime": result.sysbox_runtime,
+                "sysbox_multiplier": result.sysbox_multiplier,
+                "provider_discord_connected": result.provider_discord_connected,
+                "nvidia_driver_version": result.nvidia_driver_version,
+                "driver_multiplier": result.driver_multiplier,
+                "unrented_cap_multiplier": result.unrented_cap_multiplier,
+                "effective_rate": result.effective_rate,
+                "total_unrented_by_gpu_type": result.total_unrented_by_gpu_type,
+                "count_bucket": count_bucket,
+                "max_cap": result.max_cap,
+                "cap_dilution_applied": result.cap_dilution_applied,
+                "rental_share": result.rental_share,
+                "burn_share": result.burn_share,
+                "incentive": result.incentive,
+                "total_rental_cost": result.total_rental_cost,
+            },
+        )
+
+    @classmethod
+    def mining_score_missing(cls, hotkey: str, result: JobResult) -> MinerLogLine:
+        # Internal-error case: scoring finished without a mining score. Should not happen.
+        return cls(
+            message="Mining score is not set for job result. This should not happen.",
+            fields={
+                "hotkey": hotkey,
+                "executor_id": str(result.executor_info.uuid),
+                "score": result.score,
+                "job_score": result.job_score,
+                "gpu_model": result.gpu_model,
+                "gpu_count": result.gpu_count,
+            },
+        )

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -91,9 +91,8 @@ class MinerLogLine(BaseModel):
         """The same line as an `_m` object, for mirroring into the internal logger."""
         return _m(self.message, extra=get_extra_info(self.fields))
 
-    @classmethod
+    @staticmethod
     def _no_payout(
-        cls,
         result: JobResult,
         reason: ZeroIncentiveReason,
         message: str,
@@ -110,7 +109,7 @@ class MinerLogLine(BaseModel):
             "incentive": 0.0,
             **(extra_fields or {}),
         }
-        return cls(
+        return MinerLogLine(
             message=message,
             fields=fields,
             reason=reason,
@@ -120,9 +119,9 @@ class MinerLogLine(BaseModel):
 
     # ── Group A: excluded from BOTH pools (mining + unrented) — earns nothing ─
 
-    @classmethod
-    def no_payout_because_spot_tier(cls, result: JobResult) -> MinerLogLine:
-        return cls._no_payout(
+    @staticmethod
+    def no_payout_because_spot_tier(result: JobResult) -> MinerLogLine:
+        return MinerLogLine._no_payout(
             result,
             reason=ZeroIncentiveReason.SPOT_TIER,
             message=(
@@ -132,9 +131,9 @@ class MinerLogLine(BaseModel):
             internal_message="Executor excluded from both pools - spot tier",
         )
 
-    @classmethod
-    def no_payout_because_discord_not_connected(cls, result: JobResult) -> MinerLogLine:
-        return cls._no_payout(
+    @staticmethod
+    def no_payout_because_discord_not_connected(result: JobResult) -> MinerLogLine:
+        return MinerLogLine._no_payout(
             result,
             reason=ZeroIncentiveReason.PROVIDER_DISCORD_NOT_CONNECTED,
             message=(
@@ -145,9 +144,9 @@ class MinerLogLine(BaseModel):
             internal_fields={"provider_discord_connected": result.provider_discord_connected},
         )
 
-    @classmethod
-    def no_payout_because_paused_for_new_rentals(cls, result: JobResult) -> MinerLogLine:
-        return cls._no_payout(
+    @staticmethod
+    def no_payout_because_paused_for_new_rentals(result: JobResult) -> MinerLogLine:
+        return MinerLogLine._no_payout(
             result,
             reason=ZeroIncentiveReason.NEW_RENTALS_PAUSED,
             message=(
@@ -157,9 +156,9 @@ class MinerLogLine(BaseModel):
             internal_message="Executor excluded from both pools - paused for new rentals",
         )
 
-    @classmethod
-    def no_payout_because_running_own_default_job(cls, result: JobResult) -> MinerLogLine:
-        return cls._no_payout(
+    @staticmethod
+    def no_payout_because_running_own_default_job(result: JobResult) -> MinerLogLine:
+        return MinerLogLine._no_payout(
             result,
             reason=ZeroIncentiveReason.MINER_DEFAULT_JOB,
             message=(
@@ -171,9 +170,9 @@ class MinerLogLine(BaseModel):
 
     # ── Group B: idle but not qualified for the unrented pool ─────────────────
 
-    @classmethod
-    def no_payout_because_gpu_model_not_in_unrented_program(cls, result: JobResult) -> MinerLogLine:
-        return cls._no_payout(
+    @staticmethod
+    def no_payout_because_gpu_model_not_in_unrented_program(result: JobResult) -> MinerLogLine:
+        return MinerLogLine._no_payout(
             result,
             reason=ZeroIncentiveReason.GPU_MODEL_NOT_ELIGIBLE_FOR_UNRENTED_INCENTIVE,
             message=(
@@ -183,13 +182,13 @@ class MinerLogLine(BaseModel):
             ),
         )
 
-    @classmethod
+    @staticmethod
     def no_payout_because_price_above_market_soft_limit(
-        cls, result: JobResult, market_p90: float, rate: float
+        result: JobResult, market_p90: float, rate: float
     ) -> MinerLogLine:
         price_per_gpu = result.executor_info.price_per_gpu
         soft_limit = round(market_p90 * rate, 4)
-        return cls._no_payout(
+        return MinerLogLine._no_payout(
             result,
             reason=ZeroIncentiveReason.PRICE_ABOVE_MARKET_P90_SOFT_LIMIT,
             message=(
@@ -205,11 +204,11 @@ class MinerLogLine(BaseModel):
             },
         )
 
-    @classmethod
+    @staticmethod
     def no_payout_because_no_unrented_capacity_for_gpu_count(
-        cls, result: JobResult, count_bucket: int | None
+        result: JobResult, count_bucket: int | None
     ) -> MinerLogLine:
-        return cls._no_payout(
+        return MinerLogLine._no_payout(
             result,
             reason=ZeroIncentiveReason.NO_UNRENTED_CAPACITY_FOR_GPU_COUNT,
             message=(
@@ -225,9 +224,9 @@ class MinerLogLine(BaseModel):
             },
         )
 
-    @classmethod
-    def no_payout_because_nvidia_driver_below_minimum(cls, result: JobResult) -> MinerLogLine:
-        return cls._no_payout(
+    @staticmethod
+    def no_payout_because_nvidia_driver_below_minimum(result: JobResult) -> MinerLogLine:
+        return MinerLogLine._no_payout(
             result,
             reason=ZeroIncentiveReason.NVIDIA_DRIVER_BELOW_MINIMUM,
             message=(
@@ -241,9 +240,9 @@ class MinerLogLine(BaseModel):
             },
         )
 
-    @classmethod
-    def no_payout_because_sysbox_not_enabled(cls, result: JobResult) -> MinerLogLine:
-        return cls._no_payout(
+    @staticmethod
+    def no_payout_because_sysbox_not_enabled(result: JobResult) -> MinerLogLine:
+        return MinerLogLine._no_payout(
             result,
             reason=ZeroIncentiveReason.SYSBOX_NOT_ENABLED,
             message=(
@@ -255,9 +254,9 @@ class MinerLogLine(BaseModel):
 
     # ── Calculation reports: the per-cycle lines every scored node gets ───────
 
-    @classmethod
-    def mining_score_calculated(cls, result: JobResult, is_rented_after_cutoff: bool) -> MinerLogLine:
-        return cls(
+    @staticmethod
+    def mining_score_calculated(result: JobResult, is_rented_after_cutoff: bool) -> MinerLogLine:
+        return MinerLogLine(
             message=(
                 "Mining score is calculated successfully. Formula: score * gpu_portion * gpu_count "
                 "/ total_gpu_count * sysbox_multiplier * uptime_multiplier * driver_multiplier"
@@ -278,11 +277,11 @@ class MinerLogLine(BaseModel):
             },
         )
 
-    @classmethod
+    @staticmethod
     def mining_incentive_calculated(
-        cls, hotkey: str, result: JobResult, total_mining_score: float, mining_share: float
+        hotkey: str, result: JobResult, total_mining_score: float, mining_share: float
     ) -> MinerLogLine:
-        return cls(
+        return MinerLogLine(
             message=(
                 "Incentive score is calculated successfully. Formula: mining_share * mining_score "
                 "/ total_mining_score"
@@ -299,9 +298,9 @@ class MinerLogLine(BaseModel):
             },
         )
 
-    @classmethod
-    def rental_incentive_calculated(cls, hotkey: str, result: JobResult, count_bucket: int) -> MinerLogLine:
-        return cls(
+    @staticmethod
+    def rental_incentive_calculated(hotkey: str, result: JobResult, count_bucket: int) -> MinerLogLine:
+        return MinerLogLine(
             message=(
                 "Rental price incentive for executor is calculated successfully. Formula: "
                 "rental_share * gpu_count * effective_rate / total_rental_cost"
@@ -330,10 +329,10 @@ class MinerLogLine(BaseModel):
             },
         )
 
-    @classmethod
-    def mining_score_missing(cls, hotkey: str, result: JobResult) -> MinerLogLine:
+    @staticmethod
+    def mining_score_missing(hotkey: str, result: JobResult) -> MinerLogLine:
         # Internal-error case: scoring finished without a mining score. Should not happen.
-        return cls(
+        return MinerLogLine(
             message="Mining score is not set for job result. This should not happen.",
             fields={
                 "hotkey": hotkey,

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -41,7 +41,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
-from core.utils import _m, get_extra_info
+from core.utils import _m, _StructuredMessage, get_extra_info
 
 if TYPE_CHECKING:
     from services.task_service import JobResult
@@ -87,7 +87,7 @@ class MinerLogLine(BaseModel):
         """Render as one string; the caller appends it to result.incentive_logs."""
         return _m(self.message, extra=get_extra_info(self.fields)).to_full_string()
 
-    def as_internal_log(self):
+    def as_internal_log(self) -> _StructuredMessage:
         """The same line as an `_m` object, for mirroring into the internal logger."""
         return _m(self.message, extra=get_extra_info(self.fields))
 

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -14,14 +14,14 @@ HOW A NODE PICKS A POOL:
 WHAT THIS CATALOG HOLDS (the miner-facing log block, JobResult.incentive_logs,
 delivered via MACHINE_SPEC_CHANNEL):
 
-1. ZERO-INCENTIVE REASONS — why a validated node earns 0:
+1. ZERO-INCENTIVE REASONS — each records the fact "this executor gets NO payout
+   because <reason>" in the miner's log (`no_payout_because_*` builders):
    Group A — earns nothing in EITHER pool (built by `_reason_excluded_from_both_pools`):
-     executor_on_spot_tier, provider_discord_not_connected,
-     executor_paused_for_new_rentals, running_miners_own_default_job
+     spot tier, Discord not connected, paused for new rentals, running own default job
    Group B — idle but does not qualify for the unrented pool:
-     gpu_model_not_in_unrented_program (earns only when rented),
-     executor_price_above_market_soft_limit (miner's asking price over the ceiling -> lower it),
-     no_unrented_capacity_for_gpu_count (no cap left for that GPU-count tier this cycle)
+     GPU model not in the unrented program (earns only when rented),
+     price above the market soft limit (lower the price to earn),
+     no unrented capacity for that GPU-count tier this cycle
 
 2. CALCULATION REPORTS — the per-cycle score/incentive lines every scored node gets:
      mining_score_calculated, mining_incentive_calculated,
@@ -75,7 +75,7 @@ class ZeroIncentiveReason(BaseModel):
 
 # ── Group A: excluded from BOTH pools (mining + unrented) — earns nothing ─────
 
-def executor_on_spot_tier() -> ZeroIncentiveReason:
+def no_payout_because_spot_tier() -> ZeroIncentiveReason:
     return ZeroIncentiveReason(
         reason="spot_tier",
         message_for_miner=(
@@ -86,7 +86,7 @@ def executor_on_spot_tier() -> ZeroIncentiveReason:
     )
 
 
-def provider_discord_not_connected(is_connected: bool) -> ZeroIncentiveReason:
+def no_payout_because_discord_not_connected(is_connected: bool) -> ZeroIncentiveReason:
     return ZeroIncentiveReason(
         reason="provider_discord_not_connected",
         message_for_miner=(
@@ -98,7 +98,7 @@ def provider_discord_not_connected(is_connected: bool) -> ZeroIncentiveReason:
     )
 
 
-def executor_paused_for_new_rentals() -> ZeroIncentiveReason:
+def no_payout_because_paused_for_new_rentals() -> ZeroIncentiveReason:
     return ZeroIncentiveReason(
         reason="new_rentals_paused",
         message_for_miner=(
@@ -109,7 +109,7 @@ def executor_paused_for_new_rentals() -> ZeroIncentiveReason:
     )
 
 
-def running_miners_own_default_job() -> ZeroIncentiveReason:
+def no_payout_because_running_own_default_job() -> ZeroIncentiveReason:
     return ZeroIncentiveReason(
         reason="miner_default_job",
         message_for_miner=(
@@ -122,7 +122,7 @@ def running_miners_own_default_job() -> ZeroIncentiveReason:
 
 # ── Group B: idle but not qualified for the unrented pool ─────────────────────
 
-def gpu_model_not_in_unrented_program(gpu_model: str) -> ZeroIncentiveReason:
+def no_payout_because_gpu_model_not_in_unrented_program(gpu_model: str) -> ZeroIncentiveReason:
     return ZeroIncentiveReason(
         reason="gpu_model_not_eligible_for_unrented_incentive",
         message_for_miner=(
@@ -133,7 +133,7 @@ def gpu_model_not_in_unrented_program(gpu_model: str) -> ZeroIncentiveReason:
     )
 
 
-def executor_price_above_market_soft_limit(price_per_gpu: float, market_p90: float, rate: float) -> ZeroIncentiveReason:
+def no_payout_because_price_above_market_soft_limit(price_per_gpu: float, market_p90: float, rate: float) -> ZeroIncentiveReason:
     soft_limit = round(market_p90 * rate, 4)
     return ZeroIncentiveReason(
         reason="price_above_market_p90_soft_limit",
@@ -151,7 +151,7 @@ def executor_price_above_market_soft_limit(price_per_gpu: float, market_p90: flo
     )
 
 
-def no_unrented_capacity_for_gpu_count(
+def no_payout_because_no_unrented_capacity_for_gpu_count(
     gpu_count: int,
     gpu_model: str,
     count_bucket: int | None,

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -279,3 +279,31 @@ def mining_score_missing(hotkey: str, result: JobResult) -> MinerLogLine:
             "gpu_count": result.gpu_count,
         },
     )
+
+
+def no_payout_because_nvidia_driver_below_minimum(
+    nvidia_driver_version: str, driver_multiplier: float | None
+) -> ZeroIncentiveReason:
+    return ZeroIncentiveReason(
+        reason="nvidia_driver_below_minimum",
+        message_for_miner=(
+            f"No unrented incentive: NVIDIA driver {nvidia_driver_version} is below the "
+            "minimum version required by the network. Upgrade the NVIDIA driver on this "
+            "executor to earn the unrented incentive."
+        ),
+        miner_log_fields={
+            "nvidia_driver_version": nvidia_driver_version,
+            "driver_multiplier": driver_multiplier,
+        },
+    )
+
+
+def no_payout_because_sysbox_not_enabled(sysbox_runtime: bool) -> ZeroIncentiveReason:
+    return ZeroIncentiveReason(
+        reason="sysbox_not_enabled",
+        message_for_miner=(
+            "No unrented incentive: this executor does not run the sysbox runtime, which is "
+            "required for unrented incentive. Enable sysbox on this executor to earn."
+        ),
+        miner_log_fields={"sysbox_runtime": sysbox_runtime},
+    )

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -1,4 +1,4 @@
-"""Every reason a validated executor earns 0 subnet incentive — the single catalog.
+"""Everything a miner sees in their "Incentive Scores Calculation Logs" — one catalog.
 
 WHERE A NODE EARNS (two "pools" of subnet emission; the rest is burned):
   - Mining pool   — for RENTED executors. Paid by a mining score (GPU model/count
@@ -11,18 +11,25 @@ HOW A NODE PICKS A POOL:
   idle AND model in program AND price ok AND capacity? -> unrented pool (earns)
   otherwise                                            -> 0 incentive (reason below)
 
-THE REASONS A VALIDATED NODE EARNS 0 (what this catalog holds):
-  Group A — earns nothing in EITHER pool (built by `_reason_excluded_from_both_pools`):
-    spot_tier, provider_discord_not_connected, new_rentals_paused, miner_default_job
-  Group B — idle but does not qualify for the unrented pool:
-    gpu_model_not_in_unrented_program (earns only when rented),
-    price_over_soft_limit (priced above the market ceiling -> lower price),
-    no_unrented_capacity (no cap left for that GPU-count tier this cycle)
+WHAT THIS CATALOG HOLDS (the miner-facing log block, JobResult.incentive_logs,
+delivered via MACHINE_SPEC_CHANNEL):
 
-The scoring code (rental_price.py) detects each condition where its data naturally
-lives (some per-executor upfront, some only after cohort aggregation) and calls the
-matching builder below, then `reason.write_to_miner_log(result)`. Open THIS file to
-see the full list of what a miner can be told and exactly how each message reads.
+1. ZERO-INCENTIVE REASONS — why a validated node earns 0:
+   Group A — earns nothing in EITHER pool (built by `_reason_excluded_from_both_pools`):
+     spot_tier, provider_discord_not_connected, new_rentals_paused, miner_default_job
+   Group B — idle but does not qualify for the unrented pool:
+     gpu_model_not_in_unrented_program (earns only when rented),
+     price_over_soft_limit (priced above the market ceiling -> lower price),
+     no_unrented_capacity (no cap left for that GPU-count tier this cycle)
+
+2. CALCULATION REPORTS — the per-cycle score/incentive lines every scored node gets:
+     mining_score_calculated, mining_incentive_calculated,
+     rental_incentive_calculated, mining_score_missing (internal-error case)
+
+The scoring code (rental_price.py / default.py) detects each condition where its
+data naturally lives (some per-executor upfront, some only after cohort aggregation)
+and calls the matching builder below, then `.write_to_miner_log(result)`. Open THIS
+file to see everything a miner can be told and exactly how each message reads.
 """
 
 from __future__ import annotations
@@ -163,5 +170,111 @@ def no_unrented_capacity(
             "max_cap": max_cap,
             "unrented_cap_multiplier": cap_multiplier,
             "total_rental_cost": total_rental_cost,
+        },
+    )
+
+
+# ── Calculation reports: the per-cycle lines every scored node gets ───────────
+
+class MinerLogLine(BaseModel):
+    """One fully-built line for the miner-facing incentive log."""
+
+    message: str
+    fields: dict[str, Any] = Field(default_factory=dict)
+
+    def as_internal_log(self):
+        """The same line as an `_m` object, for mirroring into the internal logger."""
+        return _m(self.message, extra=get_extra_info(self.fields))
+
+    def write_to_miner_log(self, result: JobResult) -> None:
+        result.incentive_logs.append(self.as_internal_log().to_full_string())
+
+
+def mining_score_calculated(result: JobResult, is_rented_after_cutoff: bool) -> MinerLogLine:
+    return MinerLogLine(
+        message=(
+            "Mining score is calculated successfully. Formula: score * gpu_portion * gpu_count "
+            "/ total_gpu_count * sysbox_multiplier * uptime_multiplier * driver_multiplier"
+        ),
+        fields={
+            "executor_id": str(result.executor_info.uuid),
+            "gpu_model": result.gpu_model,
+            "gpu_count": result.gpu_count,
+            "sysbox_multiplier": result.sysbox_multiplier,
+            "driver_multiplier": result.driver_multiplier,
+            "nvidia_driver_version": result.nvidia_driver_version,
+            "uptime_multiplier": result.uptime_multiplier,
+            "mining_score": result.mining_score,
+            "gpu_portion": result.gpu_portion,
+            "total_gpu_count": result.total_gpu_count,
+            "rental_created": result.rental_created_at,
+            "is_rented_after_cutoff": is_rented_after_cutoff,
+        },
+    )
+
+
+def mining_incentive_calculated(
+    hotkey: str, result: JobResult, total_mining_score: float, mining_share: float
+) -> MinerLogLine:
+    return MinerLogLine(
+        message=(
+            "Incentive score is calculated successfully. Formula: mining_share * mining_score "
+            "/ total_mining_score"
+        ),
+        fields={
+            "hotkey": hotkey,
+            "executor_id": str(result.executor_info.uuid),
+            "mining_score": result.mining_score,
+            "total_mining_score": total_mining_score,
+            "mining_share": mining_share,
+            "gpu_model": result.gpu_model,
+            "gpu_count": result.gpu_count,
+            "incentive": result.incentive,
+        },
+    )
+
+
+def rental_incentive_calculated(hotkey: str, result: JobResult, bucket: int) -> MinerLogLine:
+    return MinerLogLine(
+        message=(
+            "Rental price incentive for executor is calculated successfully. Formula: "
+            "rental_share * gpu_count * effective_rate / total_rental_cost"
+        ),
+        fields={
+            "hotkey": hotkey,
+            "executor_id": str(result.executor_info.uuid),
+            "gpu_model": result.gpu_model,
+            "gpu_count": result.gpu_count,
+            "hourly_rate": result.hourly_rate,
+            "sysbox_runtime": result.sysbox_runtime,
+            "sysbox_multiplier": result.sysbox_multiplier,
+            "provider_discord_connected": result.provider_discord_connected,
+            "nvidia_driver_version": result.nvidia_driver_version,
+            "driver_multiplier": result.driver_multiplier,
+            "unrented_cap_multiplier": result.unrented_cap_multiplier,
+            "effective_rate": result.effective_rate,
+            "total_unrented_by_gpu_type": result.total_unrented_by_gpu_type,
+            "count_bucket": bucket,
+            "max_cap": result.max_cap,
+            "cap_dilution_applied": result.cap_dilution_applied,
+            "rental_share": result.rental_share,
+            "burn_share": result.burn_share,
+            "incentive": result.incentive,
+            "total_rental_cost": result.total_rental_cost,
+        },
+    )
+
+
+def mining_score_missing(hotkey: str, result: JobResult) -> MinerLogLine:
+    # Internal-error case: scoring finished without a mining score. Should not happen.
+    return MinerLogLine(
+        message="Mining score is not set for job result. This should not happen.",
+        fields={
+            "hotkey": hotkey,
+            "executor_id": str(result.executor_info.uuid),
+            "score": result.score,
+            "job_score": result.job_score,
+            "gpu_model": result.gpu_model,
+            "gpu_count": result.gpu_count,
         },
     )

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -36,6 +36,7 @@ Open THIS file to see everything a miner can be told and exactly how each messag
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
@@ -44,6 +45,26 @@ from core.utils import _m, get_extra_info
 
 if TYPE_CHECKING:
     from services.task_service import JobResult
+
+
+class ZeroIncentiveReason(StrEnum):
+    """Machine-readable codes for every reason a validated executor earns 0.
+
+    APPEND-ONLY contract: Loki dashboards and the backend (DAH-2340 structured
+    payload) key off these exact strings — renaming a value is a breaking change.
+    """
+
+    # Group A: excluded from BOTH pools
+    SPOT_TIER = "spot_tier"
+    PROVIDER_DISCORD_NOT_CONNECTED = "provider_discord_not_connected"
+    NEW_RENTALS_PAUSED = "new_rentals_paused"
+    MINER_DEFAULT_JOB = "miner_default_job"
+    # Group B: idle but not qualified for the unrented pool
+    GPU_MODEL_NOT_ELIGIBLE_FOR_UNRENTED_INCENTIVE = "gpu_model_not_eligible_for_unrented_incentive"
+    PRICE_ABOVE_MARKET_P90_SOFT_LIMIT = "price_above_market_p90_soft_limit"
+    NO_UNRENTED_CAPACITY_FOR_GPU_COUNT = "no_unrented_capacity_for_gpu_count"
+    NVIDIA_DRIVER_BELOW_MINIMUM = "nvidia_driver_below_minimum"
+    SYSBOX_NOT_ENABLED = "sysbox_not_enabled"
 
 
 class MinerLogLine(BaseModel):
@@ -58,7 +79,7 @@ class MinerLogLine(BaseModel):
 
     message: str                                                   # plain-English, shown to the miner
     fields: dict[str, Any] = Field(default_factory=dict)           # structured payload next to the message
-    reason: str | None = None                                      # machine-readable zero-incentive code; None for reports
+    reason: ZeroIncentiveReason | None = None                      # machine-readable zero-incentive code; None for reports
     internal_message: str | None = None                            # separate internal-log wording (both-pools exclusions only)
     internal_fields: dict[str, Any] = Field(default_factory=dict)  # extra fields for that internal log
 
@@ -74,7 +95,7 @@ class MinerLogLine(BaseModel):
     def _no_payout(
         cls,
         result: JobResult,
-        reason: str,
+        reason: ZeroIncentiveReason,
         message: str,
         extra_fields: dict[str, Any] | None = None,
         internal_message: str | None = None,
@@ -103,7 +124,7 @@ class MinerLogLine(BaseModel):
     def no_payout_because_spot_tier(cls, result: JobResult) -> MinerLogLine:
         return cls._no_payout(
             result,
-            reason="spot_tier",
+            reason=ZeroIncentiveReason.SPOT_TIER,
             message=(
                 "No subnet incentive: this executor is on the spot tier, and spot-tier "
                 "executors do not earn subnet incentive."
@@ -115,7 +136,7 @@ class MinerLogLine(BaseModel):
     def no_payout_because_discord_not_connected(cls, result: JobResult) -> MinerLogLine:
         return cls._no_payout(
             result,
-            reason="provider_discord_not_connected",
+            reason=ZeroIncentiveReason.PROVIDER_DISCORD_NOT_CONNECTED,
             message=(
                 "No subnet incentive: provider Discord is not connected. Connect your "
                 "provider Discord for this executor to start earning incentive."
@@ -128,7 +149,7 @@ class MinerLogLine(BaseModel):
     def no_payout_because_paused_for_new_rentals(cls, result: JobResult) -> MinerLogLine:
         return cls._no_payout(
             result,
-            reason="new_rentals_paused",
+            reason=ZeroIncentiveReason.NEW_RENTALS_PAUSED,
             message=(
                 "No subnet incentive: this executor is paused for new rentals and earns "
                 "nothing while paused. Resume new rentals to start earning again."
@@ -140,7 +161,7 @@ class MinerLogLine(BaseModel):
     def no_payout_because_running_own_default_job(cls, result: JobResult) -> MinerLogLine:
         return cls._no_payout(
             result,
-            reason="miner_default_job",
+            reason=ZeroIncentiveReason.MINER_DEFAULT_JOB,
             message=(
                 "No subnet incentive: this executor is running your own default job instead "
                 "of a Lium job, and executors on your own job do not earn subnet incentive."
@@ -154,7 +175,7 @@ class MinerLogLine(BaseModel):
     def no_payout_because_gpu_model_not_in_unrented_program(cls, result: JobResult) -> MinerLogLine:
         return cls._no_payout(
             result,
-            reason="gpu_model_not_eligible_for_unrented_incentive",
+            reason=ZeroIncentiveReason.GPU_MODEL_NOT_ELIGIBLE_FOR_UNRENTED_INCENTIVE,
             message=(
                 f"No subnet incentive while idle: GPU model {result.gpu_model} is not part of "
                 "the unrented (idle-node) incentive program, so this executor earns nothing "
@@ -170,7 +191,7 @@ class MinerLogLine(BaseModel):
         soft_limit = round(market_p90 * rate, 4)
         return cls._no_payout(
             result,
-            reason="price_above_market_p90_soft_limit",
+            reason=ZeroIncentiveReason.PRICE_ABOVE_MARKET_P90_SOFT_LIMIT,
             message=(
                 f"No unrented incentive: your price ${price_per_gpu}/GPU/h is above the market "
                 f"soft price limit ${soft_limit} (90th-percentile market rate ${market_p90} x "
@@ -190,7 +211,7 @@ class MinerLogLine(BaseModel):
     ) -> MinerLogLine:
         return cls._no_payout(
             result,
-            reason="no_unrented_capacity_for_gpu_count",
+            reason=ZeroIncentiveReason.NO_UNRENTED_CAPACITY_FOR_GPU_COUNT,
             message=(
                 f"No unrented incentive: there is currently no unrented-incentive capacity for "
                 f"{result.gpu_count}x {result.gpu_model} (its GPU-count tier has no cap this "
@@ -208,7 +229,7 @@ class MinerLogLine(BaseModel):
     def no_payout_because_nvidia_driver_below_minimum(cls, result: JobResult) -> MinerLogLine:
         return cls._no_payout(
             result,
-            reason="nvidia_driver_below_minimum",
+            reason=ZeroIncentiveReason.NVIDIA_DRIVER_BELOW_MINIMUM,
             message=(
                 f"No unrented incentive: NVIDIA driver {result.nvidia_driver_version} is below "
                 "the minimum version required by the network. Upgrade the NVIDIA driver on this "
@@ -224,7 +245,7 @@ class MinerLogLine(BaseModel):
     def no_payout_because_sysbox_not_enabled(cls, result: JobResult) -> MinerLogLine:
         return cls._no_payout(
             result,
-            reason="sysbox_not_enabled",
+            reason=ZeroIncentiveReason.SYSBOX_NOT_ENABLED,
             message=(
                 "No unrented incentive: this executor does not run the sysbox runtime, which is "
                 "required for unrented incentive. Enable sysbox on this executor to earn."

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -16,11 +16,12 @@ delivered via MACHINE_SPEC_CHANNEL):
 
 1. ZERO-INCENTIVE REASONS — why a validated node earns 0:
    Group A — earns nothing in EITHER pool (built by `_reason_excluded_from_both_pools`):
-     spot_tier, provider_discord_not_connected, new_rentals_paused, miner_default_job
+     executor_on_spot_tier, provider_discord_not_connected,
+     executor_paused_for_new_rentals, running_miners_own_default_job
    Group B — idle but does not qualify for the unrented pool:
      gpu_model_not_in_unrented_program (earns only when rented),
-     price_over_soft_limit (priced above the market ceiling -> lower price),
-     no_unrented_capacity (no cap left for that GPU-count tier this cycle)
+     executor_price_above_market_soft_limit (miner's asking price over the ceiling -> lower it),
+     no_unrented_capacity_for_gpu_count (no cap left for that GPU-count tier this cycle)
 
 2. CALCULATION REPORTS — the per-cycle score/incentive lines every scored node gets:
      mining_score_calculated, mining_incentive_calculated,
@@ -74,7 +75,7 @@ class ZeroIncentiveReason(BaseModel):
 
 # ── Group A: excluded from BOTH pools (mining + unrented) — earns nothing ─────
 
-def spot_tier() -> ZeroIncentiveReason:
+def executor_on_spot_tier() -> ZeroIncentiveReason:
     return ZeroIncentiveReason(
         reason="spot_tier",
         message_for_miner=(
@@ -97,7 +98,7 @@ def provider_discord_not_connected(is_connected: bool) -> ZeroIncentiveReason:
     )
 
 
-def new_rentals_paused() -> ZeroIncentiveReason:
+def executor_paused_for_new_rentals() -> ZeroIncentiveReason:
     return ZeroIncentiveReason(
         reason="new_rentals_paused",
         message_for_miner=(
@@ -108,7 +109,7 @@ def new_rentals_paused() -> ZeroIncentiveReason:
     )
 
 
-def miner_default_job() -> ZeroIncentiveReason:
+def running_miners_own_default_job() -> ZeroIncentiveReason:
     return ZeroIncentiveReason(
         reason="miner_default_job",
         message_for_miner=(
@@ -132,7 +133,7 @@ def gpu_model_not_in_unrented_program(gpu_model: str) -> ZeroIncentiveReason:
     )
 
 
-def price_over_soft_limit(price_per_gpu: float, market_p90: float, rate: float) -> ZeroIncentiveReason:
+def executor_price_above_market_soft_limit(price_per_gpu: float, market_p90: float, rate: float) -> ZeroIncentiveReason:
     soft_limit = round(market_p90 * rate, 4)
     return ZeroIncentiveReason(
         reason="price_above_market_p90_soft_limit",
@@ -150,7 +151,7 @@ def price_over_soft_limit(price_per_gpu: float, market_p90: float, rate: float) 
     )
 
 
-def no_unrented_capacity(
+def no_unrented_capacity_for_gpu_count(
     gpu_count: int,
     gpu_model: str,
     count_bucket: int | None,

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -29,8 +29,8 @@ delivered via MACHINE_SPEC_CHANNEL):
 
 The scoring code (rental_price.py / default.py) detects each condition where its
 data naturally lives (some per-executor upfront, some only after cohort aggregation)
-and calls the matching builder below, then `.write_to_miner_log(result)`. Open THIS
-file to see everything a miner can be told and exactly how each message reads.
+and appends the matching builder's `.to_log_line(...)` to result.incentive_logs. Open
+THIS file to see everything a miner can be told and exactly how each message reads.
 """
 
 from __future__ import annotations
@@ -54,11 +54,12 @@ class ZeroIncentiveReason(BaseModel):
     internal_log_message: str | None = None                        # set only for both-pools exclusions
     internal_log_fields: dict[str, Any] = Field(default_factory=dict)
 
-    def write_to_miner_log(self, result: JobResult) -> None:
-        """Append this reason to the executor's customer-facing incentive log.
+    def to_log_line(self, result: JobResult) -> str:
+        """Render this reason as one line for the customer-facing incentive log.
 
-        Lands in JobResult.incentive_logs -> the "Incentive Scores Calculation Logs"
-        block delivered to the miner via MACHINE_SPEC_CHANNEL (DAH-2327).
+        The caller appends the returned string to JobResult.incentive_logs (the
+        "Incentive Scores Calculation Logs" block delivered to the miner via
+        MACHINE_SPEC_CHANNEL, DAH-2327).
         """
         info = {
             "executor_id": str(result.executor_info.uuid),
@@ -68,9 +69,7 @@ class ZeroIncentiveReason(BaseModel):
             "incentive": 0.0,
             **self.miner_log_fields,
         }
-        result.incentive_logs.append(
-            _m(self.message_for_miner, extra=get_extra_info(info)).to_full_string()
-        )
+        return _m(self.message_for_miner, extra=get_extra_info(info)).to_full_string()
 
 
 # ── Group A: excluded from BOTH pools (mining + unrented) — earns nothing ─────
@@ -187,8 +186,9 @@ class MinerLogLine(BaseModel):
         """The same line as an `_m` object, for mirroring into the internal logger."""
         return _m(self.message, extra=get_extra_info(self.fields))
 
-    def write_to_miner_log(self, result: JobResult) -> None:
-        result.incentive_logs.append(self.as_internal_log().to_full_string())
+    def to_log_line(self) -> str:
+        """Render this line as a string; the caller appends it to incentive_logs."""
+        return self.as_internal_log().to_full_string()
 
 
 def mining_score_calculated(result: JobResult, is_rented_after_cutoff: bool) -> MinerLogLine:

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -587,21 +587,28 @@ class RentalPriceIncentive(DefaultIncentive):
 
         job_result.eligible_for_rental_share = eligible_for_rental_share
         if job_result.eligible_for_rental_share:
+            # NOT a penalty: an unrented executor of an eligible GPU model is intentionally
+            # taken out of the mining pool and paid from the unrented rental-share pool
+            # instead (its incentive is computed later in _post_process_job_result). A
+            # mining_score of 0 here is expected and does not mean the executor earns 0.
             logger.info(
                 _m(
-                    "Executor excluded from mining pool - unrented eligible GPU",
+                    "Unrented eligible GPU routed to the rental-share pool "
+                    "(earns there; not scored in the mining pool, so mining_score=0 is expected)",
                     extra={
                         "executor_id": str(job_result.executor_info.uuid),
                         "gpu_model": job_result.gpu_model,
                         "gpu_count": job_result.gpu_count,
                         "reason": "unrented_and_eligible",
+                        "mining_score": 0,
+                        "earns_in_pool": "rental_share",
                         "score": 0,
                         "pool": "rental_only",
                     },
                 )
             )
             job_result.mining_score = 0
-            return job_result # Exclude from mining pool
+            return job_result  # earns via rental-share pool, not mining
 
         if not job_result.is_rented:
             job_result.mining_score = 0

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -395,9 +395,10 @@ class RentalPriceIncentive(DefaultIncentive):
         # update incentive logs
         miner_log.rental_incentive_calculated(hotkey, result, bucket).write_to_miner_log(result)
 
-        # DAH-2327: an eligible unrented executor still finalizes at 0 when its gpu-count
-        # bucket has no unrented capacity (cap multiplier -> 0 -> effective rate -> 0). Tell
-        # the miner, otherwise the "calculated successfully" line above shows 0 with no reason.
+        # DAH-2327: an eligible unrented executor still finalizes at 0 when any factor of
+        # effective_rate collapses to 0 (no bucket capacity, driver below minimum, no
+        # sysbox). Tell the miner which one, otherwise the "calculated successfully" line
+        # above shows incentive 0 with no reason.
         if result.unrented_cap_multiplier == 0:
             miner_log.no_payout_because_no_unrented_capacity_for_gpu_count(
                 gpu_count=result.gpu_count,
@@ -406,6 +407,14 @@ class RentalPriceIncentive(DefaultIncentive):
                 max_cap=result.max_cap,
                 cap_multiplier=result.unrented_cap_multiplier,
                 total_rental_cost=result.total_rental_cost,
+            ).write_to_miner_log(result)
+        elif result.driver_multiplier == 0:
+            miner_log.no_payout_because_nvidia_driver_below_minimum(
+                result.nvidia_driver_version, result.driver_multiplier
+            ).write_to_miner_log(result)
+        elif result.sysbox_multiplier == 0:
+            miner_log.no_payout_because_sysbox_not_enabled(
+                result.sysbox_runtime
             ).write_to_miner_log(result)
 
         # aggregate miner incentives

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -18,10 +18,9 @@ from pydantic import BaseModel, Field
 
 from core.config import get_total_burn_emission, settings, shared_client
 from core.utils import _m, get_logger
-from incentive import miner_incentive_log as miner_log
 from incentive.config import BASE_GPU_MAP
 from incentive.eligibility import is_missing_discord_after_cutoff
-from incentive.miner_incentive_log import ZeroIncentiveReason
+from incentive.miner_incentive_log import MinerLogLine
 
 if TYPE_CHECKING:
     from incentive.config import IncentiveConfig
@@ -211,7 +210,7 @@ class RentalPriceIncentive(DefaultIncentive):
             )
         )
 
-    def _reason_excluded_from_both_pools(self, job_result: JobResult) -> ZeroIncentiveReason | None:
+    def _reason_excluded_from_both_pools(self, job_result: JobResult) -> MinerLogLine | None:
         """First reason (if any) the executor is excluded from BOTH incentive pools.
 
         Order matters: the first matching rule wins, mirroring the original sequential
@@ -219,13 +218,13 @@ class RentalPriceIncentive(DefaultIncentive):
         gated later by the rental-pool-only soft price limit).
         """
         if job_result.is_spot:
-            return miner_log.no_payout_because_spot_tier()
+            return MinerLogLine.no_payout_because_spot_tier(job_result)
         if is_missing_discord_after_cutoff(job_result):
-            return miner_log.no_payout_because_discord_not_connected(job_result.provider_discord_connected)
+            return MinerLogLine.no_payout_because_discord_not_connected(job_result)
         if job_result.is_new_rentals_paused and not job_result.is_rented:
-            return miner_log.no_payout_because_paused_for_new_rentals()
+            return MinerLogLine.no_payout_because_paused_for_new_rentals(job_result)
         if job_result.default_job_owner == DEFAULT_JOB_OWNER_MINER and not job_result.is_rented:
-            return miner_log.no_payout_because_running_own_default_job()
+            return MinerLogLine.no_payout_because_running_own_default_job(job_result)
         return None
 
     @staticmethod
@@ -393,7 +392,7 @@ class RentalPriceIncentive(DefaultIncentive):
         )
 
         # update incentive logs
-        report = miner_log.rental_incentive_calculated(hotkey, result, bucket)
+        report = MinerLogLine.rental_incentive_calculated(hotkey, result, bucket)
         result.incentive_logs.append(report.to_log_line())
 
         # DAH-2327: an eligible unrented executor still finalizes at 0 when any factor of
@@ -401,23 +400,14 @@ class RentalPriceIncentive(DefaultIncentive):
         # sysbox). Tell the miner which one, otherwise the "calculated successfully" line
         # above shows incentive 0 with no reason.
         if result.unrented_cap_multiplier == 0:
-            reason = miner_log.no_payout_because_no_unrented_capacity_for_gpu_count(
-                gpu_count=result.gpu_count,
-                gpu_model=result.gpu_model,
-                count_bucket=bucket,
-                max_cap=result.max_cap,
-                cap_multiplier=result.unrented_cap_multiplier,
-                total_rental_cost=result.total_rental_cost,
-            )
-            result.incentive_logs.append(reason.to_log_line(result))
+            reason = MinerLogLine.no_payout_because_no_unrented_capacity_for_gpu_count(result, bucket)
+            result.incentive_logs.append(reason.to_log_line())
         elif result.driver_multiplier == 0:
-            reason = miner_log.no_payout_because_nvidia_driver_below_minimum(
-                result.nvidia_driver_version, result.driver_multiplier
-            )
-            result.incentive_logs.append(reason.to_log_line(result))
+            reason = MinerLogLine.no_payout_because_nvidia_driver_below_minimum(result)
+            result.incentive_logs.append(reason.to_log_line())
         elif result.sysbox_multiplier == 0:
-            reason = miner_log.no_payout_because_sysbox_not_enabled(result.sysbox_runtime)
-            result.incentive_logs.append(reason.to_log_line(result))
+            reason = MinerLogLine.no_payout_because_sysbox_not_enabled(result)
+            result.incentive_logs.append(reason.to_log_line())
 
         # aggregate miner incentives
         self.miner_incentives[hotkey] = self.miner_incentives.get(hotkey, 0.0) + result.incentive
@@ -444,11 +434,11 @@ class RentalPriceIncentive(DefaultIncentive):
         # Hard exclusions: reasons a validated executor earns 0 from BOTH pools.
         # One evaluator so the internal log, the customer-facing incentive log, and the
         # scoring decision all read from the same source and cannot drift (DAH-2327).
-        exclusion: ZeroIncentiveReason | None = self._reason_excluded_from_both_pools(job_result)
+        exclusion: MinerLogLine | None = self._reason_excluded_from_both_pools(job_result)
         if exclusion is not None:
             logger.info(
                 _m(
-                    exclusion.internal_log_message,
+                    exclusion.internal_message,
                     extra={
                         "executor_id": str(job_result.executor_info.uuid),
                         "gpu_model": job_result.gpu_model,
@@ -456,13 +446,13 @@ class RentalPriceIncentive(DefaultIncentive):
                         "reason": exclusion.reason,
                         "score": 0,
                         "pool": "none",
-                        **exclusion.internal_log_fields,
+                        **exclusion.internal_fields,
                     },
                 )
             )
             job_result.mining_score = 0
             job_result.eligible_for_rental_share = False
-            job_result.incentive_logs.append(exclusion.to_log_line(job_result))
+            job_result.incentive_logs.append(exclusion.to_log_line())
             return job_result
 
         # Check if GPU is unrented and eligible (has positive cap in max_unrented_gpus)
@@ -481,10 +471,10 @@ class RentalPriceIncentive(DefaultIncentive):
             if settings.ENABLE_UNRENTED_SOFT_PRICE_LIMIT:
                 eligible_for_rental_share = False
                 p90 = shared_client.config.machine_prices_p90.get(job_result.gpu_model)
-                reason = miner_log.no_payout_because_price_above_market_soft_limit(
-                    job_result.executor_info.price_per_gpu, p90, SOFT_LIMIT_PRICE_RATE
+                reason = MinerLogLine.no_payout_because_price_above_market_soft_limit(
+                    job_result, p90, SOFT_LIMIT_PRICE_RATE
                 )
-                job_result.incentive_logs.append(reason.to_log_line(job_result))
+                job_result.incentive_logs.append(reason.to_log_line())
 
         job_result.eligible_for_rental_share = eligible_for_rental_share
         if job_result.eligible_for_rental_share:
@@ -518,8 +508,8 @@ class RentalPriceIncentive(DefaultIncentive):
             if base_model not in self.config.rental_incentive_gpu_types and (
                 job_result.score > 0 or job_result.job_score > 0
             ):
-                reason = miner_log.no_payout_because_gpu_model_not_in_unrented_program(job_result.gpu_model)
-                job_result.incentive_logs.append(reason.to_log_line(job_result))
+                reason = MinerLogLine.no_payout_because_gpu_model_not_in_unrented_program(job_result)
+                job_result.incentive_logs.append(reason.to_log_line())
             return job_result
 
         # For rented or non-eligible GPUs, use parent's default scoring logic

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -219,13 +219,13 @@ class RentalPriceIncentive(DefaultIncentive):
         gated later by the rental-pool-only soft price limit).
         """
         if job_result.is_spot:
-            return miner_log.spot_tier()
+            return miner_log.executor_on_spot_tier()
         if is_missing_discord_after_cutoff(job_result):
             return miner_log.provider_discord_not_connected(job_result.provider_discord_connected)
         if job_result.is_new_rentals_paused and not job_result.is_rented:
-            return miner_log.new_rentals_paused()
+            return miner_log.executor_paused_for_new_rentals()
         if job_result.default_job_owner == DEFAULT_JOB_OWNER_MINER and not job_result.is_rented:
-            return miner_log.miner_default_job()
+            return miner_log.running_miners_own_default_job()
         return None
 
     @staticmethod
@@ -399,7 +399,7 @@ class RentalPriceIncentive(DefaultIncentive):
         # bucket has no unrented capacity (cap multiplier -> 0 -> effective rate -> 0). Tell
         # the miner, otherwise the "calculated successfully" line above shows 0 with no reason.
         if result.unrented_cap_multiplier == 0:
-            miner_log.no_unrented_capacity(
+            miner_log.no_unrented_capacity_for_gpu_count(
                 gpu_count=result.gpu_count,
                 gpu_model=result.gpu_model,
                 count_bucket=bucket,
@@ -470,7 +470,7 @@ class RentalPriceIncentive(DefaultIncentive):
             if settings.ENABLE_UNRENTED_SOFT_PRICE_LIMIT:
                 eligible_for_rental_share = False
                 p90 = shared_client.config.machine_prices_p90.get(job_result.gpu_model)
-                miner_log.price_over_soft_limit(
+                miner_log.executor_price_above_market_soft_limit(
                     job_result.executor_info.price_per_gpu, p90, SOFT_LIMIT_PRICE_RATE
                 ).write_to_miner_log(job_result)
 

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -11,7 +11,7 @@ rental subsidy. See `incentive/config.py:MAX_UNRENTED_GPUS_BY_TYPE`.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import bittensor
 from pydantic import BaseModel, Field
@@ -112,6 +112,19 @@ class RentalPriceEstimate(BaseModel):
     total_rental_cost: float | None = None              # Total rental cost for the executor in this cycle for scoring logic
 
 
+class IncentiveDecision(BaseModel):
+    """Why a validated executor is excluded from BOTH incentive pools (earns 0).
+
+    Single source of truth shared by the internal observability log, the
+    customer-facing incentive log, and the scoring exit (DAH-2327).
+    """
+
+    reason: str                     # machine-readable code, e.g. "spot_tier"
+    log_event: str                  # internal logger.info event string
+    customer_message: str           # customer-facing incentive_logs message
+    log_extra: dict[str, Any] = {}  # extra fields for the internal structured log
+
+
 class RentalPriceIncentive(DefaultIncentive):
     """Rental price incentive algorithm.
 
@@ -208,6 +221,52 @@ class RentalPriceIncentive(DefaultIncentive):
                 },
             )
         )
+
+    def _evaluate_hard_exclusion(self, job_result: JobResult) -> IncentiveDecision | None:
+        """First reason (if any) the executor is excluded from BOTH incentive pools.
+
+        Order matters: the first matching rule wins, mirroring the original sequential
+        checks. Returns None when no hard exclusion applies (executor may still be
+        gated later by the rental-pool-only soft price limit).
+        """
+        if job_result.is_spot:
+            return IncentiveDecision(
+                reason="spot_tier",
+                log_event="Executor excluded from both pools - spot tier",
+                customer_message=(
+                    "No subnet incentive: this executor is on the spot tier, which is "
+                    "excluded from both the mining and unrented incentive pools."
+                ),
+            )
+        if is_missing_discord_after_cutoff(job_result):
+            return IncentiveDecision(
+                reason="provider_discord_not_connected",
+                log_event="Executor excluded from both pools - provider Discord not connected",
+                customer_message=(
+                    "No subnet incentive: provider Discord is not connected. Connect your "
+                    "provider Discord to this executor to become eligible for incentive."
+                ),
+                log_extra={"provider_discord_connected": job_result.provider_discord_connected},
+            )
+        if job_result.is_new_rentals_paused and not job_result.is_rented:
+            return IncentiveDecision(
+                reason="new_rentals_paused",
+                log_event="Executor excluded from both pools - paused for new rentals",
+                customer_message=(
+                    "No subnet incentive: this executor is paused for new rentals, which "
+                    "excludes it from both incentive pools. Resume new rentals to become eligible."
+                ),
+            )
+        if job_result.default_job_owner == DEFAULT_JOB_OWNER_MINER and not job_result.is_rented:
+            return IncentiveDecision(
+                reason="miner_default_job",
+                log_event="Executor excluded from both pools - running miner's own default job",
+                customer_message=(
+                    "No subnet incentive: this executor is running the miner's own default job "
+                    "instead of a Lium job, which is excluded from both incentive pools."
+                ),
+            )
+        return None
 
     def _append_zero_incentive_reason(
         self, result: JobResult, reason: str, message: str, extra: dict | None = None
@@ -461,17 +520,22 @@ class RentalPriceIncentive(DefaultIncentive):
         Returns:
             Calculated score (0 for unrented eligible GPUs, normal score otherwise)
         """
-        if job_result.is_spot:
+        # Hard exclusions: reasons a validated executor earns 0 from BOTH pools.
+        # One evaluator so the internal log, the customer-facing incentive log, and the
+        # scoring decision all read from the same source and cannot drift (DAH-2327).
+        hard_exclusion = self._evaluate_hard_exclusion(job_result)
+        if hard_exclusion is not None:
             logger.info(
                 _m(
-                    "Executor excluded from both pools - spot tier",
+                    hard_exclusion.log_event,
                     extra={
                         "executor_id": str(job_result.executor_info.uuid),
                         "gpu_model": job_result.gpu_model,
                         "gpu_count": job_result.gpu_count,
-                        "reason": "spot_tier",
+                        "reason": hard_exclusion.reason,
                         "score": 0,
                         "pool": "none",
+                        **hard_exclusion.log_extra,
                     },
                 )
             )
@@ -479,90 +543,8 @@ class RentalPriceIncentive(DefaultIncentive):
             job_result.eligible_for_rental_share = False
             self._append_zero_incentive_reason(
                 job_result,
-                reason="spot_tier",
-                message=(
-                    "No subnet incentive: this executor is on the spot tier, which is "
-                    "excluded from both the mining and unrented incentive pools."
-                ),
-            )
-            return job_result
-
-        if is_missing_discord_after_cutoff(job_result):
-            logger.info(
-                _m(
-                    "Executor excluded from both pools - provider Discord not connected",
-                    extra={
-                        "executor_id": str(job_result.executor_info.uuid),
-                        "gpu_model": job_result.gpu_model,
-                        "gpu_count": job_result.gpu_count,
-                        "provider_discord_connected": job_result.provider_discord_connected,
-                        "reason": "provider_discord_not_connected",
-                        "score": 0,
-                        "pool": "none",
-                    },
-                )
-            )
-            job_result.mining_score = 0
-            job_result.eligible_for_rental_share = False
-            self._append_zero_incentive_reason(
-                job_result,
-                reason="provider_discord_not_connected",
-                message=(
-                    "No subnet incentive: provider Discord is not connected. Connect your "
-                    "provider Discord to this executor to become eligible for incentive."
-                ),
-            )
-            return job_result
-
-        if job_result.is_new_rentals_paused and not job_result.is_rented:
-            logger.info(
-                _m(
-                    "Executor excluded from both pools - paused for new rentals",
-                    extra={
-                        "executor_id": str(job_result.executor_info.uuid),
-                        "gpu_model": job_result.gpu_model,
-                        "gpu_count": job_result.gpu_count,
-                        "reason": "new_rentals_paused",
-                        "score": 0,
-                        "pool": "none",
-                    },
-                )
-            )
-            job_result.mining_score = 0
-            job_result.eligible_for_rental_share = False
-            self._append_zero_incentive_reason(
-                job_result,
-                reason="new_rentals_paused",
-                message=(
-                    "No subnet incentive: this executor is paused for new rentals, which "
-                    "excludes it from both incentive pools. Resume new rentals to become eligible."
-                ),
-            )
-            return job_result
-
-        if job_result.default_job_owner == DEFAULT_JOB_OWNER_MINER and not job_result.is_rented:
-            logger.info(
-                _m(
-                    "Executor excluded from both pools - running miner's own default job",
-                    extra={
-                        "executor_id": str(job_result.executor_info.uuid),
-                        "gpu_model": job_result.gpu_model,
-                        "gpu_count": job_result.gpu_count,
-                        "reason": "miner_default_job",
-                        "score": 0,
-                        "pool": "none",
-                    },
-                )
-            )
-            job_result.mining_score = 0
-            job_result.eligible_for_rental_share = False
-            self._append_zero_incentive_reason(
-                job_result,
-                reason="miner_default_job",
-                message=(
-                    "No subnet incentive: this executor is running the miner's own default job "
-                    "instead of a Lium job, which is excluded from both incentive pools."
-                ),
+                reason=hard_exclusion.reason,
+                message=hard_exclusion.customer_message,
             )
             return job_result
 

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -245,7 +245,7 @@ class RentalPriceIncentive(DefaultIncentive):
     def _bucket_key_str(base_model: str, bucket: int) -> str:
         return f"{base_model}·{bucket}"
 
-    async def _pre_process_job_result(self, hotkey: str, result: JobResult):
+    async def _pre_process_job_result(self, hotkey: str, result: JobResult) -> None:
         """Aggregate per-`(base_model, bucket)` metrics for the rental-share
         algorithm. Bucket resolution is symmetric with the rate-resolution path
         so split-capable executors land in the bucket of their
@@ -353,7 +353,7 @@ class RentalPriceIncentive(DefaultIncentive):
             )
         )
 
-    async def _post_process_job_result(self, hotkey: str, result: JobResult):
+    async def _post_process_job_result(self, hotkey: str, result: JobResult) -> JobResult | None:
         """Process a job result.
 
         Calculate incentive score for the executor.

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -228,22 +228,6 @@ class RentalPriceIncentive(DefaultIncentive):
             return reasons.miner_default_job()
         return None
 
-    def _log_zero_incentive_to_miner(self, result: JobResult, reason: ZeroIncentiveReason) -> None:
-        # DAH-2327: surface the reason (from the zero_incentive_reasons catalog) in the
-        # customer-facing incentive log (JobResult.incentive_logs -> "Incentive Scores
-        # Calculation Logs"), the exact block the miner reads.
-        info = {
-            "executor_id": str(result.executor_info.uuid),
-            "gpu_model": result.gpu_model,
-            "gpu_count": result.gpu_count,
-            "reason": reason.reason,
-            "incentive": 0.0,
-            **reason.miner_log_fields,
-        }
-        result.incentive_logs.append(
-            _m(reason.message_for_miner, extra=get_extra_info(info)).to_full_string()
-        )
-
     @staticmethod
     def _resolve_bucket(result: JobResult, cap_spec: dict[int, int]) -> int:
         """Pick the gpu_count bucket the executor is rated against.
@@ -441,17 +425,14 @@ class RentalPriceIncentive(DefaultIncentive):
         # bucket has no unrented capacity (cap multiplier -> 0 -> effective rate -> 0). Tell
         # the miner, otherwise the "calculated successfully" line above shows 0 with no reason.
         if result.unrented_cap_multiplier == 0:
-            self._log_zero_incentive_to_miner(
-                result,
-                reasons.no_unrented_capacity(
-                    gpu_count=result.gpu_count,
-                    gpu_model=result.gpu_model,
-                    count_bucket=bucket,
-                    max_cap=result.max_cap,
-                    cap_multiplier=result.unrented_cap_multiplier,
-                    total_rental_cost=result.total_rental_cost,
-                ),
-            )
+            reasons.no_unrented_capacity(
+                gpu_count=result.gpu_count,
+                gpu_model=result.gpu_model,
+                count_bucket=bucket,
+                max_cap=result.max_cap,
+                cap_multiplier=result.unrented_cap_multiplier,
+                total_rental_cost=result.total_rental_cost,
+            ).write_to_miner_log(result)
 
         # aggregate miner incentives
         self.miner_incentives[hotkey] = self.miner_incentives.get(hotkey, 0.0) + result.incentive
@@ -496,7 +477,7 @@ class RentalPriceIncentive(DefaultIncentive):
             )
             job_result.mining_score = 0
             job_result.eligible_for_rental_share = False
-            self._log_zero_incentive_to_miner(job_result, exclusion)
+            exclusion.write_to_miner_log(job_result)
             return job_result
 
         # Check if GPU is unrented and eligible (has positive cap in max_unrented_gpus)
@@ -515,12 +496,9 @@ class RentalPriceIncentive(DefaultIncentive):
             if settings.ENABLE_UNRENTED_SOFT_PRICE_LIMIT:
                 eligible_for_rental_share = False
                 p90 = shared_client.config.machine_prices_p90.get(job_result.gpu_model)
-                self._log_zero_incentive_to_miner(
-                    job_result,
-                    reasons.price_over_soft_limit(
-                        job_result.executor_info.price_per_gpu, p90, SOFT_LIMIT_PRICE_RATE
-                    ),
-                )
+                reasons.price_over_soft_limit(
+                    job_result.executor_info.price_per_gpu, p90, SOFT_LIMIT_PRICE_RATE
+                ).write_to_miner_log(job_result)
 
         job_result.eligible_for_rental_share = eligible_for_rental_share
         if job_result.eligible_for_rental_share:
@@ -554,9 +532,9 @@ class RentalPriceIncentive(DefaultIncentive):
             if base_model not in self.config.rental_incentive_gpu_types and (
                 job_result.score > 0 or job_result.job_score > 0
             ):
-                self._log_zero_incentive_to_miner(
-                    job_result, reasons.gpu_model_not_in_unrented_program(job_result.gpu_model)
-                )
+                reasons.gpu_model_not_in_unrented_program(
+                    job_result.gpu_model
+                ).write_to_miner_log(job_result)
             return job_result
 
         # For rented or non-eligible GPUs, use parent's default scoring logic

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -585,6 +585,20 @@ class RentalPriceIncentive(DefaultIncentive):
 
         if not job_result.is_rented:
             job_result.mining_score = 0
+            # A validated idle executor whose GPU model is not in the unrented incentive
+            # program earns nothing while unrented (only rented usage earns). Tell the miner.
+            if base_model not in self.config.rental_incentive_gpu_types and (
+                job_result.score > 0 or job_result.job_score > 0
+            ):
+                self._append_zero_incentive_reason(
+                    job_result,
+                    reason="gpu_model_not_eligible_for_unrented_incentive",
+                    message=(
+                        f"No subnet incentive while idle: GPU model {job_result.gpu_model} is not "
+                        "part of the unrented (idle-node) incentive program, so this executor earns "
+                        "nothing unless rented. Rent it out to earn."
+                    ),
+                )
             return job_result
 
         # For rented or non-eligible GPUs, use parent's default scoring logic

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -392,7 +392,7 @@ class RentalPriceIncentive(DefaultIncentive):
         )
 
         # update incentive logs
-        report = MinerLogLine.rental_incentive_calculated(hotkey, result, bucket)
+        report: MinerLogLine = MinerLogLine.rental_incentive_calculated(hotkey, result, bucket)
         result.incentive_logs.append(report.to_log_line())
 
         # DAH-2327: an eligible unrented executor still finalizes at 0 when any factor of
@@ -400,13 +400,13 @@ class RentalPriceIncentive(DefaultIncentive):
         # sysbox). Tell the miner which one, otherwise the "calculated successfully" line
         # above shows incentive 0 with no reason.
         if result.unrented_cap_multiplier == 0:
-            reason = MinerLogLine.no_payout_because_no_unrented_capacity_for_gpu_count(result, bucket)
+            reason: MinerLogLine = MinerLogLine.no_payout_because_no_unrented_capacity_for_gpu_count(result, bucket)
             result.incentive_logs.append(reason.to_log_line())
         elif result.driver_multiplier == 0:
-            reason = MinerLogLine.no_payout_because_nvidia_driver_below_minimum(result)
+            reason: MinerLogLine = MinerLogLine.no_payout_because_nvidia_driver_below_minimum(result)
             result.incentive_logs.append(reason.to_log_line())
         elif result.sysbox_multiplier == 0:
-            reason = MinerLogLine.no_payout_because_sysbox_not_enabled(result)
+            reason: MinerLogLine = MinerLogLine.no_payout_because_sysbox_not_enabled(result)
             result.incentive_logs.append(reason.to_log_line())
 
         # aggregate miner incentives
@@ -470,8 +470,8 @@ class RentalPriceIncentive(DefaultIncentive):
             self._log_soft_price_limit(job_result)
             if settings.ENABLE_UNRENTED_SOFT_PRICE_LIMIT:
                 eligible_for_rental_share = False
-                p90 = shared_client.config.machine_prices_p90.get(job_result.gpu_model)
-                reason = MinerLogLine.no_payout_because_price_above_market_soft_limit(
+                p90: float | None = shared_client.config.machine_prices_p90.get(job_result.gpu_model)
+                reason: MinerLogLine = MinerLogLine.no_payout_because_price_above_market_soft_limit(
                     job_result, p90, SOFT_LIMIT_PRICE_RATE
                 )
                 job_result.incentive_logs.append(reason.to_log_line())
@@ -508,7 +508,7 @@ class RentalPriceIncentive(DefaultIncentive):
             if base_model not in self.config.rental_incentive_gpu_types and (
                 job_result.score > 0 or job_result.job_score > 0
             ):
-                reason = MinerLogLine.no_payout_because_gpu_model_not_in_unrented_program(job_result)
+                reason: MinerLogLine = MinerLogLine.no_payout_because_gpu_model_not_in_unrented_program(job_result)
                 job_result.incentive_logs.append(reason.to_log_line())
             return job_result
 

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -112,7 +112,7 @@ class RentalPriceEstimate(BaseModel):
     total_rental_cost: float | None = None              # Total rental cost for the executor in this cycle for scoring logic
 
 
-class IncentiveDecision(BaseModel):
+class ZeroIncentiveReason(BaseModel):
     """Why a validated executor is excluded from BOTH incentive pools (earns 0).
 
     Single source of truth shared by the internal observability log, the
@@ -120,9 +120,9 @@ class IncentiveDecision(BaseModel):
     """
 
     reason: str                     # machine-readable code, e.g. "spot_tier"
-    log_event: str                  # internal logger.info event string
-    customer_message: str           # customer-facing incentive_logs message
-    log_extra: dict[str, Any] = Field(default_factory=dict)  # extra fields for the internal structured log
+    internal_log_message: str
+    message_for_miner: str
+    internal_log_fields: dict[str, Any] = Field(default_factory=dict)
 
 
 class RentalPriceIncentive(DefaultIncentive):
@@ -222,7 +222,7 @@ class RentalPriceIncentive(DefaultIncentive):
             )
         )
 
-    def _evaluate_hard_exclusion(self, job_result: JobResult) -> IncentiveDecision | None:
+    def _reason_excluded_from_both_pools(self, job_result: JobResult) -> ZeroIncentiveReason | None:
         """First reason (if any) the executor is excluded from BOTH incentive pools.
 
         Order matters: the first matching rule wins, mirroring the original sequential
@@ -230,38 +230,38 @@ class RentalPriceIncentive(DefaultIncentive):
         gated later by the rental-pool-only soft price limit).
         """
         if job_result.is_spot:
-            return IncentiveDecision(
+            return ZeroIncentiveReason(
                 reason="spot_tier",
-                log_event="Executor excluded from both pools - spot tier",
-                customer_message=(
+                internal_log_message="Executor excluded from both pools - spot tier",
+                message_for_miner=(
                     "No subnet incentive: this executor is on the spot tier, and spot-tier "
                     "executors do not earn subnet incentive."
                 ),
             )
         if is_missing_discord_after_cutoff(job_result):
-            return IncentiveDecision(
+            return ZeroIncentiveReason(
                 reason="provider_discord_not_connected",
-                log_event="Executor excluded from both pools - provider Discord not connected",
-                customer_message=(
+                internal_log_message="Executor excluded from both pools - provider Discord not connected",
+                message_for_miner=(
                     "No subnet incentive: provider Discord is not connected. Connect your "
                     "provider Discord for this executor to start earning incentive."
                 ),
-                log_extra={"provider_discord_connected": job_result.provider_discord_connected},
+                internal_log_fields={"provider_discord_connected": job_result.provider_discord_connected},
             )
         if job_result.is_new_rentals_paused and not job_result.is_rented:
-            return IncentiveDecision(
+            return ZeroIncentiveReason(
                 reason="new_rentals_paused",
-                log_event="Executor excluded from both pools - paused for new rentals",
-                customer_message=(
+                internal_log_message="Executor excluded from both pools - paused for new rentals",
+                message_for_miner=(
                     "No subnet incentive: this executor is paused for new rentals and earns "
                     "nothing while paused. Resume new rentals to start earning again."
                 ),
             )
         if job_result.default_job_owner == DEFAULT_JOB_OWNER_MINER and not job_result.is_rented:
-            return IncentiveDecision(
+            return ZeroIncentiveReason(
                 reason="miner_default_job",
-                log_event="Executor excluded from both pools - running miner's own default job",
-                customer_message=(
+                internal_log_message="Executor excluded from both pools - running miner's own default job",
+                message_for_miner=(
                     "No subnet incentive: this executor is running your own default job instead "
                     "of a Lium job, and executors on your own job do not earn subnet incentive."
                 ),
@@ -543,19 +543,19 @@ class RentalPriceIncentive(DefaultIncentive):
         # Hard exclusions: reasons a validated executor earns 0 from BOTH pools.
         # One evaluator so the internal log, the customer-facing incentive log, and the
         # scoring decision all read from the same source and cannot drift (DAH-2327).
-        hard_exclusion = self._evaluate_hard_exclusion(job_result)
-        if hard_exclusion is not None:
+        exclusion = self._reason_excluded_from_both_pools(job_result)
+        if exclusion is not None:
             logger.info(
                 _m(
-                    hard_exclusion.log_event,
+                    exclusion.internal_log_message,
                     extra={
                         "executor_id": str(job_result.executor_info.uuid),
                         "gpu_model": job_result.gpu_model,
                         "gpu_count": job_result.gpu_count,
-                        "reason": hard_exclusion.reason,
+                        "reason": exclusion.reason,
                         "score": 0,
                         "pool": "none",
-                        **hard_exclusion.log_extra,
+                        **exclusion.internal_log_fields,
                     },
                 )
             )
@@ -563,8 +563,8 @@ class RentalPriceIncentive(DefaultIncentive):
             job_result.eligible_for_rental_share = False
             self._append_zero_incentive_reason(
                 job_result,
-                reason=hard_exclusion.reason,
-                message=hard_exclusion.customer_message,
+                reason=exclusion.reason,
+                message=exclusion.message_for_miner,
             )
             return job_result
 

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -395,10 +395,16 @@ class RentalPriceIncentive(DefaultIncentive):
         report: MinerLogLine = MinerLogLine.rental_incentive_calculated(hotkey, result, bucket)
         result.incentive_logs.append(report.to_log_line())
 
-        # DAH-2327: an eligible unrented executor still finalizes at 0 when any factor of
-        # effective_rate collapses to 0 (no bucket capacity, driver below minimum, no
-        # sysbox). Tell the miner which one, otherwise the "calculated successfully" line
-        # above shows incentive 0 with no reason.
+        self._explain_zero_effective_rate(result, bucket)
+
+        # aggregate miner incentives
+        self.miner_incentives[hotkey] = self.miner_incentives.get(hotkey, 0.0) + result.incentive
+
+    def _explain_zero_effective_rate(self, result: JobResult, bucket: int) -> None:
+        """DAH-2327: an eligible unrented executor still finalizes at 0 when any factor of
+        effective_rate collapses to 0 (no bucket capacity, driver below minimum, no sysbox).
+        Tell the miner which one, otherwise the "calculated successfully" report shows
+        incentive 0 with no reason."""
         if result.unrented_cap_multiplier == 0:
             reason: MinerLogLine = MinerLogLine.no_payout_because_no_unrented_capacity_for_gpu_count(result, bucket)
             result.incentive_logs.append(reason.to_log_line())
@@ -408,9 +414,6 @@ class RentalPriceIncentive(DefaultIncentive):
         elif result.sysbox_multiplier == 0:
             reason: MinerLogLine = MinerLogLine.no_payout_because_sysbox_not_enabled(result)
             result.incentive_logs.append(reason.to_log_line())
-
-        # aggregate miner incentives
-        self.miner_incentives[hotkey] = self.miner_incentives.get(hotkey, 0.0) + result.incentive
 
     async def calculate_executor_score(
         self,
@@ -436,20 +439,7 @@ class RentalPriceIncentive(DefaultIncentive):
         # scoring decision all read from the same source and cannot drift (DAH-2327).
         exclusion: MinerLogLine | None = self._reason_excluded_from_both_pools(job_result)
         if exclusion is not None:
-            logger.info(
-                _m(
-                    exclusion.internal_message,
-                    extra={
-                        "executor_id": str(job_result.executor_info.uuid),
-                        "gpu_model": job_result.gpu_model,
-                        "gpu_count": job_result.gpu_count,
-                        "reason": exclusion.reason,
-                        "score": 0,
-                        "pool": "none",
-                        **exclusion.internal_fields,
-                    },
-                )
-            )
+            logger.info(exclusion.to_internal_log())
             job_result.mining_score = 0
             job_result.eligible_for_rental_share = False
             job_result.incentive_logs.append(exclusion.to_log_line())

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -122,7 +122,7 @@ class IncentiveDecision(BaseModel):
     reason: str                     # machine-readable code, e.g. "spot_tier"
     log_event: str                  # internal logger.info event string
     customer_message: str           # customer-facing incentive_logs message
-    log_extra: dict[str, Any] = {}  # extra fields for the internal structured log
+    log_extra: dict[str, Any] = Field(default_factory=dict)  # extra fields for the internal structured log
 
 
 class RentalPriceIncentive(DefaultIncentive):

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -393,29 +393,35 @@ class RentalPriceIncentive(DefaultIncentive):
         )
 
         # update incentive logs
-        miner_log.rental_incentive_calculated(hotkey, result, bucket).write_to_miner_log(result)
+        result.incentive_logs.append(
+            miner_log.rental_incentive_calculated(hotkey, result, bucket).to_log_line()
+        )
 
         # DAH-2327: an eligible unrented executor still finalizes at 0 when any factor of
         # effective_rate collapses to 0 (no bucket capacity, driver below minimum, no
         # sysbox). Tell the miner which one, otherwise the "calculated successfully" line
         # above shows incentive 0 with no reason.
         if result.unrented_cap_multiplier == 0:
-            miner_log.no_payout_because_no_unrented_capacity_for_gpu_count(
-                gpu_count=result.gpu_count,
-                gpu_model=result.gpu_model,
-                count_bucket=bucket,
-                max_cap=result.max_cap,
-                cap_multiplier=result.unrented_cap_multiplier,
-                total_rental_cost=result.total_rental_cost,
-            ).write_to_miner_log(result)
+            result.incentive_logs.append(
+                miner_log.no_payout_because_no_unrented_capacity_for_gpu_count(
+                    gpu_count=result.gpu_count,
+                    gpu_model=result.gpu_model,
+                    count_bucket=bucket,
+                    max_cap=result.max_cap,
+                    cap_multiplier=result.unrented_cap_multiplier,
+                    total_rental_cost=result.total_rental_cost,
+                ).to_log_line(result)
+            )
         elif result.driver_multiplier == 0:
-            miner_log.no_payout_because_nvidia_driver_below_minimum(
-                result.nvidia_driver_version, result.driver_multiplier
-            ).write_to_miner_log(result)
+            result.incentive_logs.append(
+                miner_log.no_payout_because_nvidia_driver_below_minimum(
+                    result.nvidia_driver_version, result.driver_multiplier
+                ).to_log_line(result)
+            )
         elif result.sysbox_multiplier == 0:
-            miner_log.no_payout_because_sysbox_not_enabled(
-                result.sysbox_runtime
-            ).write_to_miner_log(result)
+            result.incentive_logs.append(
+                miner_log.no_payout_because_sysbox_not_enabled(result.sysbox_runtime).to_log_line(result)
+            )
 
         # aggregate miner incentives
         self.miner_incentives[hotkey] = self.miner_incentives.get(hotkey, 0.0) + result.incentive
@@ -460,7 +466,7 @@ class RentalPriceIncentive(DefaultIncentive):
             )
             job_result.mining_score = 0
             job_result.eligible_for_rental_share = False
-            exclusion.write_to_miner_log(job_result)
+            job_result.incentive_logs.append(exclusion.to_log_line(job_result))
             return job_result
 
         # Check if GPU is unrented and eligible (has positive cap in max_unrented_gpus)
@@ -479,9 +485,11 @@ class RentalPriceIncentive(DefaultIncentive):
             if settings.ENABLE_UNRENTED_SOFT_PRICE_LIMIT:
                 eligible_for_rental_share = False
                 p90 = shared_client.config.machine_prices_p90.get(job_result.gpu_model)
-                miner_log.no_payout_because_price_above_market_soft_limit(
-                    job_result.executor_info.price_per_gpu, p90, SOFT_LIMIT_PRICE_RATE
-                ).write_to_miner_log(job_result)
+                job_result.incentive_logs.append(
+                    miner_log.no_payout_because_price_above_market_soft_limit(
+                        job_result.executor_info.price_per_gpu, p90, SOFT_LIMIT_PRICE_RATE
+                    ).to_log_line(job_result)
+                )
 
         job_result.eligible_for_rental_share = eligible_for_rental_share
         if job_result.eligible_for_rental_share:
@@ -515,9 +523,11 @@ class RentalPriceIncentive(DefaultIncentive):
             if base_model not in self.config.rental_incentive_gpu_types and (
                 job_result.score > 0 or job_result.job_score > 0
             ):
-                miner_log.no_payout_because_gpu_model_not_in_unrented_program(
-                    job_result.gpu_model
-                ).write_to_miner_log(job_result)
+                job_result.incentive_logs.append(
+                    miner_log.no_payout_because_gpu_model_not_in_unrented_program(
+                        job_result.gpu_model
+                    ).to_log_line(job_result)
+                )
             return job_result
 
         # For rented or non-eligible GPUs, use parent's default scoring logic

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -11,15 +11,17 @@ rental subsidy. See `incentive/config.py:MAX_UNRENTED_GPUS_BY_TYPE`.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import bittensor
 from pydantic import BaseModel, Field
 
 from core.config import get_total_burn_emission, settings, shared_client
 from core.utils import _m, get_extra_info, get_logger
+from incentive import zero_incentive_reasons as reasons
 from incentive.config import BASE_GPU_MAP
 from incentive.eligibility import is_missing_discord_after_cutoff
+from incentive.zero_incentive_reasons import ZeroIncentiveReason
 
 if TYPE_CHECKING:
     from incentive.config import IncentiveConfig
@@ -110,19 +112,6 @@ class RentalPriceEstimate(BaseModel):
     rental_share: float | None = None                   # Rental share for the executor in this cycle for scoring logic
     burn_share: float | None = None                     # Burn share for the executor in this cycle for scoring logic
     total_rental_cost: float | None = None              # Total rental cost for the executor in this cycle for scoring logic
-
-
-class ZeroIncentiveReason(BaseModel):
-    """Why a validated executor is excluded from BOTH incentive pools (earns 0).
-
-    Single source of truth shared by the internal observability log, the
-    customer-facing incentive log, and the scoring exit (DAH-2327).
-    """
-
-    reason: str                     # machine-readable code, e.g. "spot_tier"
-    internal_log_message: str
-    message_for_miner: str
-    internal_log_fields: dict[str, Any] = Field(default_factory=dict)
 
 
 class RentalPriceIncentive(DefaultIncentive):
@@ -230,60 +219,30 @@ class RentalPriceIncentive(DefaultIncentive):
         gated later by the rental-pool-only soft price limit).
         """
         if job_result.is_spot:
-            return ZeroIncentiveReason(
-                reason="spot_tier",
-                internal_log_message="Executor excluded from both pools - spot tier",
-                message_for_miner=(
-                    "No subnet incentive: this executor is on the spot tier, and spot-tier "
-                    "executors do not earn subnet incentive."
-                ),
-            )
+            return reasons.spot_tier()
         if is_missing_discord_after_cutoff(job_result):
-            return ZeroIncentiveReason(
-                reason="provider_discord_not_connected",
-                internal_log_message="Executor excluded from both pools - provider Discord not connected",
-                message_for_miner=(
-                    "No subnet incentive: provider Discord is not connected. Connect your "
-                    "provider Discord for this executor to start earning incentive."
-                ),
-                internal_log_fields={"provider_discord_connected": job_result.provider_discord_connected},
-            )
+            return reasons.provider_discord_not_connected(job_result.provider_discord_connected)
         if job_result.is_new_rentals_paused and not job_result.is_rented:
-            return ZeroIncentiveReason(
-                reason="new_rentals_paused",
-                internal_log_message="Executor excluded from both pools - paused for new rentals",
-                message_for_miner=(
-                    "No subnet incentive: this executor is paused for new rentals and earns "
-                    "nothing while paused. Resume new rentals to start earning again."
-                ),
-            )
+            return reasons.new_rentals_paused()
         if job_result.default_job_owner == DEFAULT_JOB_OWNER_MINER and not job_result.is_rented:
-            return ZeroIncentiveReason(
-                reason="miner_default_job",
-                internal_log_message="Executor excluded from both pools - running miner's own default job",
-                message_for_miner=(
-                    "No subnet incentive: this executor is running your own default job instead "
-                    "of a Lium job, and executors on your own job do not earn subnet incentive."
-                ),
-            )
+            return reasons.miner_default_job()
         return None
 
-    def _log_zero_incentive_to_miner(
-        self, result: JobResult, reason: str, message: str, extra: dict[str, Any] | None = None
-    ) -> None:
-        # DAH-2327: surface every reason a validated executor earns 0 subnet incentive in the
+    def _log_zero_incentive_to_miner(self, result: JobResult, reason: ZeroIncentiveReason) -> None:
+        # DAH-2327: surface the reason (from the zero_incentive_reasons catalog) in the
         # customer-facing incentive log (JobResult.incentive_logs -> "Incentive Scores
         # Calculation Logs"), the exact block the miner reads.
         info = {
             "executor_id": str(result.executor_info.uuid),
             "gpu_model": result.gpu_model,
             "gpu_count": result.gpu_count,
-            "reason": reason,
+            "reason": reason.reason,
             "incentive": 0.0,
+            **reason.miner_log_fields,
         }
-        if extra:
-            info.update(extra)
-        result.incentive_logs.append(_m(message, extra=get_extra_info(info)).to_full_string())
+        result.incentive_logs.append(
+            _m(reason.message_for_miner, extra=get_extra_info(info)).to_full_string()
+        )
 
     @staticmethod
     def _resolve_bucket(result: JobResult, cap_spec: dict[int, int]) -> int:
@@ -484,18 +443,14 @@ class RentalPriceIncentive(DefaultIncentive):
         if result.unrented_cap_multiplier == 0:
             self._log_zero_incentive_to_miner(
                 result,
-                reason="no_unrented_capacity_for_gpu_count",
-                message=(
-                    f"No unrented incentive: there is currently no unrented-incentive capacity "
-                    f"for {result.gpu_count}x {result.gpu_model} (its GPU-count tier has no cap "
-                    f"this cycle). Rent this executor out to earn."
+                reasons.no_unrented_capacity(
+                    gpu_count=result.gpu_count,
+                    gpu_model=result.gpu_model,
+                    count_bucket=bucket,
+                    max_cap=result.max_cap,
+                    cap_multiplier=result.unrented_cap_multiplier,
+                    total_rental_cost=result.total_rental_cost,
                 ),
-                extra={
-                    "count_bucket": bucket,
-                    "max_cap": result.max_cap,
-                    "unrented_cap_multiplier": result.unrented_cap_multiplier,
-                    "total_rental_cost": result.total_rental_cost,
-                },
             )
 
         # aggregate miner incentives
@@ -541,11 +496,7 @@ class RentalPriceIncentive(DefaultIncentive):
             )
             job_result.mining_score = 0
             job_result.eligible_for_rental_share = False
-            self._log_zero_incentive_to_miner(
-                job_result,
-                reason=exclusion.reason,
-                message=exclusion.message_for_miner,
-            )
+            self._log_zero_incentive_to_miner(job_result, exclusion)
             return job_result
 
         # Check if GPU is unrented and eligible (has positive cap in max_unrented_gpus)
@@ -564,22 +515,11 @@ class RentalPriceIncentive(DefaultIncentive):
             if settings.ENABLE_UNRENTED_SOFT_PRICE_LIMIT:
                 eligible_for_rental_share = False
                 p90 = shared_client.config.machine_prices_p90.get(job_result.gpu_model)
-                soft_limit = round(p90 * SOFT_LIMIT_PRICE_RATE, 4)
                 self._log_zero_incentive_to_miner(
                     job_result,
-                    reason="price_above_market_p90_soft_limit",
-                    message=(
-                        f"No unrented incentive: your price ${job_result.executor_info.price_per_gpu}"
-                        f"/GPU/h is above the market soft price limit ${soft_limit} (90th-percentile "
-                        f"market rate ${p90} x {SOFT_LIMIT_PRICE_RATE}). Lower the price to ${soft_limit} "
-                        f"or below to earn the unrented incentive."
+                    reasons.price_over_soft_limit(
+                        job_result.executor_info.price_per_gpu, p90, SOFT_LIMIT_PRICE_RATE
                     ),
-                    extra={
-                        "price_per_gpu": job_result.executor_info.price_per_gpu,
-                        "machine_price_p90": p90,
-                        "soft_limit_rate": SOFT_LIMIT_PRICE_RATE,
-                        "soft_limit_threshold": soft_limit,
-                    },
                 )
 
         job_result.eligible_for_rental_share = eligible_for_rental_share
@@ -615,13 +555,7 @@ class RentalPriceIncentive(DefaultIncentive):
                 job_result.score > 0 or job_result.job_score > 0
             ):
                 self._log_zero_incentive_to_miner(
-                    job_result,
-                    reason="gpu_model_not_eligible_for_unrented_incentive",
-                    message=(
-                        f"No subnet incentive while idle: GPU model {job_result.gpu_model} is not "
-                        "part of the unrented (idle-node) incentive program, so this executor earns "
-                        "nothing unless rented. Rent it out to earn."
-                    ),
+                    job_result, reasons.gpu_model_not_in_unrented_program(job_result.gpu_model)
                 )
             return job_result
 

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -209,6 +209,31 @@ class RentalPriceIncentive(DefaultIncentive):
             )
         )
 
+    def _append_soft_price_limit_incentive_log(self, result: JobResult) -> None:
+        # DAH-2327: surface the zero-incentive reason in the customer-facing incentive
+        # log (JobResult.incentive_logs -> "Incentive Scores Calculation Logs"), the exact
+        # block the miner reads, at the moment the soft price limit zeros the payout.
+        p90 = shared_client.config.machine_prices_p90.get(result.gpu_model)
+        soft_limit = round(p90 * SOFT_LIMIT_PRICE_RATE, 4)
+        result.incentive_logs.append(
+            _m(
+                f"Unrented incentive set to 0: price ${result.executor_info.price_per_gpu}/GPU/h "
+                f"exceeds the market soft price limit ${soft_limit} (p90 ${p90} x "
+                f"{SOFT_LIMIT_PRICE_RATE}). Lower the price to ${soft_limit} or below to receive "
+                f"the unrented incentive.",
+                extra=get_extra_info({
+                    "executor_id": str(result.executor_info.uuid),
+                    "gpu_model": result.gpu_model,
+                    "gpu_count": result.gpu_count,
+                    "price_per_gpu": result.executor_info.price_per_gpu,
+                    "machine_price_p90": p90,
+                    "soft_limit_rate": SOFT_LIMIT_PRICE_RATE,
+                    "soft_limit_threshold": soft_limit,
+                    "reason": "price_above_market_p90_soft_limit",
+                }),
+            ).to_full_string()
+        )
+
     @staticmethod
     def _resolve_bucket(result: JobResult, cap_spec: dict[int, int]) -> int:
         """Pick the gpu_count bucket the executor is rated against.
@@ -512,6 +537,7 @@ class RentalPriceIncentive(DefaultIncentive):
             self._log_soft_price_limit(job_result)
             if settings.ENABLE_UNRENTED_SOFT_PRICE_LIMIT:
                 eligible_for_rental_share = False
+                self._append_soft_price_limit_incentive_log(job_result)
 
         job_result.eligible_for_rental_share = eligible_for_rental_share
         if job_result.eligible_for_rental_share:

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -269,7 +269,7 @@ class RentalPriceIncentive(DefaultIncentive):
         return None
 
     def _append_zero_incentive_reason(
-        self, result: JobResult, reason: str, message: str, extra: dict | None = None
+        self, result: JobResult, reason: str, message: str, extra: dict[str, Any] | None = None
     ) -> None:
         # DAH-2327: surface every reason a validated executor earns 0 subnet incentive in the
         # customer-facing incentive log (JobResult.incentive_logs -> "Incentive Scores
@@ -497,6 +497,26 @@ class RentalPriceIncentive(DefaultIncentive):
                 }),
             ).to_full_string()
         )
+
+        # DAH-2327: an eligible unrented executor still finalizes at 0 when its gpu-count
+        # bucket has no unrented capacity (cap multiplier -> 0 -> effective rate -> 0). Tell
+        # the miner, otherwise the "calculated successfully" line above shows 0 with no reason.
+        if result.unrented_cap_multiplier == 0:
+            self._append_zero_incentive_reason(
+                result,
+                reason="no_unrented_capacity_for_gpu_count",
+                message=(
+                    f"No unrented incentive: there is currently no unrented-incentive capacity "
+                    f"for {result.gpu_count}x {result.gpu_model} (its GPU-count tier has no cap "
+                    f"this cycle). Rent this executor out to earn."
+                ),
+                extra={
+                    "count_bucket": bucket,
+                    "max_cap": result.max_cap,
+                    "unrented_cap_multiplier": result.unrented_cap_multiplier,
+                    "total_rental_cost": result.total_rental_cost,
+                },
+            )
 
         # aggregate miner incentives
         self.miner_incentives[hotkey] = self.miner_incentives.get(hotkey, 0.0) + result.incentive

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -234,8 +234,8 @@ class RentalPriceIncentive(DefaultIncentive):
                 reason="spot_tier",
                 log_event="Executor excluded from both pools - spot tier",
                 customer_message=(
-                    "No subnet incentive: this executor is on the spot tier, which is "
-                    "excluded from both the mining and unrented incentive pools."
+                    "No subnet incentive: this executor is on the spot tier, and spot-tier "
+                    "executors do not earn subnet incentive."
                 ),
             )
         if is_missing_discord_after_cutoff(job_result):
@@ -244,7 +244,7 @@ class RentalPriceIncentive(DefaultIncentive):
                 log_event="Executor excluded from both pools - provider Discord not connected",
                 customer_message=(
                     "No subnet incentive: provider Discord is not connected. Connect your "
-                    "provider Discord to this executor to become eligible for incentive."
+                    "provider Discord for this executor to start earning incentive."
                 ),
                 log_extra={"provider_discord_connected": job_result.provider_discord_connected},
             )
@@ -253,8 +253,8 @@ class RentalPriceIncentive(DefaultIncentive):
                 reason="new_rentals_paused",
                 log_event="Executor excluded from both pools - paused for new rentals",
                 customer_message=(
-                    "No subnet incentive: this executor is paused for new rentals, which "
-                    "excludes it from both incentive pools. Resume new rentals to become eligible."
+                    "No subnet incentive: this executor is paused for new rentals and earns "
+                    "nothing while paused. Resume new rentals to start earning again."
                 ),
             )
         if job_result.default_job_owner == DEFAULT_JOB_OWNER_MINER and not job_result.is_rented:
@@ -262,8 +262,8 @@ class RentalPriceIncentive(DefaultIncentive):
                 reason="miner_default_job",
                 log_event="Executor excluded from both pools - running miner's own default job",
                 customer_message=(
-                    "No subnet incentive: this executor is running the miner's own default job "
-                    "instead of a Lium job, which is excluded from both incentive pools."
+                    "No subnet incentive: this executor is running your own default job instead "
+                    "of a Lium job, and executors on your own job do not earn subnet incentive."
                 ),
             )
         return None
@@ -292,10 +292,10 @@ class RentalPriceIncentive(DefaultIncentive):
             result,
             reason="price_above_market_p90_soft_limit",
             message=(
-                f"Unrented incentive set to 0: price ${result.executor_info.price_per_gpu}/GPU/h "
-                f"exceeds the market soft price limit ${soft_limit} (p90 ${p90} x "
-                f"{SOFT_LIMIT_PRICE_RATE}). Lower the price to ${soft_limit} or below to receive "
-                f"the unrented incentive."
+                f"No unrented incentive: your price ${result.executor_info.price_per_gpu}/GPU/h is "
+                f"above the market soft price limit ${soft_limit} (90th-percentile market rate "
+                f"${p90} x {SOFT_LIMIT_PRICE_RATE}). Lower the price to ${soft_limit} or below to "
+                f"earn the unrented incentive."
             ),
             extra={
                 "price_per_gpu": result.executor_info.price_per_gpu,

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -20,7 +20,7 @@ from core.config import get_total_burn_emission, settings, shared_client
 from core.utils import _m, get_logger
 from incentive.config import BASE_GPU_MAP
 from incentive.eligibility import is_missing_discord_after_cutoff
-from incentive.miner_incentive_log import MinerLogLine
+from incentive.miner_incentive_log import MinerLogLine, ZeroIncentiveReason
 
 if TYPE_CHECKING:
     from incentive.config import IncentiveConfig
@@ -204,7 +204,7 @@ class RentalPriceIncentive(DefaultIncentive):
                     "soft_limit_rate": SOFT_LIMIT_PRICE_RATE,
                     "soft_limit_threshold": p90 * SOFT_LIMIT_PRICE_RATE if p90 else None,
                     "enforced": enforced,
-                    "reason": "price_above_market_p90_soft_limit",
+                    "reason": ZeroIncentiveReason.PRICE_ABOVE_MARKET_P90_SOFT_LIMIT,
                     "pool": "rental_excluded" if enforced else "rental_kept_shadow",
                 },
             )

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -17,11 +17,11 @@ import bittensor
 from pydantic import BaseModel, Field
 
 from core.config import get_total_burn_emission, settings, shared_client
-from core.utils import _m, get_extra_info, get_logger
-from incentive import zero_incentive_reasons as reasons
+from core.utils import _m, get_logger
+from incentive import miner_incentive_log as miner_log
 from incentive.config import BASE_GPU_MAP
 from incentive.eligibility import is_missing_discord_after_cutoff
-from incentive.zero_incentive_reasons import ZeroIncentiveReason
+from incentive.miner_incentive_log import ZeroIncentiveReason
 
 if TYPE_CHECKING:
     from incentive.config import IncentiveConfig
@@ -219,13 +219,13 @@ class RentalPriceIncentive(DefaultIncentive):
         gated later by the rental-pool-only soft price limit).
         """
         if job_result.is_spot:
-            return reasons.spot_tier()
+            return miner_log.spot_tier()
         if is_missing_discord_after_cutoff(job_result):
-            return reasons.provider_discord_not_connected(job_result.provider_discord_connected)
+            return miner_log.provider_discord_not_connected(job_result.provider_discord_connected)
         if job_result.is_new_rentals_paused and not job_result.is_rented:
-            return reasons.new_rentals_paused()
+            return miner_log.new_rentals_paused()
         if job_result.default_job_owner == DEFAULT_JOB_OWNER_MINER and not job_result.is_rented:
-            return reasons.miner_default_job()
+            return miner_log.miner_default_job()
         return None
 
     @staticmethod
@@ -393,39 +393,13 @@ class RentalPriceIncentive(DefaultIncentive):
         )
 
         # update incentive logs
-        result.incentive_logs.append(
-            _m(
-                "Rental price incentive for executor is calculated successfully. Formula: rental_share * gpu_count * effective_rate / total_rental_cost",
-                extra=get_extra_info({
-                    "hotkey": hotkey,
-                    "executor_id": str(result.executor_info.uuid),
-                    "gpu_model": result.gpu_model,
-                    "gpu_count": result.gpu_count,
-                    "hourly_rate": result.hourly_rate,
-                    "sysbox_runtime": result.sysbox_runtime,
-                    "sysbox_multiplier": result.sysbox_multiplier,
-                    "provider_discord_connected": result.provider_discord_connected,
-                    "nvidia_driver_version": result.nvidia_driver_version,
-                    "driver_multiplier": result.driver_multiplier,
-                    "unrented_cap_multiplier": result.unrented_cap_multiplier,
-                    "effective_rate": result.effective_rate,
-                    "total_unrented_by_gpu_type": result.total_unrented_by_gpu_type,
-                    "count_bucket": bucket,
-                    "max_cap": result.max_cap,
-                    "cap_dilution_applied": result.cap_dilution_applied,
-                    "rental_share": result.rental_share,
-                    "burn_share": result.burn_share,
-                    "incentive": result.incentive,
-                    "total_rental_cost": result.total_rental_cost,
-                }),
-            ).to_full_string()
-        )
+        miner_log.rental_incentive_calculated(hotkey, result, bucket).write_to_miner_log(result)
 
         # DAH-2327: an eligible unrented executor still finalizes at 0 when its gpu-count
         # bucket has no unrented capacity (cap multiplier -> 0 -> effective rate -> 0). Tell
         # the miner, otherwise the "calculated successfully" line above shows 0 with no reason.
         if result.unrented_cap_multiplier == 0:
-            reasons.no_unrented_capacity(
+            miner_log.no_unrented_capacity(
                 gpu_count=result.gpu_count,
                 gpu_model=result.gpu_model,
                 count_bucket=bucket,
@@ -496,7 +470,7 @@ class RentalPriceIncentive(DefaultIncentive):
             if settings.ENABLE_UNRENTED_SOFT_PRICE_LIMIT:
                 eligible_for_rental_share = False
                 p90 = shared_client.config.machine_prices_p90.get(job_result.gpu_model)
-                reasons.price_over_soft_limit(
+                miner_log.price_over_soft_limit(
                     job_result.executor_info.price_per_gpu, p90, SOFT_LIMIT_PRICE_RATE
                 ).write_to_miner_log(job_result)
 
@@ -532,7 +506,7 @@ class RentalPriceIncentive(DefaultIncentive):
             if base_model not in self.config.rental_incentive_gpu_types and (
                 job_result.score > 0 or job_result.job_score > 0
             ):
-                reasons.gpu_model_not_in_unrented_program(
+                miner_log.gpu_model_not_in_unrented_program(
                     job_result.gpu_model
                 ).write_to_miner_log(job_result)
             return job_result

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -219,13 +219,13 @@ class RentalPriceIncentive(DefaultIncentive):
         gated later by the rental-pool-only soft price limit).
         """
         if job_result.is_spot:
-            return miner_log.executor_on_spot_tier()
+            return miner_log.no_payout_because_spot_tier()
         if is_missing_discord_after_cutoff(job_result):
-            return miner_log.provider_discord_not_connected(job_result.provider_discord_connected)
+            return miner_log.no_payout_because_discord_not_connected(job_result.provider_discord_connected)
         if job_result.is_new_rentals_paused and not job_result.is_rented:
-            return miner_log.executor_paused_for_new_rentals()
+            return miner_log.no_payout_because_paused_for_new_rentals()
         if job_result.default_job_owner == DEFAULT_JOB_OWNER_MINER and not job_result.is_rented:
-            return miner_log.running_miners_own_default_job()
+            return miner_log.no_payout_because_running_own_default_job()
         return None
 
     @staticmethod
@@ -399,7 +399,7 @@ class RentalPriceIncentive(DefaultIncentive):
         # bucket has no unrented capacity (cap multiplier -> 0 -> effective rate -> 0). Tell
         # the miner, otherwise the "calculated successfully" line above shows 0 with no reason.
         if result.unrented_cap_multiplier == 0:
-            miner_log.no_unrented_capacity_for_gpu_count(
+            miner_log.no_payout_because_no_unrented_capacity_for_gpu_count(
                 gpu_count=result.gpu_count,
                 gpu_model=result.gpu_model,
                 count_bucket=bucket,
@@ -470,7 +470,7 @@ class RentalPriceIncentive(DefaultIncentive):
             if settings.ENABLE_UNRENTED_SOFT_PRICE_LIMIT:
                 eligible_for_rental_share = False
                 p90 = shared_client.config.machine_prices_p90.get(job_result.gpu_model)
-                miner_log.executor_price_above_market_soft_limit(
+                miner_log.no_payout_because_price_above_market_soft_limit(
                     job_result.executor_info.price_per_gpu, p90, SOFT_LIMIT_PRICE_RATE
                 ).write_to_miner_log(job_result)
 
@@ -506,7 +506,7 @@ class RentalPriceIncentive(DefaultIncentive):
             if base_model not in self.config.rental_incentive_gpu_types and (
                 job_result.score > 0 or job_result.job_score > 0
             ):
-                miner_log.gpu_model_not_in_unrented_program(
+                miner_log.no_payout_because_gpu_model_not_in_unrented_program(
                     job_result.gpu_model
                 ).write_to_miner_log(job_result)
             return job_result

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -268,7 +268,7 @@ class RentalPriceIncentive(DefaultIncentive):
             )
         return None
 
-    def _append_zero_incentive_reason(
+    def _log_zero_incentive_to_miner(
         self, result: JobResult, reason: str, message: str, extra: dict[str, Any] | None = None
     ) -> None:
         # DAH-2327: surface every reason a validated executor earns 0 subnet incentive in the
@@ -284,26 +284,6 @@ class RentalPriceIncentive(DefaultIncentive):
         if extra:
             info.update(extra)
         result.incentive_logs.append(_m(message, extra=get_extra_info(info)).to_full_string())
-
-    def _append_soft_price_limit_incentive_log(self, result: JobResult) -> None:
-        p90 = shared_client.config.machine_prices_p90.get(result.gpu_model)
-        soft_limit = round(p90 * SOFT_LIMIT_PRICE_RATE, 4)
-        self._append_zero_incentive_reason(
-            result,
-            reason="price_above_market_p90_soft_limit",
-            message=(
-                f"No unrented incentive: your price ${result.executor_info.price_per_gpu}/GPU/h is "
-                f"above the market soft price limit ${soft_limit} (90th-percentile market rate "
-                f"${p90} x {SOFT_LIMIT_PRICE_RATE}). Lower the price to ${soft_limit} or below to "
-                f"earn the unrented incentive."
-            ),
-            extra={
-                "price_per_gpu": result.executor_info.price_per_gpu,
-                "machine_price_p90": p90,
-                "soft_limit_rate": SOFT_LIMIT_PRICE_RATE,
-                "soft_limit_threshold": soft_limit,
-            },
-        )
 
     @staticmethod
     def _resolve_bucket(result: JobResult, cap_spec: dict[int, int]) -> int:
@@ -502,7 +482,7 @@ class RentalPriceIncentive(DefaultIncentive):
         # bucket has no unrented capacity (cap multiplier -> 0 -> effective rate -> 0). Tell
         # the miner, otherwise the "calculated successfully" line above shows 0 with no reason.
         if result.unrented_cap_multiplier == 0:
-            self._append_zero_incentive_reason(
+            self._log_zero_incentive_to_miner(
                 result,
                 reason="no_unrented_capacity_for_gpu_count",
                 message=(
@@ -543,7 +523,7 @@ class RentalPriceIncentive(DefaultIncentive):
         # Hard exclusions: reasons a validated executor earns 0 from BOTH pools.
         # One evaluator so the internal log, the customer-facing incentive log, and the
         # scoring decision all read from the same source and cannot drift (DAH-2327).
-        exclusion = self._reason_excluded_from_both_pools(job_result)
+        exclusion: ZeroIncentiveReason | None = self._reason_excluded_from_both_pools(job_result)
         if exclusion is not None:
             logger.info(
                 _m(
@@ -561,7 +541,7 @@ class RentalPriceIncentive(DefaultIncentive):
             )
             job_result.mining_score = 0
             job_result.eligible_for_rental_share = False
-            self._append_zero_incentive_reason(
+            self._log_zero_incentive_to_miner(
                 job_result,
                 reason=exclusion.reason,
                 message=exclusion.message_for_miner,
@@ -583,7 +563,24 @@ class RentalPriceIncentive(DefaultIncentive):
             self._log_soft_price_limit(job_result)
             if settings.ENABLE_UNRENTED_SOFT_PRICE_LIMIT:
                 eligible_for_rental_share = False
-                self._append_soft_price_limit_incentive_log(job_result)
+                p90 = shared_client.config.machine_prices_p90.get(job_result.gpu_model)
+                soft_limit = round(p90 * SOFT_LIMIT_PRICE_RATE, 4)
+                self._log_zero_incentive_to_miner(
+                    job_result,
+                    reason="price_above_market_p90_soft_limit",
+                    message=(
+                        f"No unrented incentive: your price ${job_result.executor_info.price_per_gpu}"
+                        f"/GPU/h is above the market soft price limit ${soft_limit} (90th-percentile "
+                        f"market rate ${p90} x {SOFT_LIMIT_PRICE_RATE}). Lower the price to ${soft_limit} "
+                        f"or below to earn the unrented incentive."
+                    ),
+                    extra={
+                        "price_per_gpu": job_result.executor_info.price_per_gpu,
+                        "machine_price_p90": p90,
+                        "soft_limit_rate": SOFT_LIMIT_PRICE_RATE,
+                        "soft_limit_threshold": soft_limit,
+                    },
+                )
 
         job_result.eligible_for_rental_share = eligible_for_rental_share
         if job_result.eligible_for_rental_share:
@@ -617,7 +614,7 @@ class RentalPriceIncentive(DefaultIncentive):
             if base_model not in self.config.rental_incentive_gpu_types and (
                 job_result.score > 0 or job_result.job_score > 0
             ):
-                self._append_zero_incentive_reason(
+                self._log_zero_incentive_to_miner(
                     job_result,
                     reason="gpu_model_not_eligible_for_unrented_incentive",
                     message=(

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -393,35 +393,31 @@ class RentalPriceIncentive(DefaultIncentive):
         )
 
         # update incentive logs
-        result.incentive_logs.append(
-            miner_log.rental_incentive_calculated(hotkey, result, bucket).to_log_line()
-        )
+        report = miner_log.rental_incentive_calculated(hotkey, result, bucket)
+        result.incentive_logs.append(report.to_log_line())
 
         # DAH-2327: an eligible unrented executor still finalizes at 0 when any factor of
         # effective_rate collapses to 0 (no bucket capacity, driver below minimum, no
         # sysbox). Tell the miner which one, otherwise the "calculated successfully" line
         # above shows incentive 0 with no reason.
         if result.unrented_cap_multiplier == 0:
-            result.incentive_logs.append(
-                miner_log.no_payout_because_no_unrented_capacity_for_gpu_count(
-                    gpu_count=result.gpu_count,
-                    gpu_model=result.gpu_model,
-                    count_bucket=bucket,
-                    max_cap=result.max_cap,
-                    cap_multiplier=result.unrented_cap_multiplier,
-                    total_rental_cost=result.total_rental_cost,
-                ).to_log_line(result)
+            reason = miner_log.no_payout_because_no_unrented_capacity_for_gpu_count(
+                gpu_count=result.gpu_count,
+                gpu_model=result.gpu_model,
+                count_bucket=bucket,
+                max_cap=result.max_cap,
+                cap_multiplier=result.unrented_cap_multiplier,
+                total_rental_cost=result.total_rental_cost,
             )
+            result.incentive_logs.append(reason.to_log_line(result))
         elif result.driver_multiplier == 0:
-            result.incentive_logs.append(
-                miner_log.no_payout_because_nvidia_driver_below_minimum(
-                    result.nvidia_driver_version, result.driver_multiplier
-                ).to_log_line(result)
+            reason = miner_log.no_payout_because_nvidia_driver_below_minimum(
+                result.nvidia_driver_version, result.driver_multiplier
             )
+            result.incentive_logs.append(reason.to_log_line(result))
         elif result.sysbox_multiplier == 0:
-            result.incentive_logs.append(
-                miner_log.no_payout_because_sysbox_not_enabled(result.sysbox_runtime).to_log_line(result)
-            )
+            reason = miner_log.no_payout_because_sysbox_not_enabled(result.sysbox_runtime)
+            result.incentive_logs.append(reason.to_log_line(result))
 
         # aggregate miner incentives
         self.miner_incentives[hotkey] = self.miner_incentives.get(hotkey, 0.0) + result.incentive
@@ -485,11 +481,10 @@ class RentalPriceIncentive(DefaultIncentive):
             if settings.ENABLE_UNRENTED_SOFT_PRICE_LIMIT:
                 eligible_for_rental_share = False
                 p90 = shared_client.config.machine_prices_p90.get(job_result.gpu_model)
-                job_result.incentive_logs.append(
-                    miner_log.no_payout_because_price_above_market_soft_limit(
-                        job_result.executor_info.price_per_gpu, p90, SOFT_LIMIT_PRICE_RATE
-                    ).to_log_line(job_result)
+                reason = miner_log.no_payout_because_price_above_market_soft_limit(
+                    job_result.executor_info.price_per_gpu, p90, SOFT_LIMIT_PRICE_RATE
                 )
+                job_result.incentive_logs.append(reason.to_log_line(job_result))
 
         job_result.eligible_for_rental_share = eligible_for_rental_share
         if job_result.eligible_for_rental_share:
@@ -523,11 +518,8 @@ class RentalPriceIncentive(DefaultIncentive):
             if base_model not in self.config.rental_incentive_gpu_types and (
                 job_result.score > 0 or job_result.job_score > 0
             ):
-                job_result.incentive_logs.append(
-                    miner_log.no_payout_because_gpu_model_not_in_unrented_program(
-                        job_result.gpu_model
-                    ).to_log_line(job_result)
-                )
+                reason = miner_log.no_payout_because_gpu_model_not_in_unrented_program(job_result.gpu_model)
+                job_result.incentive_logs.append(reason.to_log_line(job_result))
             return job_result
 
         # For rented or non-eligible GPUs, use parent's default scoring logic

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -209,29 +209,41 @@ class RentalPriceIncentive(DefaultIncentive):
             )
         )
 
+    def _append_zero_incentive_reason(
+        self, result: JobResult, reason: str, message: str, extra: dict | None = None
+    ) -> None:
+        # DAH-2327: surface every reason a validated executor earns 0 subnet incentive in the
+        # customer-facing incentive log (JobResult.incentive_logs -> "Incentive Scores
+        # Calculation Logs"), the exact block the miner reads.
+        info = {
+            "executor_id": str(result.executor_info.uuid),
+            "gpu_model": result.gpu_model,
+            "gpu_count": result.gpu_count,
+            "reason": reason,
+            "incentive": 0.0,
+        }
+        if extra:
+            info.update(extra)
+        result.incentive_logs.append(_m(message, extra=get_extra_info(info)).to_full_string())
+
     def _append_soft_price_limit_incentive_log(self, result: JobResult) -> None:
-        # DAH-2327: surface the zero-incentive reason in the customer-facing incentive
-        # log (JobResult.incentive_logs -> "Incentive Scores Calculation Logs"), the exact
-        # block the miner reads, at the moment the soft price limit zeros the payout.
         p90 = shared_client.config.machine_prices_p90.get(result.gpu_model)
         soft_limit = round(p90 * SOFT_LIMIT_PRICE_RATE, 4)
-        result.incentive_logs.append(
-            _m(
+        self._append_zero_incentive_reason(
+            result,
+            reason="price_above_market_p90_soft_limit",
+            message=(
                 f"Unrented incentive set to 0: price ${result.executor_info.price_per_gpu}/GPU/h "
                 f"exceeds the market soft price limit ${soft_limit} (p90 ${p90} x "
                 f"{SOFT_LIMIT_PRICE_RATE}). Lower the price to ${soft_limit} or below to receive "
-                f"the unrented incentive.",
-                extra=get_extra_info({
-                    "executor_id": str(result.executor_info.uuid),
-                    "gpu_model": result.gpu_model,
-                    "gpu_count": result.gpu_count,
-                    "price_per_gpu": result.executor_info.price_per_gpu,
-                    "machine_price_p90": p90,
-                    "soft_limit_rate": SOFT_LIMIT_PRICE_RATE,
-                    "soft_limit_threshold": soft_limit,
-                    "reason": "price_above_market_p90_soft_limit",
-                }),
-            ).to_full_string()
+                f"the unrented incentive."
+            ),
+            extra={
+                "price_per_gpu": result.executor_info.price_per_gpu,
+                "machine_price_p90": p90,
+                "soft_limit_rate": SOFT_LIMIT_PRICE_RATE,
+                "soft_limit_threshold": soft_limit,
+            },
         )
 
     @staticmethod
@@ -465,6 +477,14 @@ class RentalPriceIncentive(DefaultIncentive):
             )
             job_result.mining_score = 0
             job_result.eligible_for_rental_share = False
+            self._append_zero_incentive_reason(
+                job_result,
+                reason="spot_tier",
+                message=(
+                    "No subnet incentive: this executor is on the spot tier, which is "
+                    "excluded from both the mining and unrented incentive pools."
+                ),
+            )
             return job_result
 
         if is_missing_discord_after_cutoff(job_result):
@@ -484,6 +504,14 @@ class RentalPriceIncentive(DefaultIncentive):
             )
             job_result.mining_score = 0
             job_result.eligible_for_rental_share = False
+            self._append_zero_incentive_reason(
+                job_result,
+                reason="provider_discord_not_connected",
+                message=(
+                    "No subnet incentive: provider Discord is not connected. Connect your "
+                    "provider Discord to this executor to become eligible for incentive."
+                ),
+            )
             return job_result
 
         if job_result.is_new_rentals_paused and not job_result.is_rented:
@@ -502,6 +530,14 @@ class RentalPriceIncentive(DefaultIncentive):
             )
             job_result.mining_score = 0
             job_result.eligible_for_rental_share = False
+            self._append_zero_incentive_reason(
+                job_result,
+                reason="new_rentals_paused",
+                message=(
+                    "No subnet incentive: this executor is paused for new rentals, which "
+                    "excludes it from both incentive pools. Resume new rentals to become eligible."
+                ),
+            )
             return job_result
 
         if job_result.default_job_owner == DEFAULT_JOB_OWNER_MINER and not job_result.is_rented:
@@ -520,6 +556,14 @@ class RentalPriceIncentive(DefaultIncentive):
             )
             job_result.mining_score = 0
             job_result.eligible_for_rental_share = False
+            self._append_zero_incentive_reason(
+                job_result,
+                reason="miner_default_job",
+                message=(
+                    "No subnet incentive: this executor is running the miner's own default job "
+                    "instead of a Lium job, which is excluded from both incentive pools."
+                ),
+            )
             return job_result
 
         # Check if GPU is unrented and eligible (has positive cap in max_unrented_gpus)

--- a/neurons/validators/src/incentive/zero_incentive_reasons.py
+++ b/neurons/validators/src/incentive/zero_incentive_reasons.py
@@ -1,23 +1,40 @@
 """Every reason a validated executor earns 0 subnet incentive — the single catalog.
 
+WHERE A NODE EARNS (two "pools" of subnet emission; the rest is burned):
+  - Mining pool   — for RENTED executors. Paid by a mining score (GPU model/count
+                    times sysbox / driver / uptime multipliers).
+  - Unrented pool — for IDLE executors of an eligible GPU model. Paid as if the GPU
+                    were rented, based on its rental market value (rental-share).
+
+HOW A NODE PICKS A POOL:
+  rented?                                              -> mining pool (always earns)
+  idle AND model in program AND price ok AND capacity? -> unrented pool (earns)
+  otherwise                                            -> 0 incentive (reason below)
+
+THE REASONS A VALIDATED NODE EARNS 0 (what this catalog holds):
+  Group A — earns nothing in EITHER pool (built by `_reason_excluded_from_both_pools`):
+    spot_tier, provider_discord_not_connected, new_rentals_paused, miner_default_job
+  Group B — idle but does not qualify for the unrented pool:
+    gpu_model_not_in_unrented_program (earns only when rented),
+    price_over_soft_limit (priced above the market ceiling -> lower price),
+    no_unrented_capacity (no cap left for that GPU-count tier this cycle)
+
 The scoring code (rental_price.py) detects each condition where its data naturally
 lives (some per-executor upfront, some only after cohort aggregation) and calls the
-matching builder below. Open THIS file to see the full list of what a miner can be
-told and exactly how each message reads — no need to trace the scoring flow.
-
-Each builder returns a `ZeroIncentiveReason` carrying:
-  - the machine-readable `reason` code (also used by internal Loki dashboards),
-  - `message_for_miner`: the plain-English line shown in the miner's incentive log,
-  - `miner_log_fields`: structured fields attached to that miner-facing log,
-  - `internal_log_message` / `internal_log_fields`: the separate internal observability
-    log emitted for the "excluded from both pools" reasons (None for the rest).
+matching builder below, then `reason.write_to_miner_log(result)`. Open THIS file to
+see the full list of what a miner can be told and exactly how each message reads.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
+
+from core.utils import _m, get_extra_info
+
+if TYPE_CHECKING:
+    from services.task_service import JobResult
 
 
 class ZeroIncentiveReason(BaseModel):
@@ -29,8 +46,26 @@ class ZeroIncentiveReason(BaseModel):
     internal_log_message: str | None = None                        # set only for both-pools exclusions
     internal_log_fields: dict[str, Any] = Field(default_factory=dict)
 
+    def write_to_miner_log(self, result: JobResult) -> None:
+        """Append this reason to the executor's customer-facing incentive log.
 
-# ── Excluded from BOTH pools (mining + unrented) — earns nothing at all ───────
+        Lands in JobResult.incentive_logs -> the "Incentive Scores Calculation Logs"
+        block delivered to the miner via MACHINE_SPEC_CHANNEL (DAH-2327).
+        """
+        info = {
+            "executor_id": str(result.executor_info.uuid),
+            "gpu_model": result.gpu_model,
+            "gpu_count": result.gpu_count,
+            "reason": self.reason,
+            "incentive": 0.0,
+            **self.miner_log_fields,
+        }
+        result.incentive_logs.append(
+            _m(self.message_for_miner, extra=get_extra_info(info)).to_full_string()
+        )
+
+
+# ── Group A: excluded from BOTH pools (mining + unrented) — earns nothing ─────
 
 def spot_tier() -> ZeroIncentiveReason:
     return ZeroIncentiveReason(
@@ -77,7 +112,7 @@ def miner_default_job() -> ZeroIncentiveReason:
     )
 
 
-# ── Unrented-pool-only reasons — earns only when rented / repriced ────────────
+# ── Group B: idle but not qualified for the unrented pool ─────────────────────
 
 def gpu_model_not_in_unrented_program(gpu_model: str) -> ZeroIncentiveReason:
     return ZeroIncentiveReason(

--- a/neurons/validators/src/incentive/zero_incentive_reasons.py
+++ b/neurons/validators/src/incentive/zero_incentive_reasons.py
@@ -1,0 +1,132 @@
+"""Every reason a validated executor earns 0 subnet incentive — the single catalog.
+
+The scoring code (rental_price.py) detects each condition where its data naturally
+lives (some per-executor upfront, some only after cohort aggregation) and calls the
+matching builder below. Open THIS file to see the full list of what a miner can be
+told and exactly how each message reads — no need to trace the scoring flow.
+
+Each builder returns a `ZeroIncentiveReason` carrying:
+  - the machine-readable `reason` code (also used by internal Loki dashboards),
+  - `message_for_miner`: the plain-English line shown in the miner's incentive log,
+  - `miner_log_fields`: structured fields attached to that miner-facing log,
+  - `internal_log_message` / `internal_log_fields`: the separate internal observability
+    log emitted for the "excluded from both pools" reasons (None for the rest).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ZeroIncentiveReason(BaseModel):
+    """One reason a validated executor earns 0 subnet incentive."""
+
+    reason: str                                                    # machine-readable code, e.g. "spot_tier"
+    message_for_miner: str                                         # plain-English, shown to the miner
+    miner_log_fields: dict[str, Any] = Field(default_factory=dict)
+    internal_log_message: str | None = None                        # set only for both-pools exclusions
+    internal_log_fields: dict[str, Any] = Field(default_factory=dict)
+
+
+# ── Excluded from BOTH pools (mining + unrented) — earns nothing at all ───────
+
+def spot_tier() -> ZeroIncentiveReason:
+    return ZeroIncentiveReason(
+        reason="spot_tier",
+        message_for_miner=(
+            "No subnet incentive: this executor is on the spot tier, and spot-tier "
+            "executors do not earn subnet incentive."
+        ),
+        internal_log_message="Executor excluded from both pools - spot tier",
+    )
+
+
+def provider_discord_not_connected(is_connected: bool) -> ZeroIncentiveReason:
+    return ZeroIncentiveReason(
+        reason="provider_discord_not_connected",
+        message_for_miner=(
+            "No subnet incentive: provider Discord is not connected. Connect your "
+            "provider Discord for this executor to start earning incentive."
+        ),
+        internal_log_message="Executor excluded from both pools - provider Discord not connected",
+        internal_log_fields={"provider_discord_connected": is_connected},
+    )
+
+
+def new_rentals_paused() -> ZeroIncentiveReason:
+    return ZeroIncentiveReason(
+        reason="new_rentals_paused",
+        message_for_miner=(
+            "No subnet incentive: this executor is paused for new rentals and earns "
+            "nothing while paused. Resume new rentals to start earning again."
+        ),
+        internal_log_message="Executor excluded from both pools - paused for new rentals",
+    )
+
+
+def miner_default_job() -> ZeroIncentiveReason:
+    return ZeroIncentiveReason(
+        reason="miner_default_job",
+        message_for_miner=(
+            "No subnet incentive: this executor is running your own default job instead "
+            "of a Lium job, and executors on your own job do not earn subnet incentive."
+        ),
+        internal_log_message="Executor excluded from both pools - running miner's own default job",
+    )
+
+
+# ── Unrented-pool-only reasons — earns only when rented / repriced ────────────
+
+def gpu_model_not_in_unrented_program(gpu_model: str) -> ZeroIncentiveReason:
+    return ZeroIncentiveReason(
+        reason="gpu_model_not_eligible_for_unrented_incentive",
+        message_for_miner=(
+            f"No subnet incentive while idle: GPU model {gpu_model} is not part of the "
+            "unrented (idle-node) incentive program, so this executor earns nothing "
+            "unless rented. Rent it out to earn."
+        ),
+    )
+
+
+def price_over_soft_limit(price_per_gpu: float, market_p90: float, rate: float) -> ZeroIncentiveReason:
+    soft_limit = round(market_p90 * rate, 4)
+    return ZeroIncentiveReason(
+        reason="price_above_market_p90_soft_limit",
+        message_for_miner=(
+            f"No unrented incentive: your price ${price_per_gpu}/GPU/h is above the market "
+            f"soft price limit ${soft_limit} (90th-percentile market rate ${market_p90} x "
+            f"{rate}). Lower the price to ${soft_limit} or below to earn the unrented incentive."
+        ),
+        miner_log_fields={
+            "price_per_gpu": price_per_gpu,
+            "machine_price_p90": market_p90,
+            "soft_limit_rate": rate,
+            "soft_limit_threshold": soft_limit,
+        },
+    )
+
+
+def no_unrented_capacity(
+    gpu_count: int,
+    gpu_model: str,
+    count_bucket: int | None,
+    max_cap: int | None,
+    cap_multiplier: float | None,
+    total_rental_cost: float,
+) -> ZeroIncentiveReason:
+    return ZeroIncentiveReason(
+        reason="no_unrented_capacity_for_gpu_count",
+        message_for_miner=(
+            f"No unrented incentive: there is currently no unrented-incentive capacity for "
+            f"{gpu_count}x {gpu_model} (its GPU-count tier has no cap this cycle). Rent this "
+            f"executor out to earn."
+        ),
+        miner_log_fields={
+            "count_bucket": count_bucket,
+            "max_cap": max_cap,
+            "unrented_cap_multiplier": cap_multiplier,
+            "total_rental_cost": total_rental_cost,
+        },
+    )

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -6,10 +6,32 @@ fields, and that a line actually lands in JobResult.incentive_logs.
 """
 import pytest
 from datura.requests.miner_requests import ExecutorSSHInfo
-from incentive.miner_incentive_log import MinerLogLine
+from incentive.miner_incentive_log import MinerLogLine, ZeroIncentiveReason
 from services.task_service import JobResult
 
 H200 = "NVIDIA H200"
+
+
+def test_reason_enum_pins_the_stable_code_contract():
+    # Append-only contract: dashboards and the backend (DAH-2340) key off these
+    # exact strings. Renaming any value is a breaking change.
+    assert {r.value for r in ZeroIncentiveReason} == {
+        "spot_tier",
+        "provider_discord_not_connected",
+        "new_rentals_paused",
+        "miner_default_job",
+        "gpu_model_not_eligible_for_unrented_incentive",
+        "price_above_market_p90_soft_limit",
+        "no_unrented_capacity_for_gpu_count",
+        "nvidia_driver_below_minimum",
+        "sysbox_not_enabled",
+    }
+
+
+def test_constructor_returns_enum_reason():
+    line = MinerLogLine.no_payout_because_spot_tier(_job())
+    assert line.reason is ZeroIncentiveReason.SPOT_TIER
+    assert line.reason == "spot_tier"  # StrEnum: JSON/string behaviour unchanged
 
 
 def _job(**overrides) -> JobResult:

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -105,12 +105,10 @@ def test_no_capacity_reason_carries_bucket_fields():
     assert reason.miner_log_fields["count_bucket"] == 8
 
 
-def test_write_to_miner_log_appends_message_and_reason_code():
+def test_to_log_line_renders_message_and_reason_code():
     job = _job()
-    miner_log.no_payout_because_spot_tier().write_to_miner_log(job)
+    entry = miner_log.no_payout_because_spot_tier().to_log_line(job)
 
-    assert len(job.incentive_logs) == 1
-    entry = job.incentive_logs[0]
     assert "spot tier" in entry            # human message
     assert "spot_tier" in entry            # machine reason code in the structured payload
     assert str(job.executor_info.uuid) in entry
@@ -149,12 +147,11 @@ def test_report_builder_message_and_keys(line, message_fragment, expected_keys):
         assert key in line.fields
 
 
-def test_report_line_writes_to_miner_log_and_builds_internal_log():
+def test_report_line_renders_string_and_builds_internal_log():
     job = _job(mining_score=1.0)
     line = miner_log.mining_score_calculated(job, is_rented_after_cutoff=False)
 
-    line.write_to_miner_log(job)
-    assert job.incentive_logs and "Mining score is calculated" in job.incentive_logs[0]
+    assert "Mining score is calculated" in line.to_log_line()
 
     # The same content is also available as an `_m` object for the internal logger.
     assert "Mining score is calculated" in line.as_internal_log().to_full_string()

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -1,0 +1,160 @@
+"""Unit tests for the miner_incentive_log catalog (DAH-2327).
+
+Direct coverage of every builder in the single catalog: the machine-readable
+`reason` code, the plain-English message shown to the miner, the structured
+fields, and that a line actually lands in JobResult.incentive_logs.
+"""
+import pytest
+from datura.requests.miner_requests import ExecutorSSHInfo
+from incentive import miner_incentive_log as miner_log
+from services.task_service import JobResult
+
+H200 = "NVIDIA H200"
+
+
+def _job(**overrides) -> JobResult:
+    base = dict(
+        executor_info=ExecutorSSHInfo(
+            uuid="exec-1",
+            address="10.0.0.1",
+            port=8080,
+            ssh_username="root",
+            ssh_port=22,
+            python_path="/usr/bin/python3",
+            root_dir="/tmp",
+        ),
+        score=1.0,
+        job_score=1.0,
+        job_batch_id="batch",
+        log_status="success",
+        log_text="ok",
+        gpu_model=H200,
+        gpu_count=8,
+    )
+    base.update(overrides)
+    return JobResult(**base)
+
+
+# ── Zero-incentive reason builders ───────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "reason, expected_code, message_fragment",
+    [
+        (miner_log.no_payout_because_spot_tier(), "spot_tier", "spot tier"),
+        (
+            miner_log.no_payout_because_discord_not_connected(False),
+            "provider_discord_not_connected",
+            "Discord",
+        ),
+        (
+            miner_log.no_payout_because_paused_for_new_rentals(),
+            "new_rentals_paused",
+            "paused for new rentals",
+        ),
+        (
+            miner_log.no_payout_because_running_own_default_job(),
+            "miner_default_job",
+            "own default job",
+        ),
+        (
+            miner_log.no_payout_because_gpu_model_not_in_unrented_program(H200),
+            "gpu_model_not_eligible_for_unrented_incentive",
+            H200,
+        ),
+        (
+            miner_log.no_payout_because_price_above_market_soft_limit(4.23, 3.842, 1.1),
+            "price_above_market_p90_soft_limit",
+            "soft price limit",
+        ),
+        (
+            miner_log.no_payout_because_no_unrented_capacity_for_gpu_count(8, H200, 8, 0, 0.0, 0.0),
+            "no_unrented_capacity_for_gpu_count",
+            "no unrented-incentive capacity",
+        ),
+    ],
+)
+def test_zero_reason_builder_code_and_message(reason, expected_code, message_fragment):
+    assert reason.reason == expected_code
+    assert message_fragment.lower() in reason.message_for_miner.lower()
+
+
+def test_spot_tier_carries_internal_log_message():
+    reason = miner_log.no_payout_because_spot_tier()
+    assert reason.internal_log_message == "Executor excluded from both pools - spot tier"
+
+
+def test_discord_reason_carries_connected_flag_for_internal_log():
+    reason = miner_log.no_payout_because_discord_not_connected(is_connected=False)
+    assert reason.internal_log_fields == {"provider_discord_connected": False}
+
+
+def test_soft_limit_reason_computes_threshold_and_fields():
+    # threshold = p90 3.842 * rate 1.1 = 4.2262
+    reason = miner_log.no_payout_because_price_above_market_soft_limit(4.23, 3.842, 1.1)
+    assert reason.miner_log_fields["soft_limit_threshold"] == 4.2262
+    assert reason.miner_log_fields["machine_price_p90"] == 3.842
+    assert "4.2262" in reason.message_for_miner
+    assert "4.23" in reason.message_for_miner
+
+
+def test_no_capacity_reason_carries_bucket_fields():
+    reason = miner_log.no_payout_because_no_unrented_capacity_for_gpu_count(
+        gpu_count=8, gpu_model=H200, count_bucket=8, max_cap=0, cap_multiplier=0.0, total_rental_cost=0.0
+    )
+    assert reason.miner_log_fields["max_cap"] == 0
+    assert reason.miner_log_fields["count_bucket"] == 8
+
+
+def test_write_to_miner_log_appends_message_and_reason_code():
+    job = _job()
+    miner_log.no_payout_because_spot_tier().write_to_miner_log(job)
+
+    assert len(job.incentive_logs) == 1
+    entry = job.incentive_logs[0]
+    assert "spot tier" in entry            # human message
+    assert "spot_tier" in entry            # machine reason code in the structured payload
+    assert str(job.executor_info.uuid) in entry
+
+
+# ── Calculation-report builders ──────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "line, message_fragment, expected_keys",
+    [
+        (
+            miner_log.mining_score_calculated(_job(mining_score=1.0), False),
+            "Mining score is calculated",
+            ["mining_score", "gpu_portion", "driver_multiplier"],
+        ),
+        (
+            miner_log.mining_incentive_calculated("hk", _job(incentive=0.5), 0.83, 0.13),
+            "Incentive score is calculated",
+            ["mining_score", "total_mining_score", "mining_share", "incentive"],
+        ),
+        (
+            miner_log.rental_incentive_calculated("hk", _job(incentive=0.2), 8),
+            "Rental price incentive",
+            ["effective_rate", "rental_share", "count_bucket", "incentive"],
+        ),
+        (
+            miner_log.mining_score_missing("hk", _job()),
+            "should not happen",
+            ["score", "job_score", "gpu_model"],
+        ),
+    ],
+)
+def test_report_builder_message_and_keys(line, message_fragment, expected_keys):
+    assert message_fragment.lower() in line.message.lower()
+    for key in expected_keys:
+        assert key in line.fields
+
+
+def test_report_line_writes_to_miner_log_and_builds_internal_log():
+    job = _job(mining_score=1.0)
+    line = miner_log.mining_score_calculated(job, is_rented_after_cutoff=False)
+
+    line.write_to_miner_log(job)
+    assert job.incentive_logs and "Mining score is calculated" in job.incentive_logs[0]
+
+    # The same content is also available as an `_m` object for the internal logger.
+    assert "Mining score is calculated" in line.as_internal_log().to_full_string()

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -6,7 +6,7 @@ fields, and that a line actually lands in JobResult.incentive_logs.
 """
 import pytest
 from datura.requests.miner_requests import ExecutorSSHInfo
-from incentive import miner_incentive_log as miner_log
+from incentive.miner_incentive_log import MinerLogLine
 from services.task_service import JobResult
 
 H200 = "NVIDIA H200"
@@ -38,76 +38,92 @@ def _job(**overrides) -> JobResult:
 # ── Zero-incentive reason builders ───────────────────────────────────────────
 
 @pytest.mark.parametrize(
-    "reason, expected_code, message_fragment",
+    "build, expected_code, message_fragment",
     [
-        (miner_log.no_payout_because_spot_tier(), "spot_tier", "spot tier"),
+        (lambda job: MinerLogLine.no_payout_because_spot_tier(job), "spot_tier", "spot tier"),
         (
-            miner_log.no_payout_because_discord_not_connected(False),
+            lambda job: MinerLogLine.no_payout_because_discord_not_connected(job),
             "provider_discord_not_connected",
             "Discord",
         ),
         (
-            miner_log.no_payout_because_paused_for_new_rentals(),
+            lambda job: MinerLogLine.no_payout_because_paused_for_new_rentals(job),
             "new_rentals_paused",
             "paused for new rentals",
         ),
         (
-            miner_log.no_payout_because_running_own_default_job(),
+            lambda job: MinerLogLine.no_payout_because_running_own_default_job(job),
             "miner_default_job",
             "own default job",
         ),
         (
-            miner_log.no_payout_because_gpu_model_not_in_unrented_program(H200),
+            lambda job: MinerLogLine.no_payout_because_gpu_model_not_in_unrented_program(job),
             "gpu_model_not_eligible_for_unrented_incentive",
             H200,
         ),
         (
-            miner_log.no_payout_because_price_above_market_soft_limit(4.23, 3.842, 1.1),
+            lambda job: MinerLogLine.no_payout_because_price_above_market_soft_limit(job, 3.842, 1.1),
             "price_above_market_p90_soft_limit",
             "soft price limit",
         ),
         (
-            miner_log.no_payout_because_no_unrented_capacity_for_gpu_count(8, H200, 8, 0, 0.0, 0.0),
+            lambda job: MinerLogLine.no_payout_because_no_unrented_capacity_for_gpu_count(job, 8),
             "no_unrented_capacity_for_gpu_count",
             "no unrented-incentive capacity",
         ),
+        (
+            lambda job: MinerLogLine.no_payout_because_nvidia_driver_below_minimum(job),
+            "nvidia_driver_below_minimum",
+            "driver",
+        ),
+        (
+            lambda job: MinerLogLine.no_payout_because_sysbox_not_enabled(job),
+            "sysbox_not_enabled",
+            "sysbox",
+        ),
     ],
 )
-def test_zero_reason_builder_code_and_message(reason, expected_code, message_fragment):
-    assert reason.reason == expected_code
-    assert message_fragment.lower() in reason.message_for_miner.lower()
+def test_zero_reason_constructor_code_and_message(build, expected_code, message_fragment):
+    line = build(_job())
+    assert line.reason == expected_code
+    assert message_fragment.lower() in line.message.lower()
+    assert line.fields["reason"] == expected_code
+    assert line.fields["incentive"] == 0.0
 
 
 def test_spot_tier_carries_internal_log_message():
-    reason = miner_log.no_payout_because_spot_tier()
-    assert reason.internal_log_message == "Executor excluded from both pools - spot tier"
+    line = MinerLogLine.no_payout_because_spot_tier(_job())
+    assert line.internal_message == "Executor excluded from both pools - spot tier"
 
 
 def test_discord_reason_carries_connected_flag_for_internal_log():
-    reason = miner_log.no_payout_because_discord_not_connected(is_connected=False)
-    assert reason.internal_log_fields == {"provider_discord_connected": False}
+    job = _job()
+    job.provider_discord_connected = False
+    line = MinerLogLine.no_payout_because_discord_not_connected(job)
+    assert line.internal_fields == {"provider_discord_connected": False}
 
 
 def test_soft_limit_reason_computes_threshold_and_fields():
     # threshold = p90 3.842 * rate 1.1 = 4.2262
-    reason = miner_log.no_payout_because_price_above_market_soft_limit(4.23, 3.842, 1.1)
-    assert reason.miner_log_fields["soft_limit_threshold"] == 4.2262
-    assert reason.miner_log_fields["machine_price_p90"] == 3.842
-    assert "4.2262" in reason.message_for_miner
-    assert "4.23" in reason.message_for_miner
+    job = _job()
+    job.executor_info = job.executor_info.model_copy(update={"price_per_gpu": 4.23})
+    line = MinerLogLine.no_payout_because_price_above_market_soft_limit(job, 3.842, 1.1)
+    assert line.fields["soft_limit_threshold"] == 4.2262
+    assert line.fields["machine_price_p90"] == 3.842
+    assert "4.2262" in line.message
+    assert "4.23" in line.message
 
 
 def test_no_capacity_reason_carries_bucket_fields():
-    reason = miner_log.no_payout_because_no_unrented_capacity_for_gpu_count(
-        gpu_count=8, gpu_model=H200, count_bucket=8, max_cap=0, cap_multiplier=0.0, total_rental_cost=0.0
-    )
-    assert reason.miner_log_fields["max_cap"] == 0
-    assert reason.miner_log_fields["count_bucket"] == 8
+    job = _job(max_cap=0, unrented_cap_multiplier=0.0, total_rental_cost=0.0)
+    line = MinerLogLine.no_payout_because_no_unrented_capacity_for_gpu_count(job, count_bucket=8)
+    assert line.fields["max_cap"] == 0
+    assert line.fields["count_bucket"] == 8
 
 
 def test_to_log_line_renders_message_and_reason_code():
     job = _job()
-    entry = miner_log.no_payout_because_spot_tier().to_log_line(job)
+    entry = MinerLogLine.no_payout_because_spot_tier(job).to_log_line()
 
     assert "spot tier" in entry            # human message
     assert "spot_tier" in entry            # machine reason code in the structured payload
@@ -120,22 +136,22 @@ def test_to_log_line_renders_message_and_reason_code():
     "line, message_fragment, expected_keys",
     [
         (
-            miner_log.mining_score_calculated(_job(mining_score=1.0), False),
+            MinerLogLine.mining_score_calculated(_job(mining_score=1.0), False),
             "Mining score is calculated",
             ["mining_score", "gpu_portion", "driver_multiplier"],
         ),
         (
-            miner_log.mining_incentive_calculated("hk", _job(incentive=0.5), 0.83, 0.13),
+            MinerLogLine.mining_incentive_calculated("hk", _job(incentive=0.5), 0.83, 0.13),
             "Incentive score is calculated",
             ["mining_score", "total_mining_score", "mining_share", "incentive"],
         ),
         (
-            miner_log.rental_incentive_calculated("hk", _job(incentive=0.2), 8),
+            MinerLogLine.rental_incentive_calculated("hk", _job(incentive=0.2), 8),
             "Rental price incentive",
             ["effective_rate", "rental_share", "count_bucket", "incentive"],
         ),
         (
-            miner_log.mining_score_missing("hk", _job()),
+            MinerLogLine.mining_score_missing("hk", _job()),
             "should not happen",
             ["score", "job_score", "gpu_model"],
         ),
@@ -149,7 +165,7 @@ def test_report_builder_message_and_keys(line, message_fragment, expected_keys):
 
 def test_report_line_renders_string_and_builds_internal_log():
     job = _job(mining_score=1.0)
-    line = miner_log.mining_score_calculated(job, is_rented_after_cutoff=False)
+    line = MinerLogLine.mining_score_calculated(job, is_rented_after_cutoff=False)
 
     assert "Mining score is calculated" in line.to_log_line()
 

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -122,7 +122,17 @@ def test_discord_reason_carries_connected_flag_for_internal_log():
     job = _job()
     job.provider_discord_connected = False
     line = MinerLogLine.no_payout_because_discord_not_connected(job)
-    assert line.internal_fields == {"provider_discord_connected": False}
+    assert line.internal_fields["provider_discord_connected"] is False
+    assert line.internal_fields["pool"] == "none"
+
+
+def test_to_internal_log_renders_internal_message_with_pool_fields():
+    line = MinerLogLine.no_payout_because_spot_tier(_job())
+    rendered: str = line.to_internal_log().to_full_string()
+
+    assert "Executor excluded from both pools - spot tier" in rendered
+    assert "spot_tier" in rendered
+    assert '"pool": "none"' in rendered
 
 
 def test_soft_limit_reason_computes_threshold_and_fields():

--- a/neurons/validators/tests/test_unrented_soft_price_limit.py
+++ b/neurons/validators/tests/test_unrented_soft_price_limit.py
@@ -263,3 +263,15 @@ async def test_eligible_executor_has_no_zero_incentive_reason(monkeypatch):
     log = "\n".join(result.incentive_logs)
     assert "set to 0" not in log
     assert "No subnet incentive" not in log
+
+
+def test_evaluate_hard_exclusion_returns_first_match_and_none():
+    # The evaluator is the single source of truth: first matching reason wins,
+    # None for a clean executor.
+    incentive = _build_incentive()
+
+    assert incentive._evaluate_hard_exclusion(_make_job(1.0)) is None
+    assert incentive._evaluate_hard_exclusion(_make_job(1.0, is_spot=True)).reason == "spot_tier"
+    # spot precedes discord when both apply — order is preserved
+    both = _make_job(1.0, is_spot=True, provider_discord_connected=False)
+    assert incentive._evaluate_hard_exclusion(both).reason == "spot_tier"

--- a/neurons/validators/tests/test_unrented_soft_price_limit.py
+++ b/neurons/validators/tests/test_unrented_soft_price_limit.py
@@ -251,6 +251,27 @@ async def test_unrented_non_incentive_model_appends_reason():
     assert "RTX 5080" in log
 
 
+@pytest.mark.asyncio
+async def test_eligible_zero_capacity_bucket_appends_reason():
+    # An eligible unrented GPU whose gpu-count bucket has no cap: the cap multiplier and
+    # effective rate collapse to 0, so incentive is 0 despite eligibility. Explain why.
+    incentive = _build_incentive()
+    job = _make_job(1.0)  # H200, unrented, eligible
+    job.eligible_for_rental_share = True
+    job.hourly_rate = 5.0
+    job.sysbox_multiplier = 1.0
+    job.driver_multiplier = 1.0
+    job.count_bucket = 1
+    job.max_cap = 0  # no unrented capacity for this bucket -> cap multiplier 0
+
+    await incentive._post_process_job_result("miner_hotkey", job)
+
+    assert job.incentive == 0
+    log = "\n".join(job.incentive_logs)
+    assert "no_unrented_capacity_for_gpu_count" in log
+    assert "H200" in log
+
+
 def test_evaluate_hard_exclusion_returns_first_match_and_none():
     # The evaluator is the single source of truth: first matching reason wins,
     # None for a clean executor.

--- a/neurons/validators/tests/test_unrented_soft_price_limit.py
+++ b/neurons/validators/tests/test_unrented_soft_price_limit.py
@@ -272,6 +272,53 @@ async def test_eligible_zero_capacity_bucket_appends_reason():
     assert "H200" in log
 
 
+@pytest.mark.asyncio
+async def test_eligible_driver_below_minimum_appends_reason():
+    # Live staging case (2026-07-03): driver_multiplier=0 zeroes effective_rate, so an
+    # eligible unrented executor earns 0 with no explanation. Explain why.
+    incentive = _build_incentive()
+    job = _make_job(1.0)
+    job.eligible_for_rental_share = True
+    job.hourly_rate = 5.0
+    job.sysbox_multiplier = 1.0
+    job.driver_multiplier = 0.0  # NVIDIA driver below the network minimum
+    job.nvidia_driver_version = "570.195.03"
+    job.count_bucket = 1
+    job.max_cap = 10
+    incentive.cap_multiplier_by_bucket[("H200", 1)] = 1.0  # bucket has capacity
+
+    await incentive._post_process_job_result("miner_hotkey", job)
+
+    assert job.incentive == 0
+    log = "\n".join(job.incentive_logs)
+    assert "nvidia_driver_below_minimum" in log
+    assert "570.195.03" in log
+    assert "driver" in log.lower()
+
+
+@pytest.mark.asyncio
+async def test_eligible_no_sysbox_appends_reason():
+    # sysbox_multiplier=0 (no sysbox runtime, full unrented penalty) also zeroes the
+    # effective rate -> incentive 0. Explain why.
+    incentive = _build_incentive()
+    job = _make_job(1.0)
+    job.eligible_for_rental_share = True
+    job.hourly_rate = 5.0
+    job.sysbox_multiplier = 0.0
+    job.sysbox_runtime = False
+    job.driver_multiplier = 1.0
+    job.count_bucket = 1
+    job.max_cap = 10
+    incentive.cap_multiplier_by_bucket[("H200", 1)] = 1.0  # bucket has capacity
+
+    await incentive._post_process_job_result("miner_hotkey", job)
+
+    assert job.incentive == 0
+    log = "\n".join(job.incentive_logs)
+    assert "sysbox_not_enabled" in log
+    assert "sysbox" in log.lower()
+
+
 def test_reason_excluded_from_both_pools_returns_first_match_and_none():
     # The evaluator is the single source of truth: first matching reason wins,
     # None for a clean executor.

--- a/neurons/validators/tests/test_unrented_soft_price_limit.py
+++ b/neurons/validators/tests/test_unrented_soft_price_limit.py
@@ -272,13 +272,13 @@ async def test_eligible_zero_capacity_bucket_appends_reason():
     assert "H200" in log
 
 
-def test_evaluate_hard_exclusion_returns_first_match_and_none():
+def test_reason_excluded_from_both_pools_returns_first_match_and_none():
     # The evaluator is the single source of truth: first matching reason wins,
     # None for a clean executor.
     incentive = _build_incentive()
 
-    assert incentive._evaluate_hard_exclusion(_make_job(1.0)) is None
-    assert incentive._evaluate_hard_exclusion(_make_job(1.0, is_spot=True)).reason == "spot_tier"
+    assert incentive._reason_excluded_from_both_pools(_make_job(1.0)) is None
+    assert incentive._reason_excluded_from_both_pools(_make_job(1.0, is_spot=True)).reason == "spot_tier"
     # spot precedes discord when both apply — order is preserved
     both = _make_job(1.0, is_spot=True, provider_discord_connected=False)
-    assert incentive._evaluate_hard_exclusion(both).reason == "spot_tier"
+    assert incentive._reason_excluded_from_both_pools(both).reason == "spot_tier"

--- a/neurons/validators/tests/test_unrented_soft_price_limit.py
+++ b/neurons/validators/tests/test_unrented_soft_price_limit.py
@@ -235,6 +235,22 @@ async def test_eligible_executor_has_no_zero_incentive_reason(monkeypatch):
     assert "No subnet incentive" not in log
 
 
+@pytest.mark.asyncio
+async def test_unrented_non_incentive_model_appends_reason():
+    # RTX 5080 is a valid GPU but not in rental_incentive_gpu_types: an unrented
+    # executor of this model earns nothing while idle and must be told why.
+    incentive = _build_incentive()
+
+    result = await incentive.calculate_executor_score(
+        _make_job(1.0, gpu_model="NVIDIA GeForce RTX 5080")
+    )
+
+    assert result.mining_score == 0
+    log = "\n".join(result.incentive_logs)
+    assert "gpu_model_not_eligible_for_unrented_incentive" in log
+    assert "RTX 5080" in log
+
+
 def test_evaluate_hard_exclusion_returns_first_match_and_none():
     # The evaluator is the single source of truth: first matching reason wins,
     # None for a clean executor.

--- a/neurons/validators/tests/test_unrented_soft_price_limit.py
+++ b/neurons/validators/tests/test_unrented_soft_price_limit.py
@@ -157,3 +157,33 @@ async def test_enforced_under_threshold_keeps_eligibility(monkeypatch):
 
     # Assert
     assert result.eligible_for_rental_share is True
+
+
+@pytest.mark.asyncio
+async def test_enforced_appends_customer_facing_incentive_log(monkeypatch):
+    # DAH-2327: the zero-incentive reason must reach the customer-facing incentive
+    # log (JobResult.incentive_logs -> "Incentive Scores Calculation Logs") with the
+    # numbers and the price to set. Threshold = 2.0 * 1.1 = 2.2.
+    _set_p90(monkeypatch, {H200: 2.0})
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_SOFT_PRICE_LIMIT", True)
+    incentive = _build_incentive()
+
+    result = await incentive.calculate_executor_score(_make_job(2.3))
+
+    log = "\n".join(result.incentive_logs)
+    assert "soft price limit" in log
+    assert "2.3" in log        # miner's price
+    assert "2.2" in log        # ceiling / price to set
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_does_not_append_incentive_log(monkeypatch):
+    # Flag off — payout unchanged, so no zero-incentive reason should be logged.
+    _set_p90(monkeypatch, {H200: 2.0})
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_SOFT_PRICE_LIMIT", False)
+    incentive = _build_incentive()
+
+    result = await incentive.calculate_executor_score(_make_job(2.3))
+
+    log = "\n".join(result.incentive_logs)
+    assert "soft price limit" not in log

--- a/neurons/validators/tests/test_unrented_soft_price_limit.py
+++ b/neurons/validators/tests/test_unrented_soft_price_limit.py
@@ -200,55 +200,25 @@ async def test_shadow_mode_does_not_append_incentive_log(monkeypatch):
 # ── DAH-2327: every zero-incentive exit surfaces its reason to the miner ──────
 
 
+@pytest.mark.parametrize(
+    "job_kwargs, expected_fragments",
+    [
+        ({"is_spot": True}, ["spot", "spot_tier"]),
+        ({"provider_discord_connected": False}, ["Discord", "provider_discord_not_connected"]),
+        ({"is_new_rentals_paused": True}, ["paused", "new_rentals_paused"]),
+        ({"default_job_owner": "miner"}, ["default job", "miner_default_job"]),
+    ],
+)
 @pytest.mark.asyncio
-async def test_spot_appends_customer_facing_incentive_log():
+async def test_hard_exclusion_appends_customer_facing_incentive_log(job_kwargs, expected_fragments):
     incentive = _build_incentive()
 
-    result = await incentive.calculate_executor_score(_make_job(1.0, is_spot=True))
+    result = await incentive.calculate_executor_score(_make_job(1.0, **job_kwargs))
 
-    assert result.incentive == 0.0 or result.mining_score == 0
-    log = "\n".join(result.incentive_logs)
-    assert "spot" in log.lower()
-    assert "spot_tier" in log
-
-
-@pytest.mark.asyncio
-async def test_discord_not_connected_appends_customer_facing_incentive_log():
-    incentive = _build_incentive()
-
-    result = await incentive.calculate_executor_score(
-        _make_job(1.0, provider_discord_connected=False)
-    )
-
-    log = "\n".join(result.incentive_logs)
-    assert "Discord" in log
-    assert "provider_discord_not_connected" in log
-
-
-@pytest.mark.asyncio
-async def test_new_rentals_paused_appends_customer_facing_incentive_log():
-    incentive = _build_incentive()
-
-    result = await incentive.calculate_executor_score(
-        _make_job(1.0, is_new_rentals_paused=True)
-    )
-
-    log = "\n".join(result.incentive_logs)
-    assert "paused" in log.lower()
-    assert "new_rentals_paused" in log
-
-
-@pytest.mark.asyncio
-async def test_miner_default_job_appends_customer_facing_incentive_log():
-    incentive = _build_incentive()
-
-    result = await incentive.calculate_executor_score(
-        _make_job(1.0, default_job_owner="miner")
-    )
-
-    log = "\n".join(result.incentive_logs)
-    assert "default job" in log.lower()
-    assert "miner_default_job" in log
+    assert result.mining_score == 0
+    log = "\n".join(result.incentive_logs).lower()
+    for fragment in expected_fragments:
+        assert fragment.lower() in log
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_unrented_soft_price_limit.py
+++ b/neurons/validators/tests/test_unrented_soft_price_limit.py
@@ -29,6 +29,10 @@ def _make_job(
     *,
     gpu_model: str = H200,
     is_rented: bool = False,
+    is_spot: bool = False,
+    is_new_rentals_paused: bool = False,
+    provider_discord_connected: bool = True,
+    default_job_owner: str | None = None,
 ) -> JobResult:
     return JobResult(
         executor_info=ExecutorSSHInfo(
@@ -49,6 +53,10 @@ def _make_job(
         gpu_model=gpu_model,
         gpu_count=1,
         is_rented=is_rented,
+        is_spot=is_spot,
+        is_new_rentals_paused=is_new_rentals_paused,
+        provider_discord_connected=provider_discord_connected,
+        default_job_owner=default_job_owner,
         collateral_deposited=True,
         sysbox_runtime=True,
     )
@@ -187,3 +195,71 @@ async def test_shadow_mode_does_not_append_incentive_log(monkeypatch):
 
     log = "\n".join(result.incentive_logs)
     assert "soft price limit" not in log
+
+
+# ── DAH-2327: every zero-incentive exit surfaces its reason to the miner ──────
+
+
+@pytest.mark.asyncio
+async def test_spot_appends_customer_facing_incentive_log():
+    incentive = _build_incentive()
+
+    result = await incentive.calculate_executor_score(_make_job(1.0, is_spot=True))
+
+    assert result.incentive == 0.0 or result.mining_score == 0
+    log = "\n".join(result.incentive_logs)
+    assert "spot" in log.lower()
+    assert "spot_tier" in log
+
+
+@pytest.mark.asyncio
+async def test_discord_not_connected_appends_customer_facing_incentive_log():
+    incentive = _build_incentive()
+
+    result = await incentive.calculate_executor_score(
+        _make_job(1.0, provider_discord_connected=False)
+    )
+
+    log = "\n".join(result.incentive_logs)
+    assert "Discord" in log
+    assert "provider_discord_not_connected" in log
+
+
+@pytest.mark.asyncio
+async def test_new_rentals_paused_appends_customer_facing_incentive_log():
+    incentive = _build_incentive()
+
+    result = await incentive.calculate_executor_score(
+        _make_job(1.0, is_new_rentals_paused=True)
+    )
+
+    log = "\n".join(result.incentive_logs)
+    assert "paused" in log.lower()
+    assert "new_rentals_paused" in log
+
+
+@pytest.mark.asyncio
+async def test_miner_default_job_appends_customer_facing_incentive_log():
+    incentive = _build_incentive()
+
+    result = await incentive.calculate_executor_score(
+        _make_job(1.0, default_job_owner="miner")
+    )
+
+    log = "\n".join(result.incentive_logs)
+    assert "default job" in log.lower()
+    assert "miner_default_job" in log
+
+
+@pytest.mark.asyncio
+async def test_eligible_executor_has_no_zero_incentive_reason(monkeypatch):
+    # Healthy unrented eligible executor within price — no zero-incentive reason logged.
+    _set_p90(monkeypatch, {H200: 2.0})
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_SOFT_PRICE_LIMIT", True)
+    incentive = _build_incentive()
+
+    result = await incentive.calculate_executor_score(_make_job(1.5))
+
+    log = "\n".join(result.incentive_logs)
+    assert "set to 0" not in log
+    assert "No subnet incentive" not in log


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2327](https://app.notion.com/p/Make-validator-incentive-0-reason-visible-in-customer-facing-logs-soft-price-limit-unrented-391b8bfdbde981a78d4aff041143d12b)

---

## Problem

A miner with a validated executor (job score=1.0) can still receive incentive=0.0 for several reasons, but that reason lived only in an internal validator log line and never reached the customer-facing "Incentive Scores Calculation Logs" the miner reads — so the miner saw incentive=0 with no explanation. An executor earns 0 when it is on the **spot tier**, has **no provider Discord connected**, is **paused for new rentals**, is **running the miner's own default job**, or (unrented) is priced **above the market soft price limit**. This matches the ticket's "cover all cases where incentive drops to 0" requirement.

Real prod case that surfaced this (2026-07-02, executor `b2807779-...`, 8x H200): price 4.23 vs threshold 4.2262 (p90 3.842 x 1.1) — over by $0.0038, zero incentive, no signal to the miner.

## Solution

The reason is appended to `JobResult.incentive_logs` at the point the executor is zeroed. `incentive_logs` is concatenated into `full_log_text` under the "Incentive Scores Calculation Logs:" header and published to the miner via `MACHINE_SPEC_CHANNEL` — the same block the customer already reads. Authoritative, not predictive.

The four "excluded from both pools" reasons are consolidated into a single evaluator `_evaluate_hard_exclusion(job_result) -> IncentiveDecision | None`. The `IncentiveDecision` (pydantic) is the single source of truth consumed by the internal observability log, the customer-facing incentive log, and the scoring exit — they cannot drift. The unrented soft price limit stays a separate check (different axis: rental-pool-only, flag-gated, shadow mode).

Covered reasons (each with a plain-English, actionable customer message + machine-readable `reason` code):
- `spot_tier`
- `provider_discord_not_connected` — connect provider Discord to become eligible
- `new_rentals_paused` — resume new rentals to become eligible
- `miner_default_job` — running the miner's own default job instead of a Lium job
- `gpu_model_not_eligible_for_unrented_incentive` — unrented GPU model not in the unrented-incentive program (earns only when rented)
- `price_above_market_p90_soft_limit` — lower the price to `<threshold>` (gated on `ENABLE_UNRENTED_SOFT_PRICE_LIMIT`; shadow mode logs nothing)

The existing internal `logger.info` lines (Loki dashboards) are preserved with identical fields; this only adds the customer-facing line and consolidates the branches (net -6 lines).

## Changes

- **`incentive/miner_incentive_log.py` (new)** — the single catalog of everything a miner sees in their "Incentive Scores Calculation Logs" block. Module docstring explains the two reward pools and how a node picks one. Holds:
  - `ZeroIncentiveReason` + 7 reason builders (spot_tier, provider_discord_not_connected, new_rentals_paused, miner_default_job, gpu_model_not_in_unrented_program, price_over_soft_limit, no_unrented_capacity), each with a plain-English actionable message and a machine-readable code; `reason.write_to_miner_log(result)` writes it
  - `MinerLogLine` + 4 calculation-report builders (mining_score_calculated, mining_incentive_calculated, rental_incentive_calculated, mining_score_missing) — the pre-existing success/report lines moved verbatim from default.py / rental_price.py
- `incentive/rental_price.py`: `_reason_excluded_from_both_pools()` evaluator collapses the four hard-exclusion branches; every append site is now a one-line `miner_log.<reason>(...).write_to_miner_log(...)`; misleading "excluded from mining pool" internal log reworded (routing to rental-share pool, not a penalty); added zero-reasons for non-eligible GPU model and no-capacity buckets
- `incentive/default.py`: its three incentive-log lines now come from the catalog (strings/fields unchanged)
- `tests/test_unrented_soft_price_limit.py`: a test per reason, evaluator ordering/None test, and negative tests

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review

## Other PRs

None.

## Risks

- Log/observability only — no scoring, eligibility, or control-flow change; the four consolidated branches were already identical (behavior-preserving refactor), and each append happens after the exclusion is already decided.
- One extra customer-facing incentive-log line for affected executors only.

## Test Cases

### Test Case 1

**Actions**

`cd neurons/validators && pdm run pytest tests/test_unrented_soft_price_limit.py`

**Expected Output**

18 passed. Each zero-incentive reason (spot, discord, paused, miner default job, unrented non-incentive GPU model, enforced soft-limit) appends a customer-facing line with its reason code; the evaluator returns the first match / None; shadow-mode soft-limit and a healthy eligible executor append nothing.

### Test Case 2

**Actions**

`cd neurons/validators && pdm run pytest`

**Expected Output**

Full suite green (840 passed, 4 skipped locally).

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
