### PR TITLE
DAH-2340, publish structured zero-incentive reasons on MACHINE_SPEC_CHANNEL

### DIFF
--- a/neurons/validators/src/clients/compute_client.py
+++ b/neurons/validators/src/clients/compute_client.py
@@ -317,7 +317,7 @@ class ComputeClient:
                             incentive_formula_version=data.get("incentive_formula_version"),
                             incentive_formula_inputs=data.get("incentive_formula_inputs"),
                             log_text=data["log_text"],
-                            incentive_reasons=data.get("incentive_reasons", []),
+                            incentive_reasons=data.get("incentive_reasons"),
                             miner_hotkey=data["miner_hotkey"],
                             miner_coldkey=data["miner_coldkey"],
                             validator_hotkey=validator_hotkey,

--- a/neurons/validators/src/clients/compute_client.py
+++ b/neurons/validators/src/clients/compute_client.py
@@ -317,6 +317,7 @@ class ComputeClient:
                             incentive_formula_version=data.get("incentive_formula_version"),
                             incentive_formula_inputs=data.get("incentive_formula_inputs"),
                             log_text=data["log_text"],
+                            incentive_reasons=data.get("incentive_reasons", []),
                             miner_hotkey=data["miner_hotkey"],
                             miner_coldkey=data["miner_coldkey"],
                             validator_hotkey=validator_hotkey,

--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -111,7 +111,7 @@ class DefaultIncentive(BaseIncentive):
         result.total_mining_score = self.total_mining_score
         if result.mining_score is None:
             error_report: MinerLogLine = MinerLogLine.mining_score_missing(hotkey, result)
-            result.incentive_logs.append(error_report.to_log_line())
+            result.record_incentive_log(error_report)
             return result
 
         result.incentive = (self.mining_share * result.mining_score / self.total_mining_score) if self.total_mining_score > 0 else 0.0
@@ -119,7 +119,7 @@ class DefaultIncentive(BaseIncentive):
         report: MinerLogLine = MinerLogLine.mining_incentive_calculated(
             hotkey, result, self.total_mining_score, self.mining_share
         )
-        result.incentive_logs.append(report.to_log_line())
+        result.record_incentive_log(report)
         return result
 
     async def calculate_executor_score(
@@ -210,7 +210,7 @@ class DefaultIncentive(BaseIncentive):
             job_result.sysbox_multiplier * job_result.uptime_multiplier * job_result.driver_multiplier
         )
         line: MinerLogLine = MinerLogLine.mining_score_calculated(job_result, is_rented_after_cutoff)
-        job_result.incentive_logs.append(line.to_log_line())
+        job_result.record_incentive_log(line)
         logger.info(line.as_internal_log())
         return job_result
 

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -91,6 +91,18 @@ class MinerLogLine(BaseModel):
         """Render as one string; the caller appends it to result.incentive_logs."""
         return self.as_internal_log().to_full_string()
 
+    def to_reason_payload(self) -> dict[str, Any]:
+        """Clean machine-readable subset published on MACHINE_SPEC_CHANNEL (DAH-2340).
+
+        Carries the stable `reason` code, the miner-facing message and the structured
+        `fields` — never the internal_* observability data. Downstream keys off `reason`.
+        """
+        return {
+            "reason": self.reason.value if self.reason else None,
+            "message_for_miner": self.message,
+            **{key: value for key, value in self.fields.items() if key != "reason"},
+        }
+
     def as_internal_log(self) -> _StructuredMessage:
         """The same line as an `_m` object, for mirroring into the internal logger."""
         return _m(self.message, extra=get_extra_info(self.fields))

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -32,7 +32,9 @@ WHAT THIS CATALOG HOLDS — every `MinerLogLine` the miner-facing log block
 
 The scoring code (rental_price.py / default.py) detects each condition where its
 data naturally lives (some per-executor upfront, some only after cohort aggregation),
-builds the matching line and appends `line.to_log_line()` to result.incentive_logs.
+builds the matching line and records it via `result.record_incentive_log(line)` —
+which appends the text to incentive_logs AND, for zero-incentive lines, ships the
+structured reason to the backend (DAH-2340). Never append to incentive_logs directly.
 Open THIS file to see everything a miner can be told and exactly how each message reads.
 """
 
@@ -75,10 +77,10 @@ class MinerLogLine(BaseModel):
     """One line of the miner-facing incentive log.
 
     Built ONLY via the named constructors below (the catalog). The constructor bakes
-    every field in; rendering takes no arguments:
+    every field in; recording takes no arguments:
 
         line: MinerLogLine = MinerLogLine.no_payout_because_spot_tier(result)
-        result.incentive_logs.append(line.to_log_line())
+        result.record_incentive_log(line)
     """
 
     message: str                                                   # plain-English, shown to the miner
@@ -92,16 +94,8 @@ class MinerLogLine(BaseModel):
         return self.as_internal_log().to_full_string()
 
     def to_reason_payload(self) -> dict[str, Any]:
-        """Clean machine-readable subset published on MACHINE_SPEC_CHANNEL (DAH-2340).
-
-        Carries the stable `reason` code, the miner-facing message and the structured
-        `fields` — never the internal_* observability data. Downstream keys off `reason`.
-        """
-        return {
-            "reason": self.reason.value if self.reason else None,
-            "message_for_miner": self.message,
-            **{key: value for key, value in self.fields.items() if key != "reason"},
-        }
+        """Wire payload for MACHINE_SPEC_CHANNEL (DAH-2340): zero-incentive lines only, never internal_* fields."""
+        return {**self.fields, "reason": self.reason.value, "message_for_miner": self.message}
 
     def as_internal_log(self) -> _StructuredMessage:
         """The same line as an `_m` object, for mirroring into the internal logger."""

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from core.utils import _m, _StructuredMessage, get_extra_info
 
@@ -73,6 +73,22 @@ class ZeroIncentiveReason(StrEnum):
     SYSBOX_NOT_ENABLED = "sysbox_not_enabled"
 
 
+class IncentiveReason(BaseModel):
+    """One structured zero-incentive reason as it travels on the wire (DAH-2340).
+
+    Single definition for the whole validator: built here by the catalog
+    (`MinerLogLine.to_incentive_reason`) and reused by `ExecutorSpecRequest`.
+    `reason` is a stable, append-only machine-readable code the backend keys off;
+    `message_for_miner` is free text. Extra miner_log_fields ride along via
+    extra='allow', keeping the contract additive without a schema change.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    reason: str
+    message_for_miner: str
+
+
 class MinerLogLine(BaseModel):
     """One line of the miner-facing incentive log.
 
@@ -93,9 +109,10 @@ class MinerLogLine(BaseModel):
         """Render as one string; the caller appends it to result.incentive_logs."""
         return self.as_internal_log().to_full_string()
 
-    def to_reason_payload(self) -> dict[str, Any]:
-        """Wire payload for MACHINE_SPEC_CHANNEL (DAH-2340): zero-incentive lines only, never internal_* fields."""
-        return {**self.fields, "reason": self.reason.value, "message_for_miner": self.message}
+    def to_incentive_reason(self) -> IncentiveReason:
+        """Typed wire reason for MACHINE_SPEC_CHANNEL (DAH-2340): zero-incentive lines only, never internal_* fields."""
+        # model_validate, not kwargs: fields already carries "reason" (for Loki extra) — later key wins.
+        return IncentiveReason.model_validate({**self.fields, "reason": self.reason.value, "message_for_miner": self.message})
 
     def as_internal_log(self) -> _StructuredMessage:
         """The same line as an `_m` object, for mirroring into the internal logger."""

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
 from core.utils import _m, _StructuredMessage, get_extra_info
 
@@ -78,15 +78,14 @@ class IncentiveReason(BaseModel):
 
     Single definition for the whole validator: built here by the catalog
     (`MinerLogLine.to_incentive_reason`) and reused by `ExecutorSpecRequest`.
-    `reason` is a stable, append-only machine-readable code the backend keys off;
-    `message_for_miner` is free text. Extra miner_log_fields ride along via
-    extra='allow', keeping the contract additive without a schema change.
+    The contract stays additive by growing `context` keys, never by renaming.
     """
 
-    model_config = ConfigDict(extra="allow")
-
-    reason: str
-    message_for_miner: str
+    reason: str               # stable, APPEND-ONLY machine-readable code the backend keys off
+    message_for_miner: str    # free text, may change any time
+    # per-reason details shown next to the message, e.g. soft_limit_threshold,
+    # gpu_model, gpu_count, executor_id, incentive
+    context: dict[str, Any] = Field(default_factory=dict)
 
 
 class MinerLogLine(BaseModel):
@@ -111,8 +110,9 @@ class MinerLogLine(BaseModel):
 
     def to_incentive_reason(self) -> IncentiveReason:
         """Typed wire reason for MACHINE_SPEC_CHANNEL (DAH-2340): zero-incentive lines only, never internal_* fields."""
-        # model_validate, not kwargs: fields already carries "reason" (for Loki extra) — later key wins.
-        return IncentiveReason.model_validate({**self.fields, "reason": self.reason.value, "message_for_miner": self.message})
+        # fields carries "reason" for the Loki extra; in the wire model the code already sits top-level.
+        context: dict[str, Any] = {key: value for key, value in self.fields.items() if key != "reason"}
+        return IncentiveReason(reason=self.reason.value, message_for_miner=self.message, context=context)
 
     def as_internal_log(self) -> _StructuredMessage:
         """The same line as an `_m` object, for mirroring into the internal logger."""

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -578,7 +578,7 @@ class RentalPriceIncentive(DefaultIncentive):
                 reason: MinerLogLine = MinerLogLine.no_payout_because_insufficient_disk_for_vram(
                     job_result, insufficient_disk
                 )
-                job_result.incentive_logs.append(reason.to_log_line())
+                job_result.record_incentive_log(reason)
 
         job_result.eligible_for_rental_share = eligible_for_rental_share
         if job_result.eligible_for_rental_share:

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -481,7 +481,7 @@ class RentalPriceIncentive(DefaultIncentive):
 
         # update incentive logs
         report: MinerLogLine = MinerLogLine.rental_incentive_calculated(hotkey, result, bucket)
-        result.incentive_logs.append(report.to_log_line())
+        result.record_incentive_log(report)
 
         self._explain_zero_effective_rate(result, bucket)
 
@@ -508,13 +508,13 @@ class RentalPriceIncentive(DefaultIncentive):
         incentive 0 with no reason."""
         if result.unrented_cap_multiplier == 0:
             reason: MinerLogLine = MinerLogLine.no_payout_because_no_unrented_capacity_for_gpu_count(result, bucket)
-            result.incentive_logs.append(reason.to_log_line())
+            result.record_incentive_log(reason)
         elif result.driver_multiplier == 0:
             reason: MinerLogLine = MinerLogLine.no_payout_because_nvidia_driver_below_minimum(result)
-            result.incentive_logs.append(reason.to_log_line())
+            result.record_incentive_log(reason)
         elif result.sysbox_multiplier == 0:
             reason: MinerLogLine = MinerLogLine.no_payout_because_sysbox_not_enabled(result)
-            result.incentive_logs.append(reason.to_log_line())
+            result.record_incentive_log(reason)
 
     async def calculate_executor_score(
         self,
@@ -543,7 +543,7 @@ class RentalPriceIncentive(DefaultIncentive):
             logger.info(exclusion.to_internal_log())
             job_result.mining_score = 0
             job_result.eligible_for_rental_share = False
-            job_result.incentive_logs.append(exclusion.to_log_line())
+            job_result.record_incentive_log(exclusion)
             return job_result
 
         # Check if GPU is unrented and eligible (has positive cap in max_unrented_gpus)
@@ -565,7 +565,7 @@ class RentalPriceIncentive(DefaultIncentive):
                 reason: MinerLogLine = MinerLogLine.no_payout_because_price_above_market_soft_limit(
                     job_result, p90, SOFT_LIMIT_PRICE_RATE
                 )
-                job_result.incentive_logs.append(reason.to_log_line())
+                job_result.record_incentive_log(reason)
 
         # DAH-2520 disk/VRAM gate: an idle machine without the required disk margin over its
         # GPU VRAM is not realistically rentable, so it forfeits the unrented incentive (node
@@ -613,7 +613,7 @@ class RentalPriceIncentive(DefaultIncentive):
                 job_result.score > 0 or job_result.job_score > 0
             ):
                 reason: MinerLogLine = MinerLogLine.no_payout_because_gpu_model_not_in_unrented_program(job_result)
-                job_result.incentive_logs.append(reason.to_log_line())
+                job_result.record_incentive_log(reason)
             return job_result
 
         # For rented or non-eligible GPUs, use parent's default scoring logic

--- a/neurons/validators/src/incentive/utils.py
+++ b/neurons/validators/src/incentive/utils.py
@@ -138,6 +138,6 @@ def log_for_monitoring(
 
         for job_list in job_results.values():
             for job_result in job_list:
-                logger.info(_m("", extra=job_result.model_dump(exclude={"incentive_logs"})))
+                logger.info(_m("", extra=job_result.model_dump(exclude={"incentive_logs", "zero_incentive_reasons"})))
     except Exception as e:
         logger.error(f"Error logging for monitoring: {e}", exc_info=True)

--- a/neurons/validators/src/incentive/utils.py
+++ b/neurons/validators/src/incentive/utils.py
@@ -138,6 +138,6 @@ def log_for_monitoring(
 
         for job_list in job_results.values():
             for job_result in job_list:
-                logger.info(_m("", extra=job_result.model_dump(exclude={"incentive_logs", "zero_incentive_reasons"})))
+                logger.info(_m("", extra=job_result.model_dump()))
     except Exception as e:
         logger.error(f"Error logging for monitoring: {e}", exc_info=True)

--- a/neurons/validators/src/protocol/vc_protocol/validator_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/validator_requests.py
@@ -8,6 +8,8 @@ import bittensor
 import pydantic
 from datura.requests.base import BaseRequest
 
+from incentive.miner_incentive_log import IncentiveReason
+
 
 class RequestType(enum.Enum):
     AuthenticateRequest = "AuthenticateRequest"
@@ -53,20 +55,6 @@ class AuthenticateRequest(BaseValidatorRequest):
             timestamp=int(time.time()),
         )
         return cls(payload=payload, signature=f"0x{keypair.sign(payload.blob_for_signing()).hex()}")
-
-
-class IncentiveReason(pydantic.BaseModel):
-    """One structured reason an executor earns 0 subnet incentive (DAH-2340).
-
-    `reason` is a stable, append-only machine-readable code the backend keys off;
-    `message_for_miner` is free text. Extra miner_log_fields ride along via
-    extra='allow', keeping the contract additive without a schema change.
-    """
-
-    model_config = pydantic.ConfigDict(extra="allow")
-
-    reason: str
-    message_for_miner: str
 
 
 class ExecutorSpecRequest(BaseValidatorRequest):

--- a/neurons/validators/src/protocol/vc_protocol/validator_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/validator_requests.py
@@ -101,7 +101,8 @@ class ExecutorSpecRequest(BaseValidatorRequest):
     attestation_digest: str | None = None
     tdx_attestation_passed: bool | None = None
     gpu_attestation_passed: bool | None = None
-    incentive_reasons: list[IncentiveReason] = []
+    # None = validator predates DAH-2340 (key absent); [] = evaluated, earns normally
+    incentive_reasons: list[IncentiveReason] | None = None
 
 
 class RentedMachineRequest(BaseValidatorRequest):

--- a/neurons/validators/src/protocol/vc_protocol/validator_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/validator_requests.py
@@ -55,6 +55,20 @@ class AuthenticateRequest(BaseValidatorRequest):
         return cls(payload=payload, signature=f"0x{keypair.sign(payload.blob_for_signing()).hex()}")
 
 
+class IncentiveReason(pydantic.BaseModel):
+    """One structured reason an executor earns 0 subnet incentive (DAH-2340).
+
+    `reason` is a stable, append-only machine-readable code the backend keys off;
+    `message_for_miner` is free text. Extra miner_log_fields ride along via
+    extra='allow', keeping the contract additive without a schema change.
+    """
+
+    model_config = pydantic.ConfigDict(extra="allow")
+
+    reason: str
+    message_for_miner: str
+
+
 class ExecutorSpecRequest(BaseValidatorRequest):
     message_type: RequestType = RequestType.ExecutorSpecRequest
     miner_hotkey: str
@@ -87,6 +101,7 @@ class ExecutorSpecRequest(BaseValidatorRequest):
     attestation_digest: str | None = None
     tdx_attestation_passed: bool | None = None
     gpu_attestation_passed: bool | None = None
+    incentive_reasons: list[IncentiveReason] = []
 
 
 class RentedMachineRequest(BaseValidatorRequest):

--- a/neurons/validators/src/protocol/vc_protocol/validator_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/validator_requests.py
@@ -89,7 +89,7 @@ class ExecutorSpecRequest(BaseValidatorRequest):
     attestation_digest: str | None = None
     tdx_attestation_passed: bool | None = None
     gpu_attestation_passed: bool | None = None
-    # None = validator predates DAH-2340 (key absent); [] = evaluated, earns normally
+    # None = publisher did not report the field; [] = no catalogued reason was recorded.
     incentive_reasons: list[IncentiveReason] | None = None
 
 

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -738,7 +738,7 @@ class MinerService:
                         "incentive_formula_inputs": result.incentive_formula_inputs,
                         "log_status": result.log_status,
                         "log_text": result.full_log_text,
-                        # [] when the executor earns normally — clears a stale reason next cycle (DAH-2340)
+                        # [] means this cycle reported no catalogued zero-incentive reason.
                         "incentive_reasons": [reason.model_dump() for reason in result.zero_incentive_reasons],
                         "collateral_deposited": result.collateral_deposited,
                         "ssh_pub_keys": result.ssh_pub_keys,

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -738,9 +738,8 @@ class MinerService:
                         "incentive_formula_inputs": result.incentive_formula_inputs,
                         "log_status": result.log_status,
                         "log_text": result.full_log_text,
-                        # Structured zero-incentive reasons as data (DAH-2340); empty when the
-                        # executor earns normally, so a stale reason clears on the next cycle.
-                        "incentive_reasons": [reason.to_reason_payload() for reason in result.zero_incentive_reasons],
+                        # [] when the executor earns normally — clears a stale reason next cycle (DAH-2340)
+                        "incentive_reasons": result.zero_incentive_reasons,
                         "collateral_deposited": result.collateral_deposited,
                         "ssh_pub_keys": result.ssh_pub_keys,
                         "attestation_digest": result.attestation_digest,

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -739,7 +739,7 @@ class MinerService:
                         "log_status": result.log_status,
                         "log_text": result.full_log_text,
                         # [] when the executor earns normally — clears a stale reason next cycle (DAH-2340)
-                        "incentive_reasons": result.zero_incentive_reasons,
+                        "incentive_reasons": [reason.model_dump() for reason in result.zero_incentive_reasons],
                         "collateral_deposited": result.collateral_deposited,
                         "ssh_pub_keys": result.ssh_pub_keys,
                         "attestation_digest": result.attestation_digest,

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -739,7 +739,9 @@ class MinerService:
                         "log_status": result.log_status,
                         "log_text": result.full_log_text,
                         # [] means this cycle reported no catalogued zero-incentive reason.
-                        "incentive_reasons": [reason.model_dump() for reason in result.zero_incentive_reasons],
+                        "incentive_reasons": [
+                            reason.model_dump(mode="json") for reason in result.zero_incentive_reasons
+                        ],
                         "collateral_deposited": result.collateral_deposited,
                         "ssh_pub_keys": result.ssh_pub_keys,
                         "attestation_digest": result.attestation_digest,

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -738,6 +738,9 @@ class MinerService:
                         "incentive_formula_inputs": result.incentive_formula_inputs,
                         "log_status": result.log_status,
                         "log_text": result.full_log_text,
+                        # Structured zero-incentive reasons as data (DAH-2340); empty when the
+                        # executor earns normally, so a stale reason clears on the next cycle.
+                        "incentive_reasons": [reason.to_reason_payload() for reason in result.zero_incentive_reasons],
                         "collateral_deposited": result.collateral_deposited,
                         "ssh_pub_keys": result.ssh_pub_keys,
                         "attestation_digest": result.attestation_digest,

--- a/neurons/validators/src/services/task/models.py
+++ b/neurons/validators/src/services/task/models.py
@@ -83,7 +83,7 @@ class JobResult(BaseModel):
     # Delivery buffers with dedicated export paths (full_log_text, direct publish);
     # excluded so no model_dump ever serializes them raw.
     incentive_logs: list[str] = Field(default_factory=list, exclude=True)
-    # DAH-2340 wire reasons for the backend; [] when the executor earns normally
+    # DAH-2340 wire reasons for the backend; [] when no catalogued reason was recorded.
     zero_incentive_reasons: list[IncentiveReason] = Field(default_factory=list, exclude=True)
 
     def record_incentive_log(self, line: "MinerLogLine") -> None:

--- a/neurons/validators/src/services/task/models.py
+++ b/neurons/validators/src/services/task/models.py
@@ -77,10 +77,12 @@ class JobResult(BaseModel):
     seconds_per_block: int | None = None
     fixed_ratio: float | None = None
 
-    
-    incentive_logs: list[str] = []
+
+    # Delivery buffers with dedicated export paths (full_log_text, direct publish);
+    # excluded so no model_dump ever serializes them raw.
+    incentive_logs: list[str] = Field(default_factory=list, exclude=True)
     # DAH-2340 wire payloads for the backend; [] when the executor earns normally
-    zero_incentive_reasons: list[dict[str, Any]] = []
+    zero_incentive_reasons: list[dict[str, Any]] = Field(default_factory=list, exclude=True)
 
     def record_incentive_log(self, line: "MinerLogLine") -> None:
         """Append the line to the miner-facing log; zero-incentive lines also become data for the backend."""

--- a/neurons/validators/src/services/task/models.py
+++ b/neurons/validators/src/services/task/models.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel, Field
 
 from datura.requests.miner_requests import ExecutorSSHInfo
 
+from incentive.miner_incentive_log import IncentiveReason
+
 if TYPE_CHECKING:
     from incentive.miner_incentive_log import MinerLogLine
 
@@ -81,14 +83,14 @@ class JobResult(BaseModel):
     # Delivery buffers with dedicated export paths (full_log_text, direct publish);
     # excluded so no model_dump ever serializes them raw.
     incentive_logs: list[str] = Field(default_factory=list, exclude=True)
-    # DAH-2340 wire payloads for the backend; [] when the executor earns normally
-    zero_incentive_reasons: list[dict[str, Any]] = Field(default_factory=list, exclude=True)
+    # DAH-2340 wire reasons for the backend; [] when the executor earns normally
+    zero_incentive_reasons: list[IncentiveReason] = Field(default_factory=list, exclude=True)
 
     def record_incentive_log(self, line: "MinerLogLine") -> None:
         """Append the line to the miner-facing log; zero-incentive lines also become data for the backend."""
         self.incentive_logs.append(line.to_log_line())
         if line.reason is not None:
-            self.zero_incentive_reasons.append(line.to_reason_payload())
+            self.zero_incentive_reasons.append(line.to_incentive_reason())
 
     @property
     def incentive_source(self) -> str:

--- a/neurons/validators/src/services/task/models.py
+++ b/neurons/validators/src/services/task/models.py
@@ -1,11 +1,13 @@
 import uuid
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
 from datura.requests.miner_requests import ExecutorSSHInfo
-from incentive.miner_incentive_log import MinerLogLine
+
+if TYPE_CHECKING:
+    from incentive.miner_incentive_log import MinerLogLine
 
 
 class JobResult(BaseModel):
@@ -77,21 +79,14 @@ class JobResult(BaseModel):
 
     
     incentive_logs: list[str] = []
-    # Structured zero-incentive reasons for this cycle; travel to the backend as data,
-    # never re-parsed from log text (DAH-2340). Empty when the executor earns normally.
-    zero_incentive_reasons: list[MinerLogLine] = []
+    # DAH-2340 wire payloads for the backend; [] when the executor earns normally
+    zero_incentive_reasons: list[dict[str, Any]] = []
 
-    def record_incentive_log(self, line: MinerLogLine) -> None:
-        """Record one incentive log line as BOTH human text and structured data.
-
-        Appends the rendered string to incentive_logs; when the line is a zero-incentive
-        reason (carries a machine-readable code), also keeps the structured line so the
-        reason can flow to the backend as data — text and data come from one object and
-        cannot drift (DAH-2340).
-        """
+    def record_incentive_log(self, line: "MinerLogLine") -> None:
+        """Append the line to the miner-facing log; zero-incentive lines also become data for the backend."""
         self.incentive_logs.append(line.to_log_line())
         if line.reason is not None:
-            self.zero_incentive_reasons.append(line)
+            self.zero_incentive_reasons.append(line.to_reason_payload())
 
     @property
     def incentive_source(self) -> str:

--- a/neurons/validators/src/services/task/models.py
+++ b/neurons/validators/src/services/task/models.py
@@ -5,6 +5,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from datura.requests.miner_requests import ExecutorSSHInfo
+from incentive.miner_incentive_log import MinerLogLine
 
 
 class JobResult(BaseModel):
@@ -76,6 +77,21 @@ class JobResult(BaseModel):
 
     
     incentive_logs: list[str] = []
+    # Structured zero-incentive reasons for this cycle; travel to the backend as data,
+    # never re-parsed from log text (DAH-2340). Empty when the executor earns normally.
+    zero_incentive_reasons: list[MinerLogLine] = []
+
+    def record_incentive_log(self, line: MinerLogLine) -> None:
+        """Record one incentive log line as BOTH human text and structured data.
+
+        Appends the rendered string to incentive_logs; when the line is a zero-incentive
+        reason (carries a machine-readable code), also keeps the structured line so the
+        reason can flow to the backend as data — text and data come from one object and
+        cannot drift (DAH-2340).
+        """
+        self.incentive_logs.append(line.to_log_line())
+        if line.reason is not None:
+            self.zero_incentive_reasons.append(line)
 
     @property
     def incentive_source(self) -> str:

--- a/neurons/validators/tests/test_incentive_reasons_payload.py
+++ b/neurons/validators/tests/test_incentive_reasons_payload.py
@@ -45,7 +45,7 @@ def test_published_payload_carries_reason_codes_as_data_not_just_log_text(create
     assert spec.incentive_reasons[0].message_for_miner  # miner-facing text present
 
 
-def test_extra_miner_log_fields_survive_on_the_typed_model(create_job_result) -> None:
+def test_miner_log_fields_survive_in_the_context_field(create_job_result) -> None:
     job = create_job_result()
     job.executor_info = job.executor_info.model_copy(update={"price_per_gpu": 4.23})
     job.record_incentive_log(
@@ -55,8 +55,8 @@ def test_extra_miner_log_fields_survive_on_the_typed_model(create_job_result) ->
 
     reason = spec.incentive_reasons[0]
     assert reason.reason == "price_above_market_p90_soft_limit"
-    # extra='allow' keeps the structured context next to the stable code
-    assert reason.model_dump()["soft_limit_threshold"] == 4.2262
+    # the per-reason details ride in the explicit context field
+    assert reason.context["soft_limit_threshold"] == 4.2262
 
 
 def test_payload_without_the_key_parses_as_none_meaning_not_reported() -> None:

--- a/neurons/validators/tests/test_incentive_reasons_payload.py
+++ b/neurons/validators/tests/test_incentive_reasons_payload.py
@@ -3,10 +3,14 @@ zero-incentive reasons as DATA, and the validator ExecutorSpecRequest that goes
 over the WebSocket validates them into typed IncentiveReason objects — the reason
 never has to be parsed back out of log_text downstream.
 """
+import asyncio
+import json
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from clients.compute_client import ComputeClient
 from incentive.miner_incentive_log import MinerLogLine
 from protocol.vc_protocol.validator_requests import ExecutorSpecRequest, IncentiveReason
 from services.miner_service import MinerService
@@ -37,12 +41,39 @@ def _spec(reasons: list[dict[str, Any]] | None = None) -> ExecutorSpecRequest:
     return ExecutorSpecRequest(**request_kwargs)
 
 
+async def _bridge_machine_spec(payload: dict[str, Any]) -> ExecutorSpecRequest:
+    async def listen():
+        yield {
+            "channel": MACHINE_SPEC_CHANNEL.encode(),
+            "data": json.dumps(payload).encode(),
+        }
+        raise asyncio.CancelledError
+
+    pubsub = MagicMock(listen=listen, aclose=AsyncMock())
+    client = ComputeClient.__new__(ComputeClient)
+    client.keypair = MagicMock(ss58_address="validator-hotkey")
+    client.lock = asyncio.Lock()
+    client.message_queue = []
+    client.logging_extra = {"validator_hotkey": "validator-hotkey"}
+    client.miner_service = MagicMock()
+    client.miner_service.redis_service.subscribe = AsyncMock(return_value=pubsub)
+
+    with pytest.raises(asyncio.CancelledError):
+        await client.subscribe_mesages_from_redis()
+
+    pubsub.aclose.assert_awaited_once()
+    return client.message_queue[0]
+
+
 @pytest.mark.asyncio
 async def test_publisher_carries_reason_codes_as_data_not_just_log_text(
     create_job_result, mock_settings
 ) -> None:
     job = create_job_result()
     job.record_incentive_log(MinerLogLine.no_payout_because_spot_tier(job))
+    job.zero_incentive_reasons[0].context["observed_at"] = datetime(
+        2026, 7, 29, 12, 30, tzinfo=timezone.utc
+    )
     redis_service = MagicMock()
     redis_service.publish = AsyncMock()
     service = MinerService(
@@ -56,11 +87,12 @@ async def test_publisher_carries_reason_codes_as_data_not_just_log_text(
 
     channel, payload = redis_service.publish.await_args.args
     assert channel == MACHINE_SPEC_CHANNEL
-    spec = _spec(payload["incentive_reasons"])
+    spec = await _bridge_machine_spec(payload)
 
     assert [reason.reason for reason in spec.incentive_reasons] == ["spot_tier"]
     assert isinstance(spec.incentive_reasons[0], IncentiveReason)
     assert spec.incentive_reasons[0].message_for_miner  # miner-facing text present
+    assert spec.incentive_reasons[0].context["observed_at"] == "2026-07-29T12:30:00Z"
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_incentive_reasons_payload.py
+++ b/neurons/validators/tests/test_incentive_reasons_payload.py
@@ -1,0 +1,98 @@
+"""DAH-2340: the published MACHINE_SPEC_CHANNEL payload carries structured
+zero-incentive reasons as DATA, and the validator ExecutorSpecRequest that goes
+over the WebSocket validates them into typed IncentiveReason objects — the reason
+never has to be parsed back out of log_text downstream.
+"""
+from datura.requests.miner_requests import ExecutorSSHInfo
+from incentive.miner_incentive_log import MinerLogLine
+from protocol.vc_protocol.validator_requests import ExecutorSpecRequest, IncentiveReason
+from services.task_service import JobResult
+
+
+def _job(**overrides) -> JobResult:
+    base = dict(
+        executor_info=ExecutorSSHInfo(
+            uuid="exec-1",
+            address="10.0.0.1",
+            port=8080,
+            ssh_username="root",
+            ssh_port=22,
+            python_path="/usr/bin/python3",
+            root_dir="/tmp",
+        ),
+        score=0.0,
+        job_score=0.0,
+        job_batch_id="2026-07-03 12:00:00",
+        log_status="success",
+        log_text="ok",
+        gpu_model="NVIDIA H200",
+        gpu_count=8,
+    )
+    base.update(overrides)
+    return JobResult(**base)
+
+
+def _spec(reasons: list[dict]) -> ExecutorSpecRequest:
+    """Build the ExecutorSpecRequest exactly as the redis→WS bridge does."""
+    return ExecutorSpecRequest(
+        miner_hotkey="hk",
+        miner_coldkey="ck",
+        validator_hotkey="vk",
+        executor_uuid="exec-1",
+        executor_ip="10.0.0.1",
+        executor_port=8080,
+        specs={},
+        score=0.0,
+        synthetic_job_score=0.0,
+        log_text="ok",
+        log_status="success",
+        job_batch_id="2026-07-03 12:00:00",
+        collateral_deposited=False,
+        incentive_reasons=reasons,
+    )
+
+
+def test_published_payload_carries_reason_codes_as_data_not_just_log_text():
+    job = _job()
+    job.record_incentive_log(MinerLogLine.no_payout_because_spot_tier(job))
+
+    # This is the exact expression the publisher (miner_service.publish_machine_specs) sends.
+    published_reasons = [reason.to_reason_payload() for reason in job.zero_incentive_reasons]
+    spec = _spec(published_reasons)
+
+    assert [r.reason for r in spec.incentive_reasons] == ["spot_tier"]
+    assert isinstance(spec.incentive_reasons[0], IncentiveReason)
+    assert spec.incentive_reasons[0].message_for_miner  # miner-facing text present
+
+
+def test_extra_miner_log_fields_survive_on_the_typed_model():
+    job = _job()
+    job.executor_info = job.executor_info.model_copy(update={"price_per_gpu": 4.23})
+    job.record_incentive_log(
+        MinerLogLine.no_payout_because_price_above_market_soft_limit(job, market_p90=3.842, rate=1.1)
+    )
+    spec = _spec([reason.to_reason_payload() for reason in job.zero_incentive_reasons])
+
+    reason = spec.incentive_reasons[0]
+    assert reason.reason == "price_above_market_p90_soft_limit"
+    # extra='allow' keeps the structured context next to the stable code
+    assert reason.model_dump()["soft_limit_threshold"] == 4.2262
+
+
+def test_missing_key_defaults_to_empty_list_for_backward_compat():
+    spec = ExecutorSpecRequest(
+        miner_hotkey="hk",
+        miner_coldkey="ck",
+        validator_hotkey="vk",
+        executor_uuid="exec-1",
+        executor_ip="10.0.0.1",
+        executor_port=8080,
+        specs={},
+        score=1.0,
+        synthetic_job_score=1.0,
+        log_text="ok",
+        log_status="success",
+        job_batch_id="2026-07-03 12:00:00",
+        collateral_deposited=False,
+    )
+    assert spec.incentive_reasons == []

--- a/neurons/validators/tests/test_incentive_reasons_payload.py
+++ b/neurons/validators/tests/test_incentive_reasons_payload.py
@@ -3,38 +3,15 @@ zero-incentive reasons as DATA, and the validator ExecutorSpecRequest that goes
 over the WebSocket validates them into typed IncentiveReason objects — the reason
 never has to be parsed back out of log_text downstream.
 """
-from datura.requests.miner_requests import ExecutorSSHInfo
 from incentive.miner_incentive_log import MinerLogLine
 from protocol.vc_protocol.validator_requests import ExecutorSpecRequest, IncentiveReason
-from services.task_service import JobResult
+
+pytest_plugins = ["fixtures.incentive_fixtures"]
 
 
-def _job(**overrides) -> JobResult:
-    base = dict(
-        executor_info=ExecutorSSHInfo(
-            uuid="exec-1",
-            address="10.0.0.1",
-            port=8080,
-            ssh_username="root",
-            ssh_port=22,
-            python_path="/usr/bin/python3",
-            root_dir="/tmp",
-        ),
-        score=0.0,
-        job_score=0.0,
-        job_batch_id="2026-07-03 12:00:00",
-        log_status="success",
-        log_text="ok",
-        gpu_model="NVIDIA H200",
-        gpu_count=8,
-    )
-    base.update(overrides)
-    return JobResult(**base)
-
-
-def _spec(reasons: list[dict]) -> ExecutorSpecRequest:
-    """Build the ExecutorSpecRequest exactly as the redis→WS bridge does."""
-    return ExecutorSpecRequest(
+def _spec(reasons: list[dict] | None = None) -> ExecutorSpecRequest:
+    """Build the ExecutorSpecRequest exactly as the redis→WS bridge does; omit reasons like an old payload would."""
+    request_kwargs: dict = dict(
         miner_hotkey="hk",
         miner_coldkey="ck",
         validator_hotkey="vk",
@@ -48,30 +25,31 @@ def _spec(reasons: list[dict]) -> ExecutorSpecRequest:
         log_status="success",
         job_batch_id="2026-07-03 12:00:00",
         collateral_deposited=False,
-        incentive_reasons=reasons,
     )
+    if reasons is not None:
+        request_kwargs["incentive_reasons"] = reasons
+    return ExecutorSpecRequest(**request_kwargs)
 
 
-def test_published_payload_carries_reason_codes_as_data_not_just_log_text():
-    job = _job()
+def test_published_payload_carries_reason_codes_as_data_not_just_log_text(create_job_result):
+    job = create_job_result()
     job.record_incentive_log(MinerLogLine.no_payout_because_spot_tier(job))
 
-    # This is the exact expression the publisher (miner_service.publish_machine_specs) sends.
-    published_reasons = [reason.to_reason_payload() for reason in job.zero_incentive_reasons]
-    spec = _spec(published_reasons)
+    # zero_incentive_reasons is the exact list the publisher (miner_service) sends.
+    spec = _spec(job.zero_incentive_reasons)
 
-    assert [r.reason for r in spec.incentive_reasons] == ["spot_tier"]
+    assert [reason.reason for reason in spec.incentive_reasons] == ["spot_tier"]
     assert isinstance(spec.incentive_reasons[0], IncentiveReason)
     assert spec.incentive_reasons[0].message_for_miner  # miner-facing text present
 
 
-def test_extra_miner_log_fields_survive_on_the_typed_model():
-    job = _job()
+def test_extra_miner_log_fields_survive_on_the_typed_model(create_job_result):
+    job = create_job_result()
     job.executor_info = job.executor_info.model_copy(update={"price_per_gpu": 4.23})
     job.record_incentive_log(
         MinerLogLine.no_payout_because_price_above_market_soft_limit(job, market_p90=3.842, rate=1.1)
     )
-    spec = _spec([reason.to_reason_payload() for reason in job.zero_incentive_reasons])
+    spec = _spec(job.zero_incentive_reasons)
 
     reason = spec.incentive_reasons[0]
     assert reason.reason == "price_above_market_p90_soft_limit"
@@ -80,19 +58,4 @@ def test_extra_miner_log_fields_survive_on_the_typed_model():
 
 
 def test_missing_key_defaults_to_empty_list_for_backward_compat():
-    spec = ExecutorSpecRequest(
-        miner_hotkey="hk",
-        miner_coldkey="ck",
-        validator_hotkey="vk",
-        executor_uuid="exec-1",
-        executor_ip="10.0.0.1",
-        executor_port=8080,
-        specs={},
-        score=1.0,
-        synthetic_job_score=1.0,
-        log_text="ok",
-        log_status="success",
-        job_batch_id="2026-07-03 12:00:00",
-        collateral_deposited=False,
-    )
-    assert spec.incentive_reasons == []
+    assert _spec().incentive_reasons == []

--- a/neurons/validators/tests/test_incentive_reasons_payload.py
+++ b/neurons/validators/tests/test_incentive_reasons_payload.py
@@ -4,9 +4,13 @@ over the WebSocket validates them into typed IncentiveReason objects — the rea
 never has to be parsed back out of log_text downstream.
 """
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from incentive.miner_incentive_log import MinerLogLine
 from protocol.vc_protocol.validator_requests import ExecutorSpecRequest, IncentiveReason
+from services.miner_service import MinerService
+from services.redis_service import MACHINE_SPEC_CHANNEL
 
 pytest_plugins = ["fixtures.incentive_fixtures"]
 
@@ -33,16 +37,50 @@ def _spec(reasons: list[dict[str, Any]] | None = None) -> ExecutorSpecRequest:
     return ExecutorSpecRequest(**request_kwargs)
 
 
-def test_published_payload_carries_reason_codes_as_data_not_just_log_text(create_job_result) -> None:
+@pytest.mark.asyncio
+async def test_publisher_carries_reason_codes_as_data_not_just_log_text(
+    create_job_result, mock_settings
+) -> None:
     job = create_job_result()
     job.record_incentive_log(MinerLogLine.no_payout_because_spot_tier(job))
+    redis_service = MagicMock()
+    redis_service.publish = AsyncMock()
+    service = MinerService(
+        ssh_service=MagicMock(),
+        task_service=MagicMock(),
+        redis_service=redis_service,
+        attestation_service=MagicMock(),
+    )
 
-    # model_dump per reason is exactly what the publisher (miner_service) sends.
-    spec = _spec([reason.model_dump() for reason in job.zero_incentive_reasons])
+    await service.publish_machine_specs([job], miner_hotkey="hk", miner_coldkey="ck")
+
+    channel, payload = redis_service.publish.await_args.args
+    assert channel == MACHINE_SPEC_CHANNEL
+    spec = _spec(payload["incentive_reasons"])
 
     assert [reason.reason for reason in spec.incentive_reasons] == ["spot_tier"]
     assert isinstance(spec.incentive_reasons[0], IncentiveReason)
     assert spec.incentive_reasons[0].message_for_miner  # miner-facing text present
+
+
+@pytest.mark.asyncio
+async def test_publisher_reports_empty_list_when_no_catalogued_reason_exists(
+    create_job_result, mock_settings
+) -> None:
+    job = create_job_result()
+    redis_service = MagicMock()
+    redis_service.publish = AsyncMock()
+    service = MinerService(
+        ssh_service=MagicMock(),
+        task_service=MagicMock(),
+        redis_service=redis_service,
+        attestation_service=MagicMock(),
+    )
+
+    await service.publish_machine_specs([job], miner_hotkey="hk", miner_coldkey="ck")
+
+    _, payload = redis_service.publish.await_args.args
+    assert payload["incentive_reasons"] == []
 
 
 def test_miner_log_fields_survive_in_the_context_field(create_job_result) -> None:

--- a/neurons/validators/tests/test_incentive_reasons_payload.py
+++ b/neurons/validators/tests/test_incentive_reasons_payload.py
@@ -37,8 +37,8 @@ def test_published_payload_carries_reason_codes_as_data_not_just_log_text(create
     job = create_job_result()
     job.record_incentive_log(MinerLogLine.no_payout_because_spot_tier(job))
 
-    # zero_incentive_reasons is the exact list the publisher (miner_service) sends.
-    spec = _spec(job.zero_incentive_reasons)
+    # model_dump per reason is exactly what the publisher (miner_service) sends.
+    spec = _spec([reason.model_dump() for reason in job.zero_incentive_reasons])
 
     assert [reason.reason for reason in spec.incentive_reasons] == ["spot_tier"]
     assert isinstance(spec.incentive_reasons[0], IncentiveReason)
@@ -51,7 +51,7 @@ def test_extra_miner_log_fields_survive_on_the_typed_model(create_job_result) ->
     job.record_incentive_log(
         MinerLogLine.no_payout_because_price_above_market_soft_limit(job, market_p90=3.842, rate=1.1)
     )
-    spec = _spec(job.zero_incentive_reasons)
+    spec = _spec([reason.model_dump() for reason in job.zero_incentive_reasons])
 
     reason = spec.incentive_reasons[0]
     assert reason.reason == "price_above_market_p90_soft_limit"

--- a/neurons/validators/tests/test_incentive_reasons_payload.py
+++ b/neurons/validators/tests/test_incentive_reasons_payload.py
@@ -3,15 +3,17 @@ zero-incentive reasons as DATA, and the validator ExecutorSpecRequest that goes
 over the WebSocket validates them into typed IncentiveReason objects — the reason
 never has to be parsed back out of log_text downstream.
 """
+from typing import Any
+
 from incentive.miner_incentive_log import MinerLogLine
 from protocol.vc_protocol.validator_requests import ExecutorSpecRequest, IncentiveReason
 
 pytest_plugins = ["fixtures.incentive_fixtures"]
 
 
-def _spec(reasons: list[dict] | None = None) -> ExecutorSpecRequest:
+def _spec(reasons: list[dict[str, Any]] | None = None) -> ExecutorSpecRequest:
     """Build the ExecutorSpecRequest exactly as the redis→WS bridge does; omit reasons like an old payload would."""
-    request_kwargs: dict = dict(
+    request_kwargs: dict[str, Any] = dict(
         miner_hotkey="hk",
         miner_coldkey="ck",
         validator_hotkey="vk",
@@ -31,7 +33,7 @@ def _spec(reasons: list[dict] | None = None) -> ExecutorSpecRequest:
     return ExecutorSpecRequest(**request_kwargs)
 
 
-def test_published_payload_carries_reason_codes_as_data_not_just_log_text(create_job_result):
+def test_published_payload_carries_reason_codes_as_data_not_just_log_text(create_job_result) -> None:
     job = create_job_result()
     job.record_incentive_log(MinerLogLine.no_payout_because_spot_tier(job))
 
@@ -43,7 +45,7 @@ def test_published_payload_carries_reason_codes_as_data_not_just_log_text(create
     assert spec.incentive_reasons[0].message_for_miner  # miner-facing text present
 
 
-def test_extra_miner_log_fields_survive_on_the_typed_model(create_job_result):
+def test_extra_miner_log_fields_survive_on_the_typed_model(create_job_result) -> None:
     job = create_job_result()
     job.executor_info = job.executor_info.model_copy(update={"price_per_gpu": 4.23})
     job.record_incentive_log(
@@ -57,5 +59,5 @@ def test_extra_miner_log_fields_survive_on_the_typed_model(create_job_result):
     assert reason.model_dump()["soft_limit_threshold"] == 4.2262
 
 
-def test_missing_key_defaults_to_empty_list_for_backward_compat():
-    assert _spec().incentive_reasons == []
+def test_payload_without_the_key_parses_as_none_meaning_not_reported() -> None:
+    assert _spec().incentive_reasons is None

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -249,7 +249,7 @@ def test_record_incentive_log_keeps_zero_reason_as_text_and_data():
     # human text path (unchanged, backward compatible)
     assert any("spot tier" in entry for entry in job.incentive_logs)
     # structured data path (new)
-    assert [r.reason for r in job.zero_incentive_reasons] == [ZeroIncentiveReason.SPOT_TIER]
+    assert [reason["reason"] for reason in job.zero_incentive_reasons] == [ZeroIncentiveReason.SPOT_TIER]
 
 
 def test_record_incentive_log_ignores_calculation_reports_for_the_data_path():
@@ -259,9 +259,3 @@ def test_record_incentive_log_ignores_calculation_reports_for_the_data_path():
 
     assert job.incentive_logs                      # still logged as text
     assert job.zero_incentive_reasons == []        # but not surfaced as a structured reason
-
-
-def test_earning_executor_has_no_structured_reasons_so_stale_reason_clears():
-    # Each cycle builds a fresh JobResult; an executor that earns records no reason,
-    # so the next published row carries [] and a previous cycle's reason clears (DAH-2340).
-    assert _job().zero_incentive_reasons == []

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -225,3 +225,43 @@ def test_report_line_renders_string_and_builds_internal_log():
 
     # The same content is also available as an `_m` object for the internal logger.
     assert "Mining score is calculated" in line.as_internal_log().to_full_string()
+
+
+# ── DAH-2340: structured zero-incentive reasons travel as data ────────────────
+
+def test_to_reason_payload_is_clean_subset_without_internal_fields():
+    line = MinerLogLine.no_payout_because_discord_not_connected(_job(provider_discord_connected=False))
+    payload = line.to_reason_payload()
+
+    assert payload["reason"] == "provider_discord_not_connected"
+    assert payload["message_for_miner"] == line.message
+    assert payload["executor_id"] == "exec-1"        # miner_log_fields ride along
+    assert payload["incentive"] == 0.0
+    # never leak internal-only observability data into the channel payload
+    assert "internal_message" not in payload
+    assert "pool" not in payload
+
+
+def test_record_incentive_log_keeps_zero_reason_as_text_and_data():
+    job = _job()
+    job.record_incentive_log(MinerLogLine.no_payout_because_spot_tier(job))
+
+    # human text path (unchanged, backward compatible)
+    assert any("spot tier" in entry for entry in job.incentive_logs)
+    # structured data path (new)
+    assert [r.reason for r in job.zero_incentive_reasons] == [ZeroIncentiveReason.SPOT_TIER]
+
+
+def test_record_incentive_log_ignores_calculation_reports_for_the_data_path():
+    # A calc report has reason=None: it belongs in the log text but is NOT a zero-incentive reason.
+    job = _job(mining_score=1.0)
+    job.record_incentive_log(MinerLogLine.mining_score_calculated(job, is_rented_after_cutoff=False))
+
+    assert job.incentive_logs                      # still logged as text
+    assert job.zero_incentive_reasons == []        # but not surfaced as a structured reason
+
+
+def test_earning_executor_has_no_structured_reasons_so_stale_reason_clears():
+    # Each cycle builds a fresh JobResult; an executor that earns records no reason,
+    # so the next published row carries [] and a previous cycle's reason clears (DAH-2340).
+    assert _job().zero_incentive_reasons == []

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -229,7 +229,7 @@ def test_report_line_renders_string_and_builds_internal_log():
 
 # ── DAH-2340: structured zero-incentive reasons travel as data ────────────────
 
-def test_to_reason_payload_is_clean_subset_without_internal_fields():
+def test_to_reason_payload_is_clean_subset_without_internal_fields() -> None:
     line = MinerLogLine.no_payout_because_discord_not_connected(_job(provider_discord_connected=False))
     payload = line.to_reason_payload()
 
@@ -242,7 +242,7 @@ def test_to_reason_payload_is_clean_subset_without_internal_fields():
     assert "pool" not in payload
 
 
-def test_record_incentive_log_keeps_zero_reason_as_text_and_data():
+def test_record_incentive_log_keeps_zero_reason_as_text_and_data() -> None:
     job = _job()
     job.record_incentive_log(MinerLogLine.no_payout_because_spot_tier(job))
 
@@ -252,7 +252,7 @@ def test_record_incentive_log_keeps_zero_reason_as_text_and_data():
     assert [reason["reason"] for reason in job.zero_incentive_reasons] == [ZeroIncentiveReason.SPOT_TIER]
 
 
-def test_record_incentive_log_ignores_calculation_reports_for_the_data_path():
+def test_record_incentive_log_ignores_calculation_reports_for_the_data_path() -> None:
     # A calc report has reason=None: it belongs in the log text but is NOT a zero-incentive reason.
     job = _job(mining_score=1.0)
     job.record_incentive_log(MinerLogLine.mining_score_calculated(job, is_rented_after_cutoff=False))

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -235,12 +235,12 @@ def test_to_incentive_reason_is_clean_subset_without_internal_fields() -> None:
 
     assert reason.reason == "provider_discord_not_connected"
     assert reason.message_for_miner == line.message
-    payload = reason.model_dump()
-    assert payload["executor_id"] == "exec-1"        # miner_log_fields ride along
-    assert payload["incentive"] == 0.0
-    # never leak internal-only observability data into the channel payload
-    assert "internal_message" not in payload
-    assert "pool" not in payload
+    assert reason.context["executor_id"] == "exec-1"        # miner_log_fields ride along
+    assert reason.context["incentive"] == 0.0
+    # never leak internal-only observability data or duplicate the top-level code
+    assert "internal_message" not in reason.context
+    assert "pool" not in reason.context
+    assert "reason" not in reason.context
 
 
 def test_record_incentive_log_keeps_zero_reason_as_text_and_data() -> None:

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -229,12 +229,13 @@ def test_report_line_renders_string_and_builds_internal_log():
 
 # ── DAH-2340: structured zero-incentive reasons travel as data ────────────────
 
-def test_to_reason_payload_is_clean_subset_without_internal_fields() -> None:
+def test_to_incentive_reason_is_clean_subset_without_internal_fields() -> None:
     line = MinerLogLine.no_payout_because_discord_not_connected(_job(provider_discord_connected=False))
-    payload = line.to_reason_payload()
+    reason = line.to_incentive_reason()
 
-    assert payload["reason"] == "provider_discord_not_connected"
-    assert payload["message_for_miner"] == line.message
+    assert reason.reason == "provider_discord_not_connected"
+    assert reason.message_for_miner == line.message
+    payload = reason.model_dump()
     assert payload["executor_id"] == "exec-1"        # miner_log_fields ride along
     assert payload["incentive"] == 0.0
     # never leak internal-only observability data into the channel payload
@@ -249,7 +250,7 @@ def test_record_incentive_log_keeps_zero_reason_as_text_and_data() -> None:
     # human text path (unchanged, backward compatible)
     assert any("spot tier" in entry for entry in job.incentive_logs)
     # structured data path (new)
-    assert [reason["reason"] for reason in job.zero_incentive_reasons] == [ZeroIncentiveReason.SPOT_TIER]
+    assert [reason.reason for reason in job.zero_incentive_reasons] == [ZeroIncentiveReason.SPOT_TIER]
 
 
 def test_record_incentive_log_ignores_calculation_reports_for_the_data_path() -> None:

--- a/neurons/validators/tests/test_unrented_insufficient_disk.py
+++ b/neurons/validators/tests/test_unrented_insufficient_disk.py
@@ -274,6 +274,7 @@ async def test_enforced_appends_customer_facing_incentive_log(monkeypatch):
     assert "insufficient_disk_for_vram" in log
     assert "1128.0" in log  # total VRAM
     assert "500.0" in log   # total disk
+    assert [reason.reason for reason in result.zero_incentive_reasons] == ["insufficient_disk_for_vram"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2340](https://app.notion.com/p/Incentive-data-contract-pass-structured-zero-incentive-reasons-from-validator-to-backend-392b8bfdbde98116b42fe7a7f5e8288f)

---

## Problem

The validator already explains zero incentive in provider-facing `log_text`, but downstream accounting and Portal UI must not parse prose to recover those reasons. Each catalogued provider eligibility or exclusion reason needs to travel as structured cycle data alongside the incentive calculation.

## Solution

The same `MinerLogLine` object now drives both outputs:

- `JobResult.record_incentive_log(line)` preserves the existing human-readable log.
- Lines carrying a `ZeroIncentiveReason` also produce a typed `IncentiveReason` with a stable code, provider-facing message, and explicit context.
- `publish_machine_specs` sends JSON-safe `incentive_reasons` on `MACHINE_SPEC_CHANNEL`.
- The Redis-to-WebSocket bridge forwards the field through `ExecutorSpecRequest`.

Payload semantics:

- Missing key / `null`: the publisher did not report structured reasons.
- `[]`: the cycle reported no catalogued zero-incentive reason.
- Non-empty list: structured zero-incentive reasons recorded for that cycle.

The active scoring flow short-circuits when a causal exclusion is sufficient, so it currently records at most one reason per executor and cycle. The list-shaped contract remains additive for future scoring behavior. `log_text` remains unchanged for backward compatibility.

## Changes

- Adds the typed `IncentiveReason` wire model to the existing incentive reason catalog.
- Records structured reasons on `JobResult` without including them in generic model dumps.
- Routes all ten catalogued provider eligibility and exclusion reasons in the active `rental_price` flow through `record_incentive_log`.
- Publishes and forwards `incentive_reasons` without exposing internal observability fields.
- Serializes reason context in Pydantic JSON mode so future datetime, UUID, or enum values cannot break Redis publishing.
- Preserves the newer attestation fields added to `ExecutorSpecRequest` since this PR was opened.
- Covers the newer disk-to-VRAM exclusion, which otherwise would have remained text-only.

## Current Consumer

The backend side is already deployed:

- `lium-io-backend#778` accepts the additive field and stores it in `incentive_per_validator_cycle.zero_incentive_reasons`.
- `lium-miner-portal#156` exposes cycle reasons through the Provider Earnings API.
- `lium-miner-portal-frontend#151` renders them in node timelines and expanded epoch details.

## Deployment

Deploy through the normal validator GitHub Action. The deployed backend is already backward-compatible with validators that omit the field and ready to consume this payload.

## Risks

- Low: scoring and incentive calculations are unchanged.
- The payload change is additive.
- Existing provider-facing log text is preserved.
- Reason codes remain an append-only contract; messages and context may evolve.

## Verification

- `pdm run pytest tests/test_incentive_reasons_payload.py tests/test_miner_incentive_log.py tests/test_unrented_insufficient_disk.py -q`
  - `62 passed`
  - Exercises the actual publisher payload through the Redis-to-WebSocket bridge.
  - Verifies non-primitive reason context is converted to JSON-safe values.
- `pdm run pytest tests/ -q --tb=short`
  - `1282 passed, 8 skipped`
  - Three unrelated `test_sshd_bootstrap_script.py` harness tests fail in the local macOS environment; this PR does not touch that script or its tests. Linux CI remains the authoritative full-suite result.
- `git diff --check`

## Review Request

- [x] Code review

## Checklist

- [x] PR description is current
- [x] Risks are documented
- [x] Focused tests cover the real publisher and bridge paths
- [x] Current reason catalog is covered
