### PR TITLE
DAH-2345, idempotent container delete for all workload kinds

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -3845,14 +3845,15 @@ class DockerService:
                         remove_volumes=True,
                     )
                 except Exception as exc:
-                    if (
-                        payload.workload_kind != WorkloadKind.FILLER
-                        or not _is_missing_docker_container_error(exc)
-                    ):
+                    # DAH-2345: deletion is idempotent for every workload kind — a container
+                    # that is already gone (e.g. removed by failed-create cleanup) must not
+                    # fail the delete, or the backend retries a doomed request until
+                    # force-removal and penalizes the miner.
+                    if not _is_missing_docker_container_error(exc):
                         raise
                     logger.info(
                         _m(
-                            "Filler container is already absent",
+                            "Container is already absent",
                             extra=get_extra_info(
                                 {
                                     **default_extra,
@@ -3958,7 +3959,8 @@ class DockerService:
                 executor_id=payload.executor_id,
                 pod_id=payload.pod_id,
                 workload_kind=payload.workload_kind,
-                msg=str(log_text),
+                # str(log_text) drops extra, hiding the cause from the backend
+                msg=f"Unknown Error delete_container: {e}",
                 error_type=FailedContainerErrorTypes.ContainerDeletionFailed,
                 error_code=FailedContainerErrorCodes.UnknownError,
             )

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -898,6 +898,118 @@ async def test_delete_filler_container_treats_missing_container_as_deleted(
 
 
 @pytest.mark.asyncio
+async def test_delete_customer_rental_treats_missing_container_as_deleted(
+    docker_service,
+    monkeypatch,
+):
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.remove_rented_machine = AsyncMock()
+    docker_service.redis_service.get_rented_machine = AsyncMock(return_value=None)
+    docker_service.rental_docker_client_factory.client.remove_error = Exception(
+        "Docker SDK remove container failed: 404 Client Error: Not Found "
+        '("No such container: pod_missing")'
+    )
+
+    payload = ContainerDeleteRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_missing",
+        local_volume="volume_missing",
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
+    )
+    keypair = Mock(ss58_address="validator-hotkey")
+
+    result = await docker_service.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=keypair,
+        private_key="encrypted",
+    )
+
+    assert isinstance(result, ContainerDeleted)
+    assert result.pod_id == payload.pod_id
+    assert docker_service.rental_docker_client_factory.client.pruned_images == 1
+    assert docker_service.rental_docker_client_factory.client.removed_volumes == [
+        {"volume_name": payload.local_volume, "force": False}
+    ]
+    docker_service.redis_service.remove_rented_machine.assert_awaited_once_with(
+        executor_info,
+        payload.container_name,
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_container_failure_msg_includes_underlying_error(
+    docker_service,
+    monkeypatch,
+):
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.remove_rented_machine = AsyncMock()
+    docker_service.rental_docker_client_factory.client.remove_error = Exception(
+        "Docker SDK remove container failed: 500 Server Error: daemon exploded"
+    )
+
+    payload = ContainerDeleteRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_stuck",
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
+    )
+    keypair = Mock(ss58_address="validator-hotkey")
+
+    result = await docker_service.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=keypair,
+        private_key="encrypted",
+    )
+
+    assert isinstance(result, FailedContainerRequest)
+    assert result.error_type == FailedContainerErrorTypes.ContainerDeletionFailed
+    assert "500 Server Error: daemon exploded" in result.msg
+
+
+@pytest.mark.asyncio
 async def test_inspector_lifecycle_command_quotes_executor_paths(docker_service):
     executor_info = ExecutorSSHInfo(
         uuid="exec-1",


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2345](https://app.notion.com/p/Pod-deletion-stop-doomed-retries-and-phantom-POD_UNDEPLOY_FAILED-penalties-395b8bfdbde98130ba82d8a518c917e0)

---

## Problem

"Container deletion failed" spiked to 37/24h in prod (baseline 11–19). 27 of 56 failures over 48h are Docker SDK `404 Not Found ("No such container")`: the container is already gone (creation failed with 500 on start and its cleanup removed the container), yet `delete_container` treats a missing container as a failure — the missing-container tolerance shipped with the rental Docker SDK hot path applies only to `WorkloadKind.FILLER`. Each affected pod burns 4 doomed deletion attempts (~1h), is force-removed at max retries, and the miner gets an unfair `POD_UNDEPLOY_FAILED` penalty.

Reference incident: pod `cf8165f4-caad-420d-bf6b-823cc517e082`, 2026-07-06 04:16–04:50 UTC — 4 identical 404 failures.

Additionally, `FailedContainerRequest.msg` carried only `str(log_text)`, and `_StructuredMessage.__str__` drops `extra` — the backend logged "Unknown Error delete_container" with no underlying cause.

## Solution

Deletion is idempotent for every workload kind: a missing container is treated as already deleted, and the flow continues with volume/image cleanup so the pod closes on the first attempt. The underlying error text is now included in `FailedContainerRequest.msg` so backend logs are diagnosable.

## Changes

- `delete_container`: drop the FILLER-only guard around `_is_missing_docker_container_error` — "No such container" no longer fails deletion for customer rentals.
- `delete_container` outer error handler: `msg` now includes the underlying exception text.
- Tests: customer-rental delete with missing container returns `ContainerDeleted` (volumes pruned, redis cleaned); failure `msg` preserves the underlying error.

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review

## Other PRs

- lium-io-backend: https://github.com/Datura-ai/lium-io-backend/pull/735 (short-circuit on `InvalidExecutorId` deletion failures — the other half of DAH-2345)

## Risks

- A genuinely live container whose removal fails with a message containing "No such container" would be treated as deleted — not observed in practice; the phrase is only produced by the Docker daemon for missing containers.
- Post-container cleanup steps (volume rm, image prune) now run for pods whose container was absent; if the named volume is also absent, `remove_volume` still fails the request (possible follow-up: tolerate missing volume as well).

## Test Cases

### Test Case 1

**Actions**: `pytest tests/test_docker_service.py` (124 tests) and full validator suite.

**Expected Output**: 884 passed, 8 skipped; new tests `test_delete_customer_rental_treats_missing_container_as_deleted` and `test_delete_container_failure_msg_includes_underlying_error` green.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described