### PR TITLE
DAH-2359: zero incentive for executors opted out of Lium default jobs (validator)

### DIFF
--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -316,6 +316,9 @@ class Validator:
                                         and not (
                                             job_result.is_new_rentals_paused and not job_result.is_rented
                                         )
+                                        and not (
+                                            job_result.default_job_opted_out and not job_result.is_rented
+                                        )
                                     ):
                                         total_gpu_model_count_map[job_result.gpu_model] = total_gpu_model_count_map.get(job_result.gpu_model, 0) + job_result.gpu_count
 

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -313,12 +313,7 @@ class Validator:
                                         and (job_result.score > 0 or job_result.job_score > 0)
                                         and not job_result.is_spot
                                         and not is_missing_discord_after_cutoff(job_result)
-                                        and not (
-                                            job_result.is_new_rentals_paused and not job_result.is_rented
-                                        )
-                                        and not (
-                                            job_result.default_job_opted_out and not job_result.is_rented
-                                        )
+                                        and not job_result.is_excluded_from_unrented_pool
                                     ):
                                         total_gpu_model_count_map[job_result.gpu_model] = total_gpu_model_count_map.get(job_result.gpu_model, 0) + job_result.gpu_count
 

--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -163,6 +163,25 @@ class DefaultIncentive(BaseIncentive):
             job_result.mining_score = 0
             return job_result
 
+        if job_result.default_job_opted_out and not job_result.is_rented:
+            logger.info(
+                _m(
+                    "Executor excluded from mining pool - opted out of the Lium default job",
+                    extra=get_extra_info(
+                        {
+                            "executor_id": str(job_result.executor_info.uuid),
+                            "gpu_model": job_result.gpu_model,
+                            "gpu_count": job_result.gpu_count,
+                            "reason": "default_job_opted_out",
+                            "score": 0,
+                            "pool": "none",
+                        }
+                    ),
+                )
+            )
+            job_result.mining_score = 0
+            return job_result
+
         # GPU count calculation
         job_result.total_gpu_count = self.total_gpu_model_count_map.get(job_result.gpu_model, 0)
         if not job_result.total_gpu_count:

--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -120,6 +120,31 @@ class DefaultIncentive(BaseIncentive):
         result.incentive_logs.append(report.to_log_line())
         return result
 
+    def _log_and_zero_unrented_exclusion(
+        self,
+        job_result: JobResult,
+        message: str,
+        reason: str,
+    ) -> JobResult:
+        """Log an unrented-pool exclusion and return the result with a zeroed score."""
+        logger.info(
+            _m(
+                message,
+                extra=get_extra_info(
+                    {
+                        "executor_id": str(job_result.executor_info.uuid),
+                        "gpu_model": job_result.gpu_model,
+                        "gpu_count": job_result.gpu_count,
+                        "reason": reason,
+                        "score": 0,
+                        "pool": "none",
+                    }
+                ),
+            )
+        )
+        job_result.mining_score = 0
+        return job_result
+
     async def calculate_executor_score(
         self,
         job_result: JobResult,
@@ -145,42 +170,18 @@ class DefaultIncentive(BaseIncentive):
         # directly. The active rental_price algorithm handles this before it
         # calls into DefaultIncentive.
         if job_result.is_new_rentals_paused and not job_result.is_rented:
-            logger.info(
-                _m(
-                    "Executor excluded from mining pool - paused for new rentals",
-                    extra=get_extra_info(
-                        {
-                            "executor_id": str(job_result.executor_info.uuid),
-                            "gpu_model": job_result.gpu_model,
-                            "gpu_count": job_result.gpu_count,
-                            "reason": "new_rentals_paused",
-                            "score": 0,
-                            "pool": "none",
-                        }
-                    ),
-                )
+            return self._log_and_zero_unrented_exclusion(
+                job_result,
+                message="Executor excluded from mining pool - paused for new rentals",
+                reason="new_rentals_paused",
             )
-            job_result.mining_score = 0
-            return job_result
 
         if job_result.default_job_opted_out and not job_result.is_rented:
-            logger.info(
-                _m(
-                    "Executor excluded from mining pool - opted out of the Lium default job",
-                    extra=get_extra_info(
-                        {
-                            "executor_id": str(job_result.executor_info.uuid),
-                            "gpu_model": job_result.gpu_model,
-                            "gpu_count": job_result.gpu_count,
-                            "reason": "default_job_opted_out",
-                            "score": 0,
-                            "pool": "none",
-                        }
-                    ),
-                )
+            return self._log_and_zero_unrented_exclusion(
+                job_result,
+                message="Executor excluded from mining pool - opted out of the Lium default job",
+                reason="default_job_opted_out",
             )
-            job_result.mining_score = 0
-            return job_result
 
         # GPU count calculation
         job_result.total_gpu_count = self.total_gpu_model_count_map.get(job_result.gpu_model, 0)

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -17,7 +17,8 @@ WHAT THIS CATALOG HOLDS — every `MinerLogLine` the miner-facing log block
 1. ZERO-INCENTIVE REASONS — each records the fact "this executor gets NO payout
    because <reason>" (`MinerLogLine.no_payout_because_*` constructors):
    Group A — earns nothing in EITHER pool (built by `_reason_excluded_from_both_pools`):
-     spot tier, Discord not connected, paused for new rentals, running own default job
+     spot tier, Discord not connected, paused for new rentals, running own default job,
+     opted out of the Lium default job
    Group B — idle but does not qualify for the unrented pool:
      GPU model not in the unrented program (earns only when rented),
      price above the market soft limit (lower the price to earn),
@@ -59,6 +60,7 @@ class ZeroIncentiveReason(StrEnum):
     PROVIDER_DISCORD_NOT_CONNECTED = "provider_discord_not_connected"
     NEW_RENTALS_PAUSED = "new_rentals_paused"
     MINER_DEFAULT_JOB = "miner_default_job"
+    DEFAULT_JOB_OPTED_OUT = "default_job_opted_out"
     # Group B: idle but not qualified for the unrented pool
     GPU_MODEL_NOT_ELIGIBLE_FOR_UNRENTED_INCENTIVE = "gpu_model_not_eligible_for_unrented_incentive"
     PRICE_ABOVE_MARKET_P90_SOFT_LIMIT = "price_above_market_p90_soft_limit"
@@ -185,6 +187,19 @@ class MinerLogLine(BaseModel):
                 "of a Lium job, and executors on your own job do not earn subnet incentive."
             ),
             internal_message="Executor excluded from both pools - running miner's own default job",
+        )
+
+    @staticmethod
+    def no_payout_because_default_job_opted_out(result: JobResult) -> MinerLogLine:
+        return MinerLogLine._no_payout(
+            result,
+            reason=ZeroIncentiveReason.DEFAULT_JOB_OPTED_OUT,
+            message=(
+                "No subnet incentive: this executor is opted out of the Lium default job and "
+                "forfeits incentive while unrented. Opt back in to the Lium default job to "
+                "earn while idle."
+            ),
+            internal_message="Executor excluded from both pools - opted out of the Lium default job",
         )
 
     # ── Group B: idle but not qualified for the unrented pool ─────────────────

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -223,6 +223,8 @@ class RentalPriceIncentive(DefaultIncentive):
             return MinerLogLine.no_payout_because_discord_not_connected(job_result)
         if job_result.is_new_rentals_paused and not job_result.is_rented:
             return MinerLogLine.no_payout_because_paused_for_new_rentals(job_result)
+        if job_result.default_job_opted_out and not job_result.is_rented:
+            return MinerLogLine.no_payout_because_default_job_opted_out(job_result)
         if job_result.default_job_owner == DEFAULT_JOB_OWNER_MINER and not job_result.is_rented:
             return MinerLogLine.no_payout_because_running_own_default_job(job_result)
         return None

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -682,6 +682,10 @@ class RentalPriceIncentive(DefaultIncentive):
                 # executors excluded from incentive pools should not inflate estimates.
                 if result.is_spot or is_missing_discord_after_cutoff(result):
                     continue
+                # Explicit opted-out check (not is_excluded_from_unrented_pool):
+                # the is_new_rentals_paused half is intentionally deferred to a follow-up.
+                if result.default_job_opted_out and not result.is_rented:
+                    continue
                 total_gpu_model_count_map[result.gpu_model] = (
                     total_gpu_model_count_map.get(result.gpu_model, 0) + result.gpu_count
                 )

--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -78,7 +78,7 @@ class RentedExecutorsResponse(BaseModel):
     network_ema: dict[str, NetworkEMA] = {}  # executor_id → EMA network speeds, all active executors
     spot_executor_ids: list[str] = []  # executor_ids in spot tier (no incentive, no penalty)
     new_rentals_paused_executor_ids: list[str] = []  # executor_ids paused from unrented incentives
-    default_job_opted_out_executor_ids: list[str] = []  # executor_ids opted out of the Lium default job (no unrented incentive)
+    default_job_opted_out_executor_ids: set[str] = set()  # executor_ids opted out of the Lium default job (no unrented incentive); set for O(1) hot-path membership
     provider_discord_connected_executor_ids: list[str] | None = None  # executor_ids whose provider has connected Discord
     # executor_id → "miner" | "lium"; absent = no default job. Parsed leniently as str for
     # forward-compatibility (a future owner value must not break parsing of the whole response).

--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -78,6 +78,7 @@ class RentedExecutorsResponse(BaseModel):
     network_ema: dict[str, NetworkEMA] = {}  # executor_id → EMA network speeds, all active executors
     spot_executor_ids: list[str] = []  # executor_ids in spot tier (no incentive, no penalty)
     new_rentals_paused_executor_ids: list[str] = []  # executor_ids paused from unrented incentives
+    default_job_opted_out_executor_ids: list[str] = []  # executor_ids opted out of the Lium default job (no unrented incentive)
     provider_discord_connected_executor_ids: list[str] | None = None  # executor_ids whose provider has connected Discord
     # executor_id → "miner" | "lium"; absent = no default job. Parsed leniently as str for
     # forward-compatibility (a future owner value must not break parsing of the whole response).

--- a/neurons/validators/src/services/task/models.py
+++ b/neurons/validators/src/services/task/models.py
@@ -74,6 +74,12 @@ class JobResult(BaseModel):
     def is_successful(self):
         return (self.score > 0 or self.job_score > 0) and self.gpu_model and self.gpu_count > 0
 
+    @property
+    def is_excluded_from_unrented_pool(self) -> bool:
+        """Opted out of Lium default job or paused for new rentals — no unrented incentive."""
+        has_exclusion_flag: bool = self.is_new_rentals_paused or self.default_job_opted_out
+        return has_exclusion_flag and not self.is_rented
+
 
 class ValidationEvent(BaseModel):
     event: str

--- a/neurons/validators/src/services/task/models.py
+++ b/neurons/validators/src/services/task/models.py
@@ -26,6 +26,7 @@ class JobResult(BaseModel):
     is_rented: bool = False
     is_spot: bool = False
     is_new_rentals_paused: bool = False
+    default_job_opted_out: bool = False  # opted out of the Lium default job: no incentive while unrented
     provider_discord_connected: bool = True
     rental_created_at: datetime | None = None
     default_job_owner: str | None = None  # "miner" | "lium" | None; miner default job is excluded from unrented incentive

--- a/neurons/validators/src/services/task/result_handler.py
+++ b/neurons/validators/src/services/task/result_handler.py
@@ -113,6 +113,10 @@ class ResultHandler:
             context.state.rented_data
             and executor_info.uuid in context.state.rented_data.new_rentals_paused_executor_ids
         )
+        default_job_opted_out = bool(
+            context.state.rented_data
+            and executor_info.uuid in context.state.rented_data.default_job_opted_out_executor_ids
+        )
         default_job_owner = (
             context.state.rented_data.get_default_job_owner(executor_info.uuid)
             if context.state.rented_data
@@ -177,6 +181,7 @@ class ResultHandler:
             is_rented=context.rented,
             is_spot=is_spot,
             is_new_rentals_paused=is_new_rentals_paused,
+            default_job_opted_out=default_job_opted_out,
             provider_discord_connected=provider_discord_connected,
             rental_created_at=self._get_rental_created_at(context),
             default_job_owner=default_job_owner,

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -20,6 +20,7 @@ def test_reason_enum_pins_the_stable_code_contract():
         "provider_discord_not_connected",
         "new_rentals_paused",
         "miner_default_job",
+        "default_job_opted_out",
         "gpu_model_not_eligible_for_unrented_incentive",
         "price_above_market_p90_soft_limit",
         "no_unrented_capacity_for_gpu_count",
@@ -77,6 +78,11 @@ def _job(**overrides) -> JobResult:
             lambda job: MinerLogLine.no_payout_because_running_own_default_job(job),
             "miner_default_job",
             "own default job",
+        ),
+        (
+            lambda job: MinerLogLine.no_payout_because_default_job_opted_out(job),
+            "default_job_opted_out",
+            "opted out",
         ),
         (
             lambda job: MinerLogLine.no_payout_because_gpu_model_not_in_unrented_program(job),

--- a/neurons/validators/tests/test_new_rentals_pause_filter.py
+++ b/neurons/validators/tests/test_new_rentals_pause_filter.py
@@ -18,6 +18,7 @@ from protocol.vc_protocol.compute_requests import (
 )
 from services.miner_service import MinerService
 from services.task.result_handler import ResultHandler
+from tests.helpers import build_state
 
 
 def _executor(executor_id: str) -> ExecutorSSHInfo:
@@ -140,6 +141,25 @@ def test_rented_executors_response_parses_new_rentals_paused_executor_ids():
     assert result.new_rentals_paused_executor_ids == ["paused-executor"]
 
 
+def test_rented_executors_response_defaults_default_job_opted_out_executor_ids():
+    """Older backend responses without opt-out IDs remain compatible."""
+    result = RentedExecutorsResponse.model_validate({"executors": {}})
+
+    assert result.default_job_opted_out_executor_ids == []
+
+
+def test_rented_executors_response_parses_default_job_opted_out_executor_ids():
+    """Backend opted-out executor IDs are available to incentive handling."""
+    result = RentedExecutorsResponse.model_validate(
+        {
+            "executors": {},
+            "default_job_opted_out_executor_ids": ["opted-out-executor"],
+        }
+    )
+
+    assert result.default_job_opted_out_executor_ids == ["opted-out-executor"]
+
+
 def test_rented_executors_response_defaults_provider_discord_connected_executor_ids_to_unknown():
     """Older backend responses without Discord executor IDs remain non-penalizing."""
     result = RentedExecutorsResponse.model_validate({"executors": {}})
@@ -230,6 +250,49 @@ def test_result_handler_reads_provider_discord_connected_executor_ids():
 
     assert ResultHandler._get_provider_discord_connected(connected_context) is True
     assert ResultHandler._get_provider_discord_connected(disconnected_context) is False
+
+
+@pytest.mark.asyncio
+async def test_handle_result_flags_default_job_opted_out_executor(context_factory):
+    """An executor in the backend opt-out list gets default_job_opted_out=True."""
+    rented_data = RentedExecutorsResponse(
+        executors={},
+        default_job_opted_out_executor_ids=["executor-123"],
+    )
+    state = build_state(rented_data=rented_data)
+    ctx = context_factory(state=state, score=1.0, job_score=1.0, rented=False)
+    handler = ResultHandler(redis_service=None, dry_run=True)
+
+    result = await handler.handle_result(
+        context=ctx,
+        miner_info=SimpleNamespace(miner_hotkey="miner-hotkey", job_batch_id="batch-1"),
+        executor_info=ctx.executor,
+        verified_job_info={},
+        log_text="ok",
+        success=True,
+    )
+
+    assert result.default_job_opted_out is True
+
+
+@pytest.mark.asyncio
+async def test_handle_result_defaults_default_job_opted_out_to_false(context_factory):
+    """An executor absent from the backend opt-out list keeps default_job_opted_out=False."""
+    rented_data = RentedExecutorsResponse(executors={})
+    state = build_state(rented_data=rented_data)
+    ctx = context_factory(state=state, score=1.0, job_score=1.0, rented=False)
+    handler = ResultHandler(redis_service=None, dry_run=True)
+
+    result = await handler.handle_result(
+        context=ctx,
+        miner_info=SimpleNamespace(miner_hotkey="miner-hotkey", job_batch_id="batch-1"),
+        executor_info=ctx.executor,
+        verified_job_info={},
+        log_text="ok",
+        success=True,
+    )
+
+    assert result.default_job_opted_out is False
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_new_rentals_pause_filter.py
+++ b/neurons/validators/tests/test_new_rentals_pause_filter.py
@@ -145,19 +145,20 @@ def test_rented_executors_response_defaults_default_job_opted_out_executor_ids()
     """Older backend responses without opt-out IDs remain compatible."""
     result = RentedExecutorsResponse.model_validate({"executors": {}})
 
-    assert result.default_job_opted_out_executor_ids == []
+    assert result.default_job_opted_out_executor_ids == set()
 
 
 def test_rented_executors_response_parses_default_job_opted_out_executor_ids():
-    """Backend opted-out executor IDs are available to incentive handling."""
+    """A JSON list of backend opted-out executor IDs parses into a set for O(1) lookups."""
     result = RentedExecutorsResponse.model_validate(
         {
             "executors": {},
-            "default_job_opted_out_executor_ids": ["opted-out-executor"],
+            "default_job_opted_out_executor_ids": ["opted-out-executor", "opted-out-executor"],
         }
     )
 
-    assert result.default_job_opted_out_executor_ids == ["opted-out-executor"]
+    assert isinstance(result.default_job_opted_out_executor_ids, set)
+    assert result.default_job_opted_out_executor_ids == {"opted-out-executor"}
 
 
 def test_rented_executors_response_defaults_provider_discord_connected_executor_ids_to_unknown():

--- a/neurons/validators/tests/test_rental_price_estimate.py
+++ b/neurons/validators/tests/test_rental_price_estimate.py
@@ -193,6 +193,29 @@ async def test_get_snapshot_excludes_spot_executor_from_mining_totals(
     assert snapshot.mining.total_gpu_model_count_map == {"H100": 8}
 
 
+@pytest.mark.asyncio
+async def test_get_snapshot_excludes_opted_out_unrented_executor_from_mining_totals(
+    rental_config, mock_redis, mock_price_provider, monkeypatch
+):
+    """Unrented opted-out executor is excluded from snapshot totals; a rented one still counts."""
+    opted_out_unrented = _make_job("exec-opted-out", "H100", 8, is_rented=False)
+    opted_out_unrented.default_job_opted_out = True
+    opted_out_rented = _make_job("exec-opted-out-rented", "H100", 4, is_rented=True)
+    opted_out_rented.default_job_opted_out = True
+    job_results = {
+        "miner_regular": [_make_job("exec-regular", "H100", 8, is_rented=False)],
+        "miner_opted_out": [opted_out_unrented],
+        "miner_opted_out_rented": [opted_out_rented],
+    }
+    incentive = _make_incentive(rental_config, mock_redis, mock_price_provider, job_results, monkeypatch)
+
+    await incentive.calculate_mining_scores()
+    snapshot = incentive.get_snapshot()
+
+    assert snapshot.mining.total_gpu_count == 12  # 8 regular + 4 rented opted-out
+    assert snapshot.mining.total_gpu_model_count_map == {"H100": 12}
+
+
 # ── estimate_executor() — unrented path ──────────────────────────────────────
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_rental_price_incentive_flow.py
+++ b/neurons/validators/tests/test_rental_price_incentive_flow.py
@@ -144,6 +144,7 @@ def _make_rented_data(
     new_rentals_paused_executor_ids: list[str] | None = None,
     provider_discord_connected_executor_ids: list[str] | None = None,
     default_job_owner_by_executor: dict[str, str] | None = None,
+    default_job_opted_out_executor_ids: list[str] | None = None,
 ) -> RentedExecutorsResponse:
     executors = {}
     for executor_id in rented_executor_ids or []:
@@ -161,6 +162,7 @@ def _make_rented_data(
         new_rentals_paused_executor_ids=new_rentals_paused_executor_ids or [],
         provider_discord_connected_executor_ids=provider_discord_connected_executor_ids,
         default_job_owner_by_executor=default_job_owner_by_executor or {},
+        default_job_opted_out_executor_ids=default_job_opted_out_executor_ids or [],
     )
 
 
@@ -2817,6 +2819,83 @@ async def test_rental_price_paused_unrented_excluded_from_incentives_but_still_v
     assert secure_rented.is_rented is True
     assert secure_rented.total_gpu_count == 16
     assert validator.miner_scores["miner_secure_rented"] > 0
+
+
+@pytest.mark.asyncio
+async def test_rental_price_default_job_opted_out_unrented_earns_nothing(
+    validator_with_rental_price,
+    mock_subtensor_client,
+    mock_settings,
+    create_job_result,
+    create_neuron_info,
+    mock_price_provider,
+):
+    """An executor opted out of the Lium default job earns nothing while unrented
+    (mirrors is_new_rentals_paused semantics):
+    - it is excluded from both pools (mining + rental)
+    - it does not dilute secure unrented bucket caps
+    A RENTED opted-out executor keeps the normal rental-based mining incentive.
+    """
+    validator = validator_with_rental_price
+    validator.miner_scores = {}
+
+    miners = [
+        create_neuron_info(uid=100, hotkey="burner1"),
+        create_neuron_info(uid=101, hotkey="burner2"),
+        create_neuron_info(uid=2, hotkey="miner_secure_unrented"),
+        create_neuron_info(uid=3, hotkey="miner_opted_out_rented"),
+        create_neuron_info(uid=4, hotkey="miner_opted_out"),
+    ]
+
+    secure_unrented = _job(
+        create_job_result, executor_id="exec-secure-unrented",
+        gpu_model="H100", gpu_count=8, is_rented=False,
+    )
+    opted_out_rented = _job(
+        create_job_result, executor_id="exec-opted-out-rented",
+        gpu_model="H100", gpu_count=8, is_rented=True,
+    )
+    opted_out = _job(
+        create_job_result, executor_id="exec-opted-out",
+        gpu_model="H100", gpu_count=8, is_rented=False,
+    )
+    opted_out_rented.default_job_opted_out = True
+    opted_out.default_job_opted_out = True
+
+    all_job_results = {
+        "miner_secure_unrented": [secure_unrented],
+        "miner_opted_out_rented": [opted_out_rented],
+        "miner_opted_out": [opted_out],
+    }
+
+    validator.backend_client.get_all_rented_executors = AsyncMock(
+        return_value=_make_rented_data(
+            rented_executor_ids=["exec-opted-out-rented"],
+            default_job_opted_out_executor_ids=[
+                "exec-opted-out",
+                "exec-opted-out-rented",
+            ],
+        )
+    )
+
+    await _run_sync_with_jobs(validator, miners, all_job_results)
+
+    # Opted-out and unrented -> excluded from both pools, earns nothing
+    assert opted_out.mining_score == 0
+    assert opted_out.eligible_for_rental_share is False
+    assert (opted_out.incentive or 0.0) == 0.0
+    assert validator.miner_scores.get("miner_opted_out", 0.0) == pytest.approx(0.0, abs=0.0001)
+
+    # The opted-out unrented executor must not dilute the secure unrented bucket
+    assert secure_unrented.eligible_for_rental_share is True
+    assert secure_unrented.total_unrented_by_gpu_type == 8
+    assert secure_unrented.unrented_cap_multiplier == pytest.approx(1.0)
+    assert (secure_unrented.incentive or 0.0) > 0.0
+
+    # Opted-out but RENTED -> normal rental-based mining incentive
+    assert opted_out_rented.is_rented is True
+    assert opted_out_rented.total_gpu_count == 16
+    assert validator.miner_scores["miner_opted_out_rented"] > 0
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_unrented_soft_price_limit.py
+++ b/neurons/validators/tests/test_unrented_soft_price_limit.py
@@ -33,6 +33,7 @@ def _make_job(
     is_new_rentals_paused: bool = False,
     provider_discord_connected: bool = True,
     default_job_owner: str | None = None,
+    default_job_opted_out: bool = False,
 ) -> JobResult:
     return JobResult(
         executor_info=ExecutorSSHInfo(
@@ -57,6 +58,7 @@ def _make_job(
         is_new_rentals_paused=is_new_rentals_paused,
         provider_discord_connected=provider_discord_connected,
         default_job_owner=default_job_owner,
+        default_job_opted_out=default_job_opted_out,
         collateral_deposited=True,
         sysbox_runtime=True,
     )
@@ -207,6 +209,7 @@ async def test_shadow_mode_does_not_append_incentive_log(monkeypatch):
         ({"provider_discord_connected": False}, ["Discord", "provider_discord_not_connected"]),
         ({"is_new_rentals_paused": True}, ["paused", "new_rentals_paused"]),
         ({"default_job_owner": "miner"}, ["default job", "miner_default_job"]),
+        ({"default_job_opted_out": True}, ["opted out", "default_job_opted_out"]),
     ],
 )
 @pytest.mark.asyncio
@@ -329,3 +332,15 @@ def test_reason_excluded_from_both_pools_returns_first_match_and_none():
     # spot precedes discord when both apply — order is preserved
     both = _make_job(1.0, is_spot=True, provider_discord_connected=False)
     assert incentive._reason_excluded_from_both_pools(both).reason == "spot_tier"
+
+
+def test_default_job_opted_out_excludes_only_while_unrented():
+    # Mirrors is_new_rentals_paused semantics: an opted-out executor forfeits
+    # incentive while unrented, but a RENTED opted-out executor is not excluded.
+    incentive = _build_incentive()
+
+    unrented = _make_job(1.0, default_job_opted_out=True)
+    assert incentive._reason_excluded_from_both_pools(unrented).reason == "default_job_opted_out"
+
+    rented = _make_job(1.0, default_job_opted_out=True, is_rented=True)
+    assert incentive._reason_excluded_from_both_pools(rented) is None


### PR DESCRIPTION
## What

GPU providers can opt an executor out of Lium's default-job mining — **any Lium-owned default job (PEARL, DPHN, and any future Lium strategy), not just PEARL**. An opted-out executor now receives **zero incentive while unrented** — excluded from both the mining pool and the unrented rental-share pool. A **rented** opted-out executor keeps the normal rental-based incentive, mirroring the exact semantics of `is_new_rentals_paused`.

The validator enforcement here is strategy-agnostic: it keys off the `default_job_opted_out` flag the backend sends, not the job type, so it already covers every current and future Lium-owned default job.

Notion task: https://app.notion.com/p/396b8bfdbde9810ab34dd3b76339fd6d

## Shared contract (backend PR uses these exact names)

- Wire field on `RentedExecutorsResponse`: `default_job_opted_out_executor_ids: set[str] = set()` (defaults to empty — older backends stay compatible)
- Zero-incentive reason code: `default_job_opted_out` (append-only `ZeroIncentiveReason` contract)

## Changes

- `protocol/vc_protocol/compute_requests.py` — new wire field next to `new_rentals_paused_executor_ids` (`set[str]` for O(1) membership in the scoring hot path)
- `services/task/models.py` — `JobResult.default_job_opted_out: bool = False` + `is_excluded_from_unrented_pool` property (paused OR opted-out, and not rented)
- `services/task/result_handler.py` — flag computed from the backend list, mirroring `is_new_rentals_paused`
- `incentive/rental_price.py` — new both-pools exclusion in `_reason_excluded_from_both_pools` (`opted_out and not is_rented`); `get_snapshot()` aligned so opted-out unrented executors don't inflate the estimate denominator
- `incentive/default.py` — same zero-mining-score branch for the legacy algorithm, via a shared `_log_and_zero_unrented_exclusion` helper
- `incentive/miner_incentive_log.py` — `ZeroIncentiveReason.DEFAULT_JOB_OPTED_OUT` + `no_payout_because_default_job_opted_out` miner-facing log line
- `core/validator.py` — opted-out unrented executors excluded from the `total_gpu_model_count_map` mining denominator

## Tests (written first, TDD)

Extended the existing `new_rentals_paused` coverage with equivalent opt-out cases:
- protocol parse/defaults + `ResultHandler` flag propagation (`test_new_rentals_pause_filter.py`)
- reason-code contract + log-line builder (`test_miner_incentive_log.py`)
- both-pools exclusion, incl. rented-keeps-incentive (`test_unrented_soft_price_limit.py`)
- end-to-end flow: opted-out unrented earns 0, does not dilute buckets/denominators; opted-out rented earns normally (`test_rental_price_incentive_flow.py`)
- snapshot exclusion for opted-out unrented executors (`test_rental_price_estimate.py`)

Validator suite green.

## Companion PRs

Backend (lium-io-backend) and miner-portal PRs supply the opt-out toggle and send `default_job_opted_out_executor_ids` to the validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
