### PR TITLE
DAH-2338 - Upgrade dstack CVM stack to 0.5.11 (verifier + OS image)

### DIFF
--- a/datura/datura/requests/miner_requests.py
+++ b/datura/datura/requests/miner_requests.py
@@ -52,6 +52,10 @@ class ExecutorSSHInfo(pydantic.BaseModel):
     price_per_gpu: float | None = None
     ssh_host_key: str | None = None
     tdx_quote: str | None = None
+    # NVIDIA confidential-compute GPU evidence, JSON-encoded
+    # {"nonce": <hex>, "arch": <str>, "evidence_list": [...]} — collected in-CVM
+    # only and bound to the same nonce as the TDX quote when one was issued.
+    nvidia_payload: str | None = None
 
 
 class AcceptSSHKeyRequest(BaseMinerRequest):

--- a/datura/datura/requests/validator_requests.py
+++ b/datura/datura/requests/validator_requests.py
@@ -55,6 +55,24 @@ class AuthenticateRequest(BaseValidatorRequest):
         return self.payload.blob_for_signing()
 
 
+def ssh_pubkey_signing_blob(public_key: str, nonce: str | None = None) -> str:
+    """Canonical message the validator signs over an SSH public key.
+
+    CRITICAL: This is the single source of truth for the validator_signature
+    format shared by the validator (signer), the miner (relay), and the
+    executor (verifier). Any change breaks signature compatibility fleet-wide.
+
+    Without a nonce the blob is the bare public key string — the format
+    deployed executors already verify. With an attestation nonce the nonce is
+    folded into the signed message so it cannot be stripped or swapped in
+    transit while keeping a valid signature (a stripped nonce downgrades the
+    verification to the legacy blob, which no longer matches the signature).
+    """
+    if not nonce:
+        return public_key
+    return f"{public_key}\nnonce:{nonce}"
+
+
 class SSHPubKeySubmitRequest(BaseValidatorRequest):
     message_type: RequestType = RequestType.SSHPubKeySubmitRequest
     public_key: bytes
@@ -62,6 +80,11 @@ class SSHPubKeySubmitRequest(BaseValidatorRequest):
     executor_id: Optional[str] = None
     is_rental_request: bool = False
     miner_hotkey: str
+    # Attestation challenge (hex-encoded 32 bytes), minted by the validator per
+    # attestation event. Relayed by the miner to each executor, which folds it
+    # into TDX report_data[32:64] and the GPU evidence nonce. Optional for
+    # backward compatibility with executors that predate the nonce channel.
+    nonce: str | None = None
 
 
 class SSHPubKeyRemoveRequest(BaseValidatorRequest):

--- a/neurons/executor/Dockerfile
+++ b/neurons/executor/Dockerfile
@@ -38,6 +38,16 @@ COPY --from=datura . /datura
 
 RUN pdm install --prod
 
+# G1 phase-0 (DAH-2338) — NVIDIA confidential-compute GPU attestation stack.
+# Deliberately OUTSIDE the pdm lock: the nv-ppcie-verifier dependency tree is
+# heavy and fragile, so it lives in its own opt-in layer for CVM runner builds
+# only. The single pin pulls nv_attestation_sdk, the local GPU verifier
+# (cc_admin) and pynvml transitively — same pin as the private-ml-sdk reference.
+ARG INSTALL_GPU_ATTESTATION=false
+RUN if [ "$INSTALL_GPU_ATTESTATION" = "true" ]; then \
+      pdm run pip install nv-ppcie-verifier==1.5.0; \
+    fi
+
 COPY . .
 
 RUN mv /root/app/libdmcompverify.so /usr/lib/ \

--- a/neurons/executor/dstacktee/.env.example
+++ b/neurons/executor/dstacktee/.env.example
@@ -27,6 +27,18 @@ MINER_HOTKEY_SS58_ADDRESS=
 VALIDATOR_HOTKEY_SS58_ADDRESS=
 ENABLE_TDX_ATTESTATION=true
 
+# G2 (measured runner) — REQUIRED. Digest of the approved executor-runner
+# release, published with each release. lium-cvm.sh stamps it into the measured
+# docker-compose before dstack measures compose_hash, so the runner is inside
+# the attested trust boundary. Format: sha256:<64-hex>
+EXECUTOR_RUNNER_IMAGE_DIGEST=
+
+# G1 phase-0 — NVIDIA confidential-compute GPU evidence emission (in-CVM only).
+# Requires an executor image built with INSTALL_GPU_ATTESTATION=true.
+# Arch: HOPPER | BLACKWELL.
+ENABLE_GPU_ATTESTATION=false
+GPU_ATTESTATION_ARCH=HOPPER
+
 # CVM Default Configuration
 # These settings will be used as defaults when creating new CVMs
 CVM_VCPUS=16

--- a/neurons/executor/dstacktee/README.md
+++ b/neurons/executor/dstacktee/README.md
@@ -5,10 +5,12 @@ Run compute subnet executors inside Intel TDX confidential VMs with hardware att
 ## Prerequisites
 
 - Intel CPU with TDX and SGX support
-- Ubuntu 22.04+ with KVM enabled
+- Kernel with KVM TDX (Canonical intel kernel or mainline ≥ 6.16) and the boot parameters from [docs/host-setup.md](docs/host-setup.md)
 - Docker and Docker Compose
-- QEMU with TDX support
+- The dstack QEMU 9.2.1 build — **required for attestation to pass**; one-time install, see [docs/host-setup.md](docs/host-setup.md)
 - SGX devices: `/dev/sgx_enclave` and `/dev/sgx_provision`
+
+First-time host? Follow [docs/host-setup.md](docs/host-setup.md) end to end — it covers BIOS, kernel parameters, the QEMU build, and the key provider; the steps below assume a prepared host.
 
 ## Quick Start
 
@@ -97,6 +99,9 @@ RENTING_PORT_RANGE="19001,19002,19003"
 # Identity
 MINER_HOTKEY_SS58_ADDRESS=your_hotkey_here
 ENABLE_TDX_ATTESTATION=true
+
+# Measured executor-runner release (from the release notes) — required
+EXECUTOR_RUNNER_IMAGE_DIGEST=sha256:...
 
 # Resources
 CVM_VCPUS=16

--- a/neurons/executor/dstacktee/app/docker-compose.local.yml
+++ b/neurons/executor/dstacktee/app/docker-compose.local.yml
@@ -1,16 +1,15 @@
-
 version: '3.7'
 
+# G2 (CVM attestation): local variant — see docker-compose.yml for the full
+# rationale. The executor-runner is pinned by digest inside the measured
+# compose (stamped from .env by lium-cvm.sh) and lium-watchtower is retired
+# from the measured topology.
+
 services:
-  lium-watchtower:
-    image: daturaai/lium-watchtower@sha256:f71cbff0417229cdd57af069c2d088055b7cde82bab88158d7f009c3505f5ee8
+  executor-runner:
+    image: daturaai/compute-subnet-executor-runner@${EXECUTOR_RUNNER_IMAGE_DIGEST}
+    container_name: executor-runner
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./.env:/app/.env
-    environment:
-      - WATCHTOWER_ENABLED=true
-      - WATCHTOWER_IMAGE=daturaai/compute-subnet-executor-runner
-      - WATCHTOWER_INTERVAL=300
-      - WATCHTOWER_ENV_FILE_PATH=${PWD}/.env
-    
+      - ./.env:/root/executor/.env

--- a/neurons/executor/dstacktee/app/docker-compose.staging.yml
+++ b/neurons/executor/dstacktee/app/docker-compose.staging.yml
@@ -1,16 +1,15 @@
-
 version: '3.7'
 
+# G2 (CVM attestation): staging variant — see docker-compose.yml for the full
+# rationale. The executor-runner is pinned by digest inside the measured
+# compose (stamped from .env by lium-cvm.sh) and lium-watchtower is retired
+# from the measured topology.
+
 services:
-  lium-watchtower:
-    image: daturaai/lium-watchtower@sha256:82f1c8bb209d2028fb1f416dd006185a8917ab8c650da9a5f7362f157328c150
+  executor-runner:
+    image: daturaai/compute-subnet-executor-runner@${EXECUTOR_RUNNER_IMAGE_DIGEST}
+    container_name: executor-runner
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./.env:/app/.env
-    environment:
-      - WATCHTOWER_ENABLED=true
-      - WATCHTOWER_IMAGE=daturaai/compute-subnet-executor-runner
-      - WATCHTOWER_INTERVAL=300
-      - WATCHTOWER_ENV_FILE_PATH=${PWD}/.env
-    
+      - ./.env:/root/executor/.env

--- a/neurons/executor/dstacktee/app/docker-compose.yml
+++ b/neurons/executor/dstacktee/app/docker-compose.yml
@@ -1,14 +1,23 @@
 version: '3.7'
 
+# G2 (CVM attestation): the executor-runner is pinned BY DIGEST inside this
+# measured compose so the runner release is covered by compose_hash / RTMR3 —
+# the quote the validator verifies and whitelists (with a monotonic version
+# floor). ${EXECUTOR_RUNNER_IMAGE_DIGEST} ("sha256:<64-hex>") is stamped from
+# .env by lium-cvm.sh BEFORE `dstack.py new` measures this file; rotating the
+# runner therefore changes the measurement and requires a new whitelisted
+# compose release version.
+#
+# The lium-watchtower auto-updater is retired from the measured topology: an
+# in-place runner rotation would reintroduce measured ≠ running. Runner updates
+# now ship as a CVM redeploy with a new stamped digest (zero-touch updates are
+# traded for verifiability — see the DAH-2338 remediation plan, G2/G9).
+
 services:
-  lium-watchtower:
-    image: daturaai/lium-watchtower@sha256:4c26288f06261eb33f41793a39e3364017a6b1f30c3e852770c0dd3e72595bed
+  executor-runner:
+    image: daturaai/compute-subnet-executor-runner@${EXECUTOR_RUNNER_IMAGE_DIGEST}
+    container_name: executor-runner
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./.env:/app/.env
-    environment:
-      - WATCHTOWER_ENABLED=true
-      - WATCHTOWER_IMAGE=daturaai/compute-subnet-executor-runner
-      - WATCHTOWER_INTERVAL=300
-      - WATCHTOWER_ENV_FILE_PATH=${PWD}/.env
+      - ./.env:/root/executor/.env

--- a/neurons/executor/dstacktee/app/pre_launch_script.sh
+++ b/neurons/executor/dstacktee/app/pre_launch_script.sh
@@ -1,5 +1,18 @@
-
 chmod +x /usr/bin/containerd-shim-runc-v2
+# dstack-nvidia-0.5.11 bakes upstream sysbox CE 0.6.7, which rejects --gpus
+# (docker device requests) and so fails the SN51 sysbox/GPU compatibility
+# check. Stop the baked daemons and force-install the Datura sysbox build
+# (GPU-capable, same topology as prod 0.5.5 CVMs). The installer skips itself
+# whenever any sysbox-mgr.service unit-file exists -- on 0.5.11 the baked
+# /usr/lib unit always matches -- so stub out its check_existing gate; the
+# units it drops into /run/systemd/system then shadow the baked /usr/lib ones.
+systemctl unmask sysbox-mgr sysbox-fs 2>/dev/null || true
+systemctl stop sysbox-mgr sysbox-fs 2>/dev/null || true
+systemctl disable sysbox-mgr sysbox-fs 2>/dev/null || true
 # TODO: pin digest
-docker run --rm --privileged --pid=host --net=host -v /:/host dstacktee/dstack-sysbox-installer:1.0.0@sha256:2f5dbea99176f3ea0362b85346b31b1160bfb70c1d98d1c8d375d57782127dd1
+docker run --rm --privileged --pid=host --net=host -v /:/host dstacktee/dstack-sysbox-installer:1.0.0@sha256:2f5dbea99176f3ea0362b85346b31b1160bfb70c1d98d1c8d375d57782127dd1 bash -c "sed -i '/^check_existing() {/,/^}/c\\check_existing() { return 0; }' /usr/local/bin/install-sysbox-complete.sh && /usr/local/bin/install-sysbox-complete.sh"
 systemctl restart docker
+# Warm the images the validator's sysbox/DinD probes run, so first-cycle
+# probes don't burn their timeout budget on multi-GB registry pulls.
+docker pull daturaai/dind:0.0.1 >/dev/null 2>&1 || true
+docker pull daturaai/compute-subnet-executor:latest >/dev/null 2>&1 || true

--- a/neurons/executor/dstacktee/docs/host-setup.md
+++ b/neurons/executor/dstacktee/docs/host-setup.md
@@ -1,0 +1,149 @@
+# CVM host setup — dstack-nvidia-0.5.11
+
+Provider guide for taking a TDX host from bare metal to an attested Lium CVM executor. The quick start in [../README.md](../README.md) assumes the host is already prepared; this document covers that preparation. Almost everything here is **one-time per host** — the per-executor work is one `.env` file and two `lium-cvm.sh` commands.
+
+| Phase | Frequency | Hands-on time |
+|---|---|---|
+| §1–§4 host bring-up (BIOS, kernel, QEMU, key provider) | once per host | ~1–2 h (dominated by BIOS + QEMU build) |
+| §5 executor deployment | once per executor | ~15 min |
+| §6 upgrades | per release | ~10 min |
+
+## 1. Hardware and firmware
+
+- **CPU**: Intel Xeon with TDX **and** SGX — Sapphire Rapids (XCC/MCC SKUs only), Emerald Rapids, or Granite Rapids. SGX is not optional: the sealing-key provider runs in an SGX enclave.
+- **GPU**: NVIDIA Confidential-Computing capable — Hopper (H100/H200) or Blackwell (B200/B300). Enable CC mode with [gpu-admin-tools](https://github.com/NVIDIA/gpu-admin-tools) (`--set-cc-mode=on`, after `--set-ppcie-mode=off`; both reset the GPU).
+- **BIOS**: latest vendor BIOS; enable TDX, SGX, VT-x/VT-d. After boot, `/dev/sgx_enclave` and `/dev/sgx_provision` must exist.
+
+## 2. Kernel and boot parameters
+
+Any kernel with KVM TDX support works: Canonical's Intel-optimized kernel (`6.14.0-1009-intel` tested) or mainline **≥ 6.16** (KVM TDX merged upstream; 6.17 is what the full attestation chain was validated on).
+
+`GRUB_CMDLINE_LINUX_DEFAULT` in `/etc/default/grub` must include:
+
+```
+kvm_intel.tdx=on intel_iommu=on iommu=pt nohibernate \
+vfio-pci.ids=<your GPU/NVSwitch PCI IDs, e.g. 10de:2335> \
+vfio_iommu_type1.dma_entry_limit=16777216
+```
+
+- `vfio_iommu_type1.dma_entry_limit=16777216` is **required**, not tuning. The launcher passes GPUs through via the legacy type1 VFIO container (see §3), and TDX shared↔private page conversions exhaust the default 65 535 DMA mappings — QEMU dies mid-boot with `VFIO_MAP_DMA failed: No space left on device`. To apply without a reboot: `echo 16777216 | sudo tee /sys/module/vfio_iommu_type1/parameters/dma_entry_limit` (runtime-only; the GRUB entry is what persists).
+- `vfio-pci.ids=` must cover the GPUs **and** any NVSwitches being passed through.
+
+Then `sudo update-grub && sudo reboot`, and verify:
+
+```bash
+cat /sys/module/kvm_intel/parameters/tdx     # Y
+lspci -nnk -s <gpu-addr>                      # Kernel driver in use: vfio-pci
+```
+
+## 3. QEMU — the dstack 9.2.1 build (required for attestation)
+
+**Why this specific QEMU:** the validator's dstack-verifier reconstructs RTMR0 using an ACPI oracle built from the dstack QEMU 9.2.1 tree. RTMR0 only reproduces when the guest actually runs under that same QEMU. A host on distro QEMU ≥ 10.x can **never** pass — the oracle cannot forward-emulate newer ACPI. Once attestation enforcement is enabled on validators, a wrong host QEMU means failed attestation and a zero score.
+
+**How often:** install **once per host**. Rebuild only when a release note says the verifier's QEMU changed — never per executor, per reboot, or per runner release. (A prebuilt tarball per supported Ubuntu release is planned; until then, build from source.)
+
+```bash
+sudo apt-get install -y --no-install-recommends build-essential git ninja-build pkg-config \
+    python3-pip python3-venv libglib2.0-dev libpixman-1-dev libslirp-dev flex bison
+
+git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 \
+    --branch dstack-qemu-9.2.1 --single-branch qemu-tdx-src
+cd qemu-tdx-src
+git fetch --depth 1 origin dbcec07c0854bf873d346a09e87e4c993ccf2633
+git checkout dbcec07c0854bf873d346a09e87e4c993ccf2633   # pin: the exact tree the verifier oracle is built from
+
+mkdir build && cd build
+../configure --prefix=/opt/qemu-dstack --target-list=x86_64-softmmu \
+    --disable-werror --enable-kvm --enable-slirp
+make -j"$(nproc)"
+sudo make install
+
+/opt/qemu-dstack/bin/qemu-system-x86_64 --version   # QEMU emulator version 9.2.1
+```
+
+This is a plain build — do **not** add the `DUMP_ACPI_TABLES` define (that variant is only for the verifier's oracle binary and cannot run VMs).
+
+Point the launcher at it via `/etc/dstack/client.conf`:
+
+```ini
+[qemu]
+path = /opt/qemu-dstack/bin/qemu-system-x86_64
+```
+
+(`dstack.py` merges `/etc/dstack/client.conf`, `~/.config/dstack/client.conf`, and any `.dstack/client.conf` at or above the working directory, later files overriding earlier ones. `/etc/dstack/client.conf` is recommended because `lium-cvm.sh` runs under sudo.)
+
+Optionally symlink it so `lium-cvm.sh check` finds a QEMU on PATH:
+
+```bash
+sudo ln -s /opt/qemu-dstack/bin/qemu-system-x86_64 /usr/local/bin/qemu-system-x86_64
+```
+
+The launcher handles everything else automatically: it stamps `qemu_version` and `ovmf_variant` into the measured vm_config, and uses the legacy type1 VFIO backend for QEMU < 10 (this build's iommufd binding fails with EINVAL on modern kernels — expected, handled).
+
+## 4. Key provider and PCCS
+
+The sealing-key provider must run on the host before any CVM boots (`lium-cvm.sh run` auto-starts it, but starting manually first surfaces build errors early):
+
+```bash
+cd key-provider && docker compose up --build -d
+docker compose logs -f gramine-sealing-key-provider   # watch first start
+curl -k https://localhost:3443                        # endpoint reachable
+```
+
+Two containers: `aesmd` (SGX architectural enclaves, host network) and `gramine-sealing-key-provider` (`127.0.0.1:3443`). DCAP collateral comes from the PCCS configured in [`key-provider/sgx_default_qcnl.conf`](../key-provider/sgx_default_qcnl.conf) — the default is Phala's public PCCS and works out of the box; point `pccs_url` at your own PCCS if you run one.
+
+## 5. Per-executor deployment
+
+1. Configure:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   Required beyond the obvious (`MINER_HOTKEY_SS58_ADDRESS`, ports, `CVM_VCPUS/MEMORY/DISK`, `CVM_GPUS`):
+
+   - `ENABLE_TDX_ATTESTATION=true`
+   - `EXECUTOR_RUNNER_IMAGE_DIGEST=sha256:<64-hex>` — copy from the release notes. `lium-cvm.sh new` pins this digest into the measured compose (the attested trust boundary) and refuses to run without it.
+
+2. Create and boot (the OS image downloads once per host, then is reused):
+
+   ```bash
+   sudo ./lium-cvm.sh new my-executor
+   sudo ./lium-cvm.sh run my-executor
+   ```
+
+   Everything attestation-related inside the guest — sysbox force-install, digest-pinned runner, quote generation — is baked into the measured compose; there is nothing to configure in the guest.
+
+3. Verify: the executor API answers on `EXTERNAL_PORT` and SSH banners on `SSH_PORT` within ~3–5 minutes of boot. `./lium-cvm.sh list` shows the VM.
+
+4. Register the executor with your miner exactly like a non-CVM executor. Attestation runs automatically when the validator connects.
+
+**Do not modify** `app/docker-compose*.yml`, `app/pre_launch_script.sh`, or `app/init_script.sh`: they are measured into the compose hash the validator whitelists — any local change makes attestation fail.
+
+## 6. Upgrades
+
+Per release:
+
+```bash
+sudo ./lium-cvm.sh stop my-executor
+git pull                                   # the release tag
+# update EXECUTOR_RUNNER_IMAGE_DIGEST in .env from the release notes
+sudo rm -rf run/vms/my-executor            # see warning below
+sudo ./lium-cvm.sh new my-executor
+sudo ./lium-cvm.sh run my-executor
+```
+
+> **Warning — data disk.** The CVM's encrypted data disk key derives from the launch measurements. Any upgrade that changes measurements (OS image, host QEMU, OVMF, compose content) makes the existing `hda.img` undecryptable: the guest reboot-loops with `Failed to open encrypted data disk` even though the launcher reports success. Drain rentals before upgrading and recreate the VM directory. The new compose hash is whitelisted by Datura at release time — nothing to do on your side, but the compose must be exactly as released.
+
+The host QEMU from §3 is **not** touched by executor releases; leave it alone unless a release note says otherwise.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| QEMU exits during guest boot: `VFIO_MAP_DMA failed: No space left on device` | default `dma_entry_limit` (65 535) exhausted by TDX page conversions | §2 — set `vfio_iommu_type1.dma_entry_limit=16777216` (runtime echo + GRUB persist) |
+| Guest reboot-loops; console shows `Failed to open encrypted data disk` | measurements changed under an existing `hda.img` (QEMU/image/compose changed) | recreate the VM (`stop`, remove `run/vms/<name>`, `new`, `run`) — data on the old disk is unrecoverable by design |
+| Attestation fails on RTMR0 / quote not whitelisted, image and compose correct | host running distro QEMU instead of the dstack 9.2.1 build | §3 — install the fork and set `client.conf`; confirm with `--version` |
+| QEMU launch error mentioning `iommufd` / `VFIO_DEVICE_BIND_IOMMUFD` EINVAL | launcher predates the QEMU-version-gated VFIO backend | update to the current release — `dstack.py` now selects type1 automatically for QEMU < 10 |
+| Validation fails `CHECK_SYSBOX_COMPATIBILITY` inside the guest | compose not the released one (pre-launch sysbox force-install missing or altered) | redeploy with the unmodified released compose (§5) |
+| `lium-cvm.sh check` reports QEMU missing although §3 is done | `check` looks for `qemu-system-x86_64` on PATH; the launcher itself uses `client.conf` | add the §3 symlink, or ignore this one check line |

--- a/neurons/executor/dstacktee/key-provider/Dockerfile.aesmd
+++ b/neurons/executor/dstacktee/key-provider/Dockerfile.aesmd
@@ -15,7 +15,8 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Install AESM service and dependencies
 RUN apt-get update && apt-get install -y \
-    wget curl gnupg2 \
+    wget curl gnupg2 ca-certificates \
+    && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # Add Intel SGX repository

--- a/neurons/executor/dstacktee/key-provider/Dockerfile.key-provider
+++ b/neurons/executor/dstacktee/key-provider/Dockerfile.key-provider
@@ -3,6 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 FROM gramineproject/gramine:v1.5@sha256:615849089db84477f03cd13209c08eaf6b6a3a68b4df733e097db56781935589
 
+# The base image's CA store is too old to trust download.01.org's current
+# Sectigo cert; upgrade ca-certificates from the Ubuntu repos first.
+RUN apt-get update 2>/dev/null || true
+RUN apt-get install -y --only-upgrade ca-certificates && update-ca-certificates
+
 RUN apt-get update && apt-get install -y \
     git=1:2.25.1-1ubuntu3.14 \
     build-essential=12.8ubuntu1.1 \

--- a/neurons/executor/dstacktee/lium-cvm.sh
+++ b/neurons/executor/dstacktee/lium-cvm.sh
@@ -432,6 +432,31 @@ new_cvm() {
     # Ensure VMs directory exists
     mkdir -p "$VMS_DIR"
 
+    # G2 (CVM attestation) — stamp the pinned executor-runner digest into the
+    # measured compose BEFORE dstack.py measures it into compose_hash. The
+    # resolved copy (not the template) is what gets attested, so the runner
+    # release is inside the trust boundary the validator whitelists.
+    if grep -q '${EXECUTOR_RUNNER_IMAGE_DIGEST}' "$compose_file"; then
+        if [ -z "$EXECUTOR_RUNNER_IMAGE_DIGEST" ]; then
+            log_error "EXECUTOR_RUNNER_IMAGE_DIGEST is not set (required to pin the measured executor-runner)"
+            log_info "Set it in $env_file to the approved runner release, e.g."
+            log_info "  EXECUTOR_RUNNER_IMAGE_DIGEST=sha256:<digest>"
+            return 1
+        fi
+        case "$EXECUTOR_RUNNER_IMAGE_DIGEST" in
+        sha256:*) ;;
+        *)
+            log_error "EXECUTOR_RUNNER_IMAGE_DIGEST must start with 'sha256:' (got: $EXECUTOR_RUNNER_IMAGE_DIGEST)"
+            return 1
+            ;;
+        esac
+        local resolved_compose="$VMS_DIR/$cvm_name-docker-compose.yml"
+        EXECUTOR_RUNNER_IMAGE_DIGEST="$EXECUTOR_RUNNER_IMAGE_DIGEST" \
+            envsubst '${EXECUTOR_RUNNER_IMAGE_DIGEST}' <"$compose_file" >"$resolved_compose"
+        log_info "Pinned executor-runner digest into measured compose: $EXECUTOR_RUNNER_IMAGE_DIGEST"
+        compose_file="$resolved_compose"
+    fi
+
     # Build the command
     python3 $SCRIPTS_DIR/dstack.py new "$compose_file" \
         --init-script "$INIT_SCRIPT" \

--- a/neurons/executor/dstacktee/lium-cvm.sh
+++ b/neurons/executor/dstacktee/lium-cvm.sh
@@ -13,10 +13,11 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Configuration
-OS_IMAGE_NAME=${OS:-dstack-nvidia-0.5.5}
-# DAH-2311: serve the Lium-built image (NVIDIA driver 595.71.05) from the private-ml-sdk
-# release; override OS_IMAGE_URL to point elsewhere (e.g. staging mirror).
-OS_IMAGE_URL="${OS_IMAGE_URL:-https://github.com/Datura-ai/private-ml-sdk/releases/download/v0.5.5/$OS_IMAGE_NAME.tar.gz}"
+OS_IMAGE_NAME=${OS:-dstack-nvidia-0.5.11}
+# DAH-2338: default to the official upstream image (NVIDIA driver 595.58.03 = R595 TRD1,
+# sysbox baked in). To run the legacy Lium-built 0.5.5 image, set OS=dstack-nvidia-0.5.5
+# and OS_IMAGE_URL to the private-ml-sdk v0.5.5 release asset.
+OS_IMAGE_URL="${OS_IMAGE_URL:-https://github.com/Dstack-TEE/meta-dstack/releases/download/v0.5.11/$OS_IMAGE_NAME.tar.gz}"
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 KEY_PROVIDER_DIR="$THIS_DIR/key-provider"
 SCRIPTS_DIR="$THIS_DIR/scripts"

--- a/neurons/executor/dstacktee/scripts/dstack.py
+++ b/neurons/executor/dstacktee/scripts/dstack.py
@@ -141,7 +141,7 @@ class QemuConfig:
                 self.pic = False
 
 
-def gen_vm_config(vm_dir, host_port, manifest=None, os_image_hash=None):
+def gen_vm_config(vm_dir, host_port, manifest=None, os_image_hash=None, ovmf_variant=None):
     shared_dir = os.path.join(vm_dir, "shared")
     for filename in ["config.json", ".sys-config.json"]:
         config_file = os.path.join(shared_dir, filename)
@@ -160,28 +160,27 @@ def gen_vm_config(vm_dir, host_port, manifest=None, os_image_hash=None):
 
             qemu_cfg = QemuConfig()
             qemu_version_str = get_qemu_version_string()
-            update_guest_config(
-                config_file,
-                {
-                    "vm_config": json.dumps(
-                        {
-                            "spec_version": 1,
-                            "os_image_hash": os_image_hash,
-                            "cpu_count": manifest["vcpu"],
-                            "memory_size": manifest["memory"] * 1024 * 1024,
-                            "qemu_single_pass_add_pages": qemu_cfg.single_pass_add_pages,
-                            "pic": qemu_cfg.pic,
-                            "pci_hole64_size": qemu_cfg.pci_hole64_size,
-                            "num_gpus": num_gpus,
-                            "num_nvswitches": num_nvswitches,
-                            "hugepages": False,
-                            "hotplug_off": qemu_cfg.hotplug_off,
-                            "qemu_version": qemu_version_str,
-                            "image": manifest.get("image"),
-                        }
-                    )
-                },
-            )
+            vm_config = {
+                "spec_version": 1,
+                "os_image_hash": os_image_hash,
+                "cpu_count": manifest["vcpu"],
+                "memory_size": manifest["memory"] * 1024 * 1024,
+                "qemu_single_pass_add_pages": qemu_cfg.single_pass_add_pages,
+                "pic": qemu_cfg.pic,
+                "pci_hole64_size": qemu_cfg.pci_hole64_size,
+                "num_gpus": num_gpus,
+                "num_nvswitches": num_nvswitches,
+                "hugepages": False,
+                "hotplug_off": qemu_cfg.hotplug_off,
+                "qemu_version": qemu_version_str,
+                "image": manifest.get("image"),
+            }
+            # The verifier prefers an explicit OVMF variant over inferring it from
+            # the image name (which mis-picks Stable202505 for dstack-nvidia-0.5.11);
+            # stamp it from the image metadata like upstream dstack-vmm does.
+            if ovmf_variant:
+                vm_config["ovmf_variant"] = ovmf_variant
+            update_guest_config(config_file, {"vm_config": json.dumps(vm_config)})
 
 
 @dataclass
@@ -523,7 +522,13 @@ class DStackManager:
             img_metadata = json.load(f)
 
         os_image_hash = open(os.path.join(image_path, "digest.txt"), "r").read().strip()
-        gen_vm_config(vm_dir, host_port, manifest, os_image_hash)
+        gen_vm_config(
+            vm_dir,
+            host_port,
+            manifest,
+            os_image_hash,
+            ovmf_variant=img_metadata.get("ovmf_variant"),
+        )
 
         mem_gb = manifest["memory"] // 1024
         vcpu_count = manifest["vcpu"]
@@ -635,7 +640,15 @@ class DStackManager:
                 )
                 bus_nr += count + 1
         if gpus:
-            cmd_args.extend(["-object", "iommufd,id=iommufd0"])
+            # QEMU 9.2.1 (dstack fork) fails VFIO_DEVICE_BIND_IOMMUFD (EINVAL)
+            # against mainline 6.16+ kernels; fall back to the legacy type1
+            # container there (needs a raised vfio_iommu_type1.dma_entry_limit —
+            # TDX shared/private conversions exhaust the default 65535 entries).
+            qemu_ver = get_qemu_version()
+            use_iommufd = bool(qemu_ver and qemu_ver >= (10, 0, 0))
+            iommufd_suffix = ",iommufd=iommufd0" if use_iommufd else ""
+            if use_iommufd:
+                cmd_args.extend(["-object", "iommufd,id=iommufd0"])
             if not hugepages:
                 for dev in gpus:
                     slot = dev["slot"]
@@ -644,7 +657,7 @@ class DStackManager:
                             "-device",
                             f"pcie-root-port,id=pci.{dev_num},bus=pcie.0,chassis={dev_num}",
                             "-device",
-                            f"vfio-pci,host={slot},bus=pci.{dev_num},iommufd=iommufd0",
+                            f"vfio-pci,host={slot},bus=pci.{dev_num}{iommufd_suffix}",
                         ]
                     )
                     dev_num += 1
@@ -657,7 +670,7 @@ class DStackManager:
                             "-device",
                             f"pcie-root-port,id=pci.{dev_num},bus=pcie.node{node},chassis={dev_num}",
                             "-device",
-                            f"vfio-pci,host={slot},bus=pci.{dev_num},iommufd=iommufd0",
+                            f"vfio-pci,host={slot},bus=pci.{dev_num}{iommufd_suffix}",
                         ]
                     )
                     dev_num += 1
@@ -668,7 +681,7 @@ class DStackManager:
                         "-device",
                         f"pcie-root-port,id=pci.{dev_num},bus=pcie.0,chassis={dev_num}",
                         "-device",
-                        f"vfio-pci,host={slot},bus=pci.{dev_num},iommufd=iommufd0",
+                        f"vfio-pci,host={slot},bus=pci.{dev_num}{iommufd_suffix}",
                     ]
                 )
                 dev_num += 1

--- a/neurons/executor/src/core/config.py
+++ b/neurons/executor/src/core/config.py
@@ -49,5 +49,19 @@ class Settings(BaseSettings):
     TDX_QUOTE_TIMEOUT: int = Field(env="TDX_QUOTE_TIMEOUT", default=60)
     SSH_HOST_KEY_PATH: str = Field(env="SSH_HOST_KEY_PATH", default="/etc/ssh/ssh_host_ed25519_key.pub")
 
+    # G1 phase-0 — NVIDIA CC GPU evidence emission. Collected ONLY when this flag
+    # is on AND the executor runs inside a dstack CVM (socket below exists): in
+    # host-mode pynvml would attest a non-CC bare-metal GPU, which must never be
+    # emitted as confidential-compute evidence (topology guard).
+    ENABLE_GPU_ATTESTATION: bool = Field(env="ENABLE_GPU_ATTESTATION", default=False)
+    # NVIDIA attestation SDK arch tag routing the evidence at NRAS ("HOPPER", "BLACKWELL").
+    GPU_ATTESTATION_ARCH: str = Field(env="GPU_ATTESTATION_ARCH", default="HOPPER")
+    # dstack guest marker; also what the dstack SDK talks to for TDX quotes.
+    DSTACK_SOCKET_PATH: str = Field(env="DSTACK_SOCKET_PATH", default="/var/run/dstack.sock")
+    # G3 enforcement phase: reject SSH-key uploads without a validator attestation
+    # nonce. Leave off until the validator fleet mints nonces (migration order:
+    # executors accept optional nonce first, then validators send, then this).
+    REQUIRE_ATTESTATION_NONCE: bool = Field(env="REQUIRE_ATTESTATION_NONCE", default=False)
+
 
 settings = Settings()

--- a/neurons/executor/src/payloads/miner.py
+++ b/neurons/executor/src/payloads/miner.py
@@ -9,6 +9,10 @@ class MinerAuthPayload(BaseModel):
 class UploadSShKeyPayload(MinerAuthPayload):
     public_key: str
     validator_signature: str
+    # Validator-issued attestation challenge (hex-encoded 32 bytes), relayed by
+    # the miner. When present it is covered by validator_signature and folded
+    # into TDX report_data[32:64] and the GPU-evidence nonce.
+    nonce: str | None = None
 
 
 class GetPodLogsPaylod(MinerAuthPayload):

--- a/neurons/executor/src/routes/apis.py
+++ b/neurons/executor/src/routes/apis.py
@@ -10,12 +10,13 @@ from typing import Annotated, Optional
 
 import bittensor
 import docker
+from datura.requests.validator_requests import ssh_pubkey_signing_blob
 from fastapi import APIRouter, Depends, Query, Header, HTTPException
 from fastapi.responses import StreamingResponse
 from services.miner_service import MinerService
 from services.pod_log_service import PodLogService
 from services.hardware_service import get_system_metrics, get_container_metrics
-from core.config import VALIDATOR_HOTKEY_SS58
+from core.config import VALIDATOR_HOTKEY_SS58, settings
 
 from payloads.miner import UploadSShKeyPayload, GetPodLogsPaylod
 from payloads.backend import ContainerUtilizationPayload
@@ -157,11 +158,22 @@ def _validate_ssh_key_consistency(payload: UploadSShKeyPayload) -> None:
         raise HTTPException(status_code=400, detail="Public key mismatch")
 
 
-def _validate_validator_signature(payload: UploadSShKeyPayload) -> None:
-    """Require a valid validator signature over the SSH public key."""
+def _validate_validator_signature(payload: UploadSShKeyPayload, require_nonce: bool = False) -> None:
+    """Require a valid validator signature over the SSH public key.
+
+    When the request carries an attestation nonce the signature must cover
+    public_key AND nonce (datura.ssh_pubkey_signing_blob) — stripping or swapping
+    the nonce invalidates the signature. Legacy requests without a nonce keep
+    the bare-public-key format. `require_nonce` is the G3 enforcement phase:
+    attestation-relevant requests without a nonce are rejected outright.
+    """
+    if require_nonce and not payload.nonce:
+        logger.warning("Rejecting SSH-key upload without an attestation nonce (enforcement on)")
+        raise HTTPException(status_code=401, detail="Attestation nonce required")
     try:
         keypair = bittensor.Keypair(ss58_address=VALIDATOR_HOTKEY_SS58)
-        if not keypair.verify(payload.public_key, payload.validator_signature):
+        signed_blob = ssh_pubkey_signing_blob(payload.public_key, payload.nonce)
+        if not keypair.verify(signed_blob, payload.validator_signature):
             raise HTTPException(status_code=401, detail="Invalid validator signature")
         logger.info("Validator signature verification successful")
     except HTTPException:
@@ -178,7 +190,9 @@ async def upload_ssh_key(
     logger.info("upload_ssh_key route entered")
     _validate_ssh_key_consistency(payload)
     logger.info("upload_ssh_key SSH key consistency validated")
-    _validate_validator_signature(payload)
+    # The nonce requirement applies only to uploads (the attestation-bearing
+    # request); removals never carry a nonce.
+    _validate_validator_signature(payload, require_nonce=settings.REQUIRE_ATTESTATION_NONCE)
     logger.info("upload_ssh_key validator signature validated")
     logger.info("upload_ssh_key service call started")
     response = await miner_service.upload_ssh_key(payload)

--- a/neurons/executor/src/services/gpu_attestation_service.py
+++ b/neurons/executor/src/services/gpu_attestation_service.py
@@ -1,0 +1,132 @@
+import asyncio
+import json
+import logging
+import os
+import secrets
+
+from core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class GPUAttestationService:
+    """Collects NVIDIA confidential-compute GPU evidence (G1 phase-0 emission).
+
+    Mirrors the working private-ml-sdk flow (vllm-proxy quote.py): pynvml probes
+    the device count, then `cc_admin.collect_gpu_evidence_remote(nonce)` (single
+    GPU) or the nv_attestation_sdk REMOTE attester (multi-GPU) gathers evidence
+    that the validator submits to NRAS.
+
+    Topology guard (load-bearing): the same executor image serves both the
+    in-CVM topology (GPU via VFIO passthrough inside the TDX guest) and
+    host-mode (bare metal, privileged). Evidence is collected ONLY in-CVM —
+    detected via the dstack guest socket — because host-mode pynvml would attest
+    a non-CC bare-metal GPU. Host-mode therefore never emits evidence, it does
+    not error.
+
+    The NVIDIA verifier stack ships only in CVM runner builds (executor
+    Dockerfile, build arg INSTALL_GPU_ATTESTATION=true — kept out of the pdm
+    lock to isolate its fragile dependency tree); a missing stack is a
+    structured error and a None result, never a crash of the SSH-key upload path.
+    """
+
+    def __init__(self) -> None:
+        self.enabled: bool = bool(
+            settings.ENABLE_TDX_ATTESTATION and settings.ENABLE_GPU_ATTESTATION
+        )
+        self.arch: str = settings.GPU_ATTESTATION_ARCH
+
+    @staticmethod
+    def _in_cvm() -> bool:
+        return os.path.exists(settings.DSTACK_SOCKET_PATH)
+
+    @staticmethod
+    def _normalise_nonce(nonce: str | None) -> str | None:
+        """Return a valid 32-byte hex nonce: the validator's when usable, else a
+        self-generated one (phase-0 shape — emission without the nonce channel).
+
+        A malformed validator nonce is a protocol error: return None so the
+        caller skips emission (the validator fails the event closed on its side)
+        rather than silently substituting a self-nonce for an issued challenge.
+        """
+        if nonce is None:
+            return secrets.token_hex(32)
+        try:
+            if len(bytes.fromhex(nonce)) == 32:
+                return nonce.lower()
+        except ValueError:
+            pass
+        logger.error("Invalid attestation nonce for GPU evidence (expected 32-byte hex)")
+        return None
+
+    def _collect_evidence(self, nonce_hex: str) -> list:
+        """Blocking NVIDIA evidence collection — run in a worker thread.
+
+        Import errors are separated from collection errors so a runner image
+        missing the NVIDIA stack (pre-mortem #2) is directly visible in logs.
+        """
+        try:
+            import pynvml
+            from nv_attestation_sdk import attestation
+            from verifier import cc_admin
+        except ImportError as exc:
+            raise RuntimeError(
+                f"NVIDIA attestation stack unavailable in this image (build with "
+                f"INSTALL_GPU_ATTESTATION=true): {exc}"
+            ) from exc
+
+        try:
+            pynvml.nvmlInit()
+            device_count = pynvml.nvmlDeviceGetCount()
+            if device_count == 1:
+                return cc_admin.collect_gpu_evidence_remote(nonce_hex)
+            attester = attestation.Attestation()
+            attester.set_name(self.arch)
+            attester.set_nonce(nonce_hex)
+            attester.set_claims_version("2.0")
+            attester.set_ocsp_nonce_disabled(True)
+            attester.add_verifier(
+                dev=attestation.Devices.GPU,
+                env=attestation.Environment["REMOTE"],
+                url=None,
+                evidence="",
+            )
+            return attester.get_evidence(options={"ppcie_mode": False})
+        finally:
+            try:
+                pynvml.nvmlShutdown()
+            except pynvml.NVMLError:
+                pass
+
+    async def collect(self, nonce: str | None = None) -> str | None:
+        """Collect GPU evidence and return the JSON nvidia_payload, or None.
+
+        Payload shape matches the private-ml-sdk reference exactly:
+        {"nonce": <hex>, "evidence_list": [...], "arch": <arch>}.
+        """
+        if not self.enabled:
+            return None
+
+        if not self._in_cvm():
+            logger.info(
+                "GPU attestation enabled but no dstack guest detected at %s — "
+                "host-mode topology, skipping GPU evidence collection",
+                settings.DSTACK_SOCKET_PATH,
+            )
+            return None
+
+        nonce_hex = self._normalise_nonce(nonce)
+        if nonce_hex is None:
+            return None
+
+        try:
+            evidences = await asyncio.to_thread(self._collect_evidence, nonce_hex)
+        except Exception as exc:
+            logger.error("GPU evidence collection failed: %s", exc)
+            return None
+
+        if not evidences:
+            logger.error("GPU evidence collection returned no evidence")
+            return None
+
+        return json.dumps({"nonce": nonce_hex, "evidence_list": evidences, "arch": self.arch})

--- a/neurons/executor/src/services/miner_service.py
+++ b/neurons/executor/src/services/miner_service.py
@@ -7,6 +7,7 @@ from typing import Annotated
 from fastapi import Depends
 
 from core.config import settings
+from services.gpu_attestation_service import GPUAttestationService
 from services.ssh_service import SSHService
 from services.tdx_service import TDXQuoteService
 
@@ -20,15 +21,21 @@ class MinerService:
         self,
         ssh_service: Annotated[SSHService, Depends(SSHService)],
         tdx_service: Annotated[TDXQuoteService, Depends(TDXQuoteService)],
+        gpu_attestation_service: Annotated[GPUAttestationService, Depends(GPUAttestationService)],
     ):
         self.ssh_service = ssh_service
         self.tdx_service = tdx_service
+        self.gpu_attestation_service = gpu_attestation_service
 
     async def upload_ssh_key(self, paylod: UploadSShKeyPayload):
         self.ssh_service.add_pubkey_to_host(paylod.public_key)
 
         host_key = self.ssh_service.get_host_public_key()
-        tdx_quote = await self.tdx_service.get_quote(host_key)
+        # The validator nonce (when present) binds the TDX quote and the GPU
+        # evidence to this attestation event; both fall back to their legacy /
+        # self-nonce shapes when it is absent.
+        tdx_quote = await self.tdx_service.get_quote(host_key, nonce=paylod.nonce)
+        nvidia_payload = await self.gpu_attestation_service.collect(nonce=paylod.nonce)
 
         response = {
             "ssh_username": self.ssh_service.get_current_os_user(),
@@ -42,6 +49,8 @@ class MinerService:
             response["ssh_host_key"] = host_key
         if tdx_quote:
             response["tdx_quote"] = tdx_quote
+        if nvidia_payload:
+            response["nvidia_payload"] = nvidia_payload
         return response
 
     async def remove_ssh_key(self, paylod: UploadSShKeyPayload):

--- a/neurons/executor/src/services/tdx_service.py
+++ b/neurons/executor/src/services/tdx_service.py
@@ -30,15 +30,42 @@ class TDXQuoteService:
                     self._client = AsyncDstackClient(timeout=self.timeout)
         return self._client
 
-    def _report_data(self, host_key: str) -> Tuple[str, bytes]:
+    @staticmethod
+    def _parse_nonce(nonce: str | None) -> bytes | None:
+        """Parse a validator-issued attestation nonce (hex, exactly 32 bytes)."""
+        if not nonce:
+            return None
+        try:
+            nonce_bytes = bytes.fromhex(nonce)
+        except ValueError as exc:
+            raise ValueError("Attestation nonce must be hex-encoded") from exc
+        if len(nonce_bytes) != 32:
+            raise ValueError("Attestation nonce must be 32 bytes")
+        return nonce_bytes
+
+    def _report_data(self, host_key: str, nonce_bytes: bytes | None = None) -> Tuple[str, bytes]:
+        """Build report data: sha256("SSH_HOST_KEY:" + host_key) ‖ nonce.
+
+        The host-key hash fills the first 32 bytes (identity — preserves the
+        validator's prefix check); the validator-issued nonce fills bytes 32:64
+        (freshness). Without a nonce the legacy 32-byte form is kept and dstack
+        zero-pads the second half.
+        """
         digest = hashlib.sha256(self.REPORT_PREFIX +
                                 host_key.encode("utf-8")).hexdigest()
-        report_hex = f"0x{digest}"
         report_bytes = bytes.fromhex(digest)
+        if nonce_bytes is not None:
+            report_bytes += nonce_bytes
+        report_hex = f"0x{report_bytes.hex()}"
         return report_hex, report_bytes
 
-    async def get_quote(self, host_key: Optional[str]) -> Optional[str]:
-        """Return a cached or freshly generated TDX quote as a JSON string."""
+    async def get_quote(self, host_key: str | None, nonce: str | None = None) -> str | None:
+        """Return a TDX quote as a JSON string.
+
+        Quotes are cached only for the legacy (nonce-less) path; a nonce-bound
+        quote is freshly generated per attestation event by design — replaying a
+        cached quote would fail the validator's report_data[32:64] check.
+        """
         if not self.enabled:
             return None
         if not host_key:
@@ -46,8 +73,14 @@ class TDXQuoteService:
                 "TDX attestation enabled but SSH host key is unavailable")
             return None
 
-        report_hex, report_bytes = self._report_data(host_key)
-        if self._cached_quote and self._cached_report_data == report_hex:
+        try:
+            nonce_bytes = self._parse_nonce(nonce)
+        except ValueError as exc:
+            logger.error("Invalid attestation nonce received: %s", exc)
+            return None
+
+        report_hex, report_bytes = self._report_data(host_key, nonce_bytes)
+        if nonce_bytes is None and self._cached_quote and self._cached_report_data == report_hex:
             return self._cached_quote
 
         try:
@@ -58,6 +91,7 @@ class TDXQuoteService:
             return None
 
         quote_json = response.model_dump_json()
-        self._cached_report_data = report_hex
-        self._cached_quote = quote_json
+        if nonce_bytes is None:
+            self._cached_report_data = report_hex
+            self._cached_quote = quote_json
         return quote_json

--- a/neurons/executor/tests/test_attestation_nonce_and_gpu.py
+++ b/neurons/executor/tests/test_attestation_nonce_and_gpu.py
@@ -1,0 +1,295 @@
+"""
+Executor-side tests for the CVM attestation gap remediation (DAH-2338, G1/G3).
+
+Covers:
+- G3 signature surface: validator_signature must cover public_key ‖ nonce when a
+  nonce rides the request — swapping or stripping the nonce invalidates it; the
+  legacy (no-nonce) format keeps working; REQUIRE_ATTESTATION_NONCE gates the
+  enforcement phase on the upload route only.
+- G3 quote binding: TDX report_data becomes sha256 half ‖ nonce half, nonce-bound
+  quotes bypass the cache, malformed nonces are rejected.
+- G1 topology guard: GPU evidence is emitted only in-CVM with the feature flag on;
+  host-mode never emits; a missing NVIDIA stack degrades to a logged None.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import bittensor
+import pytest
+from datura.requests.validator_requests import ssh_pubkey_signing_blob
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from middlewares.miner import MinerMiddleware
+
+# conftest.py already inserted src/ into sys.path and set required env vars.
+from core.config import settings
+from routes.apis import apis_router
+from services.gpu_attestation_service import GPUAttestationService
+from services.miner_service import MinerService
+from services.tdx_service import TDXQuoteService
+
+_SSH_KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKey123456789abcdef user@host"
+_NONCE = "ab" * 32
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (same shape as test_upload_ssh_key_auth.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def validator_keypair():
+    return bittensor.Keypair.create_from_uri("//LiumTestValidator")
+
+
+@pytest.fixture(scope="module")
+def miner_keypair():
+    return bittensor.Keypair.create_from_uri("//LiumTestMiner")
+
+
+@pytest.fixture()
+def client(validator_keypair, miner_keypair, monkeypatch):
+    monkeypatch.setattr(settings, "MINER_HOTKEY_SS58_ADDRESS", miner_keypair.ss58_address)
+    monkeypatch.setattr(settings, "DEFAULT_MINER_HOTKEY", miner_keypair.ss58_address)
+    monkeypatch.setattr("routes.apis.VALIDATOR_HOTKEY_SS58", validator_keypair.ss58_address)
+
+    app = FastAPI()
+    app.add_middleware(MinerMiddleware)
+    app.include_router(apis_router)
+
+    mock_service = MagicMock()
+    mock_service.upload_ssh_key = AsyncMock(
+        return_value={"ssh_username": "testuser", "ssh_port": 2200}
+    )
+    mock_service.remove_ssh_key = AsyncMock(return_value=None)
+    app.dependency_overrides[MinerService] = lambda: mock_service
+
+    return TestClient(app)
+
+
+def _build_payload(miner_kp, validator_kp, nonce=None, signed_nonce="__same__") -> dict:
+    """Signed payload; `signed_nonce` lets tests sign over a different nonce
+    than the one shipped in the payload (swap/strip attacks)."""
+    if signed_nonce == "__same__":
+        signed_nonce = nonce
+    miner_sig = "0x" + miner_kp.sign(_SSH_KEY).hex()
+    validator_sig = "0x" + validator_kp.sign(ssh_pubkey_signing_blob(_SSH_KEY, signed_nonce)).hex()
+    payload = {
+        "public_key": _SSH_KEY,
+        "data_to_sign": _SSH_KEY,
+        "signature": miner_sig,
+        "validator_signature": validator_sig,
+    }
+    if nonce is not None:
+        payload["nonce"] = nonce
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# G3 — signature surface
+# ---------------------------------------------------------------------------
+
+
+def test_nonce_covered_signature_accepted(client, miner_keypair, validator_keypair):
+    # Arrange — signature over public_key ‖ nonce, nonce shipped in payload
+    payload = _build_payload(miner_keypair, validator_keypair, nonce=_NONCE)
+
+    # Act
+    response = client.post("/upload_ssh_key", json=payload)
+
+    # Assert
+    assert response.status_code == 200
+
+
+def test_legacy_no_nonce_signature_still_accepted(client, miner_keypair, validator_keypair):
+    # Arrange — deployed-fleet format: bare public key signature, no nonce
+    payload = _build_payload(miner_keypair, validator_keypair, nonce=None)
+
+    # Act / Assert
+    assert client.post("/upload_ssh_key", json=payload).status_code == 200
+
+
+def test_swapped_nonce_rejected(client, miner_keypair, validator_keypair):
+    # Arrange — valid signature over one nonce, a different nonce in the payload
+    payload = _build_payload(
+        miner_keypair, validator_keypair, nonce="cd" * 32, signed_nonce=_NONCE
+    )
+
+    # Act / Assert — covers the plan's nonce-swap-with-valid-signature case
+    assert client.post("/upload_ssh_key", json=payload).status_code == 401
+
+
+def test_stripped_nonce_rejected(client, miner_keypair, validator_keypair):
+    # Arrange — validator signed public_key ‖ nonce but the nonce was removed
+    payload = _build_payload(
+        miner_keypair, validator_keypair, nonce=None, signed_nonce=_NONCE
+    )
+
+    # Act / Assert — downgrade-to-legacy verification must fail
+    assert client.post("/upload_ssh_key", json=payload).status_code == 401
+
+
+def test_nonce_without_covering_signature_rejected(client, miner_keypair, validator_keypair):
+    # Arrange — nonce in payload but the signature only covers the public key
+    payload = _build_payload(
+        miner_keypair, validator_keypair, nonce=_NONCE, signed_nonce=None
+    )
+
+    # Act / Assert
+    assert client.post("/upload_ssh_key", json=payload).status_code == 401
+
+
+def test_require_nonce_enforcement_upload_only(
+    client, miner_keypair, validator_keypair, monkeypatch
+):
+    # Arrange — enforcement phase: uploads without a nonce are rejected
+    monkeypatch.setattr(settings, "REQUIRE_ATTESTATION_NONCE", True)
+    no_nonce = _build_payload(miner_keypair, validator_keypair, nonce=None)
+    with_nonce = _build_payload(miner_keypair, validator_keypair, nonce=_NONCE)
+
+    # Act / Assert
+    assert client.post("/upload_ssh_key", json=no_nonce).status_code == 401
+    assert client.post("/upload_ssh_key", json=with_nonce).status_code == 200
+    # Removals never carry a nonce and must keep working during enforcement.
+    assert client.post("/remove_ssh_key", json=no_nonce).status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# G3 — TDX quote nonce binding
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def tdx_service(monkeypatch):
+    monkeypatch.setattr(settings, "ENABLE_TDX_ATTESTATION", True)
+    return TDXQuoteService()
+
+
+def _fake_dstack_client(calls):
+    client = MagicMock()
+
+    async def fake_get_quote(report_bytes):
+        calls.append(report_bytes)
+        response = MagicMock()
+        response.model_dump_json.return_value = '{"quote": "aa"}'
+        return response
+
+    client.get_quote = fake_get_quote
+    return client
+
+
+def test_report_data_layout_with_nonce(tdx_service):
+    # Act
+    _, legacy = tdx_service._report_data("host-key")
+    _, bound = tdx_service._report_data("host-key", bytes.fromhex(_NONCE))
+
+    # Assert — identity half preserved, nonce fills [32:64]
+    assert len(legacy) == 32
+    assert len(bound) == 64
+    assert bound[:32] == legacy
+    assert bound[32:] == bytes.fromhex(_NONCE)
+
+
+def test_get_quote_binds_nonce_and_skips_cache(tdx_service, monkeypatch):
+    # Arrange — the executor suite has no async pytest plugin; drive with asyncio.run
+    calls = []
+    client = _fake_dstack_client(calls)
+
+    async def fake_get_client():
+        return client
+
+    monkeypatch.setattr(tdx_service, "_get_client", fake_get_client)
+
+    async def scenario():
+        # two nonce-bound calls and two legacy calls
+        await tdx_service.get_quote("host-key", nonce=_NONCE)
+        await tdx_service.get_quote("host-key", nonce=_NONCE)
+        await tdx_service.get_quote("host-key")
+        await tdx_service.get_quote("host-key")
+
+    # Act
+    asyncio.run(scenario())
+
+    # Assert — nonce path regenerates per event (no cache), legacy path caches
+    assert len(calls) == 3
+    assert calls[0][32:] == bytes.fromhex(_NONCE)
+    assert len(calls[2]) == 32
+
+
+def test_get_quote_rejects_malformed_nonce(tdx_service, monkeypatch):
+    # Arrange
+    calls = []
+    client = _fake_dstack_client(calls)
+
+    async def fake_get_client():
+        return client
+
+    monkeypatch.setattr(tdx_service, "_get_client", fake_get_client)
+
+    async def scenario():
+        return (
+            await tdx_service.get_quote("host-key", nonce="zz"),
+            await tdx_service.get_quote("host-key", nonce="ab"),
+        )
+
+    # Act
+    bad_hex, bad_length = asyncio.run(scenario())
+
+    # Assert — bad hex and wrong length both refuse to mint a quote
+    assert bad_hex is None
+    assert bad_length is None
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# G1 — GPU evidence emission topology guard
+# ---------------------------------------------------------------------------
+
+
+def test_gpu_collection_disabled_by_default():
+    # Arrange — both flags default off
+    service = GPUAttestationService()
+
+    # Act / Assert
+    assert asyncio.run(service.collect(_NONCE)) is None
+
+
+def test_gpu_collection_skipped_in_host_mode(monkeypatch):
+    # Arrange — flags on but no dstack guest socket (bare-metal topology)
+    monkeypatch.setattr(settings, "ENABLE_TDX_ATTESTATION", True)
+    monkeypatch.setattr(settings, "ENABLE_GPU_ATTESTATION", True)
+    monkeypatch.setattr(settings, "DSTACK_SOCKET_PATH", "/nonexistent/dstack.sock")
+    service = GPUAttestationService()
+
+    # Act / Assert — host-mode must never emit CC evidence
+    assert asyncio.run(service.collect(_NONCE)) is None
+
+
+def test_gpu_collection_survives_missing_nvidia_stack(monkeypatch, tmp_path):
+    # Arrange — in-CVM topology but the NVIDIA verifier stack is not installed
+    # (this test environment has no nv_attestation_sdk — the real import fails)
+    socket = tmp_path / "dstack.sock"
+    socket.touch()
+    monkeypatch.setattr(settings, "ENABLE_TDX_ATTESTATION", True)
+    monkeypatch.setattr(settings, "ENABLE_GPU_ATTESTATION", True)
+    monkeypatch.setattr(settings, "DSTACK_SOCKET_PATH", str(socket))
+    service = GPUAttestationService()
+
+    # Act / Assert — logged failure, never a crash of the upload path
+    assert asyncio.run(service.collect(_NONCE)) is None
+
+
+def test_gpu_nonce_normalisation():
+    # Arrange
+    service = GPUAttestationService()
+
+    # Act / Assert — validator nonce passes through lowercased
+    assert service._normalise_nonce("AB" * 32) == "ab" * 32
+    # Malformed validator nonce is a protocol error → refuse (no silent self-nonce)
+    assert service._normalise_nonce("zz") is None
+    assert service._normalise_nonce("ab") is None
+    # No nonce (phase-0) → self-generated 32-byte hex
+    self_nonce = service._normalise_nonce(None)
+    assert self_nonce is not None
+    assert len(bytes.fromhex(self_nonce)) == 32

--- a/neurons/miners/src/consumers/validator_consumer.py
+++ b/neurons/miners/src/consumers/validator_consumer.py
@@ -158,6 +158,7 @@ class ValidatorConsumer(BaseConsumer):
                     msg.public_key,
                     msg.validator_signature,
                     msg.executor_id,
+                    nonce=msg.nonce,
                 )
                 if msg.is_rental_request and len(executors) == 1:
                     await self.invoke_rental_request_hook(

--- a/neurons/miners/src/routes/validator_interface.py
+++ b/neurons/miners/src/routes/validator_interface.py
@@ -113,6 +113,7 @@ async def submit_ssh_pubkey(
             request.public_key,
             request.validator_signature,
             request.executor_id,
+            nonce=request.nonce,
         )
         
         if request.is_rental_request and len(executors) == 1:

--- a/neurons/miners/src/services/executor_service.py
+++ b/neurons/miners/src/services/executor_service.py
@@ -239,13 +239,16 @@ class ExecutorService:
         return result
 
     async def send_pubkey_to_executor(
-        self, executor: Executor, pubkey: str, validator_signature: str
+        self, executor: Executor, pubkey: str, validator_signature: str,
+        nonce: str | None = None,
     ) -> ExecutorSSHInfo | None:
         """TODO: Send API request to executor with pubkey
 
         Args:
             executor (Executor): Executor instance that register validator hotkey
             pubkey (str): SSH public key from validator
+            nonce (Optional[str]): Validator attestation challenge, relayed
+                verbatim (it is covered by validator_signature)
 
         Return:
             response (ExecutorSSHInfo | None): Executor SSH connection info.
@@ -259,6 +262,8 @@ class ExecutorService:
             "data_to_sign": pubkey,
             "signature": f"0x{keypair.sign(pubkey).hex()}"
         }
+        if nonce is not None:
+            payload["nonce"] = nonce
         
         base_log_extra = {
             "executor_id": str(executor.uuid),
@@ -365,12 +370,15 @@ class ExecutorService:
         pubkey: bytes,
         validator_signature: str,
         executor_id: Optional[str] = None,
+        nonce: str | None = None,
     ):
         """Register pubkeys to executors for given validator.
 
         Args:
             validator_hotkey (str): Validator hotkey
             pubkey (bytes): SSH pubkey from validator.
+            nonce (Optional[str]): Validator attestation challenge, relayed to
+                each executor untouched (covered by validator_signature).
 
         Return:
             List[dict/object]: Executors SSH connection infos that accepted validator pubkey.
@@ -378,7 +386,9 @@ class ExecutorService:
         executors = await self.get_executors_for_validator(validator_hotkey, miner_hotkey, executor_id)
         tasks = [
             asyncio.create_task(
-                self.send_pubkey_to_executor(executor, pubkey.decode("utf-8"), validator_signature),
+                self.send_pubkey_to_executor(
+                    executor, pubkey.decode("utf-8"), validator_signature, nonce=nonce
+                ),
                 name=f"{executor}.send_pubkey_to_executor",
             )
             for executor in executors

--- a/neurons/validators/docker-compose.app.dstacktee.dev.yml
+++ b/neurons/validators/docker-compose.app.dstacktee.dev.yml
@@ -24,11 +24,14 @@ services:
       - redis_data:/data
 
   dstack-verifier:
-    image: dstacktee/dstack-verifier@sha256:3f36162ca8dd2d4207601a6302881de6b497e610eb44050bb0874776fc8ded07
+    # DAH-2338: verifier 0.5.11 — dcap-qvl 0.3.10 (CVE-2026-22696) + dstack-mr support
+    # for dstack 0.5.11 OS images; still verifies the legacy 0.5.5 images.
+    image: dstacktee/dstack-verifier@sha256:06a20b777e59196c7f54b0cd02ffe567df6d05ae39a0b2fea9cb0642fb23c1fd
     restart: unless-stopped
     environment:
-      # DAH-2311: fetch the Lium-built OS image measurements (NVIDIA 595.71.05) from the
-      # private-ml-sdk release. {OS_IMAGE_HASH} is substituted by the verifier, not compose.
+      # Measurement bundles are hash-named (mr_<os_image_hash>.tar.gz), so this one URL
+      # template serves both the legacy 0.5.5 image and the upstream 0.5.11 image.
+      # {OS_IMAGE_HASH} is substituted by the verifier, not compose.
       - DSTACK_VERIFIER_IMAGE_DOWNLOAD_URL=https://github.com/Datura-ai/private-ml-sdk/releases/download/v0.5.5/mr_{OS_IMAGE_HASH}.tar.gz
 
   validator:

--- a/neurons/validators/docker-compose.app.dstacktee.yml
+++ b/neurons/validators/docker-compose.app.dstacktee.yml
@@ -24,11 +24,14 @@ services:
       - redis_data:/data
 
   dstack-verifier:
-    image: dstacktee/dstack-verifier@sha256:3f36162ca8dd2d4207601a6302881de6b497e610eb44050bb0874776fc8ded07
+    # DAH-2338: verifier 0.5.11 — dcap-qvl 0.3.10 (CVE-2026-22696) + dstack-mr support
+    # for dstack 0.5.11 OS images; still verifies the legacy 0.5.5 images.
+    image: dstacktee/dstack-verifier@sha256:06a20b777e59196c7f54b0cd02ffe567df6d05ae39a0b2fea9cb0642fb23c1fd
     restart: unless-stopped
     environment:
-      # DAH-2311: fetch the Lium-built OS image measurements (NVIDIA 595.71.05) from the
-      # private-ml-sdk release. {OS_IMAGE_HASH} is substituted by the verifier, not compose.
+      # Measurement bundles are hash-named (mr_<os_image_hash>.tar.gz), so this one URL
+      # template serves both the legacy 0.5.5 image and the upstream 0.5.11 image.
+      # {OS_IMAGE_HASH} is substituted by the verifier, not compose.
       - DSTACK_VERIFIER_IMAGE_DOWNLOAD_URL=https://github.com/Datura-ai/private-ml-sdk/releases/download/v0.5.5/mr_{OS_IMAGE_HASH}.tar.gz
 
   validator:

--- a/neurons/validators/src/clients/compute_client.py
+++ b/neurons/validators/src/clients/compute_client.py
@@ -319,6 +319,10 @@ class ComputeClient:
                             price_per_gpu=data["price_per_gpu"],
                             collateral_deposited=data["collateral_deposited"],
                             ssh_pub_keys=data["ssh_pub_keys"],
+                            tee_type=data.get("tee_type"),
+                            attestation_digest=data.get("attestation_digest"),
+                            tdx_attestation_passed=data.get("tdx_attestation_passed"),
+                            gpu_attestation_passed=data.get("gpu_attestation_passed"),
                         )
 
                         async with self.lock:

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -204,6 +204,66 @@ class Settings(BaseSettings):
     TDX_VERIFIER_URL: str | None = Field(env="TDX_VERIFIER_URL", default=None)
     ENABLE_ATTESTATION_WHITELIST: bool = Field(env="ENABLE_ATTESTATION_WHITELIST", default=False)
 
+    # G4 — TCB/advisory enforcement (CVM attestation gap remediation).
+    # Off = warn-only telemetry: violations are logged with structured reasons but do
+    # not reject the quote. On = fail closed with AttestationError naming the value.
+    # Also gates the minimal-G5 hooks: fail-closed on an omitted quote from a
+    # previously-attested (CVM-ratcheted) executor, and the CVM score gate.
+    ENABLE_TCB_ENFORCEMENT: bool = Field(env="ENABLE_TCB_ENFORCEMENT", default=False)
+    # Comma-separated allowlists. TCB statuses other than these reject (when enforced);
+    # advisory IDs (e.g. INTEL-SA-XXXXX) not listed here reject (when enforced).
+    TDX_ALLOWED_TCB_STATUSES: str = Field(env="TDX_ALLOWED_TCB_STATUSES", default="UpToDate")
+    TDX_ALLOWED_ADVISORY_IDS: str = Field(env="TDX_ALLOWED_ADVISORY_IDS", default="")
+
+    # G3 — freshness/anti-replay nonce channel. When enabled the validator mints a
+    # 32-byte challenge per attestation event, folds it into the signed SSH-key
+    # request, and requires the executor to echo it in TDX report_data[32:64].
+    ENABLE_ATTESTATION_NONCE: bool = Field(env="ENABLE_ATTESTATION_NONCE", default=False)
+    # A nonce-bound attestation event is required at most once per this interval per
+    # miner (freshness = "bounded, provably recent", not "every wave") — GPU evidence
+    # collection is too expensive to force fleet-wide every cycle.
+    TDX_REATTEST_INTERVAL_SECONDS: int = Field(env="TDX_REATTEST_INTERVAL_SECONDS", default=3600)
+    # Issued nonce validity window; a quote echoing an older nonce is stale.
+    ATTESTATION_NONCE_TTL_SECONDS: int = Field(env="ATTESTATION_NONCE_TTL_SECONDS", default=600)
+
+    # G1 — NVIDIA GPU confidential-compute attestation (validator-side verification).
+    # Off = observe-only: nvidia_payload, when present, is verified and logged but
+    # never affects the outcome. On = a CVM executor (verified TDX quote) must supply
+    # GPU evidence bound to the issued nonce; any failure raises AttestationError.
+    ENABLE_GPU_ATTESTATION_ENFORCEMENT: bool = Field(
+        env="ENABLE_GPU_ATTESTATION_ENFORCEMENT", default=False
+    )
+    # Hosted NRAS endpoint (interim verification locus; a local nv-verifier removes
+    # this outbound SPOF before fleet enforcement — see remediation plan CD4).
+    NVIDIA_NRAS_URL: str = Field(
+        env="NVIDIA_NRAS_URL", default="https://nras.attestation.nvidia.com/v3/attest/gpu"
+    )
+    # Optional comma-separated allowlist of NRAS `hwmodel` claims (e.g. "GH100 A01 GSP BROM").
+    # Empty = no hwmodel constraint. Substring-prefix match per entry.
+    GPU_ATTESTATION_ALLOWED_HWMODELS: str = Field(env="GPU_ATTESTATION_ALLOWED_HWMODELS", default="")
+
+    # N3 — rental host-key policy. Off preserves today's behavior (a non-attestation
+    # error while building the policy falls back to unpinned SSH). On = fail closed:
+    # no host-key policy ⇒ no rental SSH.
+    ENABLE_RENTAL_HOSTKEY_FAIL_CLOSED: bool = Field(
+        env="ENABLE_RENTAL_HOSTKEY_FAIL_CLOSED", default=False
+    )
+
+    # G2 — monotonic version floor for the measured compose (runner) releases.
+    # Whitelisted compose hashes carry a version; hashes below the floor are rejected
+    # ("≥ approved version", newest-wins — never a rolling window). 0 accepts every
+    # whitelisted hash (today's behavior).
+    TDX_MINIMUM_COMPOSE_VERSION: int = Field(env="TDX_MINIMUM_COMPOSE_VERSION", default=0)
+
+    def get_allowed_tcb_statuses(self) -> set[str]:
+        return {s.strip() for s in self.TDX_ALLOWED_TCB_STATUSES.split(",") if s.strip()}
+
+    def get_allowed_advisory_ids(self) -> set[str]:
+        return {s.strip() for s in self.TDX_ALLOWED_ADVISORY_IDS.split(",") if s.strip()}
+
+    def get_allowed_gpu_hwmodels(self) -> set[str]:
+        return {s.strip() for s in self.GPU_ATTESTATION_ALLOWED_HWMODELS.split(",") if s.strip()}
+
     # Use REST API instead of WebSocket for miner communication
     USE_REST_API: bool = Field(env="USE_REST_API", default=False)
 

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -66,7 +66,7 @@ class Validator:
         self.validation_service = ValidationService()
         self.verifyx_validation_service = VerifyXValidationService()
         self.collateral_contract_service = CollateralContractService()
-        self.attestation_service = AttestationService()
+        self.attestation_service = AttestationService(redis_service=self.redis_service)
 
         # Backend client for API requests
         keypair = settings.get_bittensor_wallet().get_hotkey()

--- a/neurons/validators/src/protocol/vc_protocol/validator_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/validator_requests.py
@@ -71,6 +71,13 @@ class ExecutorSpecRequest(BaseValidatorRequest):
     job_batch_id: str
     collateral_deposited: bool
     ssh_pub_keys: list[str] | None = None
+    # CVM attestation provenance (minimal-G5: the connector must not drop these).
+    # Optional so the backend, which ignores unknown fields until it adopts them,
+    # stays compatible in both directions.
+    tee_type: str | None = None
+    attestation_digest: str | None = None
+    tdx_attestation_passed: bool | None = None
+    gpu_attestation_passed: bool | None = None
 
 
 class RentedMachineRequest(BaseValidatorRequest):

--- a/neurons/validators/src/services/attestation_service.py
+++ b/neurons/validators/src/services/attestation_service.py
@@ -1,22 +1,85 @@
+import base64
+import binascii
 import hashlib
+import json
 import logging
-from datetime import datetime
-from typing import Optional, Tuple
+import secrets
+import time
+from dataclasses import dataclass, field
+from typing import Annotated, Any
 
 import aiohttp
 import asyncssh
-from services.const import TDX_WHITELIST
-
 from datura.requests.miner_requests import ExecutorSSHInfo
+from fastapi import Depends
 
 from core.config import settings
 from core.utils import _m, get_extra_info
+from services.const import TDX_WHITELIST
+from services.redis_service import RedisService
 
 logger = logging.getLogger(__name__)
+
+# Redis set of executor UUIDs that have ever presented a valid TDX quote.
+# Minimal-G5 ratchet: once an executor is known-CVM, an omitted quote is treated
+# as a bypass attempt (fail-closed under ENABLE_TCB_ENFORCEMENT), not as a
+# bare-metal node.
+TDX_ATTESTED_EXECUTOR_SET = "tdx_attested_executors"
+
+# Redis key prefix recording the last nonce-bound attestation event per miner,
+# used to bound re-attestation cadence (G3: freshness = provably recent, not
+# every wave).
+TDX_LAST_ATTESTATION_EVENT_PREFIX = "tdx_last_attestation_event"
 
 
 class AttestationError(RuntimeError):
     """Raised when attestation or host verification fails."""
+
+
+@dataclass
+class AttestationNonce:
+    """Validator-minted challenge binding one attestation event (G3 + G1).
+
+    The hex value rides inside the signed SSHPubKeySubmitRequest, is folded by
+    the executor into TDX report_data[32:64] and into the NVIDIA GPU-evidence
+    nonce, and is asserted on the way back. One nonce is minted per attestation
+    event (a validation request to one miner) and fans out to that miner's
+    executors; per-executor uniqueness comes from the identity half of
+    report_data, freshness from the nonce half.
+    """
+
+    value_hex: str
+    issued_at: float = field(default_factory=time.time)
+
+    @classmethod
+    def issue(cls) -> "AttestationNonce":
+        return cls(value_hex=secrets.token_hex(32))
+
+    @property
+    def value_bytes(self) -> bytes:
+        return bytes.fromhex(self.value_hex)
+
+    def is_expired(self, ttl_seconds: int) -> bool:
+        return (time.time() - self.issued_at) > ttl_seconds
+
+
+@dataclass
+class HostPolicyResult:
+    """Outcome of prepare_host_policy.
+
+    attestation_passed enforces the G1 invariant: it requires the TDX digest AND
+    that GPU verification did not fail (a verified-bad GPU can never surface as
+    passed; None = GPU verification not performed).
+    """
+
+    known_hosts: asyncssh.SSHKnownHosts | None = None
+    attestation_digest: str | None = None
+    tee_type: str | None = None
+    gpu_attestation_passed: bool | None = None
+
+    @property
+    def attestation_passed(self) -> bool:
+        return self.attestation_digest is not None and self.gpu_attestation_passed is not False
 
 
 class AttestationService:
@@ -30,14 +93,59 @@ class AttestationService:
 
     REPORT_PREFIX = b"SSH_HOST_KEY:"
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        redis_service: Annotated[RedisService | None, Depends(RedisService)] = None,
+    ) -> None:
         self.enabled: bool = bool(
             settings.ENABLE_TDX_ATTESTATION and settings.TDX_VERIFIER_URL)
-        self.verifier_url: Optional[str] = settings.TDX_VERIFIER_URL
+        self.verifier_url: str | None = settings.TDX_VERIFIER_URL
         self.quote_timeout: int = 60
+        # Injected by FastAPI DI or passed explicitly (ioc / validator core).
+        # Used for the minimal-G5 CVM ratchet and the re-attest cadence; both
+        # degrade gracefully (log-only) when Redis is absent (e.g. unit tests).
+        self.redis_service = redis_service
 
     def _should_verify(self, executor: ExecutorSSHInfo) -> bool:
         return self.enabled and bool(executor.tdx_quote)
+
+    # ------------------------------------------------------------------
+    # G3 — attestation-event cadence + nonce issuance
+    # ------------------------------------------------------------------
+
+    @property
+    def nonce_enabled(self) -> bool:
+        return self.enabled and settings.ENABLE_ATTESTATION_NONCE
+
+    async def maybe_issue_nonce(self, miner_hotkey: str) -> AttestationNonce | None:
+        """Mint a fresh attestation nonce when this miner is due for a
+        nonce-bound attestation event.
+
+        Freshness is bounded by TDX_REATTEST_INTERVAL_SECONDS rather than
+        demanded every validation wave — GPU evidence collection is seconds per
+        node, so the cadence is load-shed (see remediation plan §4). The event
+        timestamp is recorded at issuance so a persistently failing executor
+        cannot force per-wave collection. Without Redis the interval cannot be
+        tracked, so a nonce is issued every wave (safe, just not load-shed).
+        """
+        if not self.nonce_enabled:
+            return None
+
+        if self.redis_service is not None:
+            key = f"{TDX_LAST_ATTESTATION_EVENT_PREFIX}:{miner_hotkey}"
+            try:
+                raw = await self.redis_service.get(key)
+                last = float(raw.decode() if isinstance(raw, bytes) else raw) if raw else 0.0
+                if (time.time() - last) < settings.TDX_REATTEST_INTERVAL_SECONDS:
+                    return None
+                await self.redis_service.set(key, str(time.time()))
+            except Exception as exc:
+                logger.warning(_m(
+                    "Failed to read/record attestation-event cadence; issuing nonce",
+                    extra=get_extra_info({"miner_hotkey": miner_hotkey, "error": str(exc)}),
+                ))
+
+        return AttestationNonce.issue()
 
     def _expected_report_data(self, host_key: str) -> str:
         digest = hashlib.sha256(self.REPORT_PREFIX +
@@ -74,7 +182,7 @@ class AttestationService:
                         "Verifier response was not JSON") from exc
 
     @staticmethod
-    def _normalise_report_data(value: Optional[str]) -> Optional[bytes]:
+    def _normalise_report_data(value: str | None) -> bytes | None:
         if not value:
             return None
         token = value.strip().lower()
@@ -85,13 +193,100 @@ class AttestationService:
         except ValueError:
             return None
 
-    async def _check_whitelist(self, compose_hash: str, os_image_hash: str) -> bool:
-        """Check if an attestation digest is in the whitelist for the given TEE type."""
-        if compose_hash in TDX_WHITELIST["COMPOSE_HASH"][settings.DEPLOY_ENV] and os_image_hash in TDX_WHITELIST["OS_IMAGE_HASH"]:
-            return True
-        return False
+    async def _check_whitelist(self, compose_hash: str, os_image_hash: str, executor: ExecutorSSHInfo) -> bool:
+        """Check the attestation digest against the whitelist.
 
-    def _validate_verifier_response(self, verifier_payload: dict, expected_report_hex: str, executor: ExecutorSSHInfo) -> None:
+        G2: compose hashes carry a monotonic release version; acceptance requires
+        the version to be at/above TDX_MINIMUM_COMPOSE_VERSION so a below-floor
+        (rotated-back or known-bad) runner release is rejected immediately
+        instead of aging out of a rolling window.
+        """
+        if os_image_hash not in TDX_WHITELIST["OS_IMAGE_HASH"]:
+            return False
+
+        compose_version = TDX_WHITELIST["COMPOSE_HASH"][settings.DEPLOY_ENV].get(compose_hash)
+        if compose_version is None:
+            return False
+
+        if compose_version < settings.TDX_MINIMUM_COMPOSE_VERSION:
+            logger.warning(_m(
+                "Attestation rejected: measured compose release below the minimum version floor",
+                extra=get_extra_info({
+                    "executor": f"{executor.address}:{executor.port}",
+                    "reason": "runner_below_floor",
+                    "compose_hash": compose_hash,
+                    "compose_version": compose_version,
+                    "minimum_version": settings.TDX_MINIMUM_COMPOSE_VERSION,
+                }),
+            ))
+            return False
+
+        return True
+
+    # ------------------------------------------------------------------
+    # G4 — TCB status / advisory enforcement
+    # ------------------------------------------------------------------
+
+    def _collect_tcb_violations(self, details: dict) -> list[tuple[str, Any]]:
+        """Collect (reason_code, offending_value) pairs from the verifier response.
+
+        Checked explicitly rather than leaning on the aggregate is_valid flag:
+        tcb_status, advisory_ids, event_log_verified, os_image_hash_verified.
+        The TDX debug attribute is not currently surfaced by dstack-verifier
+        (absent from its response schema); when it appears it must be asserted
+        off here — tracked as a plan follow-up.
+        """
+        violations: list[tuple[str, Any]] = []
+
+        tcb_status = details.get("tcb_status")
+        if tcb_status not in settings.get_allowed_tcb_statuses():
+            violations.append(("tcb_status_not_allowed", tcb_status))
+
+        advisory_ids = details.get("advisory_ids") or []
+        unexpected_advisories = sorted(set(advisory_ids) - settings.get_allowed_advisory_ids())
+        if unexpected_advisories:
+            violations.append(("advisory_present", unexpected_advisories))
+
+        if not details.get("event_log_verified"):
+            violations.append(("event_log_not_verified", details.get("event_log_verified")))
+
+        if not details.get("os_image_hash_verified"):
+            violations.append(("os_image_hash_not_verified", details.get("os_image_hash_verified")))
+
+        return violations
+
+    def _enforce_tcb(self, details: dict, executor: ExecutorSSHInfo) -> None:
+        violations = self._collect_tcb_violations(details)
+        if not violations:
+            return
+
+        extra = get_extra_info({
+            "executor": f"{executor.address}:{executor.port}",
+            "violations": [
+                {"reason": reason, "value": value} for reason, value in violations
+            ],
+            "enforced": settings.ENABLE_TCB_ENFORCEMENT,
+        })
+
+        if settings.ENABLE_TCB_ENFORCEMENT:
+            reason, value = violations[0]
+            logger.warning(_m("TCB enforcement rejected TDX quote", extra=extra))
+            raise AttestationError(
+                f"TCB enforcement failed for executor {executor.address}:{executor.port}: "
+                f"{reason}={value!r}"
+                + (f" (+{len(violations) - 1} more violations)" if len(violations) > 1 else "")
+            )
+
+        # Warn-only telemetry window: size the blast radius before enforcing.
+        logger.warning(_m("TCB enforcement warning (not enforced)", extra=extra))
+
+    def _validate_verifier_response(
+        self,
+        verifier_payload: dict,
+        expected_report_hex: str,
+        executor: ExecutorSSHInfo,
+        nonce: AttestationNonce | None = None,
+    ) -> None:
         details = verifier_payload.get("details")
         if not isinstance(details, dict):
             raise AttestationError(
@@ -114,10 +309,244 @@ class AttestationService:
                 f"Verifier rejected TDX quote for executor {executor.address}:{executor.port}"
             )
 
+        # G3 — the quote must echo the issued challenge in report_data[32:64].
+        if nonce is not None:
+            if nonce.is_expired(settings.ATTESTATION_NONCE_TTL_SECONDS):
+                logger.warning(_m(
+                    "Attestation rejected: issued nonce expired before verification",
+                    extra=get_extra_info({
+                        "executor": f"{executor.address}:{executor.port}",
+                        "reason": "nonce_stale",
+                        "nonce_age_seconds": int(time.time() - nonce.issued_at),
+                    }),
+                ))
+                raise AttestationError(
+                    f"Attestation nonce expired for executor {executor.address}:{executor.port}"
+                )
+
+            echoed = returned_bytes[32:64] if returned_bytes and len(returned_bytes) >= 64 else b""
+            if echoed != nonce.value_bytes:
+                logger.warning(_m(
+                    "Attestation rejected: report_data does not echo the issued nonce",
+                    extra=get_extra_info({
+                        "executor": f"{executor.address}:{executor.port}",
+                        "reason": "nonce_mismatch",
+                        "expected_nonce": nonce.value_hex,
+                        "echoed": echoed.hex(),
+                    }),
+                ))
+                raise AttestationError(
+                    f"TDX quote for executor {executor.address}:{executor.port} does not echo "
+                    "the issued attestation nonce (stale or replayed quote)"
+                )
+
+        # G4 — enforce TCB/advisory posture (warn-only unless ENABLE_TCB_ENFORCEMENT).
+        self._enforce_tcb(details, executor)
+
+    # ------------------------------------------------------------------
+    # G1 — NVIDIA GPU confidential-compute attestation (verification side)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _decode_jwt_claims(jwt_token: str) -> dict:
+        """Decode the claims segment of a JWT without signature verification.
+
+        The NRAS response is fetched by this validator directly over TLS, so
+        transport authenticates the origin (interim posture — the local
+        nv-verifier replaces NRAS before fleet enforcement, removing both the
+        outbound SPOF and this trust-on-TLS).
+        """
+        try:
+            payload_b64 = jwt_token.split(".")[1]
+            padded = payload_b64 + "=" * ((4 - len(payload_b64) % 4) % 4)
+            return json.loads(base64.urlsafe_b64decode(padded).decode())
+        except (IndexError, ValueError, binascii.Error) as exc:
+            raise AttestationError(f"Malformed NRAS attestation token: {exc}") from exc
+
+    async def _post_nras(self, payload: dict, executor: ExecutorSSHInfo) -> Any:
+        timeout = aiohttp.ClientTimeout(total=self.quote_timeout)
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(settings.NVIDIA_NRAS_URL, json=payload) as response:
+                    if response.status >= 400:
+                        snippet = (await response.text())[:200]
+                        raise AttestationError(
+                            f"NRAS returned {response.status} for executor "
+                            f"{executor.address}:{executor.port}: {snippet}"
+                        )
+                    return await response.json()
+        except AttestationError:
+            raise
+        except Exception as exc:
+            raise AttestationError(
+                f"NRAS unreachable for executor {executor.address}:{executor.port}: {exc}"
+            ) from exc
+
+    def _check_gpu_claims(
+        self,
+        nras_response: Any,
+        expected_nonce_hex: str | None,
+        executor: ExecutorSSHInfo,
+    ) -> tuple[bool, list[str]]:
+        """Evaluate the NRAS response: overall verdict, nonce echo, per-GPU claims.
+
+        Returns (passed, failure_reasons). The overall verdict is the
+        load-bearing check (matching the private-ml-sdk reference verifier);
+        optional per-GPU claims (measres, eat_nonce, dbgstat, secboot, hwmodel)
+        are asserted when present.
+        """
+        failures: list[str] = []
+
+        if not (isinstance(nras_response, list) and nras_response
+                and isinstance(nras_response[0], list | tuple) and len(nras_response[0]) >= 2):
+            return False, ["nras_response_malformed"]
+
+        overall_claims = self._decode_jwt_claims(nras_response[0][1])
+        if overall_claims.get("x-nvidia-overall-att-result") is not True:
+            failures.append("gpu_att_failed:overall_result")
+
+        if expected_nonce_hex:
+            overall_nonce = overall_claims.get("eat_nonce")
+            if isinstance(overall_nonce, str) and overall_nonce.lower() != expected_nonce_hex.lower():
+                failures.append("gpu_att_failed:eat_nonce_mismatch")
+
+        allowed_hwmodels = settings.get_allowed_gpu_hwmodels()
+        per_gpu = nras_response[1] if len(nras_response) > 1 and isinstance(nras_response[1], dict) else {}
+        for gpu_name, gpu_token in per_gpu.items():
+            if not isinstance(gpu_token, str):
+                continue
+            claims = self._decode_jwt_claims(gpu_token)
+            if claims.get("measres") not in (None, "success"):
+                failures.append(f"gpu_att_failed:{gpu_name}:measres")
+            if expected_nonce_hex:
+                gpu_nonce = claims.get("eat_nonce")
+                if isinstance(gpu_nonce, str) and gpu_nonce.lower() != expected_nonce_hex.lower():
+                    failures.append(f"gpu_att_failed:{gpu_name}:eat_nonce_mismatch")
+            dbgstat = claims.get("dbgstat")
+            if dbgstat is not None and dbgstat != "disabled":
+                failures.append(f"gpu_att_failed:{gpu_name}:dbgstat={dbgstat}")
+            secboot = claims.get("secboot")
+            if secboot is not None and secboot is not True:
+                failures.append(f"gpu_att_failed:{gpu_name}:secboot={secboot}")
+            hwmodel = claims.get("hwmodel")
+            if allowed_hwmodels and isinstance(hwmodel, str):
+                if not any(hwmodel.startswith(allowed) for allowed in allowed_hwmodels):
+                    failures.append(f"gpu_att_failed:{gpu_name}:hwmodel={hwmodel}")
+
+        return not failures, failures
+
+    async def _verify_gpu(
+        self,
+        executor: ExecutorSSHInfo,
+        nonce: AttestationNonce | None,
+    ) -> bool | None:
+        """Verify the executor's NVIDIA CC GPU evidence.
+
+        Enforcement (ENABLE_GPU_ATTESTATION_ENFORCEMENT) applies on attestation
+        events (a nonce was issued): missing/unbound/failed evidence raises
+        AttestationError. Outside events, or with enforcement off, verification
+        is observe-only: the result is logged and recorded but never raises.
+
+        Returns True (verified), False (verified-bad), or None (not performed /
+        undeterminable). Never returns True unless NRAS accepted the evidence.
+        """
+        enforce_event = settings.ENABLE_GPU_ATTESTATION_ENFORCEMENT and nonce is not None
+        payload_raw = executor.nvidia_payload
+        log_extra = {"executor": f"{executor.address}:{executor.port}"}
+
+        if not payload_raw:
+            if enforce_event:
+                logger.warning(_m(
+                    "GPU attestation rejected: evidence missing on attestation event",
+                    extra=get_extra_info({**log_extra, "reason": "payload_missing"}),
+                ))
+                raise AttestationError(
+                    f"Executor {executor.address}:{executor.port} did not provide NVIDIA GPU "
+                    "evidence while GPU attestation enforcement is enabled"
+                )
+            return None
+
+        try:
+            payload = json.loads(payload_raw)
+            if not isinstance(payload, dict) or "evidence_list" not in payload:
+                raise ValueError("missing evidence_list")
+        except (ValueError, TypeError) as exc:
+            if enforce_event:
+                raise AttestationError(
+                    f"Malformed NVIDIA GPU evidence from executor {executor.address}:{executor.port}: {exc}"
+                ) from exc
+            logger.warning(_m(
+                "Malformed NVIDIA GPU evidence (observe-only)",
+                extra=get_extra_info({**log_extra, "reason": "payload_malformed", "error": str(exc)}),
+            ))
+            return False
+
+        # On an attestation event the GPU evidence must be bound to the issued
+        # nonce — a self-generated (phase-0) nonce is replayable and rejected.
+        payload_nonce = payload.get("nonce")
+        if nonce is not None and payload_nonce != nonce.value_hex:
+            if enforce_event:
+                logger.warning(_m(
+                    "GPU attestation rejected: evidence nonce is not the issued challenge",
+                    extra=get_extra_info({
+                        **log_extra,
+                        "reason": "gpu_nonce_unbound",
+                        "expected_nonce": nonce.value_hex,
+                        "payload_nonce": payload_nonce,
+                    }),
+                ))
+                raise AttestationError(
+                    f"NVIDIA GPU evidence from executor {executor.address}:{executor.port} is not "
+                    "bound to the issued attestation nonce"
+                )
+            logger.info(_m(
+                "GPU evidence nonce differs from issued challenge (observe-only, likely phase-0 self-nonce)",
+                extra=get_extra_info({**log_extra, "payload_nonce": payload_nonce}),
+            ))
+
+        expected_nonce_hex = nonce.value_hex if (nonce is not None and payload_nonce == nonce.value_hex) else (
+            payload_nonce if isinstance(payload_nonce, str) else None
+        )
+
+        try:
+            nras_response = await self._post_nras(payload, executor)
+            passed, failures = self._check_gpu_claims(nras_response, expected_nonce_hex, executor)
+        except AttestationError as exc:
+            if enforce_event:
+                raise
+            logger.warning(_m(
+                "GPU attestation verification undeterminable (observe-only)",
+                extra=get_extra_info({**log_extra, "reason": "nras_unreachable", "error": str(exc)}),
+            ))
+            return None
+
+        if passed:
+            logger.info(_m(
+                "NVIDIA GPU attestation verified",
+                extra=get_extra_info({
+                    **log_extra,
+                    "nonce_bound": bool(nonce is not None and payload_nonce == nonce.value_hex),
+                    "gpu_count": len(nras_response[1]) if len(nras_response) > 1 and isinstance(nras_response[1], dict) else None,
+                }),
+            ))
+            return True
+
+        logger.warning(_m(
+            "NVIDIA GPU attestation failed",
+            extra=get_extra_info({**log_extra, "reason": "gpu_att_failed", "failures": failures}),
+        ))
+        if enforce_event:
+            raise AttestationError(
+                f"NVIDIA GPU attestation failed for executor {executor.address}:{executor.port}: "
+                + "; ".join(failures)
+            )
+        return False
+
     async def _verify_tdx(
         self,
         executor: ExecutorSSHInfo,
-    ) -> Tuple[Optional[str], Optional[str]]:
+        nonce: AttestationNonce | None = None,
+    ) -> tuple[str | None, str | None]:
         """Verify TDX quote and return (attestation_digest, tee_type).
 
         Validates the quote string, calls the external verifier, extracts
@@ -135,7 +564,7 @@ class AttestationService:
 
         expected_report = self._expected_report_data(executor.ssh_host_key)
         verifier_payload = await self._call_verifier(quote.strip(), executor)
-        self._validate_verifier_response(verifier_payload, expected_report, executor)
+        self._validate_verifier_response(verifier_payload, expected_report, executor, nonce=nonce)
 
         details = verifier_payload.get("details", {})
         app_info = details.get("app_info", {})
@@ -167,7 +596,7 @@ class AttestationService:
                 )
 
             is_whitelisted = await self._check_whitelist(
-                compose_hash=compose_hash, os_image_hash=os_image_hash
+                compose_hash=compose_hash, os_image_hash=os_image_hash, executor=executor
             )
             if not is_whitelisted:
                 raise AttestationError(
@@ -190,10 +619,53 @@ class AttestationService:
 
         return attestation_digest, tee_type
 
+    async def _record_attested_executor(self, executor: ExecutorSSHInfo) -> None:
+        """Ratchet: remember that this executor is a CVM (minimal-G5)."""
+        if self.redis_service is None:
+            return
+        try:
+            await self.redis_service.sadd(TDX_ATTESTED_EXECUTOR_SET, str(executor.uuid))
+        except Exception as exc:
+            logger.warning(_m(
+                "Failed to record attested executor in ratchet set",
+                extra=get_extra_info({"executor_uuid": executor.uuid, "error": str(exc)}),
+            ))
+
+    async def _reject_omitted_quote_if_ratcheted(self, executor: ExecutorSSHInfo) -> None:
+        """Minimal-G5 fail-closed: a previously attested executor cannot silently
+        drop its quote to skip verification (host-key-only bypass)."""
+        if not (self.enabled and settings.ENABLE_TCB_ENFORCEMENT):
+            return
+        if executor.tdx_quote or self.redis_service is None:
+            return
+        try:
+            is_ratcheted = await self.redis_service.is_elem_exists_in_set(
+                TDX_ATTESTED_EXECUTOR_SET, str(executor.uuid)
+            )
+        except Exception as exc:
+            logger.warning(_m(
+                "Failed to check attested-executor ratchet set",
+                extra=get_extra_info({"executor_uuid": executor.uuid, "error": str(exc)}),
+            ))
+            return
+        if is_ratcheted:
+            logger.warning(_m(
+                "Attestation rejected: previously attested executor omitted its TDX quote",
+                extra=get_extra_info({
+                    "executor": f"{executor.address}:{executor.port}",
+                    "executor_uuid": executor.uuid,
+                    "reason": "quote_omitted_ratcheted",
+                }),
+            ))
+            raise AttestationError(
+                f"Executor {executor.address}:{executor.port} previously attested as a CVM "
+                "but omitted its TDX quote (fail-closed)"
+            )
+
     def _build_known_hosts(
         self,
         executor: ExecutorSSHInfo,
-    ) -> Optional[asyncssh.SSHKnownHosts]:
+    ) -> asyncssh.SSHKnownHosts | None:
         """Build an asyncssh known-hosts policy from executor.ssh_host_key.
 
         Constructs a known_hosts entry that covers both the bare address and the
@@ -228,17 +700,23 @@ class AttestationService:
     async def prepare_host_policy(
         self,
         executor: ExecutorSSHInfo,
-    ) -> Tuple[Optional[asyncssh.SSHKnownHosts], Optional[str], Optional[str]]:
-        """Verify TDX attestation and build SSH known_hosts policy for the executor.
+        nonce: AttestationNonce | None = None,
+    ) -> HostPolicyResult:
+        """Verify TDX (and, when supplied, NVIDIA GPU) attestation and build the
+        SSH known_hosts policy for the executor.
 
-        Returns (known_hosts, attestation_digest, tee_type):
+        Returns a HostPolicyResult carrying:
         - known_hosts: SSH host key policy built from the verified TDX quote
         - attestation_digest: os_image_hash + compose_hash identifying the CVM software stack
-        - tee_type: TEE technology, e.g. "dstack/tdx"
+        - tee_type: "dstack/tdx", upgraded to "dstack/tdx+nvcc" when nonce-bound
+          GPU evidence verified
+        - gpu_attestation_passed: True / False / None (None = not performed)
 
-        All three values are None when attestation is disabled or the executor has no
-        host key.  Raises AttestationError if verification is enabled but fails.
+        All fields are None when attestation is disabled or the executor has no
+        host key. Raises AttestationError if verification is enabled but fails.
         """
+        await self._reject_omitted_quote_if_ratcheted(executor)
+
         should_verify = self._should_verify(executor)
 
         if not executor.ssh_host_key:
@@ -246,11 +724,24 @@ class AttestationService:
                 raise AttestationError(
                     f"Executor {executor.address}:{executor.port} missing SSH host key for attestation"
                 )
-            return None, None, None
+            return HostPolicyResult()
 
         attestation_digest, tee_type = None, None
+        gpu_attestation_passed: bool | None = None
         if should_verify:
-            attestation_digest, tee_type = await self._verify_tdx(executor)
+            attestation_digest, tee_type = await self._verify_tdx(executor, nonce=nonce)
+            await self._record_attested_executor(executor)
+
+            gpu_attestation_passed = await self._verify_gpu(executor, nonce)
+            # tee_type only claims verified GPU CC when the evidence was bound
+            # to the validator-issued challenge (an unbound pass is replayable).
+            if gpu_attestation_passed is True and nonce is not None:
+                tee_type = "dstack/tdx+nvcc"
 
         known_hosts = self._build_known_hosts(executor)
-        return known_hosts, attestation_digest, tee_type
+        return HostPolicyResult(
+            known_hosts=known_hosts,
+            attestation_digest=attestation_digest,
+            tee_type=tee_type,
+            gpu_attestation_passed=gpu_attestation_passed,
+        )

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -243,21 +243,21 @@ TDX_WHITELIST = {
             "a6eafc5f007f642d8ea90c7fa8881f1e6715720ccb531941a28218f4f26d7b02",
         ]
     ),
-    "COMPOSE_HASH": { # compose file hash will be vary depending on the environment (depends on lium-watchtower)
-        "PROD": set(
-            [
-                "a77f05d55bdb6c8fe86f2cd76271192a0b95617f198da4700d92c20d8798d4ee",
-            ]
-        ),
-        "STAGE": set(
-            [
-                "72c9c91a1b72cb016e1ed2ac85cdb1414502165dc3eb3723642f30a5ef0fcb11",
-            ]
-        ),
-        "LOCAL": set( 
-            [
-                "2d655bf8eca15eaec6cc5800acae99eaeb21fc3dafcfcf594139c827596a7828",
-            ]
-        ),
+    # Compose-file hashes vary per environment. G2: each approved hash carries a
+    # monotonically increasing release version — append-only, next release gets the
+    # next integer. Acceptance requires version >= settings.TDX_MINIMUM_COMPOSE_VERSION
+    # ("at/above the floor", newest-wins) so a known-bad release is retired by raising
+    # the floor instead of aging out of a rolling window. Membership checks
+    # (`hash in TDX_WHITELIST["COMPOSE_HASH"][env]`) keep working on the dict keys.
+    "COMPOSE_HASH": {
+        "PROD": {
+            "a77f05d55bdb6c8fe86f2cd76271192a0b95617f198da4700d92c20d8798d4ee": 1,
+        },
+        "STAGE": {
+            "72c9c91a1b72cb016e1ed2ac85cdb1414502165dc3eb3723642f30a5ef0fcb11": 1,
+        },
+        "LOCAL": {
+            "2d655bf8eca15eaec6cc5800acae99eaeb21fc3dafcfcf594139c827596a7828": 1,
+        },
     }
 }

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -233,13 +233,11 @@ RENTAL_CONTAINER_PREFIXES = ("pod_", "filler_", "container_", "health_check_")
 TDX_WHITELIST = {
     "OS_IMAGE_HASH": set(
         [
-            # dstack-nvidia 0.5.5 — upstream download.dstack.org build
-            "9b69bb1698bacbb6985409a2c272bcb892e09cdcea63d5399c6768b67d3ff677",
-            # DAH-2311 — dstack-nvidia 0.5.5 rebuilt with NVIDIA driver 595.71.05
-            # (private-ml-sdk git_revision 0a1dcf7, prod/non-dev image)
-            "dbfde5432af2762da24d2ee3f39dcb7fdb676064fce1891edab3f6d924e8dc3d",
             # DAH-2338 — official upstream dstack-nvidia 0.5.11 (meta-dstack v0.5.11
-            # release, git_revision ce04e924, NVIDIA driver 595.58.03, prod/non-dev image)
+            # release, git_revision ce04e924, NVIDIA driver 595.58.03, prod/non-dev
+            # image). Single-image policy: the legacy 0.5.5 hashes (upstream 9b69bb16…
+            # and DAH-2311 rebuilt dbfde543…) are removed — CVMs still booting them
+            # must be redeployed on 0.5.11.
             "a6eafc5f007f642d8ea90c7fa8881f1e6715720ccb531941a28218f4f26d7b02",
         ]
     ),

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -251,7 +251,13 @@ TDX_WHITELIST = {
     # (`hash in TDX_WHITELIST["COMPOSE_HASH"][env]`) keep working on the dict keys.
     "COMPOSE_HASH": {
         "PROD": {
-            "a77f05d55bdb6c8fe86f2cd76271192a0b95617f198da4700d92c20d8798d4ee": 1,
+            # DAH-2338 — 0.5.11 measured compose: executor-runner pinned to the
+            # current prod runner digest sha256:b58211e7… (:latest, 2026-06-26),
+            # pre-launch sysbox force-install included. Replaces the legacy
+            # watchtower-era hash a77f05d5… — CVMs still on that compose must be
+            # redeployed under the digest-pinned scheme (the 0.5.11 migration
+            # re-creates them anyway). Assumes default `lium-cvm.sh new` flags.
+            "0995e41b73e98ba4798b40c79c3f671f193648b9cd895726753a89c5ff024b72": 2,
         },
         "STAGE": {
             "72c9c91a1b72cb016e1ed2ac85cdb1414502165dc3eb3723642f30a5ef0fcb11": 1,

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -255,6 +255,11 @@ TDX_WHITELIST = {
         },
         "STAGE": {
             "72c9c91a1b72cb016e1ed2ac85cdb1414502165dc3eb3723642f30a5ef0fcb11": 1,
+            # DAH-2338 — 0.5.11 staging compose: executor-runner pinned to
+            # daturaai/compute-subnet-executor-runner:dev digest sha256:58db7cd5…
+            # (pushed 2026-07-06), pre-launch sysbox force-install included.
+            # Assumes default `lium-cvm.sh new` flags (no --enable-logs/--enable-sysinfo).
+            "feedf7cb08a9905f3ef66eb9bab4af310310965589e5aed070594c326bf44e16": 2,
         },
         "LOCAL": {
             "2d655bf8eca15eaec6cc5800acae99eaeb21fc3dafcfcf594139c827596a7828": 1,

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -238,6 +238,9 @@ TDX_WHITELIST = {
             # DAH-2311 — dstack-nvidia 0.5.5 rebuilt with NVIDIA driver 595.71.05
             # (private-ml-sdk git_revision 0a1dcf7, prod/non-dev image)
             "dbfde5432af2762da24d2ee3f39dcb7fdb676064fce1891edab3f6d924e8dc3d",
+            # DAH-2338 — official upstream dstack-nvidia 0.5.11 (meta-dstack v0.5.11
+            # release, git_revision ce04e924, NVIDIA driver 595.58.03, prod/non-dev image)
+            "a6eafc5f007f642d8ea90c7fa8881f1e6715720ccb531941a28218f4f26d7b02",
         ]
     ),
     "COMPOSE_HASH": { # compose file hash will be vary depending on the environment (depends on lium-watchtower)

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -725,14 +725,33 @@ class DockerService:
         miner_hotkey: str | None,
         log_context: dict,
     ) -> asyncssh.SSHKnownHosts | None:
+        """Single chokepoint for every rental-path SSH host-key policy.
+
+        N3 (CVM attestation gap remediation): with ENABLE_RENTAL_HOSTKEY_FAIL_CLOSED
+        an unexpected error here fails closed — no host-key policy means no rental
+        SSH — instead of silently falling back to unpinned SSH. Rental-path
+        freshness rides the most recent validation-cycle attestation; no nonce is
+        minted here by design.
+        """
         try:
-            known_hosts, _, _ = await self.attestation_service.prepare_host_policy(
-                executor, 
+            host_policy = await self.attestation_service.prepare_host_policy(
+                executor,
             )
-            return known_hosts
+            return host_policy.known_hosts
         except AttestationError:
             raise
         except Exception as exc:
+            if settings.ENABLE_RENTAL_HOSTKEY_FAIL_CLOSED:
+                logger.warning(
+                    _m(
+                        "Unable to prepare known_hosts policy — failing closed (no rental SSH)",
+                        extra=get_extra_info({**log_context, "error": str(exc)}),
+                    )
+                )
+                raise AttestationError(
+                    f"Unable to prepare host-key policy for executor "
+                    f"{executor.address}:{executor.port}; refusing unpinned rental SSH"
+                ) from exc
             logger.warning(
                 _m(
                     "Unable to prepare known_hosts policy",

--- a/neurons/validators/src/services/ioc.py
+++ b/neurons/validators/src/services/ioc.py
@@ -40,7 +40,7 @@ async def initiate_services():
     ioc["ValidationService"] = ValidationService()
     ioc["VerifyXValidationService"] = VerifyXValidationService()
     ioc["CollateralContractService"] = CollateralContractService()
-    ioc["AttestationService"] = AttestationService()
+    ioc["AttestationService"] = AttestationService(redis_service=ioc["RedisService"])
     port_tester = PortTester()
     runner = ContainerRunner()
     ioc["ExecutorConnectivityService"] = ExecutorConnectivityService(

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -25,6 +25,7 @@ from datura.requests.validator_requests import (
     SSHPubKeySubmitRequest,
     GetPodLogsRequest,
     AuthenticationPayload,
+    ssh_pubkey_signing_blob,
 )
 from fastapi import Depends
 from clients.validator_portal_api import ValidatorPortalAPI
@@ -164,9 +165,20 @@ class MinerService:
     def _normalize_public_key(public_key: bytes | str) -> str:
         return public_key.decode("utf-8") if isinstance(public_key, bytes) else public_key
 
-    def _sign_validator_pubkey(self, keypair: bittensor.Keypair, public_key: bytes | str) -> str:
+    def _sign_validator_pubkey(
+        self,
+        keypair: bittensor.Keypair,
+        public_key: bytes | str,
+        nonce: str | None = None,
+    ) -> str:
+        """Sign the canonical SSH-pubkey blob (see datura.ssh_pubkey_signing_blob).
+
+        Without a nonce this is the legacy signature over the bare public key.
+        When an attestation nonce rides the request it MUST be passed here so it
+        is covered by the signature — otherwise the executor rejects the request.
+        """
         pubkey = self._normalize_public_key(public_key)
-        return f"0x{keypair.sign(pubkey).hex()}"
+        return f"0x{keypair.sign(ssh_pubkey_signing_blob(pubkey, nonce)).hex()}"
 
     async def request_job_to_miner(
         self,
@@ -222,12 +234,20 @@ class MinerService:
                 # generate ssh key and send it to miner
                 private_key, public_key = self.ssh_service.generate_ssh_key(my_key.ss58_address)
 
+                # G3 — attestation event: when due, mint a challenge that executors
+                # must echo in TDX report_data[32:64] / GPU evidence. The nonce is
+                # covered by validator_signature so it cannot be stripped or swapped.
+                attestation_nonce = await self.attestation_service.maybe_issue_nonce(
+                    payload.miner_hotkey
+                )
+                nonce_hex = attestation_nonce.value_hex if attestation_nonce else None
 
                 await miner_client.send_model(
                     SSHPubKeySubmitRequest(
                         public_key=public_key,
-                        validator_signature=self._sign_validator_pubkey(my_key, public_key),
+                        validator_signature=self._sign_validator_pubkey(my_key, public_key, nonce=nonce_hex),
                         miner_hotkey=payload.miner_hotkey, # include miner's hotkey in the request
+                        nonce=nonce_hex,
                     )
                 )
 
@@ -283,6 +303,7 @@ class MinerService:
                                     public_key=public_key.decode("utf-8"),
                                     encrypted_files=encrypted_files,
                                     rented_data=rented_data,
+                                    attestation_nonce=attestation_nonce,
                                 ),
                                 timeout=settings.JOB_TIME_OUT - 120
                             )
@@ -487,6 +508,7 @@ class MinerService:
                         "attestation_digest": result.attestation_digest,
                         "tee_type": result.tee_type,
                         "tdx_attestation_passed": result.tdx_attestation_passed,
+                        "gpu_attestation_passed": result.gpu_attestation_passed,
                     },
                 )
             except Exception as e:
@@ -1446,12 +1468,19 @@ class MinerService:
             
             # Generate SSH key
             private_key, public_key = self.ssh_service.generate_ssh_key(my_key.ss58_address)
-            
+
+            # G3 — attestation event (REST path); see the WebSocket path for details.
+            attestation_nonce = await self.attestation_service.maybe_issue_nonce(
+                payload.miner_hotkey
+            )
+            nonce_hex = attestation_nonce.value_hex if attestation_nonce else None
+
             # Prepare request
             ssh_request = SSHPubKeySubmitRequest(
                 public_key=public_key,
-                validator_signature=self._sign_validator_pubkey(my_key, public_key),
+                validator_signature=self._sign_validator_pubkey(my_key, public_key, nonce=nonce_hex),
                 miner_hotkey=payload.miner_hotkey,
+                nonce=nonce_hex,
             )
             
             # Make REST API call
@@ -1506,6 +1535,7 @@ class MinerService:
                                 public_key=public_key.decode("utf-8"),
                                 encrypted_files=encrypted_files,
                                 rented_data=rented_data,
+                                attestation_nonce=attestation_nonce,
                             ),
                             timeout=settings.JOB_TIME_OUT - 120
                         )

--- a/neurons/validators/src/services/task/models.py
+++ b/neurons/validators/src/services/task/models.py
@@ -34,6 +34,8 @@ class JobResult(BaseModel):
     attestation_digest: str | None = None
     tee_type: str | None = None
     tdx_attestation_passed: bool = False
+    # G1 — NVIDIA CC GPU attestation outcome (None = not performed)
+    gpu_attestation_passed: bool | None = None
 
     inspector_outcome: str = "SKIPPED"
 

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -128,6 +128,9 @@ class Context(BaseModel):
     log_text: str | None = None
     success: bool = False
     tdx_attestation_passed: bool = False
+    # G1 — NVIDIA CC GPU attestation outcome: True/False when verified, None when
+    # not performed (non-CVM node, no evidence supplied, or NRAS undeterminable).
+    gpu_attestation_passed: bool | None = None
 
 
 class Check(Protocol):

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -127,6 +127,7 @@ class PipelineFactory:
         encrypted_files: MinerJobEnryptedFiles,
         rented_data: RentedExecutorsResponse,
         tdx_attestation_passed: bool = False,
+        gpu_attestation_passed: bool | None = None,
     ) -> Context:
         """Build the base validation context with all configuration.
 
@@ -139,6 +140,7 @@ class PipelineFactory:
             public_key: Public key for SSH
             encrypted_files: Encrypted validation files
             tdx_attestation_passed: Whether TDX attestation passed
+            gpu_attestation_passed: NVIDIA CC GPU attestation outcome (None = not performed)
 
         Returns:
             Configured Context ready for pipeline execution
@@ -216,6 +218,7 @@ class PipelineFactory:
             ),
             is_rental_succeed=is_rental_succeed,
             tdx_attestation_passed=tdx_attestation_passed,
+            gpu_attestation_passed=gpu_attestation_passed,
         )
 
     @staticmethod

--- a/neurons/validators/src/services/task/result_handler.py
+++ b/neurons/validators/src/services/task/result_handler.py
@@ -127,6 +127,11 @@ class ResultHandler:
             "tdx_attestation_passed": context.tdx_attestation_passed,
             "is_spot": is_spot,
         }
+        # G1 — NVIDIA CC GPU attestation outcome. Only added when a verification
+        # was actually performed (None → key omitted), mirroring gpu_metrics.
+        # Rides executor.specs to the backend like tdx_attestation_passed.
+        if context.gpu_attestation_passed is not None:
+            specs["gpu_attestation_passed"] = context.gpu_attestation_passed
         # FP32 TFLOPS metrics (device-0 representative), captured by CapabilityCheck.
         # Only added when present; absent → fail-safe (TFLOPS disabled/failed). The
         # backend types this nested object as MachineSpecs.gpu_metrics.
@@ -181,6 +186,7 @@ class ResultHandler:
             rental_created_at=self._get_rental_created_at(context),
             default_job_owner=default_job_owner,
             tdx_attestation_passed=context.tdx_attestation_passed,
+            gpu_attestation_passed=context.gpu_attestation_passed,
             inspector_outcome=inspector_outcome,
         )
 

--- a/neurons/validators/src/services/task/score_calculator.py
+++ b/neurons/validators/src/services/task/score_calculator.py
@@ -47,6 +47,20 @@ def calculate_scores(
             f"GPU price exceeds the limit. limit: {base_price * max_price_rate}, actual: {price_per_gpu}"
         )
 
+    # Minimal-G5 CVM attestation gate: a CVM-flagged executor (it presented a TDX
+    # quote) whose attestation did not pass earns nothing while TCB enforcement is
+    # on. Non-CVM executors (no quote) are untouched — omitted-quote bypass by a
+    # known CVM is rejected upstream by the attestation ratchet.
+    if (
+        settings.ENABLE_TDX_ATTESTATION
+        and settings.ENABLE_TCB_ENFORCEMENT
+        and ctx.executor.tdx_quote
+        and not ctx.tdx_attestation_passed
+    ):
+        actual_score = 0.0
+        job_score = 0.0
+        warning_messages.append("CVM attestation not passed (TDX/GPU attestation required)")
+
     # EMA verifyx download speed check — threshold enforced upstream in VerifyXCheck
     ema_verifyx_download = ((ctx.state.specs or {}).get("network") or {}).get(
         "ema_verifyx_download_speed"

--- a/neurons/validators/src/services/task/service.py
+++ b/neurons/validators/src/services/task/service.py
@@ -10,7 +10,7 @@ from clients.backend_client import BackendClient
 from core.config import settings
 from core.utils import _m, get_extra_info
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
-from services.attestation_service import AttestationService, AttestationError
+from services.attestation_service import AttestationError, AttestationNonce, AttestationService
 from services.collateral_contract_service import CollateralContractService
 from services.executor_connectivity_service import ExecutorConnectivityService
 from services.interactive_shell_service import InteractiveShellService
@@ -62,11 +62,13 @@ class TaskService:
         public_key: str,
         encrypted_files: MinerJobEnryptedFiles,
         rented_data: RentedExecutorsResponse,
+        attestation_nonce: AttestationNonce | None = None,
     ):
         """New pipeline-based validation task implementation."""
         attestation_digest = None
         tee_type = None
         attestation_passed = False
+        gpu_attestation_passed = None
 
         try:
             # Decrypt private key
@@ -74,10 +76,17 @@ class TaskService:
 
             # Prepare attestation host policy before SSH connection
             try:
-                known_hosts_policy, attestation_digest, tee_type = await self.attestation_service.prepare_host_policy(
+                host_policy = await self.attestation_service.prepare_host_policy(
                     executor_info,
+                    nonce=attestation_nonce,
                 )
-                attestation_passed = attestation_digest is not None
+                known_hosts_policy = host_policy.known_hosts
+                attestation_digest = host_policy.attestation_digest
+                tee_type = host_policy.tee_type
+                gpu_attestation_passed = host_policy.gpu_attestation_passed
+                # G1 invariant: a verified-bad GPU can never surface as passed
+                # (HostPolicyResult.attestation_passed requires tdx ∧ gpu-not-False).
+                attestation_passed = host_policy.attestation_passed
             except AttestationError as exc:
                 log_text = _m(
                     "Attestation failed",
@@ -109,6 +118,7 @@ class TaskService:
                     encrypted_files=encrypted_files,
                     rented_data=rented_data,
                     tdx_attestation_passed=attestation_passed,
+                    gpu_attestation_passed=gpu_attestation_passed,
                 )
 
                 # Build and run validation pipeline
@@ -138,6 +148,7 @@ class TaskService:
                 )
                 result.attestation_digest = attestation_digest
                 result.tee_type = tee_type
+                result.gpu_attestation_passed = gpu_attestation_passed
                 return result
 
         except Exception as e:
@@ -169,6 +180,7 @@ class TaskService:
                 sysbox_runtime=False,
                 attestation_digest=attestation_digest,
                 tee_type=tee_type,
+                gpu_attestation_passed=gpu_attestation_passed,
             )
 
 

--- a/neurons/validators/tests/test_attestation_gaps_g1_g4.py
+++ b/neurons/validators/tests/test_attestation_gaps_g1_g4.py
@@ -1,0 +1,596 @@
+"""
+Unit tests for the CVM attestation gap remediation (DAH-2338, G1–G4).
+
+Covers, per the remediation-plan test matrix (§6):
+- G4: tcb_status / advisory_ids / event_log_verified / os_image_hash_verified
+  rejection when enforced, warn-only telemetry when not.
+- G3: nonce round-trip in report_data[32:64], mismatch/stale rejection, legacy
+  (no-nonce) behavior preserved.
+- G1: NRAS overall-result / eat_nonce / missing / malformed payload handling,
+  observe-vs-enforce modes, and the attestation_passed invariant
+  (TDX-pass + GPU-fail is never "passed").
+- Minimal-G5: the CVM ratchet fail-closed on an omitted quote and the score gate.
+- G2: monotonic compose version floor in the whitelist check.
+"""
+
+import base64
+import json
+import sys
+import time
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+THIS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = THIS_DIR / ".." / ".." / ".."
+VALIDATOR_SRC = REPO_ROOT / "neurons" / "validators" / "src"
+if str(VALIDATOR_SRC) not in sys.path:
+    sys.path.insert(0, str(VALIDATOR_SRC))
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+if "celium_collateral_contracts" not in sys.modules:
+    module = types.ModuleType("celium_collateral_contracts")
+
+    class CollateralContract:  # type: ignore
+        ...
+
+    module.CollateralContract = CollateralContract
+    sys.modules["celium_collateral_contracts"] = module
+
+from datura.requests.miner_requests import ExecutorSSHInfo  # noqa: E402
+from datura.requests.validator_requests import ssh_pubkey_signing_blob  # noqa: E402
+
+from core.config import settings  # noqa: E402
+from services.attestation_service import (  # noqa: E402
+    TDX_ATTESTED_EXECUTOR_SET,
+    AttestationError,
+    AttestationNonce,
+    AttestationService,
+    HostPolicyResult,
+)
+from services.task.score_calculator import calculate_scores  # noqa: E402
+
+VERIFIER_RESPONSE_PATH = THIS_DIR / "fixtures" / "verifier_response.json"
+TDX_FIXTURE_PATH = THIS_DIR / "fixtures" / "tdx_quote.json"
+
+# The validators suite runs pytest-asyncio in strict mode; mark the whole module
+# (pytest-asyncio only applies the marker to coroutine tests).
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _verifier_response() -> dict:
+    return json.loads(VERIFIER_RESPONSE_PATH.read_text())
+
+
+def _make_executor(**overrides) -> ExecutorSSHInfo:
+    defaults = dict(
+        uuid="test-executor",
+        address="executor.example",
+        port=2222,
+        ssh_username="exec-user",
+        ssh_port=2222,
+        python_path="/usr/bin/python",
+        root_dir="/opt/executor",
+        ssh_host_key="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKey user@host",
+        tdx_quote='{"quote": "00"}',
+    )
+    defaults.update(overrides)
+    return ExecutorSSHInfo(**defaults)
+
+
+class FakeRedis:
+    def __init__(self):
+        self.sets: dict[str, set] = {}
+        self.kv: dict[str, str] = {}
+
+    async def sadd(self, key, elem):
+        self.sets.setdefault(key, set()).add(elem)
+
+    async def is_elem_exists_in_set(self, key, elem):
+        return elem in self.sets.get(key, set())
+
+    async def get(self, key):
+        return self.kv.get(key)
+
+    async def set(self, key, value):
+        self.kv[key] = value
+
+
+def _jwt(claims: dict) -> str:
+    def seg(obj):
+        raw = base64.urlsafe_b64encode(json.dumps(obj).encode()).decode()
+        return raw.rstrip("=")
+
+    return f"{seg({'alg': 'none'})}.{seg(claims)}.sig"
+
+
+def _nras_response(
+    overall: bool = True,
+    nonce: str | None = None,
+    per_gpu: dict | None = None,
+) -> list:
+    overall_claims = {"x-nvidia-overall-att-result": overall}
+    if nonce is not None:
+        overall_claims["eat_nonce"] = nonce
+    response = [["JWT", _jwt(overall_claims)]]
+    if per_gpu is not None:
+        response.append({name: _jwt(claims) for name, claims in per_gpu.items()})
+    return response
+
+
+@pytest.fixture()
+def service(monkeypatch):
+    monkeypatch.setattr(settings, "ENABLE_TDX_ATTESTATION", True)
+    monkeypatch.setattr(settings, "TDX_VERIFIER_URL", "https://verifier.example/verify")
+    monkeypatch.setattr(settings, "ENABLE_ATTESTATION_WHITELIST", False)
+    monkeypatch.setattr(settings, "ENABLE_TCB_ENFORCEMENT", False)
+    monkeypatch.setattr(settings, "ENABLE_GPU_ATTESTATION_ENFORCEMENT", False)
+    monkeypatch.setattr(settings, "ENABLE_ATTESTATION_NONCE", False)
+    return AttestationService()
+
+
+# ---------------------------------------------------------------------------
+# G4 — TCB / advisory enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_status", ["OutOfDate", "SWHardeningNeeded", "ConfigurationNeeded"])
+def test_g4_bad_tcb_status_rejected_when_enforced(service, monkeypatch, bad_status):
+    # Arrange
+    monkeypatch.setattr(settings, "ENABLE_TCB_ENFORCEMENT", True)
+    response = _verifier_response()
+    response["details"]["tcb_status"] = bad_status
+    expected = "0x" + response["details"]["report_data"][:64]
+
+    # Act / Assert
+    with pytest.raises(AttestationError, match="tcb_status_not_allowed"):
+        service._validate_verifier_response(response, expected, _make_executor())
+
+
+def test_g4_bad_tcb_status_warn_only_when_not_enforced(service):
+    # Arrange — enforcement off (fixture default): violations must not reject
+    response = _verifier_response()
+    response["details"]["tcb_status"] = "OutOfDate"
+    expected = "0x" + response["details"]["report_data"][:64]
+
+    # Act — must not raise
+    service._validate_verifier_response(response, expected, _make_executor())
+
+
+def test_g4_allowlisted_tcb_status_accepted(service, monkeypatch):
+    # Arrange
+    monkeypatch.setattr(settings, "ENABLE_TCB_ENFORCEMENT", True)
+    monkeypatch.setattr(settings, "TDX_ALLOWED_TCB_STATUSES", "UpToDate,SWHardeningNeeded")
+    response = _verifier_response()
+    response["details"]["tcb_status"] = "SWHardeningNeeded"
+    expected = "0x" + response["details"]["report_data"][:64]
+
+    # Act — must not raise
+    service._validate_verifier_response(response, expected, _make_executor())
+
+
+def test_g4_unexpected_advisory_rejected_when_enforced(service, monkeypatch):
+    # Arrange
+    monkeypatch.setattr(settings, "ENABLE_TCB_ENFORCEMENT", True)
+    response = _verifier_response()
+    response["details"]["advisory_ids"] = ["INTEL-SA-00837"]
+    expected = "0x" + response["details"]["report_data"][:64]
+
+    # Act / Assert
+    with pytest.raises(AttestationError, match="advisory_present"):
+        service._validate_verifier_response(response, expected, _make_executor())
+
+
+def test_g4_allowlisted_advisory_accepted(service, monkeypatch):
+    # Arrange
+    monkeypatch.setattr(settings, "ENABLE_TCB_ENFORCEMENT", True)
+    monkeypatch.setattr(settings, "TDX_ALLOWED_ADVISORY_IDS", "INTEL-SA-00837")
+    response = _verifier_response()
+    response["details"]["advisory_ids"] = ["INTEL-SA-00837"]
+    expected = "0x" + response["details"]["report_data"][:64]
+
+    # Act — must not raise
+    service._validate_verifier_response(response, expected, _make_executor())
+
+
+@pytest.mark.parametrize("flag", ["event_log_verified", "os_image_hash_verified"])
+def test_g4_unverified_flags_rejected_when_enforced(service, monkeypatch, flag):
+    # Arrange
+    monkeypatch.setattr(settings, "ENABLE_TCB_ENFORCEMENT", True)
+    response = _verifier_response()
+    response["details"][flag] = False
+    expected = "0x" + response["details"]["report_data"][:64]
+
+    # Act / Assert
+    with pytest.raises(AttestationError):
+        service._validate_verifier_response(response, expected, _make_executor())
+
+
+# ---------------------------------------------------------------------------
+# G3 — freshness nonce
+# ---------------------------------------------------------------------------
+
+
+def test_g3_nonce_round_trip_accepted(service):
+    # Arrange — report_data[32:64] echoes the issued nonce
+    nonce = AttestationNonce.issue()
+    response = _verifier_response()
+    prefix = response["details"]["report_data"][:64]
+    response["details"]["report_data"] = prefix + nonce.value_hex
+
+    # Act — must not raise
+    service._validate_verifier_response(response, "0x" + prefix, _make_executor(), nonce=nonce)
+
+
+def test_g3_nonce_mismatch_rejected(service):
+    # Arrange — fixture report_data carries zeros in [32:64], not the nonce
+    nonce = AttestationNonce.issue()
+    response = _verifier_response()
+    expected = "0x" + response["details"]["report_data"][:64]
+
+    # Act / Assert
+    with pytest.raises(AttestationError, match="does not echo"):
+        service._validate_verifier_response(response, expected, _make_executor(), nonce=nonce)
+
+
+def test_g3_stale_nonce_rejected(service, monkeypatch):
+    # Arrange — nonce issued beyond the TTL window
+    monkeypatch.setattr(settings, "ATTESTATION_NONCE_TTL_SECONDS", 600)
+    nonce = AttestationNonce.issue()
+    nonce.issued_at = time.time() - 601
+    response = _verifier_response()
+    prefix = response["details"]["report_data"][:64]
+    response["details"]["report_data"] = prefix + nonce.value_hex
+
+    # Act / Assert
+    with pytest.raises(AttestationError, match="nonce expired"):
+        service._validate_verifier_response(response, "0x" + prefix, _make_executor(), nonce=nonce)
+
+
+def test_g3_legacy_no_nonce_still_accepted(service):
+    # Arrange — no nonce issued: the legacy prefix-only check applies
+    response = _verifier_response()
+    expected = "0x" + response["details"]["report_data"][:64]
+
+    # Act — must not raise
+    service._validate_verifier_response(response, expected, _make_executor(), nonce=None)
+
+
+async def test_g3_maybe_issue_nonce_respects_interval(monkeypatch):
+    # Arrange
+    monkeypatch.setattr(settings, "ENABLE_TDX_ATTESTATION", True)
+    monkeypatch.setattr(settings, "TDX_VERIFIER_URL", "https://verifier.example/verify")
+    monkeypatch.setattr(settings, "ENABLE_ATTESTATION_NONCE", True)
+    monkeypatch.setattr(settings, "TDX_REATTEST_INTERVAL_SECONDS", 3600)
+    service = AttestationService(redis_service=FakeRedis())
+
+    # Act
+    first = await service.maybe_issue_nonce("miner-hotkey")
+    second = await service.maybe_issue_nonce("miner-hotkey")
+
+    # Assert — one event per interval per miner
+    assert first is not None
+    assert len(first.value_bytes) == 32
+    assert second is None
+
+
+async def test_g3_maybe_issue_nonce_disabled_returns_none(service):
+    # Arrange — ENABLE_ATTESTATION_NONCE is off in the service fixture
+
+    # Act / Assert
+    assert await service.maybe_issue_nonce("miner-hotkey") is None
+
+
+def test_g3_signing_blob_covers_nonce():
+    # Arrange
+    nonce = AttestationNonce.issue()
+
+    # Act
+    legacy_blob = ssh_pubkey_signing_blob("ssh-ed25519 AAAA key")
+    nonce_blob = ssh_pubkey_signing_blob("ssh-ed25519 AAAA key", nonce.value_hex)
+
+    # Assert — stripping or swapping the nonce changes the signed message
+    assert legacy_blob == "ssh-ed25519 AAAA key"
+    assert nonce_blob != legacy_blob
+    assert nonce.value_hex in nonce_blob
+    assert ssh_pubkey_signing_blob("ssh-ed25519 AAAA key", "ff" * 32) != nonce_blob
+
+
+# ---------------------------------------------------------------------------
+# G1 — NVIDIA GPU attestation (validator verification side)
+# ---------------------------------------------------------------------------
+
+
+def _gpu_payload(nonce_hex: str) -> str:
+    return json.dumps(
+        {"nonce": nonce_hex, "evidence_list": [{"evidence": "ZXY=", "certificate": "chain"}],
+         "arch": "HOPPER"}
+    )
+
+
+async def test_g1_missing_payload_rejected_when_enforced(service, monkeypatch):
+    # Arrange
+    monkeypatch.setattr(settings, "ENABLE_GPU_ATTESTATION_ENFORCEMENT", True)
+    nonce = AttestationNonce.issue()
+    executor = _make_executor(nvidia_payload=None)
+
+    # Act / Assert
+    with pytest.raises(AttestationError, match="did not provide NVIDIA GPU"):
+        await service._verify_gpu(executor, nonce)
+
+
+async def test_g1_missing_payload_none_when_not_enforced(service):
+    # Act / Assert — observe-only: not performed
+    assert await service._verify_gpu(_make_executor(nvidia_payload=None), None) is None
+
+
+async def test_g1_malformed_payload_rejected_when_enforced(service, monkeypatch):
+    # Arrange
+    monkeypatch.setattr(settings, "ENABLE_GPU_ATTESTATION_ENFORCEMENT", True)
+    nonce = AttestationNonce.issue()
+    executor = _make_executor(nvidia_payload="not-json{")
+
+    # Act / Assert
+    with pytest.raises(AttestationError, match="Malformed"):
+        await service._verify_gpu(executor, nonce)
+
+
+async def test_g1_unbound_nonce_rejected_when_enforced(service, monkeypatch):
+    # Arrange — payload carries a self-generated nonce, not the issued challenge
+    monkeypatch.setattr(settings, "ENABLE_GPU_ATTESTATION_ENFORCEMENT", True)
+    nonce = AttestationNonce.issue()
+    executor = _make_executor(nvidia_payload=_gpu_payload("ab" * 32))
+
+    # Act / Assert
+    with pytest.raises(AttestationError, match="not\nbound|not bound"):
+        await service._verify_gpu(executor, nonce)
+
+
+async def test_g1_nras_overall_failure_rejected_when_enforced(service, monkeypatch):
+    # Arrange
+    monkeypatch.setattr(settings, "ENABLE_GPU_ATTESTATION_ENFORCEMENT", True)
+    nonce = AttestationNonce.issue()
+    executor = _make_executor(nvidia_payload=_gpu_payload(nonce.value_hex))
+
+    async def fake_post(payload, executor_):
+        return _nras_response(overall=False, nonce=nonce.value_hex)
+
+    monkeypatch.setattr(service, "_post_nras", fake_post)
+
+    # Act / Assert
+    with pytest.raises(AttestationError, match="overall_result"):
+        await service._verify_gpu(executor, nonce)
+
+
+async def test_g1_nras_overall_failure_observed_as_false(service, monkeypatch):
+    # Arrange — enforcement off: verified-bad is recorded, never raised
+    nonce = AttestationNonce.issue()
+    executor = _make_executor(nvidia_payload=_gpu_payload(nonce.value_hex))
+
+    async def fake_post(payload, executor_):
+        return _nras_response(overall=False, nonce=nonce.value_hex)
+
+    monkeypatch.setattr(service, "_post_nras", fake_post)
+
+    # Act / Assert
+    assert await service._verify_gpu(executor, nonce) is False
+
+
+async def test_g1_eat_nonce_mismatch_rejected(service, monkeypatch):
+    # Arrange — NRAS echoes a different nonce than the payload claimed
+    monkeypatch.setattr(settings, "ENABLE_GPU_ATTESTATION_ENFORCEMENT", True)
+    nonce = AttestationNonce.issue()
+    executor = _make_executor(nvidia_payload=_gpu_payload(nonce.value_hex))
+
+    async def fake_post(payload, executor_):
+        return _nras_response(overall=True, nonce="cd" * 32)
+
+    monkeypatch.setattr(service, "_post_nras", fake_post)
+
+    # Act / Assert
+    with pytest.raises(AttestationError, match="eat_nonce_mismatch"):
+        await service._verify_gpu(executor, nonce)
+
+
+async def test_g1_per_gpu_claims_checked(service, monkeypatch):
+    # Arrange — one GPU reports measres failure
+    monkeypatch.setattr(settings, "ENABLE_GPU_ATTESTATION_ENFORCEMENT", True)
+    nonce = AttestationNonce.issue()
+    executor = _make_executor(nvidia_payload=_gpu_payload(nonce.value_hex))
+
+    async def fake_post(payload, executor_):
+        return _nras_response(
+            overall=True,
+            nonce=nonce.value_hex,
+            per_gpu={"GPU-0": {"measres": "success", "eat_nonce": nonce.value_hex},
+                     "GPU-1": {"measres": "fail", "eat_nonce": nonce.value_hex}},
+        )
+
+    monkeypatch.setattr(service, "_post_nras", fake_post)
+
+    # Act / Assert
+    with pytest.raises(AttestationError, match="GPU-1:measres"):
+        await service._verify_gpu(executor, nonce)
+
+
+async def test_g1_nras_pass_returns_true(service, monkeypatch):
+    # Arrange
+    monkeypatch.setattr(settings, "ENABLE_GPU_ATTESTATION_ENFORCEMENT", True)
+    nonce = AttestationNonce.issue()
+    executor = _make_executor(nvidia_payload=_gpu_payload(nonce.value_hex))
+
+    async def fake_post(payload, executor_):
+        return _nras_response(
+            overall=True,
+            nonce=nonce.value_hex,
+            per_gpu={"GPU-0": {"measres": "success", "eat_nonce": nonce.value_hex,
+                               "dbgstat": "disabled", "secboot": True}},
+        )
+
+    monkeypatch.setattr(service, "_post_nras", fake_post)
+
+    # Act / Assert
+    assert await service._verify_gpu(executor, nonce) is True
+
+
+async def test_g1_nras_unreachable_fail_closed_when_enforced(service, monkeypatch):
+    # Arrange
+    monkeypatch.setattr(settings, "ENABLE_GPU_ATTESTATION_ENFORCEMENT", True)
+    nonce = AttestationNonce.issue()
+    executor = _make_executor(nvidia_payload=_gpu_payload(nonce.value_hex))
+
+    async def fake_post(payload, executor_):
+        raise AttestationError("NRAS unreachable for executor x: boom")
+
+    monkeypatch.setattr(service, "_post_nras", fake_post)
+
+    # Act / Assert — enforcement: fail closed
+    with pytest.raises(AttestationError, match="NRAS unreachable"):
+        await service._verify_gpu(executor, nonce)
+
+    # Arrange — observe-only: undeterminable, not verified-bad
+    monkeypatch.setattr(settings, "ENABLE_GPU_ATTESTATION_ENFORCEMENT", False)
+
+    # Act / Assert
+    assert await service._verify_gpu(executor, nonce) is None
+
+
+def test_g1_attestation_passed_invariant():
+    # Assert — TDX pass + GPU fail can never surface as passed
+    assert HostPolicyResult(attestation_digest="d", gpu_attestation_passed=False).attestation_passed is False
+    assert HostPolicyResult(attestation_digest="d", gpu_attestation_passed=True).attestation_passed is True
+    assert HostPolicyResult(attestation_digest="d", gpu_attestation_passed=None).attestation_passed is True
+    assert HostPolicyResult(attestation_digest=None).attestation_passed is False
+
+
+# ---------------------------------------------------------------------------
+# Minimal-G5 — CVM ratchet + score gate
+# ---------------------------------------------------------------------------
+
+
+async def test_g5_ratcheted_executor_omitting_quote_fails_closed(monkeypatch):
+    # Arrange — executor previously attested (in the ratchet set), now no quote
+    monkeypatch.setattr(settings, "ENABLE_TDX_ATTESTATION", True)
+    monkeypatch.setattr(settings, "TDX_VERIFIER_URL", "https://verifier.example/verify")
+    monkeypatch.setattr(settings, "ENABLE_TCB_ENFORCEMENT", True)
+    redis = FakeRedis()
+    await redis.sadd(TDX_ATTESTED_EXECUTOR_SET, "test-executor")
+    service = AttestationService(redis_service=redis)
+    executor = _make_executor(tdx_quote=None)
+
+    # Act / Assert
+    with pytest.raises(AttestationError, match="omitted its TDX quote"):
+        await service.prepare_host_policy(executor)
+
+
+async def test_g5_unknown_executor_without_quote_unaffected(monkeypatch):
+    # Arrange — bare-metal executor (never attested) stays on the legacy path
+    monkeypatch.setattr(settings, "ENABLE_TDX_ATTESTATION", True)
+    monkeypatch.setattr(settings, "TDX_VERIFIER_URL", "https://verifier.example/verify")
+    monkeypatch.setattr(settings, "ENABLE_TCB_ENFORCEMENT", True)
+    import asyncssh
+
+    monkeypatch.setattr(asyncssh, "import_known_hosts", lambda value: object())
+    service = AttestationService(redis_service=FakeRedis())
+    executor = _make_executor(tdx_quote=None)
+
+    # Act
+    host_policy = await service.prepare_host_policy(executor)
+
+    # Assert — no attestation claimed, no rejection
+    assert host_policy.attestation_digest is None
+    assert host_policy.gpu_attestation_passed is None
+
+
+def _score_ctx(tdx_quote, attestation_passed):
+    executor = SimpleNamespace(price_per_gpu=None, tdx_quote=tdx_quote)
+    state = SimpleNamespace(
+        gpu_model="",
+        specs={"network": {"ema_verifyx_download_speed": 500.0}},
+    )
+    return SimpleNamespace(
+        state=state,
+        collateral_deposited=True,
+        collateral_error_message=None,
+        contract_version=None,
+        executor=executor,
+        tdx_attestation_passed=attestation_passed,
+    )
+
+
+def test_g5_score_gate_zeroes_failed_cvm(monkeypatch):
+    # Arrange
+    monkeypatch.setattr(settings, "ENABLE_TDX_ATTESTATION", True)
+    monkeypatch.setattr(settings, "ENABLE_TCB_ENFORCEMENT", True)
+
+    # Act
+    actual, job, warning = calculate_scores(_score_ctx('{"quote":"00"}', False), rented=False)
+
+    # Assert
+    assert actual == 0.0
+    assert job == 0.0
+    assert "CVM attestation not passed" in warning
+
+
+def test_g5_score_gate_passes_attested_cvm_and_bare_metal(monkeypatch):
+    # Arrange
+    monkeypatch.setattr(settings, "ENABLE_TDX_ATTESTATION", True)
+    monkeypatch.setattr(settings, "ENABLE_TCB_ENFORCEMENT", True)
+
+    # Act / Assert — attested CVM keeps its score
+    actual, _, _ = calculate_scores(_score_ctx('{"quote":"00"}', True), rented=False)
+    assert actual == 1.0
+
+    # Act / Assert — bare-metal node (no quote) is untouched by the gate
+    actual, _, _ = calculate_scores(_score_ctx(None, False), rented=False)
+    assert actual == 1.0
+
+
+def test_g5_score_gate_inert_when_enforcement_off(monkeypatch):
+    # Arrange — safe-off default: gate must not fire
+    monkeypatch.setattr(settings, "ENABLE_TDX_ATTESTATION", True)
+    monkeypatch.setattr(settings, "ENABLE_TCB_ENFORCEMENT", False)
+
+    # Act / Assert
+    actual, _, _ = calculate_scores(_score_ctx('{"quote":"00"}', False), rented=False)
+    assert actual == 1.0
+
+
+# ---------------------------------------------------------------------------
+# G2 — monotonic compose version floor
+# ---------------------------------------------------------------------------
+
+
+async def test_g2_compose_version_floor(service, monkeypatch):
+    # Arrange
+    from services import const
+
+    monkeypatch.setattr(settings, "DEPLOY_ENV", "LOCAL")
+    monkeypatch.setitem(
+        const.TDX_WHITELIST["COMPOSE_HASH"], "LOCAL", {"old-hash": 1, "new-hash": 2}
+    )
+    os_image = next(iter(const.TDX_WHITELIST["OS_IMAGE_HASH"]))
+    executor = _make_executor()
+
+    # Act / Assert — floor 0 (default): every whitelisted hash accepted
+    monkeypatch.setattr(settings, "TDX_MINIMUM_COMPOSE_VERSION", 0)
+    assert await service._check_whitelist("old-hash", os_image, executor) is True
+
+    # Act / Assert — floor 2: version-1 release rejected, version-2 accepted
+    monkeypatch.setattr(settings, "TDX_MINIMUM_COMPOSE_VERSION", 2)
+    assert await service._check_whitelist("old-hash", os_image, executor) is False
+    assert await service._check_whitelist("new-hash", os_image, executor) is True
+
+    # Act / Assert — unknown hash always rejected
+    assert await service._check_whitelist("unknown-hash", os_image, executor) is False
+
+    # Act / Assert — unknown OS image always rejected
+    assert await service._check_whitelist("new-hash", "bad-os-image", executor) is False

--- a/neurons/validators/tests/test_attestation_service.py
+++ b/neurons/validators/tests/test_attestation_service.py
@@ -77,5 +77,10 @@ async def test_attestation_service_accepts_fixture_quote(monkeypatch):
         tdx_quote=quote_json,
     )
 
-    policy, digest, _ = await service.prepare_host_policy(executor_info)
-    assert policy is not None
+    host_policy = await service.prepare_host_policy(executor_info)
+    assert host_policy.known_hosts is not None
+    assert host_policy.attestation_digest is not None
+    assert host_policy.tee_type == "dstack/tdx"
+    # No GPU evidence supplied and enforcement off → not performed, still passed.
+    assert host_policy.gpu_attestation_passed is None
+    assert host_policy.attestation_passed is True

--- a/neurons/validators/tests/test_new_rentals_pause_filter.py
+++ b/neurons/validators/tests/test_new_rentals_pause_filter.py
@@ -98,6 +98,9 @@ def _miner_service() -> MinerService:
     service.task_service = MagicMock()
     service.redis_service = MagicMock()
     service.attestation_service = MagicMock()
+    # request_job_to_miner awaits this before submitting the SSH key (G3);
+    # None = no attestation event, the legacy path.
+    service.attestation_service.maybe_issue_nonce = AsyncMock(return_value=None)
     return service
 
 


### PR DESCRIPTION
## Describe your changes

Upgrade the TDX CVM stack from dstack v0.5.5 to v0.5.11 (plan: https://claude.ai/code/artifact/d930fe02-7c3b-4450-85b9-bcf3aeec1b8e). Two independently deployable pieces:

**1. dstack-verifier 0.5.4 → 0.5.11** (both `docker-compose.app.dstacktee*.yml`)
- Digest pin `3f36162c…` → `06a20b77…` (= Docker Hub tag `0.5.11`, 2026-06-10).
- Picks up dcap-qvl 0.3.10 (fixes CVE-2026-22696) and the dstack-mr that can measure 0.5.11 images; still verifies the legacy 0.5.5 images (request/response schema unchanged 0.5.4→0.5.11, verified at source).
- `DSTACK_VERIFIER_IMAGE_DOWNLOAD_URL` unchanged — the new image's measurement bundle `mr_a6eafc5f….tar.gz` is uploaded to the same private-ml-sdk v0.5.5 release (assets are hash-named, one template serves both images).

**2. Default CVM OS image → official upstream `dstack-nvidia-0.5.11`**
- `lium-cvm.sh`: `OS_IMAGE_NAME`/`OS_IMAGE_URL` default to the official meta-dstack v0.5.11 release asset (Option A from the plan — no custom build). Env overrides preserved for the legacy image.
- `const.py`: `TDX_WHITELIST` now accepts **only** the 0.5.11 stack. `OS_IMAGE_HASH` = the official image's `a6eafc5f007f642d8ea90c7fa8881f1e6715720ccb531941a28218f4f26d7b02` alone (extracted from the release tarball's `digest.txt`, chain re-verified: sha256(sha256sum.txt) == digest); the legacy 0.5.5 hashes were removed (`5e1d1493`). The PROD/STAGE compose whitelists carry the measured digest-pinned releases (`80af259a` / `f1701844`): prod pins the current `:latest` runner `sha256:b58211e7…`, staging the 2026-07-06 `:dev` runner `sha256:58db7cd5…` — both hashes computed offline with a replica validated byte-for-byte against live quotes (local + staging). ⚠️ Any CVM still on a 0.5.5 image or the watchtower-era compose fails attestation once this ships — validator deploy and CVM fleet redeploy are one coordinated step.
- Guest driver becomes 595.58.03 (NVIDIA R595 TRD1 GA — Blackwell B200/B300 CC line); its NVML digest is already in `LIB_NVIDIA_ML_DIGESTS`. `COMPOSE_HASH` untouched (executor compose content unchanged). The 0.5.11 image additionally bakes in sysbox 0.6.7 + zfs (⚠️ see §4 finding 3).

Verified: `bash -n` on lium-cvm.sh, YAML parse on both compose files, `ruff@0.5.1` clean on const.py, `test_attestation_service.py` passes against this branch. Staging E2E (boot new image on a TDX+GPU host → quote → verifier → whitelist) is the next step per the plan's verification ladder and should gate prod deploy. **Update 2026-07-06:** the full E2E chain (boot → quote → verifier → whitelist → validator pipeline, incl. a fail-closed negative test) has now been exercised end-to-end on a local TDX+GPU host — results and rollout-gating findings in §4; a staging run remains the prod gate.


**3. CVM attestation gap remediation G1–G4** (`6f7f006f`, plan: `cvm-gap-analysis/04-remediation-plan-G1-G4.md`)

All flag-gated, defaults preserve today's behavior:
- **§1/G3 freshness** — the validator mints a 32-byte challenge per attestation event (`ENABLE_ATTESTATION_NONCE`, cadence `TDX_REATTEST_INTERVAL_SECONDS`); it rides `SSHPubKeySubmitRequest.nonce` **inside** `validator_signature` (`datura.ssh_pubkey_signing_blob` — stripping/swapping the nonce invalidates the signature), the miner relays it, the executor folds it into TDX `report_data[32:64]`, and the validator asserts the echo + TTL. Executor enforcement-phase flag: `REQUIRE_ATTESTATION_NONCE`.
- **G1 GPU CC attestation** — the executor collects NVIDIA evidence in-CVM only (dstack-socket topology guard; host-mode never emits), bound to the same nonce (private-ml-sdk reference shape); the validator verifies via NRAS (overall verdict, `eat_nonce`, per-GPU claims), observe-only until `ENABLE_GPU_ATTESTATION_ENFORCEMENT`; `attestation_passed` now requires TDX ∧ GPU-not-failed; `tee_type="dstack/tdx+nvcc"` when nonce-bound GPU evidence verifies. The NVIDIA stack is an opt-in executor Dockerfile layer (`INSTALL_GPU_ATTESTATION=true`), kept outside pdm.lock.
- **G4 TCB enforcement** — explicit `tcb_status` / `advisory_ids` / `event_log_verified` / `os_image_hash_verified` checks with configurable allowlists; `ENABLE_TCB_ENFORCEMENT` off = warn-only telemetry window.
- **Minimal-G5** — attested-executor ratchet fails closed when a known CVM omits its quote; the connector forwards `tee_type`/`attestation_digest`/`tdx_attestation_passed`/`gpu_attestation_passed` (backend ignores unknown fields until it adopts them); the score calculator zeroes CVM-flagged executors whose attestation failed.
- **N3** — the rental host-key chokepoint fails closed (`ENABLE_RENTAL_HOSTKEY_FAIL_CLOSED`) instead of admitting unpinned SSH on policy errors.
- **G2 measured runner** — the executor-runner is digest-pinned inside the measured dstacktee compose (stamped by `lium-cvm.sh` from `.env`; watchtower retired from the measured topology), and `COMPOSE_HASH` whitelist entries carry a monotonic release version gated by `TDX_MINIMUM_COMPOSE_VERSION`. ⚠️ Deploy note: new CVM setups now require `EXECUTOR_RUNNER_IMAGE_DIGEST=sha256:…` in `.env`, and the new compose content needs a fresh whitelisted `COMPOSE_HASH` at release time.

Tests: validators 915 ✓ (new `test_attestation_gaps_g1_g4.py` — TCB negatives, nonce round-trip/mismatch/stale, NRAS negatives, signature swap/strip, ratchet, score gate, version floor), executor 40 ✓ (new `test_attestation_nonce_and_gpu.py`), miners 13 ✓. Deferred: backend Track B / field adoption, local nv-verifier (hosted NRAS is the declared interim), staging Hopper phase-0 emission run.

**4. Local phase-0 E2E attestation run — PASSED (2026-07-06)**

Full chain exercised on a local 8×H200 + 4×NVSwitch TDX host (Ubuntu, mainline 6.17 kernel) booting the official `dstack-nvidia-0.5.11` image with a measured, digest-pinned executor-runner compose (G2 chain held: `app-compose.json` sha256 == RTMR3 compose-hash event == `COMPOSE_HASH` whitelist entry, release version 2):

- **Verifier 0.5.11: `is_valid=true`** — quote signature, event log, RTMR0/MRTD reconstruction (`os_image_hash_verified=true`), TCB `UpToDate`, no advisories.
- **Validator pipeline green with `ENABLE_TDX_ATTESTATION=True` + `ENABLE_ATTESTATION_WHITELIST=True`**: "Attestation verified" → "Attestation digest verified against whitelist" → `VALIDATION_COMPLETED` → executor published to the backend (and rented / SSH'd / torn down in the same setup).
- **Version-floor negative test** (`TDX_MINIMUM_COMPOSE_VERSION=3` vs whitelisted version 2): "Attestation rejected: measured compose release below the minimum version floor" → pipeline fails closed (score 0); restoring the floor goes green again next cycle.
- Still deferred: G1 GPU-evidence emission (executor image built without `INSTALL_GPU_ATTESTATION`) and backend Track B adoption.

⚠️ **Rollout findings from the run (these gate staging/prod deploy):**
1. **RTMR0 only reproduces when the CVM host runs the dstack QEMU** — `kvinwang/qemu-tdx` branch `dstack-qemu-9.2.1` @ `dbcec07c` (the exact source the verifier's `dstack-acpi-tables` oracle is built from; normal build **without** `-DDUMP_ACPI_TABLES`). Hosts on distro QEMU ≥ 10.x can never pass: the oracle is pinned at 9.2.1 and cannot forward-emulate newer ACPI (proven byte-for-byte — only RTMR0 events [08]–[10], the fw_cfg ACPI blobs, diverge; MRTD and the other 10 events match). The fork runs TDs on mainline 6.16+ KVM (validated on 6.17) with two host provisions: use legacy type1 VFIO for GPU passthrough (its iommufd cdev bind returns EINVAL on modern kernels) and raise `vfio_iommu_type1.dma_entry_limit` (TDX shared/private conversion churn exhausts the default 65535 → `VFIO_MAP_DMA: No space left on device`).
2. **The CVM launcher must stamp `ovmf_variant` into vm_config** (read from the image's `metadata.json`, mirroring upstream dstack-vmm): the official 0.5.11 nvidia image ships the pre-202505 OVMF (13 RTMR0 events), but the verifier's name-based fallback maps `*-0.5.10+` names to `stable202505` (17 events) and fails RTMR0. Landed on this branch as `43cf42b0` (ovmf_variant stamp + the QEMU-version-gated iommufd from finding 1).
3. **The image's baked sysbox 0.6.7 zero-scores 0.5.11 CVMs** (rejects `--gpus` device requests → `CHECK_SYSBOX_COMPATIBILITY` fails → DAH-2313 bans the node), and the Datura sysbox installer's unit-file gate always skips itself on this image. The pre-launch force-install landed as `a0c1da2d` (measured into the compose — hence the fresh `COMPOSE_HASH` per §2's deploy note); long-term, fix the installer gate (check `is-active`, not unit-file existence) or strip sysbox from the image build.
4. **Measurement-changing host upgrades orphan CVM data disks** — the disk key derives from the measurements, so after the QEMU swap the existing `hda.img` fails to open ("Failed to open encrypted data disk") and the guest reboot-loops while the launcher still reports success. Fleet migration plans must include data-disk re-provisioning.

**Docs:** provider host-setup guide landed as `5b4e057a` (`neurons/executor/dstacktee/docs/host-setup.md`) — kernel boot parameters (incl. the mandatory `dma_entry_limit` raise), the QEMU build + `client.conf`, key-provider/PCCS, per-executor flow (`EXECUTOR_RUNNER_IMAGE_DIGEST`), and the upgrade/data-disk caveats above. The lium-docs provider page (`providers/nodes/cvm`) is being updated to match in a separate lium-docs PR.

## Issue ticket number and link

[DAH-2338 - Dstack upgrade v0.5.5 → v0.5.11 (TDX CVM stack)](https://app.notion.com/p/Dstack-upgrade-v0-5-5-v0-5-11-TDX-CVM-stack-392b8bfdbde981328d44fef00ad80a14)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?
