### PR TITLE
DAH-2345, extend Docker SDK delete timeouts

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -126,6 +126,8 @@ _LOCAL_VOLUME_TIMEOUT_THRESHOLD_GB = 100
 _LOCAL_VOLUME_TIMEOUT_BASE_SEC = 30
 _LOCAL_VOLUME_TIMEOUT_GB_PER_SEC = 10
 _LOCAL_VOLUME_TIMEOUT_MAX_SEC = 180
+_DELETE_CONTAINER_TIMEOUT_SEC = 180
+_DELETE_VOLUME_TIMEOUT_SEC = 180
 _FILLER_EXTERNAL_PORT_OFFSET = 20
 _DOCKER_NO_SUCH_CONTAINER_PHRASE = "No such container"
 HOST_KEY_REQUIRED_EXTRA = {
@@ -547,10 +549,12 @@ class DockerService:
                     container_name=container_name,
                     force=True,
                     remove_volumes=False,
+                    timeout=_DELETE_CONTAINER_TIMEOUT_SEC,
                 ),
                 container_name=container_name,
                 force=True,
                 remove_volumes=False,
+                timeout_seconds=_DELETE_CONTAINER_TIMEOUT_SEC,
             )
         except asyncio.CancelledError:
             raise
@@ -3839,10 +3843,12 @@ class DockerService:
                             container_name=payload.container_name,
                             force=True,
                             remove_volumes=True,
+                            timeout=_DELETE_CONTAINER_TIMEOUT_SEC,
                         ),
                         container_name=payload.container_name,
                         force=True,
                         remove_volumes=True,
+                        timeout_seconds=_DELETE_CONTAINER_TIMEOUT_SEC,
                     )
                 except Exception as exc:
                     # DAH-2345: deletion is idempotent for every workload kind — a container
@@ -3900,10 +3906,12 @@ class DockerService:
                             operation="remove_volume",
                             log_extra=default_extra,
                             call=lambda: docker_client.remove_volume(
-                                volume_name=payload.local_volume
+                                volume_name=payload.local_volume,
+                                timeout=_DELETE_VOLUME_TIMEOUT_SEC,
                             ),
                             volume_name=payload.local_volume,
                             volume_role="local",
+                            timeout_seconds=_DELETE_VOLUME_TIMEOUT_SEC,
                         )
                     except Exception as exc:
                         logger.error(
@@ -3926,10 +3934,12 @@ class DockerService:
                             operation="remove_volume",
                             log_extra=default_extra,
                             call=lambda: docker_client.remove_volume(
-                                volume_name=payload.external_volume
+                                volume_name=payload.external_volume,
+                                timeout=_DELETE_VOLUME_TIMEOUT_SEC,
                             ),
                             volume_name=payload.external_volume,
                             volume_role="external",
+                            timeout_seconds=_DELETE_VOLUME_TIMEOUT_SEC,
                         )
                         await self.disable_s3fs_volume_plugin(ssh_client)
                     except Exception as exc:

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -249,11 +249,13 @@ class RentalDockerSdkClient:
         container_name: str,
         force: bool = True,
         remove_volumes: bool = True,
+        timeout: int | None = None,
     ) -> None:
         await self._call_api(
             container_name,
             operation_label="remove container",
             api_method=self._api_client.remove_container,
+            client_timeout=timeout,
             force=force,
             v=remove_volumes,
         )
@@ -279,11 +281,18 @@ class RentalDockerSdkClient:
                 _wrap_error_message("Docker SDK create volume failed", exc)
             ) from exc
 
-    async def remove_volume(self, *, volume_name: str, force: bool = False) -> None:
+    async def remove_volume(
+        self,
+        *,
+        volume_name: str,
+        force: bool = False,
+        timeout: int | None = None,
+    ) -> None:
         await self._call_api(
             volume_name,
             operation_label="remove volume",
             api_method=self._api_client.remove_volume,
+            client_timeout=timeout,
             force=force,
         )
 
@@ -298,9 +307,22 @@ class RentalDockerSdkClient:
         if close is not None:
             await asyncio.to_thread(close)
 
-    async def _call_api(self, *args, operation_label: str, api_method, **kwargs) -> None:
+    async def _call_api(
+        self,
+        *args,
+        operation_label: str,
+        api_method,
+        client_timeout: int | None = None,
+        **kwargs,
+    ) -> None:
         try:
-            await asyncio.to_thread(api_method, *args, **kwargs)
+            await asyncio.to_thread(
+                self._call_api_sync,
+                *args,
+                api_method=api_method,
+                client_timeout=client_timeout,
+                **kwargs,
+            )
         except Exception as exc:
             raise RentalDockerOperationError(
                 _wrap_error_message(f"Docker SDK {operation_label} failed", exc)
@@ -419,6 +441,26 @@ class RentalDockerSdkClient:
                 driver=driver,
                 driver_opts=driver_opts,
             )
+        finally:
+            if should_override_timeout:
+                self._api_client.timeout = original_timeout
+
+    def _call_api_sync(
+        self,
+        *args,
+        api_method,
+        client_timeout: int | None,
+        **kwargs,
+    ) -> None:
+        original_timeout = getattr(self._api_client, "timeout", None)
+        should_override_timeout = client_timeout is not None and hasattr(
+            self._api_client,
+            "timeout",
+        )
+        if should_override_timeout:
+            self._api_client.timeout = None if client_timeout == 0 else client_timeout
+        try:
+            api_method(*args, **kwargs)
         finally:
             if should_override_timeout:
                 self._api_client.timeout = original_timeout

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -103,12 +103,14 @@ class _FakeRentalDockerClient:
         container_name: str,
         force: bool = True,
         remove_volumes: bool = True,
+        timeout: int | None = None,
     ) -> None:
         self.removed_containers.append(
             {
                 "container_name": container_name,
                 "force": force,
                 "remove_volumes": remove_volumes,
+                "timeout": timeout,
             }
         )
         if self.remove_error is not None:
@@ -131,9 +133,15 @@ class _FakeRentalDockerClient:
             }
         )
 
-    async def remove_volume(self, *, volume_name: str, force: bool = False) -> None:
+    async def remove_volume(
+        self,
+        *,
+        volume_name: str,
+        force: bool = False,
+        timeout: int | None = None,
+    ) -> None:
         self.removed_volumes.append(
-            {"volume_name": volume_name, "force": force}
+            {"volume_name": volume_name, "force": force, "timeout": timeout}
         )
         if self.remove_volume_error is not None:
             raise self.remove_volume_error
@@ -891,11 +899,12 @@ async def test_delete_filler_container_treats_missing_container_as_deleted(
             "container_name": payload.container_name,
             "force": True,
             "remove_volumes": True,
+            "timeout": 180,
         }
     ]
     assert docker_service.rental_docker_client_factory.client.pruned_images == 1
     assert docker_service.rental_docker_client_factory.client.removed_volumes == [
-        {"volume_name": payload.local_volume, "force": False}
+        {"volume_name": payload.local_volume, "force": False, "timeout": 180}
     ]
     docker_service.redis_service.remove_rented_machine.assert_awaited_once_with(
         executor_info,
@@ -956,7 +965,7 @@ async def test_delete_customer_rental_treats_missing_container_as_deleted(
     assert result.pod_id == payload.pod_id
     assert docker_service.rental_docker_client_factory.client.pruned_images == 1
     assert docker_service.rental_docker_client_factory.client.removed_volumes == [
-        {"volume_name": payload.local_volume, "force": False}
+        {"volume_name": payload.local_volume, "force": False, "timeout": 180}
     ]
     docker_service.redis_service.remove_rented_machine.assert_awaited_once_with(
         executor_info,
@@ -1074,6 +1083,7 @@ async def test_delete_container_volume_read_timeout_still_deleted(
             "container_name": payload.container_name,
             "force": True,
             "remove_volumes": True,
+            "timeout": 180,
         }
     ]
     docker_service.redis_service.remove_rented_machine.assert_awaited_once_with(
@@ -1170,7 +1180,7 @@ async def test_delete_container_prune_images_failure_still_deleted(
     # prune ran (and raised); the local volume is still removed afterwards
     assert docker_service.rental_docker_client_factory.client.pruned_images == 1
     assert docker_service.rental_docker_client_factory.client.removed_volumes == [
-        {"volume_name": payload.local_volume, "force": False}
+        {"volume_name": payload.local_volume, "force": False, "timeout": 180}
     ]
     docker_service.redis_service.remove_rented_machine.assert_awaited_once_with(
         executor_info,

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -117,12 +117,14 @@ class RecordingRentalDockerClient:
         container_name: str,
         force: bool = True,
         remove_volumes: bool = True,
+        timeout: int | None = None,
     ) -> None:
         self.removed_containers.append(
             {
                 "container_name": container_name,
                 "force": force,
                 "remove_volumes": remove_volumes,
+                "timeout": timeout,
             }
         )
 
@@ -143,9 +145,15 @@ class RecordingRentalDockerClient:
             }
         )
 
-    async def remove_volume(self, *, volume_name: str, force: bool = False) -> None:
+    async def remove_volume(
+        self,
+        *,
+        volume_name: str,
+        force: bool = False,
+        timeout: int | None = None,
+    ) -> None:
         self.removed_volumes.append(
-            {"volume_name": volume_name, "force": force}
+            {"volume_name": volume_name, "force": force, "timeout": timeout}
         )
 
     async def prune_images(self) -> None:
@@ -739,11 +747,12 @@ async def test_lifecycle_operations_pass_container_names_as_sdk_data(
             "container_name": HOSTILE_CONTAINER_NAME,
             "force": True,
             "remove_volumes": True,
+            "timeout": 180,
         }
     ]
     assert docker_client.pruned_images == 1
     assert docker_client.removed_volumes == [
-        {"volume_name": "volume_lifecycle", "force": False}
+        {"volume_name": "volume_lifecycle", "force": False, "timeout": 180}
     ]
 
 

--- a/neurons/validators/tests/test_rental_docker_sdk.py
+++ b/neurons/validators/tests/test_rental_docker_sdk.py
@@ -89,6 +89,9 @@ class FakeApiClient:
         self.pruned_images = False
         self.created_volumes = []
         self.removed_volumes = []
+        self.removed_containers = []
+        self.remove_volume_error = None
+        self.remove_container_error = None
         self.timeout = 60
         self.closed = False
 
@@ -140,12 +143,19 @@ class FakeApiClient:
         self.pruned_images = True
         return {"ImagesDeleted": []}
 
+    def remove_container(self, container_name, **kwargs):
+        self.removed_containers.append((container_name, kwargs, self.timeout))
+        if self.remove_container_error is not None:
+            raise self.remove_container_error
+
     def create_volume(self, **kwargs):
         self.created_volumes.append({**kwargs, "client_timeout": self.timeout})
         return {"Name": kwargs.get("name")}
 
     def remove_volume(self, volume_name, **kwargs):
-        self.removed_volumes.append((volume_name, kwargs))
+        self.removed_volumes.append((volume_name, kwargs, self.timeout))
+        if self.remove_volume_error is not None:
+            raise self.remove_volume_error
 
     def close(self):
         self.closed = True
@@ -888,7 +898,13 @@ async def test_delete_helpers_call_sdk_volume_and_prune_apis():
         timeout=133,
     )
     await client.prune_images()
-    await client.remove_volume(volume_name="volume_test", force=True)
+    await client.remove_container(
+        container_name="pod_test",
+        force=True,
+        remove_volumes=True,
+        timeout=181,
+    )
+    await client.remove_volume(volume_name="volume_test", force=True, timeout=182)
 
     assert api_client.created_volumes == [
         {
@@ -900,7 +916,29 @@ async def test_delete_helpers_call_sdk_volume_and_prune_apis():
     ]
     assert api_client.timeout == 60
     assert api_client.pruned_images is True
-    assert api_client.removed_volumes == [("volume_test", {"force": True})]
+    assert api_client.removed_containers == [
+        ("pod_test", {"force": True, "v": True}, 181)
+    ]
+    assert api_client.removed_volumes == [("volume_test", {"force": True}, 182)]
+
+
+@pytest.mark.asyncio
+async def test_delete_helper_restores_sdk_timeout_after_failure():
+    api_client = FakeApiClient()
+    api_client.remove_volume_error = TimeoutError("slow volume delete")
+    client = RentalDockerSdkClient(api_client)
+
+    with pytest.raises(RentalDockerOperationError, match="slow volume delete"):
+        await client.remove_volume(
+            volume_name="volume_slow",
+            force=True,
+            timeout=182,
+        )
+
+    assert api_client.removed_volumes == [
+        ("volume_slow", {"force": True}, 182)
+    ]
+    assert api_client.timeout == 60
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds per-call timeout overrides for Docker SDK remove_container/remove_volume and uses 180s for rental cleanup deletes. Root cause: docker 7.1.0 public delete helpers call _delete(), which applies APIClient.timeout; our rental factory sets that to 60s, matching prod remove_volume read-timeout logs around 60039ms. #1109 made post-teardown failures non-fatal but did not fix the SDK timeout, so slow named-volume cleanup could still leave disk behind. Tested with validator SDK/docker service unit suites and diff check. After deploy to staging, verify connector logs include timeout_seconds=180 on remove_container/remove_volume and run a targeted rental delete smoke.