### PR TITLE
DAH-2346: forward per-executor incentive + default_job_owner to backend

### DIFF
--- a/neurons/validators/src/clients/compute_client.py
+++ b/neurons/validators/src/clients/compute_client.py
@@ -319,6 +319,8 @@ class ComputeClient:
                             price_per_gpu=data["price_per_gpu"],
                             collateral_deposited=data["collateral_deposited"],
                             ssh_pub_keys=data["ssh_pub_keys"],
+                            incentive=data.get("incentive"),
+                            default_job_owner=data.get("default_job_owner"),
                         )
 
                         async with self.lock:

--- a/neurons/validators/src/protocol/vc_protocol/validator_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/validator_requests.py
@@ -71,6 +71,8 @@ class ExecutorSpecRequest(BaseValidatorRequest):
     job_batch_id: str
     collateral_deposited: bool
     ssh_pub_keys: list[str] | None = None
+    incentive: float | None = None
+    default_job_owner: str | None = None
 
 
 class RentedMachineRequest(BaseValidatorRequest):

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -479,6 +479,8 @@ class MinerService:
                         "price_per_gpu": result.executor_info.price_per_gpu,
                         "score": result.score,
                         "synthetic_job_score": result.job_score,
+                        "incentive": result.incentive,
+                        "default_job_owner": result.default_job_owner,
                         "job_batch_id": result.job_batch_id,
                         "log_status": result.log_status,
                         "log_text": result.full_log_text,

--- a/neurons/validators/tests/test_publish_incentive.py
+++ b/neurons/validators/tests/test_publish_incentive.py
@@ -1,0 +1,53 @@
+"""The validator must forward the per-executor incentive + default_job_owner to the
+backend. They live on JobResult but were previously dropped when building the
+MACHINE_SPEC_CHANNEL payload; this guards that they are included."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from datura.requests.miner_requests import ExecutorSSHInfo
+
+from services.miner_service import MinerService
+from services.task_service import JobResult
+
+
+def _make_job(*, incentive: float | None, default_job_owner: str | None) -> JobResult:
+    return JobResult(
+        executor_info=ExecutorSSHInfo(
+            uuid="executor-1",
+            address="10.0.0.1",
+            port=8080,
+            ssh_username="root",
+            ssh_port=22,
+            python_path="/usr/bin/python3",
+            root_dir="/tmp",
+        ),
+        score=1.0,
+        job_score=1.0,
+        job_batch_id="incentive-test-batch",
+        log_status="success",
+        log_text="ok",
+        incentive=incentive,
+        default_job_owner=default_job_owner,
+    )
+
+
+def _miner_service() -> MinerService:
+    return MinerService(
+        ssh_service=Mock(),
+        task_service=Mock(),
+        redis_service=AsyncMock(),
+        attestation_service=Mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_machine_specs_includes_incentive_fields():
+    svc = _miner_service()
+    job = _make_job(incentive=0.42, default_job_owner="lium")
+
+    await svc.publish_machine_specs([job], miner_hotkey="miner_hk", miner_coldkey="miner_ck")
+
+    _, published = svc.redis_service.publish.await_args.args
+    assert published["incentive"] == 0.42
+    assert published["default_job_owner"] == "lium"


### PR DESCRIPTION
## What
Forwards the per-executor `incentive` and `default_job_owner` (already on `JobResult`) to the backend over the existing validator→backend path. They were computed each cycle but dropped when building the `MACHINE_SPEC_CHANNEL` payload, so the backend never saw them.

## Changes
- `services/miner_service.py` — add `incentive` + `default_job_owner` to the `MACHINE_SPEC_CHANNEL` publish dict.
- `clients/compute_client.py` — pass both into `ExecutorSpecRequest(...)` (tolerant `.get()`).
- `protocol/vc_protocol/validator_requests.py` — add the two nullable fields to `ExecutorSpecRequest`.
- Test: `tests/test_publish_incentive.py` asserts the published payload includes both fields.

## Why
Backend needs to persist unrented incentive to TimescaleDB for the Default-Job revenue/incentive dashboard (DAH-2344). `default_job_owner` lets the dashboard isolate Lium's idle nodes.

## Deploy safety
Fields are optional with defaults and the backend model ignores extras → deploy order between this repo and lium-io-backend does not break the integration. **Paired with lium-io-backend PR (DAH-2346)** which reads and stores them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)