### PR TITLE
DAH-2341 - Make rental SSH bootstrap race-safe against self-starting images

### DIFF
--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -266,19 +266,18 @@ class ContainerCreateRequest(ContainerBaseRequest):
     # builds the image from this Dockerfile on the executor host instead of pulling
     # `docker_image`. None or "" keeps the normal image-pull path.
     dockerfile_content: str | None = None
-    # DAH-1524 (cached-template deploy): when truthy, the validator skips the
-    # ENTIRE post-creation sshd bootstrap (install_open_ssh_server_and_start_ssh_service
-    # -> sshd_bootstrap.sh). That bootstrap normally provides FOUR guarantees, ALL of
-    # which are surrendered when this flag is set:
-    #   (a) starts the sshd daemon                 (sshd_bootstrap.sh:110-117, main 166)
-    #   (b) generates host keys via `ssh-keygen -A` (sshd_bootstrap.sh:106)
-    #   (c) hardens config: PasswordAuthentication/KbdInteractive/ChallengeResponse no
-    #                                              (sshd_bootstrap.sh:89-99)
-    #   (d) installs a 30s self-heal restart watchdog (sshd_bootstrap.sh:119-156)
-    # Setting ships_sshd=True ASSERTS the image itself provides all four; the validator
-    # then only re-ensures ~/.ssh for key injection. None/False (default) preserves
-    # today's always-bootstrap behavior. Populated by lium-io-backend in a follow-up;
-    # ships inert here (no producer sets it yet).
+    # DAH-1524 introduced this flag ("skip the bootstrap for cached templates");
+    # its semantics have since changed TWICE — do not trust older comments:
+    #   - 2345af85 reverted the skip: the sshd bootstrap ALWAYS runs, because a
+    #     renter's custom startup_commands replaces the image CMD, so the image
+    #     alone can never be trusted to bring sshd up.
+    #   - DAH-2341 made the bootstrap converge with a self-starting image
+    #     instead of racing it (grace-wait, adopt a running sshd, no keygen
+    #     when adopted; see sshd_bootstrap.sh header).
+    # Today ships_sshd=True (set by lium-io-backend for cached recommended
+    # images) means exactly one thing: a bootstrap failure is FATAL to the
+    # deploy (RuntimeError -> FailedContainerRequest). None/False keeps
+    # bootstrap failures lenient (logged, deploy continues).
     ships_sshd: bool | None = None
 
 

--- a/neurons/validators/src/services/assets/sshd_bootstrap.sh
+++ b/neurons/validators/src/services/assets/sshd_bootstrap.sh
@@ -424,6 +424,12 @@ prepare_sshd_runtime
 if ! start_sshd_if_needed; then
     log "Fallback sshd start failed"
 fi
+# start_sshd_if_needed may have *adopted* an sshd that appeared concurrently
+# (either before its running-check or by losing the bind race) — that daemon
+# loaded the pre-hardening config, so nudge it like the converge path does.
+# No-op when the config did not change; redundant-but-harmless SIGHUP when
+# the daemon we just started already read the hardened config.
+reload_sshd_if_config_changed
 release_lock
 spawn_watchdog
 

--- a/neurons/validators/src/services/assets/sshd_bootstrap.sh
+++ b/neurons/validators/src/services/assets/sshd_bootstrap.sh
@@ -1,10 +1,70 @@
 #!/bin/sh
+# Rental-container SSH bootstrap (DAH-2341: race-safe against images that
+# start sshd themselves).
+#
+# The container image's own entrypoint may generate host keys and start sshd
+# concurrently with this script (e.g. runpod-style /start.sh). This script
+# therefore never assumes it owns sshd bring-up; it converges on an invariant
+# instead: "host keys exist and sshd is listening on :22". Who got there
+# first does not matter.
+#
+# Decision flow:
+#   1. sshd already running          -> converge (no keygen), verify, exit.
+#   2. sshd binary present           -> wait up to a grace period for the
+#      image to start sshd itself; if it appears -> converge, verify, exit.
+#   3. fallback: install sshd if missing, then (under a lock shared with
+#      lium images' /start.sh) generate missing host keys, harden config,
+#      start sshd. A failed start is re-checked: if sshd is running anyway
+#      (lost a benign start race), that is success.
+#   4. verify: sshd running AND listening on port 22 — the exit code of this
+#      script reflects the invariant, not individual command exit codes.
+#
+# Callers treat a non-zero exit as bootstrap failure (fatal for templates
+# with ships_sshd=True), so exit 1 only when sshd is genuinely not serving.
 set -eu
 
-WATCHDOG_PIDFILE="/run/sshd-watchdog.pid"
+# LIUM_* environment overrides exist for tests (which cannot write /run or
+# /root) and for operational tuning; production execs never set them.
+RUN_DIR="${LIUM_RUN_DIR:-/run}"
+SSH_DIR="${LIUM_SSH_DIR:-/root/.ssh}"
+SSHD_CONFIG="${LIUM_SSHD_CONFIG:-/etc/ssh/sshd_config}"
+
+WATCHDOG_PIDFILE="$RUN_DIR/sshd-watchdog.pid"
 WATCHDOG_LOG="/tmp/sshd-watchdog.log"
 SLEEP_SECONDS=30
 SCRIPT_PATH="$0"
+
+# Non-negative integer (capped) or the fallback — the timing knobs feed
+# `[ -lt/-ge ]` tests that would abort the script under `set -eu` on malformed
+# input, and `docker exec` inherits the image's ENV, so a hostile image must
+# not be able to stretch the wait loops via oversized LIUM_* values.
+int_or() {
+    case "${1:-}" in
+        *[!0-9]* | "")
+            printf '%s' "$2"
+            return 0
+            ;;
+    esac
+    if [ "$1" -gt "$3" ]; then
+        printf '%s' "$3"
+    else
+        printf '%s' "$1"
+    fi
+}
+
+# Shared with lium images' /start.sh setup_ssh — keep the path in sync.
+LOCK_DIR="$RUN_DIR/lium-ssh-setup.lock"
+LOCK_TIMEOUT_SECS="$(int_or "${LIUM_SSH_LOCK_TIMEOUT_SECS:-}" 60 300)"
+LOCK_HELD=0
+
+# Grace period to let a self-starting image bring sshd up before the fallback
+# takes over. Resolved in main: --grace flag > LIUM_SSHD_GRACE_SECS > default
+# (only applies when an sshd binary ships in the image — an image without
+# sshd cannot self-start it, so waiting would be pure latency).
+DEFAULT_GRACE_SECS="$(int_or "${LIUM_SSHD_GRACE_SECS:-}" 10 300)"
+VERIFY_TIMEOUT_SECS="$(int_or "${LIUM_SSHD_VERIFY_SECS:-}" 15 120)"
+
+CONFIG_CHANGED=0
 
 log() {
     printf '%s\n' "$1"
@@ -30,7 +90,40 @@ is_sshd_running() {
     return 1
 }
 
+# A listener on :22 (hex 0016) in LISTEN state (0A). The remote address of a
+# listening socket is all zeroes, which keeps established/outbound rows with
+# port 22 on the far side from matching.
+is_sshd_listening() {
+    checked=0
+    # Intentionally unquoted: space-separated list of files.
+    for tcp_file in ${LIUM_PROC_TCP_FILES:-/proc/net/tcp /proc/net/tcp6}; do
+        [ -r "$tcp_file" ] || continue
+        checked=1
+        if grep -E ':0016 0+:0+ 0A ' "$tcp_file" >/dev/null 2>&1; then
+            return 0
+        fi
+    done
+
+    # No readable /proc/net/tcp* — cannot observe sockets; do not fail the
+    # bootstrap on missing observability alone.
+    if [ "$checked" -eq 0 ]; then
+        return 0
+    fi
+
+    return 1
+}
+
 get_sshd_binary() {
+    # Exclusive override (absolute path) — when set, the standard locations
+    # are not consulted at all, so tests fully control binary presence.
+    if [ -n "${LIUM_SSHD_BIN:-}" ]; then
+        if [ -x "$LIUM_SSHD_BIN" ]; then
+            printf '%s\n' "$LIUM_SSHD_BIN"
+            return 0
+        fi
+        return 1
+    fi
+
     if [ -x /usr/sbin/sshd ]; then
         printf '%s\n' "/usr/sbin/sshd"
         return 0
@@ -86,23 +179,83 @@ ensure_sshd_installed() {
     return 1
 }
 
+acquire_lock() {
+    waited=0
+    while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+        if [ "$waited" -ge "$LOCK_TIMEOUT_SECS" ]; then
+            log "SSH setup lock busy for ${LOCK_TIMEOUT_SECS}s; proceeding without it"
+            return 0
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    LOCK_HELD=1
+    # Never leak the lock, whatever exit path `set -eu` takes.
+    trap release_lock EXIT
+}
+
+release_lock() {
+    if [ "$LOCK_HELD" -eq 1 ]; then
+        rmdir "$LOCK_DIR" 2>/dev/null || true
+        LOCK_HELD=0
+    fi
+}
+
 harden_sshd_config() {
-    sshd_config="/etc/ssh/sshd_config"
+    sshd_config="$SSHD_CONFIG"
     [ -f "$sshd_config" ] || return 0
     if grep -q '^# lium-hardened$' "$sshd_config" 2>/dev/null; then
         return 0
     fi
     # sshd honors the first matching directive — comment out any existing
     # occurrences before appending, otherwise our values would be ignored on
-    # base images that ship explicit settings.
-    sed -i -E 's/^[[:space:]]*(PasswordAuthentication|ChallengeResponseAuthentication|KbdInteractiveAuthentication)[[:space:]]+.*/# lium-disabled &/I' "$sshd_config"
-    printf '\n# lium-hardened\nPasswordAuthentication no\nKbdInteractiveAuthentication no\nChallengeResponseAuthentication no\n' >> "$sshd_config"
+    # base images that ship explicit settings. A read-only /etc/ssh must not
+    # abort the whole bootstrap (the exit code belongs to the sshd invariant,
+    # not to hardening), so failures here are logged and skipped.
+    if ! sed -i -E 's/^[[:space:]]*(PasswordAuthentication|ChallengeResponseAuthentication|KbdInteractiveAuthentication)[[:space:]]+.*/# lium-disabled &/I' "$sshd_config" 2>/dev/null; then
+        log "Could not harden sshd config (read-only?); skipping"
+        return 0
+    fi
+    if ! printf '\n# lium-hardened\nPasswordAuthentication no\nKbdInteractiveAuthentication no\nChallengeResponseAuthentication no\n' >> "$sshd_config" 2>/dev/null; then
+        log "Could not append hardened sshd config; skipping"
+        return 0
+    fi
+    CONFIG_CHANGED=1
+}
+
+# A running sshd only re-reads its config on SIGHUP/restart. When the config
+# was hardened after the daemon came up (image-started sshd), nudge the master
+# via its pidfile — never pgrep, which would also hit per-session processes.
+reload_sshd_if_config_changed() {
+    if [ "$CONFIG_CHANGED" -ne 1 ]; then
+        return 0
+    fi
+
+    for pidfile in "$RUN_DIR/sshd.pid" /var/run/sshd.pid; do
+        if [ -f "$pidfile" ]; then
+            sshd_pid="$(cat "$pidfile" 2>/dev/null || true)"
+            case "${sshd_pid:-}" in
+                *[!0-9]* | "") continue ;;
+            esac
+            if kill -0 "$sshd_pid" 2>/dev/null; then
+                kill -HUP "$sshd_pid" 2>/dev/null || true
+                log "Sent SIGHUP to sshd (pid $sshd_pid) to load hardened config"
+                return 0
+            fi
+        fi
+    done
+
+    log "Hardened sshd config but found no sshd pidfile to reload"
+}
+
+prepare_ssh_dir() {
+    mkdir -p "$RUN_DIR/sshd"
+    mkdir -p "$SSH_DIR"
+    chmod 700 "$SSH_DIR"
 }
 
 prepare_sshd_runtime() {
-    mkdir -p /run/sshd
-    mkdir -p /root/.ssh
-    chmod 700 /root/.ssh
+    prepare_ssh_dir
     ssh-keygen -A
     harden_sshd_config
 }
@@ -113,17 +266,77 @@ start_sshd_if_needed() {
     fi
 
     sshd_bin="$(get_sshd_binary)"
-    "$sshd_bin"
+    if ! "$sshd_bin"; then
+        # Lost a benign start race (the image's sshd bound :22 between our
+        # check and our start) — only a real failure if sshd is still down.
+        if is_sshd_running; then
+            log "sshd was started concurrently; continuing"
+            return 0
+        fi
+        return 1
+    fi
+}
+
+# Adopt an sshd somebody else (image entrypoint, previous bootstrap) started:
+# no keygen, just the pieces this script still guarantees — key-injection
+# dir, config hardening, and the restart watchdog.
+converge_on_running_sshd() {
+    prepare_ssh_dir
+    harden_sshd_config
+    reload_sshd_if_config_changed
+    spawn_watchdog
+}
+
+# Terminal adopt path: converge, prove the invariant, and exit with it.
+adopt_and_finish() {
+    log "$1"
+    converge_on_running_sshd
+    verify_sshd
+    exit 0
+}
+
+wait_for_image_sshd() {
+    grace="$1"
+    waited=0
+    while [ "$waited" -lt "$grace" ]; do
+        if is_sshd_running; then
+            return 0
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    is_sshd_running
+}
+
+verify_sshd() {
+    waited=0
+    while [ "$waited" -lt "$VERIFY_TIMEOUT_SECS" ]; do
+        if is_sshd_running && is_sshd_listening; then
+            return 0
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    running=no
+    listening=no
+    if is_sshd_running; then running=yes; fi
+    if is_sshd_listening; then listening=yes; fi
+    log "sshd verification failed after ${VERIFY_TIMEOUT_SECS}s"
+    log "(running=$running, listening=$listening)"
+    return 1
 }
 
 watchdog_loop() {
     while true; do
         if ! is_sshd_running; then
             if ensure_sshd_installed; then
+                acquire_lock
                 prepare_sshd_runtime
                 if ! start_sshd_if_needed; then
                     log "Failed to restart sshd from watchdog"
                 fi
+                release_lock
             else
                 log "Watchdog could not install sshd"
             fi
@@ -161,7 +374,58 @@ if [ "${1:-}" = "--watchdog-loop" ]; then
     exit 0
 fi
 
+GRACE_SECS=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --grace)
+            shift
+            GRACE_SECS="${1:-}"
+            ;;
+        *)
+            log "Ignoring unknown argument: $1"
+            ;;
+    esac
+    shift || break
+done
+GRACE_SECS="$(int_or "${GRACE_SECS:-}" "" 300)"
+
+# 1. Somebody already brought sshd up (image entrypoint won outright, or this
+#    is a re-run) — adopt it, never touch host keys.
+if is_sshd_running; then
+    adopt_and_finish "sshd already running; adopting existing daemon"
+fi
+
+# 2. The image ships an sshd binary, so its entrypoint may be about to start
+#    it (possibly delayed behind dockerd/pre-start work). Give it a grace
+#    period before the fallback claims ownership — this is what removes the
+#    concurrent-keygen window against images we do not control.
+if get_sshd_binary >/dev/null 2>&1; then
+    if [ -z "${GRACE_SECS:-}" ]; then
+        GRACE_SECS="$DEFAULT_GRACE_SECS"
+    fi
+    if [ "$GRACE_SECS" -gt 0 ]; then
+        log "Waiting up to ${GRACE_SECS}s for image-provided sshd"
+        if wait_for_image_sshd "$GRACE_SECS"; then
+            adopt_and_finish "Image-provided sshd came up; adopting it"
+        fi
+        log "No image-provided sshd after ${GRACE_SECS}s; falling back to own bring-up"
+    fi
+fi
+
+# 3. Fallback: this script owns sshd bring-up.
 ensure_sshd_installed
+acquire_lock
+if is_sshd_running; then
+    # The image's setup slipped in while we were installing/locking.
+    release_lock
+    adopt_and_finish "sshd appeared before fallback bring-up; adopting it"
+fi
 prepare_sshd_runtime
-start_sshd_if_needed
+if ! start_sshd_if_needed; then
+    log "Fallback sshd start failed"
+fi
+release_lock
 spawn_watchdog
+
+# 4. The exit code reflects the invariant, not who did what.
+verify_sshd

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -3302,6 +3302,20 @@ class DockerService:
                 await self.stream_log("Created Docker Container", "success", log_tag)
 
                 try:
+                    # DAH-2341: inject the customer's public keys before the sshd
+                    # bootstrap. The keys are plain data (mkdir + append) with no
+                    # dependency on a running sshd, and the bootstrap may now spend
+                    # a grace period waiting for an image-provided sshd — whichever
+                    # sshd comes up first must already find the keys in place.
+                    current_step = "add_public_keys"
+                    await self.add_ssh_public_keys_with_rental_docker(
+                        docker_client=docker_client,
+                        container_name=container_name,
+                        public_keys=payload.user_public_keys,
+                        log_tag=log_tag,
+                        log_extra=default_extra,
+                    )
+
                     current_step = "ssh_bootstrap"
                     if payload.ships_sshd:
                         logger.info(
@@ -3335,19 +3349,10 @@ class DockerService:
                         )
                         jupyter_url = f"http://{executor_info.address}:{jupyter_port_map[1]}/lab?token={jupyter_token}"
 
-                    # Add profiler for ssh service installation
+                    # Add profiler for ssh service installation (covers key
+                    # injection + bootstrap + jupyter since the running check)
                     profilers.append(ProfilerStep.since(ProfilerStepName.SSH_SERVICE_INSTALLATION, prev_timestamp))
                     prev_timestamp = now_ms()
-
-                    # add rest of public keys
-                    current_step = "add_public_keys"
-                    await self.add_ssh_public_keys_with_rental_docker(
-                        docker_client=docker_client,
-                        container_name=container_name,
-                        public_keys=payload.user_public_keys,
-                        log_tag=log_tag,
-                        log_extra=default_extra,
-                    )
 
                     # add environment variables
                     current_step = "set_environment"
@@ -3361,7 +3366,8 @@ class DockerService:
                     if not environment_ok:
                         raise RuntimeError("Failed to set environment variables")
 
-                    # Add profiler for adding public keys
+                    # Historical name — key injection moved before the bootstrap
+                    # (DAH-2341), so this step now times the environment setup.
                     profilers.append(ProfilerStep.since(ProfilerStepName.ADDING_PUBLIC_KEYS, prev_timestamp))
                     prev_timestamp = now_ms()
 

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -593,12 +593,15 @@ def build_authorized_keys_exec_spec(
     import shlex
 
     key_data = "".join(f"{public_key}\n" for public_key in public_keys)
+    # chmod up front: key injection now runs before the sshd bootstrap's own
+    # `chmod 700` (DAH-2341), and sshd may come up in between.
+    quoted_dir = shlex.quote(target_path.rsplit("/", 1)[0])
     return ContainerExecSpec(
         container_name=container_name,
         argv=(
             "sh",
             "-c",
-            f"mkdir -p {shlex.quote(target_path.rsplit('/', 1)[0])} "
+            f"mkdir -p {quoted_dir} && chmod 700 {quoted_dir} "
             f"&& cat >> {shlex.quote(target_path)}",
         ),
         stdin=key_data,

--- a/neurons/validators/tests/test_deploy_optimizations.py
+++ b/neurons/validators/tests/test_deploy_optimizations.py
@@ -386,9 +386,25 @@ async def test_ships_sshd_true_with_jupyter(svc, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_key_injection_runs_after_shipped_sshd_bootstrap(svc, monkeypatch):
+async def test_key_injection_runs_before_sshd_bootstrap(svc, monkeypatch):
+    """DAH-2341: keys are plain data (mkdir + append) with no dependency on a
+    running sshd, and the bootstrap may spend a grace period waiting for an
+    image-provided sshd — whichever sshd comes up first must already find the
+    customer's keys in place."""
     ssh_client = _ssh_client(inspect_exit=0)
     _patch_happy(svc, monkeypatch, ssh_client)
+
+    exec_texts_at_bootstrap: list[str] = []
+
+    async def _snapshot_then_succeed(*args, **kwargs):
+        exec_texts_at_bootstrap.extend(
+            " ".join(spec.argv) for spec in _docker_client(svc).exec_specs
+        )
+        return True
+
+    svc.install_open_ssh_server_and_start_ssh_service_with_rental_docker.side_effect = (
+        _snapshot_then_succeed
+    )
 
     keys = ["ssh-ed25519 key-one", "ssh-ed25519 key-two"]
     result = await _run(svc, _payload(ships_sshd=True, user_public_keys=keys))
@@ -402,6 +418,9 @@ async def test_key_injection_runs_after_shipped_sshd_bootstrap(svc, monkeypatch)
     assert len(authorized) == 1
     assert "key-one" in authorized[0].stdin
     assert "key-two" in authorized[0].stdin
+    assert any("authorized_keys" in text for text in exec_texts_at_bootstrap), (
+        "public keys must already be injected when the sshd bootstrap starts"
+    )
 
 
 # ------------------------------------------------------------------

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -1390,7 +1390,8 @@ def test_ssh_bootstrap_script_uses_single_watchdog_with_30_second_sleep(docker_s
     """The watchdog loop is single-instance and checks sshd every 30 seconds."""
     script = docker_service._ssh_bootstrap_script_path().read_text()
 
-    assert 'WATCHDOG_PIDFILE="/run/sshd-watchdog.pid"' in script
+    assert 'WATCHDOG_PIDFILE="$RUN_DIR/sshd-watchdog.pid"' in script
+    assert 'RUN_DIR="${LIUM_RUN_DIR:-/run}"' in script
     assert 'WATCHDOG_LOG="/tmp/sshd-watchdog.log"' in script
     assert 'SLEEP_SECONDS=30' in script
     assert 'kill -0 "$watchdog_pid"' in script

--- a/neurons/validators/tests/test_sshd_bootstrap_script.py
+++ b/neurons/validators/tests/test_sshd_bootstrap_script.py
@@ -9,6 +9,7 @@ of the race-safe flow runs for real without root or a container:
 - fall back to own bring-up when the image never starts sshd,
 - skip the grace wait entirely when the image ships no sshd binary,
 - tolerate losing the sshd start race (bind conflict),
+- reload the hardened config when the fallback path adopts an sshd,
 - fail (exit 1) only when sshd is genuinely not serving,
 - require a :22 listener for success, not just a process,
 - proceed after the shared setup-lock times out.
@@ -17,6 +18,7 @@ of the race-safe flow runs for real without root or a container:
 from __future__ import annotations
 
 import os
+import signal
 import stat
 import subprocess
 from pathlib import Path
@@ -285,6 +287,27 @@ def test_tolerates_losing_the_sshd_start_race(harness):
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "sshd was started concurrently" in result.stdout
+
+
+def test_fallback_adopt_after_bind_race_reloads_hardened_config(harness):
+    """The adopted (image-started) sshd loaded the pre-hardening config, so the
+    fallback path must SIGHUP the master after hardening — not just converge."""
+    harness.install_sshd_bin(SSHD_LOSES_BIND_RACE)
+    master = subprocess.Popen(["/bin/sleep", "60"])
+    (harness.run_dir / "sshd.pid").write_text(f"{master.pid}\n")
+
+    try:
+        result = harness.run("--grace", "1")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "sshd was started concurrently" in result.stdout
+        assert f"Sent SIGHUP to sshd (pid {master.pid})" in result.stdout
+        # SIGHUP's default disposition terminates sleep — proof it was delivered.
+        assert master.wait(timeout=5) == -signal.SIGHUP
+    finally:
+        if master.poll() is None:
+            master.kill()
+            master.wait()
 
 
 def test_fails_when_sshd_never_serves(harness):

--- a/neurons/validators/tests/test_sshd_bootstrap_script.py
+++ b/neurons/validators/tests/test_sshd_bootstrap_script.py
@@ -1,0 +1,321 @@
+"""DAH-2341 — behavioral tests for sshd_bootstrap.sh's decision flow.
+
+The script is exercised as a real subprocess with a shim PATH (pgrep,
+ssh-keygen, sleep, nohup, apt-get) and LIUM_* path overrides, so every branch
+of the race-safe flow runs for real without root or a container:
+
+- adopt an already-running sshd (no keygen),
+- adopt an sshd that appears during the grace window,
+- fall back to own bring-up when the image never starts sshd,
+- skip the grace wait entirely when the image ships no sshd binary,
+- tolerate losing the sshd start race (bind conflict),
+- fail (exit 1) only when sshd is genuinely not serving,
+- require a :22 listener for success, not just a process,
+- proceed after the shared setup-lock times out.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parent.parent / "src" / "services" / "assets" / "sshd_bootstrap.sh"
+)
+
+# One LISTEN row on 0.0.0.0:22 (0016 hex), plus noise that must not match:
+# an ESTABLISHED (01) row on :22 and a LISTEN row on another port.
+PROC_TCP_WITH_LISTENER = (
+    "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid\n"
+    "   0: 00000000:0016 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0\n"
+    "   1: 0100007F:0016 0100007F:D2A0 01 00000000:00000000 00:00000000 00000000     0\n"
+)
+PROC_TCP_WITHOUT_LISTENER = (
+    "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid\n"
+    "   1: 0100007F:0016 0100007F:D2A0 01 00000000:00000000 00:00000000 00000000     0\n"
+    "   2: 00000000:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0\n"
+)
+
+PGREP_SHIM = """#!/bin/sh
+# sshd is "running" when the state marker exists. An optional countdown file
+# makes it appear after N pgrep calls, simulating an image entrypoint that
+# starts sshd mid-grace.
+if [ -f "$SHIM_STATE/sshd_running" ]; then
+    exit 0
+fi
+if [ -f "$SHIM_STATE/pgrep_countdown" ]; then
+    n=$(cat "$SHIM_STATE/pgrep_countdown")
+    n=$((n - 1))
+    printf '%s\\n' "$n" > "$SHIM_STATE/pgrep_countdown"
+    if [ "$n" -le 0 ]; then
+        touch "$SHIM_STATE/sshd_running"
+        exit 0
+    fi
+fi
+exit 1
+"""
+
+SLEEP_SHIM = """#!/bin/sh
+# Keep the script's second-granularity loops honest but fast.
+exec /bin/sleep 0.01
+"""
+
+# is_sshd_running falls through to `ps` when pgrep reports nothing — without
+# this shim the host machine's real sshd would leak into every scenario.
+PS_SHIM = """#!/bin/sh
+if [ -f "$SHIM_STATE/sshd_running" ]; then
+    echo "root         1     0  0 00:00 ?        00:00:00 sshd"
+fi
+exit 0
+"""
+
+SSH_KEYGEN_SHIM = """#!/bin/sh
+printf '%s\\n' "$*" >> "$SHIM_STATE/keygen_calls"
+exit 0
+"""
+
+NOHUP_SHIM = """#!/bin/sh
+# Record the watchdog spawn without actually starting the loop.
+printf '%s\\n' "$*" >> "$SHIM_STATE/nohup_calls"
+exit 0
+"""
+
+APT_GET_SHIM = """#!/bin/sh
+printf '%s\\n' "$*" >> "$SHIM_STATE/apt_calls"
+case "$*" in
+    *install*)
+        cp "$SHIM_STATE/sshd_payload" "$LIUM_SSHD_BIN"
+        chmod +x "$LIUM_SSHD_BIN"
+        ;;
+esac
+exit 0
+"""
+
+SSHD_STARTS = """#!/bin/sh
+touch "$SHIM_STATE/sshd_running"
+printf 'started\\n' >> "$SHIM_STATE/sshd_started"
+exit 0
+"""
+
+# Exits non-zero as if the bind failed, while the concurrent (image) sshd is
+# in fact up — the script must treat this as success after re-checking.
+SSHD_LOSES_BIND_RACE = """#!/bin/sh
+touch "$SHIM_STATE/sshd_running"
+printf 'failed\\n' >> "$SHIM_STATE/sshd_started"
+exit 1
+"""
+
+SSHD_NEVER_SERVES = """#!/bin/sh
+printf 'failed\\n' >> "$SHIM_STATE/sshd_started"
+exit 1
+"""
+
+
+class BootstrapHarness:
+    def __init__(self, tmp_path: Path):
+        self.root = tmp_path
+        self.shims = tmp_path / "shims"
+        self.state = tmp_path / "state"
+        self.run_dir = tmp_path / "run"
+        self.ssh_dir = tmp_path / "ssh"
+        self.shims.mkdir()
+        self.state.mkdir()
+        self.run_dir.mkdir()
+
+        self.sshd_config = tmp_path / "sshd_config"
+        self.sshd_config.write_text("PasswordAuthentication yes\n")
+
+        self.proc_tcp = tmp_path / "proc_tcp"
+        self.proc_tcp.write_text(PROC_TCP_WITH_LISTENER)
+
+        self.sshd_bin = self.state / "sshd"
+
+        for name, body in (
+            ("pgrep", PGREP_SHIM),
+            ("ps", PS_SHIM),
+            ("sleep", SLEEP_SHIM),
+            ("ssh-keygen", SSH_KEYGEN_SHIM),
+            ("nohup", NOHUP_SHIM),
+            ("apt-get", APT_GET_SHIM),
+        ):
+            self._write_executable(self.shims / name, body)
+
+    def _write_executable(self, path: Path, body: str) -> None:
+        path.write_text(body)
+        path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    def install_sshd_bin(self, body: str) -> None:
+        self._write_executable(self.sshd_bin, body)
+
+    def stage_sshd_payload(self, body: str) -> None:
+        """Payload `apt-get install` copies onto LIUM_SSHD_BIN."""
+        self._write_executable(self.state / "sshd_payload", body)
+
+    def mark_sshd_running(self) -> None:
+        (self.state / "sshd_running").touch()
+
+    def set_pgrep_countdown(self, calls: int) -> None:
+        (self.state / "pgrep_countdown").write_text(str(calls))
+
+    def keygen_calls(self) -> list[str]:
+        path = self.state / "keygen_calls"
+        return path.read_text().splitlines() if path.exists() else []
+
+    def apt_calls(self) -> list[str]:
+        path = self.state / "apt_calls"
+        return path.read_text().splitlines() if path.exists() else []
+
+    def sshd_start_attempts(self) -> list[str]:
+        path = self.state / "sshd_started"
+        return path.read_text().splitlines() if path.exists() else []
+
+    def watchdog_spawned(self) -> bool:
+        return (self.state / "nohup_calls").exists()
+
+    def run(self, *args: str, verify_secs: int = 2) -> subprocess.CompletedProcess:
+        env = {
+            **os.environ,
+            "PATH": f"{self.shims}:{os.environ['PATH']}",
+            "SHIM_STATE": str(self.state),
+            "LIUM_RUN_DIR": str(self.run_dir),
+            "LIUM_SSH_DIR": str(self.ssh_dir),
+            "LIUM_SSHD_CONFIG": str(self.sshd_config),
+            "LIUM_SSHD_BIN": str(self.sshd_bin),
+            "LIUM_PROC_TCP_FILES": str(self.proc_tcp),
+            "LIUM_SSHD_VERIFY_SECS": str(verify_secs),
+            "LIUM_SSH_LOCK_TIMEOUT_SECS": "1",
+        }
+        return subprocess.run(
+            ["sh", str(SCRIPT), *args],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+        )
+
+
+@pytest.fixture
+def harness(tmp_path):
+    return BootstrapHarness(tmp_path)
+
+
+def test_adopts_already_running_sshd_without_touching_host_keys(harness):
+    harness.mark_sshd_running()
+    harness.install_sshd_bin(SSHD_STARTS)
+
+    result = harness.run("--grace", "5")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "adopting existing daemon" in result.stdout
+    assert harness.keygen_calls() == []
+    assert harness.sshd_start_attempts() == []
+    assert harness.watchdog_spawned()
+
+
+def test_adopt_path_hardens_config_for_key_only_auth(harness):
+    harness.mark_sshd_running()
+
+    result = harness.run()
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    hardened = harness.sshd_config.read_text()
+    assert "# lium-hardened" in hardened
+    assert "# lium-disabled PasswordAuthentication yes" in hardened
+    assert "\nPasswordAuthentication no\n" in hardened
+    # No sshd pidfile exists in the harness, so the reload is skipped loudly.
+    assert "no sshd pidfile to reload" in result.stdout
+
+
+def test_adopts_sshd_that_appears_during_grace(harness):
+    harness.set_pgrep_countdown(3)
+    harness.install_sshd_bin(SSHD_STARTS)
+
+    result = harness.run("--grace", "10")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Waiting up to 10s for image-provided sshd" in result.stdout
+    assert "Image-provided sshd came up" in result.stdout
+    assert harness.keygen_calls() == []
+    assert harness.sshd_start_attempts() == []
+
+
+def test_fallback_owns_bringup_when_image_never_starts_sshd(harness):
+    harness.install_sshd_bin(SSHD_STARTS)
+
+    result = harness.run("--grace", "1")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "falling back to own bring-up" in result.stdout
+    assert harness.keygen_calls() == ["-A"]
+    assert harness.sshd_start_attempts() == ["started"]
+    assert harness.watchdog_spawned()
+
+
+def test_no_grace_wait_when_image_ships_no_sshd_binary(harness):
+    # LIUM_SSHD_BIN does not exist yet; the apt-get shim "installs" it.
+    harness.stage_sshd_payload(SSHD_STARTS)
+
+    result = harness.run()
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Waiting up to" not in result.stdout
+    assert any("install" in call for call in harness.apt_calls())
+    assert harness.keygen_calls() == ["-A"]
+    assert harness.sshd_start_attempts() == ["started"]
+
+
+def test_grace_zero_skips_waiting_even_with_sshd_binary(harness):
+    harness.install_sshd_bin(SSHD_STARTS)
+
+    result = harness.run("--grace", "0")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Waiting up to" not in result.stdout
+    assert harness.keygen_calls() == ["-A"]
+
+
+def test_tolerates_losing_the_sshd_start_race(harness):
+    harness.install_sshd_bin(SSHD_LOSES_BIND_RACE)
+
+    result = harness.run("--grace", "1")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "sshd was started concurrently" in result.stdout
+
+
+def test_fails_when_sshd_never_serves(harness):
+    harness.install_sshd_bin(SSHD_NEVER_SERVES)
+
+    result = harness.run("--grace", "1")
+
+    assert result.returncode != 0
+    assert "sshd verification failed" in result.stdout
+    assert "running=no" in result.stdout
+
+
+def test_verify_requires_listener_on_port_22_not_just_a_process(harness):
+    harness.mark_sshd_running()
+    harness.proc_tcp.write_text(PROC_TCP_WITHOUT_LISTENER)
+
+    result = harness.run(verify_secs=1)
+
+    assert result.returncode != 0
+    assert "sshd verification failed" in result.stdout
+    assert "running=yes" in result.stdout
+    assert "listening=no" in result.stdout
+
+
+def test_lock_timeout_proceeds_instead_of_hanging(harness):
+    harness.install_sshd_bin(SSHD_STARTS)
+    # Simulate a crashed holder: the lock dir exists and nobody releases it.
+    (harness.run_dir / "lium-ssh-setup.lock").mkdir()
+
+    result = harness.run("--grace", "0")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "proceeding without it" in result.stdout
+    assert harness.sshd_start_attempts() == ["started"]


### PR DESCRIPTION
## Describe your changes

Fixes the race between a rental image's own SSH setup (entrypoint `/start.sh`: host-key generation + `service ssh start`) and the validator's post-create `sshd_bootstrap.sh`. In the staging repro (pod `93b13164-863a-4f2d-8e27-c0f3b32c98a2`, custom `fortunelucky777/pytorch:...-dind` on the L40), the validator's `ssh-keygen -A` created a host key between the image's `[ ! -f ]` check and its per-type `ssh-keygen -t rsa -f`, which then blocked PID 1 on `Overwrite (y/n)?` — pod RUNNING, ports published, SSH connection refused.

The bootstrap now **converges on an invariant** ("host keys exist and sshd is listening on :22") instead of racing to create it:

- **Adopt, don't fight**: if sshd is already running, adopt it — no keygen at all. If the image ships an sshd binary, wait a grace period (default 10s) for the image to start it before the fallback takes over. Images without an sshd binary skip the wait entirely (no latency change for them).
- **Fallback under a lock**: own bring-up (keygen -A, hardening, start) runs under `mkdir /run/lium-ssh-setup.lock`, shared with the patched lium image `start.sh` (companion PR). A failed sshd start is re-checked — losing a benign bind race is success, not failure.
- **Exit code = invariant**: the script verifies sshd is running AND a `:22` listener exists (`/proc/net/tcp{,6}`) before exiting 0; command exit codes no longer produce false-fatal `RuntimeError("SSH bootstrap failed")` for `ships_sshd` templates.
- **Hardening determinism**: when config is hardened after an adopted sshd was already up, the master gets SIGHUP via its pidfile so `PasswordAuthentication no` actually loads. Read-only `/etc/ssh` no longer aborts the adopt path.
- **Keys before bootstrap** (`docker_service.py`): the customer's public keys are plain data (mkdir + append, now with `chmod 700`) and are injected *before* the bootstrap, so whichever sshd comes up first already finds them.
- Hostile-image hygiene: `docker exec` inherits image ENV, so the `LIUM_*` timing knobs are integer-validated and capped (grace ≤300s, verify ≤120s, lock ≤300s).
- Updated the stale `ships_sshd` docstring in `payloads.py` (it still described the reverted DAH-1524 "skip" semantics); today the flag only escalates bootstrap failure to fatal.

**Latency note**: images that ship an sshd binary but never self-start it (including today's default `daturaai/pytorch` tags, whose `start.sh` gates SSH on `PUBLIC_KEY`) pay up to +10s in `SSH_SERVICE_INSTALLATION` (grace window). This self-resolves for the rebuilt self-starting images (companion PR): the wait exits the moment sshd appears. Follow-ups deliberately out of scope: backend declaring per-tag sshd behavior, and a host-side reachability probe of the mapped port before `ContainerCreated` (the in-container `:22` listener check covers this task's failure class; port publication was already correct in the repro).

Companion PR: Datura-ai/computenet-docker-images — race-safe `setup_ssh` (ssh-keygen -A, shared lock, never kill PID 1) + stale nested-dockerd pidfile cleanup that caused the post-crash restart loop.

**Test plan** (from the task spec):
- [x] Unit tests for the new decision flow — `tests/test_sshd_bootstrap_script.py` runs the real script through shims: adopt-running (no keygen), adopt-during-grace, fallback bring-up, no-wait-without-binary, grace-0, bind-race tolerance, exit-1 only when sshd never serves, listener-required, lock-timeout. 10/10 passed.
- [x] Full validator suite: 892 passed, 8 skipped (includes updated key-before-bootstrap ordering test).
- [x] Forced-concurrency smoke (image `setup_ssh` vs bootstrap, 30 rounds, `--grace 0` worst case): 0 keygen collisions, both sides exit 0, single sshd, 3 host keys — every round.
- [ ] Post-deploy (staging): re-run the failed custom-image case on L40 (`fortunelucky777/pytorch:2.12.0-py3.12-cuda12.8-devel-ubuntu24.04-dind`) → RUNNING + direct SSH OK.
- [ ] Post-deploy (staging): default-template smoke across A6000 38.80.122.73 / L40 38.80.122.143 / A4000 149.36.1.151.

## Issue ticket number and link

[DAH-2341 — Fix rental SSH bootstrap race with images that start sshd](https://app.notion.com/p/Fix-rental-SSH-bootstrap-race-with-images-that-start-sshd-392b8bfdbde98176b12ae7833ddf2d70)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?