### PR TITLE
DAH-2345, idempotent container delete + isolate post-container teardown steps

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -3864,42 +3864,88 @@ class DockerService:
                         ),
                     )
 
+                # DAH-2345: the container is gone once remove_container succeeds; a failure
+                # in any post-container teardown step below must not fail the undeploy, or the
+                # backend retries a doomed request and penalizes the miner for a pod that is
+                # already removed. Each step is guarded individually and only logged on error.
+
                 # DAH-2211: always-on inline cleanup of custom-build artifacts
                 # for this pod. No-op if the pod was not a custom build.
+                # (self-guarding: logs and never raises)
                 await self._cleanup_custom_build_artifacts(
                     ssh_client=ssh_client,
                     pod_id=payload.pod_id,
                     default_extra=default_extra,
                 )
 
-                await run_logged_rental_docker_sdk_operation(
-                    operation="prune_images",
-                    log_extra=default_extra,
-                    call=docker_client.prune_images,
-                )
+                try:
+                    await run_logged_rental_docker_sdk_operation(
+                        operation="prune_images",
+                        log_extra=default_extra,
+                        call=docker_client.prune_images,
+                    )
+                except Exception as exc:
+                    logger.error(
+                        _m(
+                            "delete_container post-teardown step failed (non-fatal)",
+                            extra=get_extra_info(
+                                {**default_extra, "step": "prune_images", "error": str(exc)}
+                            ),
+                        ),
+                    )
 
                 if payload.local_volume:
-                    await run_logged_rental_docker_sdk_operation(
-                        operation="remove_volume",
-                        log_extra=default_extra,
-                        call=lambda: docker_client.remove_volume(
-                            volume_name=payload.local_volume
-                        ),
-                        volume_name=payload.local_volume,
-                        volume_role="local",
-                    )
+                    try:
+                        await run_logged_rental_docker_sdk_operation(
+                            operation="remove_volume",
+                            log_extra=default_extra,
+                            call=lambda: docker_client.remove_volume(
+                                volume_name=payload.local_volume
+                            ),
+                            volume_name=payload.local_volume,
+                            volume_role="local",
+                        )
+                    except Exception as exc:
+                        logger.error(
+                            _m(
+                                "delete_container post-teardown step failed (non-fatal)",
+                                extra=get_extra_info(
+                                    {
+                                        **default_extra,
+                                        "step": "remove_volume_local",
+                                        "volume_name": payload.local_volume,
+                                        "error": str(exc),
+                                    }
+                                ),
+                            ),
+                        )
 
                 if payload.external_volume:
-                    await run_logged_rental_docker_sdk_operation(
-                        operation="remove_volume",
-                        log_extra=default_extra,
-                        call=lambda: docker_client.remove_volume(
-                            volume_name=payload.external_volume
-                        ),
-                        volume_name=payload.external_volume,
-                        volume_role="external",
-                    )
-                    await self.disable_s3fs_volume_plugin(ssh_client)
+                    try:
+                        await run_logged_rental_docker_sdk_operation(
+                            operation="remove_volume",
+                            log_extra=default_extra,
+                            call=lambda: docker_client.remove_volume(
+                                volume_name=payload.external_volume
+                            ),
+                            volume_name=payload.external_volume,
+                            volume_role="external",
+                        )
+                        await self.disable_s3fs_volume_plugin(ssh_client)
+                    except Exception as exc:
+                        logger.error(
+                            _m(
+                                "delete_container post-teardown step failed (non-fatal)",
+                                extra=get_extra_info(
+                                    {
+                                        **default_extra,
+                                        "step": "remove_volume_external",
+                                        "volume_name": payload.external_volume,
+                                        "error": str(exc),
+                                    }
+                                ),
+                            ),
+                        )
 
                 logger.info(
                     _m(
@@ -3915,21 +3961,42 @@ class DockerService:
                     ),
                 )
 
-                await self.redis_service.remove_rented_machine(executor_info, payload.container_name)
+                try:
+                    await self.redis_service.remove_rented_machine(executor_info, payload.container_name)
+                except Exception as exc:
+                    logger.error(
+                        _m(
+                            "delete_container post-teardown step failed (non-fatal)",
+                            extra=get_extra_info(
+                                {**default_extra, "step": "remove_rented_machine", "error": str(exc)}
+                            ),
+                        ),
+                    )
+
                 # Stop inspector only after the last customer pod leaves this executor.
-                if (
-                    settings.ENABLE_INSPECTOR
-                    and payload.workload_kind != WorkloadKind.FILLER
-                    and not await self._has_rented_customer_containers(executor_info)
-                ):
-                    await self._run_inspector_collector_lifecycle(
-                        ssh_client=ssh_client,
-                        executor_info=executor_info,
-                        action="stop",
-                        default_extra={
-                            **default_extra,
-                            "container_name": payload.container_name,
-                        },
+                try:
+                    if (
+                        settings.ENABLE_INSPECTOR
+                        and payload.workload_kind != WorkloadKind.FILLER
+                        and not await self._has_rented_customer_containers(executor_info)
+                    ):
+                        await self._run_inspector_collector_lifecycle(
+                            ssh_client=ssh_client,
+                            executor_info=executor_info,
+                            action="stop",
+                            default_extra={
+                                **default_extra,
+                                "container_name": payload.container_name,
+                            },
+                        )
+                except Exception as exc:
+                    logger.error(
+                        _m(
+                            "delete_container post-teardown step failed (non-fatal)",
+                            extra=get_extra_info(
+                                {**default_extra, "step": "inspector_stop", "error": str(exc)}
+                            ),
+                        ),
                     )
 
                 # Port release now handled by backend

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -3845,14 +3845,15 @@ class DockerService:
                         remove_volumes=True,
                     )
                 except Exception as exc:
-                    if (
-                        payload.workload_kind != WorkloadKind.FILLER
-                        or not _is_missing_docker_container_error(exc)
-                    ):
+                    # DAH-2345: deletion is idempotent for every workload kind — a container
+                    # that is already gone (e.g. removed by failed-create cleanup) must not
+                    # fail the delete, or the backend retries a doomed request until
+                    # force-removal and penalizes the miner.
+                    if not _is_missing_docker_container_error(exc):
                         raise
                     logger.info(
                         _m(
-                            "Filler container is already absent",
+                            "Container is already absent",
                             extra=get_extra_info(
                                 {
                                     **default_extra,
@@ -3958,7 +3959,8 @@ class DockerService:
                 executor_id=payload.executor_id,
                 pod_id=payload.pod_id,
                 workload_kind=payload.workload_kind,
-                msg=str(log_text),
+                # str(log_text) drops extra, hiding the cause from the backend
+                msg=f"Unknown Error delete_container: {e}",
                 error_type=FailedContainerErrorTypes.ContainerDeletionFailed,
                 error_code=FailedContainerErrorCodes.UnknownError,
             )

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -63,6 +63,8 @@ class _FakeRentalDockerClient:
         self.start_error = None
         self.stop_error = None
         self.remove_error = None
+        self.remove_volume_error = None
+        self.prune_images_error = None
 
     async def login(self, *, username: str, password: str) -> None:
         self.login_calls.append({"username": username, "password": password})
@@ -133,9 +135,13 @@ class _FakeRentalDockerClient:
         self.removed_volumes.append(
             {"volume_name": volume_name, "force": force}
         )
+        if self.remove_volume_error is not None:
+            raise self.remove_volume_error
 
     async def prune_images(self) -> None:
         self.pruned_images += 1
+        if self.prune_images_error is not None:
+            raise self.prune_images_error
 
 
 class _FakeRentalDockerFactory:
@@ -1007,6 +1013,213 @@ async def test_delete_container_failure_msg_includes_underlying_error(
     assert isinstance(result, FailedContainerRequest)
     assert result.error_type == FailedContainerErrorTypes.ContainerDeletionFailed
     assert "500 Server Error: daemon exploded" in result.msg
+
+
+def _delete_container_executor_info(executor_id: str) -> ExecutorSSHInfo:
+    return ExecutorSSHInfo(
+        uuid=executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_container_volume_read_timeout_still_deleted(
+    docker_service,
+    monkeypatch,
+):
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.remove_rented_machine = AsyncMock()
+    docker_service.rental_docker_client_factory.client.remove_volume_error = Exception(
+        "Docker SDK remove volume failed: HTTPConnectionPool: Read timed out (read timeout=60)"
+    )
+
+    payload = ContainerDeleteRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_slow_volume",
+        local_volume="volume_slow",
+    )
+    executor_info = _delete_container_executor_info(payload.executor_id)
+    keypair = Mock(ss58_address="validator-hotkey")
+
+    result = await docker_service.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=keypair,
+        private_key="encrypted",
+    )
+
+    assert isinstance(result, ContainerDeleted)
+    assert result.pod_id == payload.pod_id
+    # container was removed; the volume timeout must not fail the undeploy
+    assert docker_service.rental_docker_client_factory.client.removed_containers == [
+        {
+            "container_name": payload.container_name,
+            "force": True,
+            "remove_volumes": True,
+        }
+    ]
+    docker_service.redis_service.remove_rented_machine.assert_awaited_once_with(
+        executor_info,
+        payload.container_name,
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_container_missing_volume_still_deleted(
+    docker_service,
+    monkeypatch,
+):
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.remove_rented_machine = AsyncMock()
+    docker_service.rental_docker_client_factory.client.remove_volume_error = Exception(
+        "Docker SDK remove volume failed: 404 Client Error: Not Found "
+        '("No such volume: volume_gone")'
+    )
+
+    payload = ContainerDeleteRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_retry",
+        local_volume="volume_gone",
+    )
+    executor_info = _delete_container_executor_info(payload.executor_id)
+    keypair = Mock(ss58_address="validator-hotkey")
+
+    result = await docker_service.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=keypair,
+        private_key="encrypted",
+    )
+
+    assert isinstance(result, ContainerDeleted)
+    docker_service.redis_service.remove_rented_machine.assert_awaited_once_with(
+        executor_info,
+        payload.container_name,
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_container_prune_images_failure_still_deleted(
+    docker_service,
+    monkeypatch,
+):
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.remove_rented_machine = AsyncMock()
+    docker_service.rental_docker_client_factory.client.prune_images_error = Exception(
+        "Docker SDK prune images failed: 500 Server Error"
+    )
+
+    payload = ContainerDeleteRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_prune_fail",
+        local_volume="volume_ok",
+    )
+    executor_info = _delete_container_executor_info(payload.executor_id)
+    keypair = Mock(ss58_address="validator-hotkey")
+
+    result = await docker_service.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=keypair,
+        private_key="encrypted",
+    )
+
+    assert isinstance(result, ContainerDeleted)
+    # prune ran (and raised); the local volume is still removed afterwards
+    assert docker_service.rental_docker_client_factory.client.pruned_images == 1
+    assert docker_service.rental_docker_client_factory.client.removed_volumes == [
+        {"volume_name": payload.local_volume, "force": False}
+    ]
+    docker_service.redis_service.remove_rented_machine.assert_awaited_once_with(
+        executor_info,
+        payload.container_name,
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_container_remove_container_error_fails_undeploy(
+    docker_service,
+    monkeypatch,
+):
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.remove_rented_machine = AsyncMock()
+    docker_service.rental_docker_client_factory.client.remove_error = Exception(
+        "Docker SDK remove container failed: 500 Server Error: daemon exploded"
+    )
+
+    payload = ContainerDeleteRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_stuck",
+        local_volume="volume_stuck",
+    )
+    executor_info = _delete_container_executor_info(payload.executor_id)
+    keypair = Mock(ss58_address="validator-hotkey")
+
+    result = await docker_service.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=keypair,
+        private_key="encrypted",
+    )
+
+    assert isinstance(result, FailedContainerRequest)
+    assert result.error_type == FailedContainerErrorTypes.ContainerDeletionFailed
+    assert "500 Server Error: daemon exploded" in result.msg
+    docker_service.redis_service.remove_rented_machine.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -898,6 +898,118 @@ async def test_delete_filler_container_treats_missing_container_as_deleted(
 
 
 @pytest.mark.asyncio
+async def test_delete_customer_rental_treats_missing_container_as_deleted(
+    docker_service,
+    monkeypatch,
+):
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.remove_rented_machine = AsyncMock()
+    docker_service.redis_service.get_rented_machine = AsyncMock(return_value=None)
+    docker_service.rental_docker_client_factory.client.remove_error = Exception(
+        "Docker SDK remove container failed: 404 Client Error: Not Found "
+        '("No such container: pod_missing")'
+    )
+
+    payload = ContainerDeleteRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_missing",
+        local_volume="volume_missing",
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
+    )
+    keypair = Mock(ss58_address="validator-hotkey")
+
+    result = await docker_service.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=keypair,
+        private_key="encrypted",
+    )
+
+    assert isinstance(result, ContainerDeleted)
+    assert result.pod_id == payload.pod_id
+    assert docker_service.rental_docker_client_factory.client.pruned_images == 1
+    assert docker_service.rental_docker_client_factory.client.removed_volumes == [
+        {"volume_name": payload.local_volume, "force": False}
+    ]
+    docker_service.redis_service.remove_rented_machine.assert_awaited_once_with(
+        executor_info,
+        payload.container_name,
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_container_failure_msg_includes_underlying_error(
+    docker_service,
+    monkeypatch,
+):
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.remove_rented_machine = AsyncMock()
+    docker_service.rental_docker_client_factory.client.remove_error = Exception(
+        "Docker SDK remove container failed: 500 Server Error: daemon exploded"
+    )
+
+    payload = ContainerDeleteRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_stuck",
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
+    )
+    keypair = Mock(ss58_address="validator-hotkey")
+
+    result = await docker_service.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=keypair,
+        private_key="encrypted",
+    )
+
+    assert isinstance(result, FailedContainerRequest)
+    assert result.error_type == FailedContainerErrorTypes.ContainerDeletionFailed
+    assert "500 Server Error: daemon exploded" in result.msg
+
+
+@pytest.mark.asyncio
 async def test_inspector_lifecycle_command_quotes_executor_paths(docker_service):
     executor_info = ExecutorSSHInfo(
         uuid="exec-1",


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2345](https://app.notion.com/p/Pod-deletion-stop-doomed-retries-and-phantom-POD_UNDEPLOY_FAILED-penalties-395b8bfdbde98130ba82d8a518c917e0)

---

## Problem

`delete_container` wraps the entire pod teardown in one `try/except`, so every sub-cause collapses into `Unknown Error delete_container` → `FailedContainerRequest(UnknownError)` → the backend retries 4 doomed times (~1h) and applies a `POD_UNDEPLOY_FAILED` penalty to the miner. Investigation of 7 days of prod logs (56 failures / 19 pods) + `penalty_events` found two false-positive classes:

1. **Missing container (404 "No such container")** — the container is already gone (e.g. removed by failed-create cleanup), but the tolerance shipped with the rental Docker SDK hot path applies only to `WorkloadKind.FILLER`. Customer rentals are penalized for a teardown whose goal is already met.
2. **Post-container cleanup failures** — the container is removed successfully, then `remove_volume` hits a 60s SSH read timeout (or, on the retry, "No such volume"), or `prune_images`/redis/inspector-stop flakes — and the whole undeploy is marked failed. This class carries the largest amounts: $292, $510, $760 in single penalties over the investigated window (all manually reverted as goodwill).

Fleet impact: 22 applied `POD_UNDEPLOY_FAILED` penalties / $4,435 withheld in 8 days; the classes above account for the confirmed false positives.

## Solution

Only a genuine `remove_container` failure (or a connection-level failure) can fail the undeploy.

- **Idempotent delete for all workload kinds** (cherry-picked from #1108 by @taiberium, authorship preserved): a missing container is treated as already deleted for customer rentals too, and `FailedContainerRequest.msg` now carries the underlying exception text so backend logs are diagnosable.
- **Post-container teardown step isolation** (new): `prune_images`, `remove_volume` (local), `remove_volume` (external) + `disable_s3fs_volume_plugin`, `redis_service.remove_rented_machine`, and the inspector-stop block are each guarded individually — failures are logged with a `step` tag (`delete_container post-teardown step failed (non-fatal)`) and the delete still returns `ContainerDeleted`.

## Changes

- `neurons/validators/src/services/docker_service.py::delete_container`:
  - drop the FILLER-only guard around `_is_missing_docker_container_error`;
  - include the underlying error in the outer handler's `msg`;
  - wrap each post-container teardown step in its own non-fatal guard.
- `neurons/validators/tests/test_docker_service.py`: `_FakeRentalDockerClient` can now raise from `remove_volume`/`prune_images`; 6 new tests (all fail on `origin/main` src, pass here):
  - customer-rental delete with missing container → `ContainerDeleted`;
  - `remove_volume` read-timeout → `ContainerDeleted`, redis cleanup still runs;
  - `remove_volume` "No such volume" → `ContainerDeleted`;
  - `prune_images` failure → `ContainerDeleted`;
  - genuine `remove_container` 500 → `FailedContainerRequest` with the underlying error in `msg`;
  - failure `msg` preserves the underlying error text.

## Relation to #1108 / lium-io-backend#735

Supersedes #1108 (its commit is included via cherry-pick) and additionally closes the post-container-step class, which #1108's own Risks section left open ("if the named volume is also absent, `remove_volume` still fails the request"). The backend half (lium-io-backend#735, `InvalidExecutorId` short-circuit) is deliberately NOT paired with this PR: it removes a penalty class we currently classify as justified (miner deregistered the executor mid-rental) and needs a separate policy decision.

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review

## Risks

- A live container whose removal error text contains "No such container" would be treated as deleted — the phrase is only produced by the Docker daemon for missing containers, and the pardon is scoped to the single `remove_container(payload.container_name)` call.
- Redis `remove_rented_machine` is now non-fatal: a missed removal self-heals — the rented-machines set is rebuilt from the backend's authoritative list every ~10 min; the only consumer (`TenantEnforcementCheck`) fails safe for an already-gone container.
- Inspector-stop is now non-fatal: if the redis read inside `_has_rented_customer_containers` flakes during the last customer pod's undeploy, the inspector collector keeps running on the executor until the next customer create/delete cycle (monitoring-only component, no resource gate).
- Genuine unremovable-container failures still return `FailedContainerRequest` and still lead to a penalty — unchanged by design.

## Test Cases

### Test Case 1

**Actions**: `pdm run pytest tests/test_docker_service.py -q`

**Expected Output**: 128 passed (incl. the 6 new tests).

### Test Case 2

**Actions**: `pdm run pytest -q` (full validator suite)

**Expected Output**: 879 passed, 8 skipped, 9 errors — the 9 errors are pre-existing environment-only failures in `tests/test_port_mapping_dao.py` (missing `greenlet` in a fresh pdm venv), identical on pristine `origin/main`.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
