### PR TITLE
DAH-2360: retry connection-level errors in BackendClient + bounded keep-alive

### DIFF
--- a/neurons/validators/src/clients/backend_client.py
+++ b/neurons/validators/src/clients/backend_client.py
@@ -32,6 +32,20 @@ class BackendClient:
     _session: ClassVar[aiohttp.ClientSession | None] = None
     _session_lock: ClassVar[asyncio.Lock] = asyncio.Lock()
 
+    # DAH-2360: writing to a stale pooled keep-alive connection fails with
+    # EPIPE before the request reaches the backend, so these errors are safe
+    # to retry even for non-idempotent POSTs. Timeouts and 5xx are NOT retried:
+    # by then the request may have reached the backend and run server-side.
+    CONNECTION_ERRORS: ClassVar[tuple[type[Exception], ...]] = (
+        aiohttp.ServerDisconnectedError,
+        aiohttp.ClientConnectorError,
+        aiohttp.ClientOSError,
+    )
+    CONNECTION_RETRY_ATTEMPTS: ClassVar[int] = 2
+    CONNECTION_RETRY_BACKOFF_SECONDS: ClassVar[float] = 0.5
+    # Drop idle pooled connections well before the server/ingress closes them.
+    KEEPALIVE_TIMEOUT_SECONDS: ClassVar[int] = 30
+
     def __init__(self, base_url: str, keypair: bittensor.Keypair):
         self.base_url = base_url.rstrip("/")
         self.keypair = keypair
@@ -41,7 +55,11 @@ class BackendClient:
         if cls._session is None or cls._session.closed:
             async with cls._session_lock:
                 if cls._session is None or cls._session.closed:
-                    connector = aiohttp.TCPConnector(limit=100, limit_per_host=10)
+                    connector = aiohttp.TCPConnector(
+                        limit=100,
+                        limit_per_host=10,
+                        keepalive_timeout=cls.KEEPALIVE_TIMEOUT_SECONDS,
+                    )
                     cls._session = aiohttp.ClientSession(
                         timeout=aiohttp.ClientTimeout(total=None),
                         connector=connector,
@@ -80,41 +98,55 @@ class BackendClient:
                 headers.update(extra_headers)
 
             session = await self.get_session()
-            start_time = time.perf_counter()
-            async with session.get(
-                url, headers=headers, timeout=aiohttp.ClientTimeout(total=timeout)
-            ) as resp:
-                elapsed_ms = (time.perf_counter() - start_time) * 1000
-                logger.info(
-                    _m(
-                        "HTTP GET completed",
-                        extra=get_extra_info({**context, "status": resp.status, "elapsed_ms": round(elapsed_ms, 1)}),
-                    )
-                )
-                if resp.status != 200:
-                    logger.error(
+            for attempt in range(1 + self.CONNECTION_RETRY_ATTEMPTS):
+                try:
+                    start_time = time.perf_counter()
+                    async with session.get(
+                        url, headers=headers, timeout=aiohttp.ClientTimeout(total=timeout)
+                    ) as resp:
+                        elapsed_ms = (time.perf_counter() - start_time) * 1000
+                        logger.info(
+                            _m(
+                                "HTTP GET completed",
+                                extra=get_extra_info({**context, "status": resp.status, "elapsed_ms": round(elapsed_ms, 1)}),
+                            )
+                        )
+                        if resp.status != 200:
+                            logger.error(
+                                _m(
+                                    "HTTP GET failed",
+                                    extra=get_extra_info({**context, "status": resp.status}),
+                                )
+                            )
+                            return None
+
+                        try:
+                            data = await resp.json()
+                        except (aiohttp.ContentTypeError, json.JSONDecodeError) as e:
+                            logger.error(
+                                _m("Invalid JSON", extra=get_extra_info({**context, "error": str(e)}))
+                            )
+                            return None
+
+                        try:
+                            return response_model.model_validate(data)
+                        except ValidationError as e:
+                            logger.error(
+                                _m("Validation failed", extra=get_extra_info({**context, "error": str(e)}))
+                            )
+                            return None
+                except self.CONNECTION_ERRORS as e:
+                    if attempt >= self.CONNECTION_RETRY_ATTEMPTS:
+                        raise
+                    logger.warning(
                         _m(
-                            "HTTP GET failed",
-                            extra=get_extra_info({**context, "status": resp.status}),
+                            "GET connection error, retrying",
+                            extra=get_extra_info(
+                                {**context, "error": str(e), "attempt": attempt + 1}
+                            ),
                         )
                     )
-                    return None
-
-                try:
-                    data = await resp.json()
-                except (aiohttp.ContentTypeError, json.JSONDecodeError) as e:
-                    logger.error(
-                        _m("Invalid JSON", extra=get_extra_info({**context, "error": str(e)}))
-                    )
-                    return None
-
-                try:
-                    return response_model.model_validate(data)
-                except ValidationError as e:
-                    logger.error(
-                        _m("Validation failed", extra=get_extra_info({**context, "error": str(e)}))
-                    )
-                    return None
+                    await asyncio.sleep(self.CONNECTION_RETRY_BACKOFF_SECONDS)
 
         except TimeoutError:
             logger.error(_m("GET timeout", extra=get_extra_info(context)))
@@ -147,41 +179,55 @@ class BackendClient:
                 headers.update(extra_headers)
 
             session = await self.get_session()
-            start_time = time.perf_counter()
-            async with session.post(
-                url, headers=headers, json=json_data, timeout=aiohttp.ClientTimeout(total=timeout)
-            ) as resp:
-                elapsed_ms = (time.perf_counter() - start_time) * 1000
-                logger.info(
-                    _m(
-                        "HTTP POST completed",
-                        extra=get_extra_info({**context, "status": resp.status, "elapsed_ms": round(elapsed_ms, 1)}),
-                    )
-                )
-                if resp.status != 200:
-                    logger.error(
+            for attempt in range(1 + self.CONNECTION_RETRY_ATTEMPTS):
+                try:
+                    start_time = time.perf_counter()
+                    async with session.post(
+                        url, headers=headers, json=json_data, timeout=aiohttp.ClientTimeout(total=timeout)
+                    ) as resp:
+                        elapsed_ms = (time.perf_counter() - start_time) * 1000
+                        logger.info(
+                            _m(
+                                "HTTP POST completed",
+                                extra=get_extra_info({**context, "status": resp.status, "elapsed_ms": round(elapsed_ms, 1)}),
+                            )
+                        )
+                        if resp.status != 200:
+                            logger.error(
+                                _m(
+                                    "HTTP POST failed",
+                                    extra=get_extra_info({**context, "status": resp.status}),
+                                )
+                            )
+                            return None
+
+                        try:
+                            data = await resp.json()
+                        except (aiohttp.ContentTypeError, json.JSONDecodeError) as e:
+                            logger.error(
+                                _m("Invalid JSON", extra=get_extra_info({**context, "error": str(e)}))
+                            )
+                            return None
+
+                        try:
+                            return response_model.model_validate(data)
+                        except ValidationError as e:
+                            logger.error(
+                                _m("Validation failed", extra=get_extra_info({**context, "error": str(e)}))
+                            )
+                            return None
+                except self.CONNECTION_ERRORS as e:
+                    if attempt >= self.CONNECTION_RETRY_ATTEMPTS:
+                        raise
+                    logger.warning(
                         _m(
-                            "HTTP POST failed",
-                            extra=get_extra_info({**context, "status": resp.status}),
+                            "POST connection error, retrying",
+                            extra=get_extra_info(
+                                {**context, "error": str(e), "attempt": attempt + 1}
+                            ),
                         )
                     )
-                    return None
-
-                try:
-                    data = await resp.json()
-                except (aiohttp.ContentTypeError, json.JSONDecodeError) as e:
-                    logger.error(
-                        _m("Invalid JSON", extra=get_extra_info({**context, "error": str(e)}))
-                    )
-                    return None
-
-                try:
-                    return response_model.model_validate(data)
-                except ValidationError as e:
-                    logger.error(
-                        _m("Validation failed", extra=get_extra_info({**context, "error": str(e)}))
-                    )
-                    return None
+                    await asyncio.sleep(self.CONNECTION_RETRY_BACKOFF_SECONDS)
 
         except TimeoutError:
             logger.error(_m("POST timeout", extra=get_extra_info(context)))

--- a/neurons/validators/src/clients/backend_client.py
+++ b/neurons/validators/src/clients/backend_client.py
@@ -91,76 +91,14 @@ class BackendClient:
         timeout: int = 30,
         extra_headers: dict[str, str] | None = None,
     ) -> T | None:
-        url = f"{self.base_url}/{path.lstrip('/')}"
-        context = {"url": url, "method": "GET"}
-
-        try:
-            headers = self._get_signature_headers() if add_signature else {}
-            if extra_headers:
-                headers.update(extra_headers)
-
-            session = await self.get_session()
-            for attempt in range(1 + self.CONNECTION_RETRY_ATTEMPTS):
-                try:
-                    start_time = time.perf_counter()
-                    async with session.get(
-                        url, headers=headers, timeout=aiohttp.ClientTimeout(total=timeout)
-                    ) as resp:
-                        elapsed_ms = (time.perf_counter() - start_time) * 1000
-                        logger.info(
-                            _m(
-                                "HTTP GET completed",
-                                extra=get_extra_info({**context, "status": resp.status, "elapsed_ms": round(elapsed_ms, 1)}),
-                            )
-                        )
-                        if resp.status != 200:
-                            logger.error(
-                                _m(
-                                    "HTTP GET failed",
-                                    extra=get_extra_info({**context, "status": resp.status}),
-                                )
-                            )
-                            return None
-
-                        try:
-                            data = await resp.json()
-                        except (aiohttp.ContentTypeError, json.JSONDecodeError) as e:
-                            logger.error(
-                                _m("Invalid JSON", extra=get_extra_info({**context, "error": str(e)}))
-                            )
-                            return None
-
-                        try:
-                            return response_model.model_validate(data)
-                        except ValidationError as e:
-                            logger.error(
-                                _m("Validation failed", extra=get_extra_info({**context, "error": str(e)}))
-                            )
-                            return None
-                except self.CONNECTION_ERRORS as e:
-                    if attempt >= self.CONNECTION_RETRY_ATTEMPTS:
-                        raise
-                    logger.warning(
-                        _m(
-                            "GET connection error, retrying",
-                            extra=get_extra_info(
-                                {**context, "error": str(e), "attempt": attempt + 1}
-                            ),
-                        )
-                    )
-                    await asyncio.sleep(self.CONNECTION_RETRY_BACKOFF_SECONDS[attempt])
-
-        except TimeoutError:
-            logger.error(_m("GET timeout", extra=get_extra_info(context)))
-            return None
-        except aiohttp.ClientError as e:
-            logger.error(_m("GET client error", extra=get_extra_info({**context, "error": str(e)})))
-            return None
-        except Exception as e:
-            logger.error(
-                _m("GET error", extra=get_extra_info({**context, "error": str(e)})), exc_info=True
-            )
-            return None
+        return await self._request(
+            "GET",
+            path,
+            response_model,
+            add_signature=add_signature,
+            timeout=timeout,
+            extra_headers=extra_headers,
+        )
 
     async def post(
         self,
@@ -172,8 +110,30 @@ class BackendClient:
         timeout: int = 30,
         extra_headers: dict[str, str] | None = None,
     ) -> T | None:
+        return await self._request(
+            "POST",
+            path,
+            response_model,
+            json_data=json_data,
+            add_signature=add_signature,
+            timeout=timeout,
+            extra_headers=extra_headers,
+        )
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        response_model: type[T],
+        *,
+        json_data: dict[str, Any] | None = None,
+        add_signature: bool = True,
+        timeout: int = 30,
+        extra_headers: dict[str, str] | None = None,
+    ) -> T | None:
+        # single signed round-trip, retrying connection-level errors per backoff schedule
         url = f"{self.base_url}/{path.lstrip('/')}"
-        context = {"url": url, "method": "POST"}
+        context = {"url": url, "method": method}
 
         try:
             headers = self._get_signature_headers() if add_signature else {}
@@ -184,20 +144,24 @@ class BackendClient:
             for attempt in range(1 + self.CONNECTION_RETRY_ATTEMPTS):
                 try:
                     start_time = time.perf_counter()
-                    async with session.post(
-                        url, headers=headers, json=json_data, timeout=aiohttp.ClientTimeout(total=timeout)
+                    async with session.request(
+                        method,
+                        url,
+                        headers=headers,
+                        json=json_data,
+                        timeout=aiohttp.ClientTimeout(total=timeout),
                     ) as resp:
                         elapsed_ms = (time.perf_counter() - start_time) * 1000
                         logger.info(
                             _m(
-                                "HTTP POST completed",
+                                f"HTTP {method} completed",
                                 extra=get_extra_info({**context, "status": resp.status, "elapsed_ms": round(elapsed_ms, 1)}),
                             )
                         )
                         if resp.status != 200:
                             logger.error(
                                 _m(
-                                    "HTTP POST failed",
+                                    f"HTTP {method} failed",
                                     extra=get_extra_info({**context, "status": resp.status}),
                                 )
                             )
@@ -223,7 +187,7 @@ class BackendClient:
                         raise
                     logger.warning(
                         _m(
-                            "POST connection error, retrying",
+                            f"{method} connection error, retrying",
                             extra=get_extra_info(
                                 {**context, "error": str(e), "attempt": attempt + 1}
                             ),
@@ -232,16 +196,16 @@ class BackendClient:
                     await asyncio.sleep(self.CONNECTION_RETRY_BACKOFF_SECONDS[attempt])
 
         except TimeoutError:
-            logger.error(_m("POST timeout", extra=get_extra_info(context)))
+            logger.error(_m(f"{method} timeout", extra=get_extra_info(context)))
             return None
         except aiohttp.ClientError as e:
             logger.error(
-                _m("POST client error", extra=get_extra_info({**context, "error": str(e)}))
+                _m(f"{method} client error", extra=get_extra_info({**context, "error": str(e)}))
             )
             return None
         except Exception as e:
             logger.error(
-                _m("POST error", extra=get_extra_info({**context, "error": str(e)})), exc_info=True
+                _m(f"{method} error", extra=get_extra_info({**context, "error": str(e)})), exc_info=True
             )
             return None
 

--- a/neurons/validators/src/clients/backend_client.py
+++ b/neurons/validators/src/clients/backend_client.py
@@ -41,8 +41,10 @@ class BackendClient:
         aiohttp.ClientConnectorError,
         aiohttp.ClientOSError,
     )
-    CONNECTION_RETRY_ATTEMPTS: ClassVar[int] = 2
-    CONNECTION_RETRY_BACKOFF_SECONDS: ClassVar[float] = 0.5
+    # Short first pause (a stale connection heals instantly), longer second one
+    # so a restarting backend pod has time to become ready.
+    CONNECTION_RETRY_BACKOFF_SECONDS: ClassVar[tuple[float, ...]] = (1.0, 5.0)
+    CONNECTION_RETRY_ATTEMPTS: ClassVar[int] = len(CONNECTION_RETRY_BACKOFF_SECONDS)
     # Drop idle pooled connections well before the server/ingress closes them.
     KEEPALIVE_TIMEOUT_SECONDS: ClassVar[int] = 30
 
@@ -146,7 +148,7 @@ class BackendClient:
                             ),
                         )
                     )
-                    await asyncio.sleep(self.CONNECTION_RETRY_BACKOFF_SECONDS)
+                    await asyncio.sleep(self.CONNECTION_RETRY_BACKOFF_SECONDS[attempt])
 
         except TimeoutError:
             logger.error(_m("GET timeout", extra=get_extra_info(context)))
@@ -227,7 +229,7 @@ class BackendClient:
                             ),
                         )
                     )
-                    await asyncio.sleep(self.CONNECTION_RETRY_BACKOFF_SECONDS)
+                    await asyncio.sleep(self.CONNECTION_RETRY_BACKOFF_SECONDS[attempt])
 
         except TimeoutError:
             logger.error(_m("POST timeout", extra=get_extra_info(context)))

--- a/neurons/validators/tests/test_backend_client.py
+++ b/neurons/validators/tests/test_backend_client.py
@@ -45,7 +45,7 @@ def create_mock_response(status: int, json_data: dict | None = None):
     return mock_resp
 
 
-def create_mock_session(mock_response, method: str = "get"):
+def create_mock_session(mock_response):
     mock_session = AsyncMock()
     mock_session.closed = False
     mock_session.close = AsyncMock()
@@ -54,10 +54,7 @@ def create_mock_session(mock_response, method: str = "get"):
     async_cm.__aenter__ = AsyncMock(return_value=mock_response)
     async_cm.__aexit__ = AsyncMock(return_value=None)
 
-    if method == "get":
-        mock_session.get = MagicMock(return_value=async_cm)
-    else:
-        mock_session.post = MagicMock(return_value=async_cm)
+    mock_session.request = MagicMock(return_value=async_cm)
 
     return mock_session
 
@@ -66,7 +63,7 @@ def create_mock_session(mock_response, method: str = "get"):
 async def test_get_success(reset_session, client):
     response_data = {"data": "test", "count": 42}
     mock_response = create_mock_response(200, response_data)
-    mock_session = create_mock_session(mock_response, "get")
+    mock_session = create_mock_session(mock_response)
 
     with patch.object(BackendClient, "get_session", return_value=mock_session):
         result = await client.get("/data", SampleResponse)
@@ -94,7 +91,7 @@ async def test_get_pod_rental_active_uses_internal_endpoint(client):
 @pytest.mark.asyncio
 async def test_get_non_200_status(reset_session, client):
     mock_response = create_mock_response(500)
-    mock_session = create_mock_session(mock_response, "get")
+    mock_session = create_mock_session(mock_response)
 
     with patch.object(BackendClient, "get_session", return_value=mock_session):
         result = await client.get("/data", SampleResponse)
@@ -105,7 +102,7 @@ async def test_get_non_200_status(reset_session, client):
 async def test_get_validation_error(reset_session, client):
     invalid_data = {"wrong_field": "value"}
     mock_response = create_mock_response(200, invalid_data)
-    mock_session = create_mock_session(mock_response, "get")
+    mock_session = create_mock_session(mock_response)
 
     with patch.object(BackendClient, "get_session", return_value=mock_session):
         result = await client.get("/data", SampleResponse)
@@ -118,7 +115,7 @@ async def test_get_timeout(reset_session, client):
     async_cm = AsyncMock()
     async_cm.__aenter__ = AsyncMock(side_effect=TimeoutError())
     async_cm.__aexit__ = AsyncMock()
-    mock_session.get = MagicMock(return_value=async_cm)
+    mock_session.request = MagicMock(return_value=async_cm)
 
     with patch.object(BackendClient, "get_session", return_value=mock_session):
         result = await client.get("/data", SampleResponse, timeout=1)
@@ -129,12 +126,12 @@ async def test_get_timeout(reset_session, client):
 async def test_get_with_signature(reset_session, client):
     response_data = {"data": "test", "count": 42}
     mock_response = create_mock_response(200, response_data)
-    mock_session = create_mock_session(mock_response, "get")
+    mock_session = create_mock_session(mock_response)
 
     with patch.object(BackendClient, "get_session", return_value=mock_session):
         await client.get("/data", SampleResponse, add_signature=True)
 
-        call_args = mock_session.get.call_args
+        call_args = mock_session.request.call_args
         headers = call_args.kwargs.get("headers", {})
         assert "hotkey" in headers
         assert "timestamp" in headers
@@ -146,7 +143,7 @@ async def test_post_success(reset_session, client):
     request_data = {"action": "create"}
     response_data = {"data": "created", "count": 1}
     mock_response = create_mock_response(200, response_data)
-    mock_session = create_mock_session(mock_response, "post")
+    mock_session = create_mock_session(mock_response)
 
     with patch.object(BackendClient, "get_session", return_value=mock_session):
         result = await client.post("/submit", SampleResponse, json_data=request_data)
@@ -159,13 +156,13 @@ async def test_post_success(reset_session, client):
 async def test_url_construction(reset_session, client):
     response_data = {"data": "test", "count": 42}
     mock_response = create_mock_response(200, response_data)
-    mock_session = create_mock_session(mock_response, "get")
+    mock_session = create_mock_session(mock_response)
 
     with patch.object(BackendClient, "get_session", return_value=mock_session):
         await client.get("/some/path", SampleResponse)
 
-        call_args = mock_session.get.call_args
-        assert call_args[0][0] == "https://api.example.com/some/path"
+        call_args = mock_session.request.call_args
+        assert call_args[0] == ("GET", "https://api.example.com/some/path")
 
 
 @pytest.mark.asyncio
@@ -301,7 +298,7 @@ async def test_get_all_rented_executors_parses_filler_mapping(reset_session, cli
         },
     }
     mock_response = create_mock_response(200, response_data)
-    mock_session = create_mock_session(mock_response, "get")
+    mock_session = create_mock_session(mock_response)
 
     with patch.object(BackendClient, "get_session", return_value=mock_session):
         result = await client.get_all_rented_executors()
@@ -313,7 +310,7 @@ async def test_get_all_rented_executors_parses_filler_mapping(reset_session, cli
     }
 
 
-def create_mock_session_with_attempts(side_effects, method: str = "post"):
+def create_mock_session_with_attempts(side_effects):
     """Session whose request yields one side effect per attempt (exception or response)."""
     mock_session = AsyncMock()
     mock_session.closed = False
@@ -328,10 +325,7 @@ def create_mock_session_with_attempts(side_effects, method: str = "post"):
         async_cm.__aexit__ = AsyncMock(return_value=None)
         cms.append(async_cm)
 
-    if method == "get":
-        mock_session.get = MagicMock(side_effect=cms)
-    else:
-        mock_session.post = MagicMock(side_effect=cms)
+    mock_session.request = MagicMock(side_effect=cms)
 
     return mock_session
 
@@ -351,7 +345,7 @@ async def test_post_retries_connection_error_then_succeeds(reset_session, client
     """DAH-2360: broken pipe on a stale pooled connection is retried, not surfaced."""
     ok_response = create_mock_response(200, {"data": "ok", "count": 1})
     mock_session = create_mock_session_with_attempts(
-        [aiohttp.ClientOSError(32, "Broken pipe"), ok_response], "post"
+        [aiohttp.ClientOSError(32, "Broken pipe"), ok_response]
     )
 
     with (
@@ -362,14 +356,14 @@ async def test_post_retries_connection_error_then_succeeds(reset_session, client
 
     assert result is not None
     assert result.data == "ok"
-    assert mock_session.post.call_count == 2
+    assert mock_session.request.call_count == 2
 
 
 @pytest.mark.asyncio
 async def test_get_retries_server_disconnected_then_succeeds(reset_session, client):
     ok_response = create_mock_response(200, {"data": "ok", "count": 1})
     mock_session = create_mock_session_with_attempts(
-        [aiohttp.ServerDisconnectedError(), ok_response], "get"
+        [aiohttp.ServerDisconnectedError(), ok_response]
     )
 
     with (
@@ -380,14 +374,14 @@ async def test_get_retries_server_disconnected_then_succeeds(reset_session, clie
 
     assert result is not None
     assert result.data == "ok"
-    assert mock_session.get.call_count == 2
+    assert mock_session.request.call_count == 2
 
 
 @pytest.mark.asyncio
 async def test_post_returns_none_when_connection_retries_exhausted(reset_session, client):
     attempts = 1 + BackendClient.CONNECTION_RETRY_ATTEMPTS
     mock_session = create_mock_session_with_attempts(
-        [aiohttp.ClientOSError(32, "Broken pipe") for _ in range(attempts)], "post"
+        [aiohttp.ClientOSError(32, "Broken pipe") for _ in range(attempts)]
     )
     sleep_mock = AsyncMock()
 
@@ -398,7 +392,7 @@ async def test_post_returns_none_when_connection_retries_exhausted(reset_session
         result = await client.post("/submit", SampleResponse)
 
     assert result is None
-    assert mock_session.post.call_count == attempts
+    assert mock_session.request.call_count == attempts
     assert [c.args[0] for c in sleep_mock.await_args_list] == list(
         BackendClient.CONNECTION_RETRY_BACKOFF_SECONDS
     )
@@ -407,21 +401,21 @@ async def test_post_returns_none_when_connection_retries_exhausted(reset_session
 @pytest.mark.asyncio
 async def test_post_timeout_is_not_retried(reset_session, client):
     """Timeouts may have reached the backend — retrying could double-run long operations."""
-    mock_session = create_mock_session_with_attempts([TimeoutError()], "post")
+    mock_session = create_mock_session_with_attempts([TimeoutError()])
 
     with patch.object(BackendClient, "get_session", return_value=mock_session):
         result = await client.post("/submit", SampleResponse, timeout=1)
 
     assert result is None
-    assert mock_session.post.call_count == 1
+    assert mock_session.request.call_count == 1
 
 
 @pytest.mark.asyncio
 async def test_post_generic_client_error_is_not_retried(reset_session, client):
-    mock_session = create_mock_session_with_attempts([aiohttp.ClientError("boom")], "post")
+    mock_session = create_mock_session_with_attempts([aiohttp.ClientError("boom")])
 
     with patch.object(BackendClient, "get_session", return_value=mock_session):
         result = await client.post("/submit", SampleResponse)
 
     assert result is None
-    assert mock_session.post.call_count == 1
+    assert mock_session.request.call_count == 1

--- a/neurons/validators/tests/test_backend_client.py
+++ b/neurons/validators/tests/test_backend_client.py
@@ -389,15 +389,19 @@ async def test_post_returns_none_when_connection_retries_exhausted(reset_session
     mock_session = create_mock_session_with_attempts(
         [aiohttp.ClientOSError(32, "Broken pipe") for _ in range(attempts)], "post"
     )
+    sleep_mock = AsyncMock()
 
     with (
         patch.object(BackendClient, "get_session", return_value=mock_session),
-        patch("asyncio.sleep", new=AsyncMock()),
+        patch("asyncio.sleep", new=sleep_mock),
     ):
         result = await client.post("/submit", SampleResponse)
 
     assert result is None
     assert mock_session.post.call_count == attempts
+    assert [c.args[0] for c in sleep_mock.await_args_list] == list(
+        BackendClient.CONNECTION_RETRY_BACKOFF_SECONDS
+    )
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_backend_client.py
+++ b/neurons/validators/tests/test_backend_client.py
@@ -3,6 +3,7 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 from neurons.validators.src.clients.backend_client import BackendClient
 from pydantic import BaseModel
@@ -310,3 +311,113 @@ async def test_get_all_rented_executors_parses_filler_mapping(reset_session, cli
     assert result.filler_containers_by_executor == {
         "executor-123": "filler_5703f4c9-c2f4-4fae-a652-3dee4753030a"
     }
+
+
+def create_mock_session_with_attempts(side_effects, method: str = "post"):
+    """Session whose request yields one side effect per attempt (exception or response)."""
+    mock_session = AsyncMock()
+    mock_session.closed = False
+
+    cms = []
+    for effect in side_effects:
+        async_cm = AsyncMock()
+        if isinstance(effect, BaseException):
+            async_cm.__aenter__ = AsyncMock(side_effect=effect)
+        else:
+            async_cm.__aenter__ = AsyncMock(return_value=effect)
+        async_cm.__aexit__ = AsyncMock(return_value=None)
+        cms.append(async_cm)
+
+    if method == "get":
+        mock_session.get = MagicMock(side_effect=cms)
+    else:
+        mock_session.post = MagicMock(side_effect=cms)
+
+    return mock_session
+
+
+@pytest.mark.asyncio
+async def test_get_session_bounds_keepalive_timeout(reset_session):
+    """DAH-2360: pooled connections must not idle past the keepalive window."""
+    session = await BackendClient.get_session()
+    try:
+        assert session.connector._keepalive_timeout == BackendClient.KEEPALIVE_TIMEOUT_SECONDS
+    finally:
+        await BackendClient.close_session()
+
+
+@pytest.mark.asyncio
+async def test_post_retries_connection_error_then_succeeds(reset_session, client):
+    """DAH-2360: broken pipe on a stale pooled connection is retried, not surfaced."""
+    ok_response = create_mock_response(200, {"data": "ok", "count": 1})
+    mock_session = create_mock_session_with_attempts(
+        [aiohttp.ClientOSError(32, "Broken pipe"), ok_response], "post"
+    )
+
+    with (
+        patch.object(BackendClient, "get_session", return_value=mock_session),
+        patch("asyncio.sleep", new=AsyncMock()),
+    ):
+        result = await client.post("/submit", SampleResponse)
+
+    assert result is not None
+    assert result.data == "ok"
+    assert mock_session.post.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_retries_server_disconnected_then_succeeds(reset_session, client):
+    ok_response = create_mock_response(200, {"data": "ok", "count": 1})
+    mock_session = create_mock_session_with_attempts(
+        [aiohttp.ServerDisconnectedError(), ok_response], "get"
+    )
+
+    with (
+        patch.object(BackendClient, "get_session", return_value=mock_session),
+        patch("asyncio.sleep", new=AsyncMock()),
+    ):
+        result = await client.get("/data", SampleResponse)
+
+    assert result is not None
+    assert result.data == "ok"
+    assert mock_session.get.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_post_returns_none_when_connection_retries_exhausted(reset_session, client):
+    attempts = 1 + BackendClient.CONNECTION_RETRY_ATTEMPTS
+    mock_session = create_mock_session_with_attempts(
+        [aiohttp.ClientOSError(32, "Broken pipe") for _ in range(attempts)], "post"
+    )
+
+    with (
+        patch.object(BackendClient, "get_session", return_value=mock_session),
+        patch("asyncio.sleep", new=AsyncMock()),
+    ):
+        result = await client.post("/submit", SampleResponse)
+
+    assert result is None
+    assert mock_session.post.call_count == attempts
+
+
+@pytest.mark.asyncio
+async def test_post_timeout_is_not_retried(reset_session, client):
+    """Timeouts may have reached the backend — retrying could double-run long operations."""
+    mock_session = create_mock_session_with_attempts([TimeoutError()], "post")
+
+    with patch.object(BackendClient, "get_session", return_value=mock_session):
+        result = await client.post("/submit", SampleResponse, timeout=1)
+
+    assert result is None
+    assert mock_session.post.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_post_generic_client_error_is_not_retried(reset_session, client):
+    mock_session = create_mock_session_with_attempts([aiohttp.ClientError("boom")], "post")
+
+    with patch.object(BackendClient, "get_session", return_value=mock_session):
+        result = await client.post("/submit", SampleResponse)
+
+    assert result is None
+    assert mock_session.post.call_count == 1


### PR DESCRIPTION
## Problem

Validator's `RentalVerificationCheck` intermittently fails with `RENTAL_CHECK_API_ERROR` ("API returned None") even though the backend is healthy: ~129 events per 6h across 27+ distinct executors on prod (2026-07-07), clustered at validation-wave boundaries.

Root cause: `BackendClient` holds a long-lived aiohttp session with a default keep-alive pool. When the backend/ingress closes a pooled connection, the validator's next write on it fails with `[Errno 32] Broken pipe` → `post()` returns `None` → the check fails the executor. Backend logs confirm the request never reached the app.

Notion: DAH-2360

## Fix

- Retry loop (2 retries, exponential backoff 1s → 5s) in `BackendClient.get()`/`post()` for connection-level errors only: `ServerDisconnectedError`, `ClientConnectorError`, `ClientOSError`. The short first pause heals stale-connection EPIPE instantly; the longer second one rides out a restarting backend pod. Timeouts and 5xx are deliberately NOT retried — by then the request may have reached the backend and run a long server-side operation twice.
- `TCPConnector(keepalive_timeout=30)` so stale pooled connections are dropped before the server closes them.
- Each retry logs a distinct `GET/POST connection error, retrying` warning for post-deploy measurement.

## Tests

- retry on `ClientOSError` (broken pipe) and `ServerDisconnectedError` succeeds on 2nd attempt
- returns `None` after retry budget exhausted (call count + backoff sequence asserted)
- timeout and generic `ClientError` are NOT retried (single call asserted)
- session keepalive bound asserted

`pdm run pytest tests/` in `neurons/validators`: 926 passed, 8 skipped (9 pre-existing greenlet env errors in `test_port_mapping_dao.py`, present on clean main).
