### PR TITLE
DAH-2362 - Route 2 more burn slots to payout UID 47

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -155,8 +155,8 @@ class Settings(BaseSettings):
     VERSION: str = (pathlib.Path(__file__).parent / ".." / ".." / "version.txt").read_text().strip()
 
     BURNERS: list[int] = [4, 206, 207, 208]
-    # Duplicate entries are slot weights: UID 47 holds the aggregated share of 5 retired burners.
-    NEW_BURNERS: list[int] = [187, 188, 189, 190, 191, 47, 47, 47, 47, 47]
+    # Duplicate entries are slot weights: UID 47 holds the aggregated share of 7 retired burners.
+    NEW_BURNERS: list[int] = [187, 188, 189, 47, 47, 47, 47, 47, 47, 47]
     ENABLE_NEW_BURN_LOGIC: bool = True
 
     ENABLE_NO_COLLATERAL: bool = True

--- a/neurons/validators/tests/test_burn_service.py
+++ b/neurons/validators/tests/test_burn_service.py
@@ -111,7 +111,8 @@ async def test_new_logic_distributes_partial_burn_share(
     [
         (1, 10, 0.10),  # single-slot burner gets 1/10
         (3, 10, 0.30),  # DAH-2089: UID 47 owns 3/10 slots → 30%
-        (5, 10, 0.50),  # majority burner
+        (5, 10, 0.50),  # DAH-2125: UID 47 owns 5/10 slots → 50%
+        (7, 10, 0.70),  # DAH-2362: UID 47 owns 7/10 slots → 70%
         (4, 4, 1.00),   # entire pool collapsed to one UID
     ],
 )
@@ -171,6 +172,34 @@ async def test_new_logic_dah_2089_uid_47_absorbs_retired_burner_shares(
     per_slot = TOTAL_BURN_EMISSION / 10
     assert scores["hk_47"] == pytest.approx(per_slot * 3)
     for uid in (187, 188, 189, 190, 191, 192, 193):
+        assert scores[f"hk_{uid}"] == pytest.approx(per_slot)
+    assert sum(scores.values()) == pytest.approx(TOTAL_BURN_EMISSION)
+
+
+@pytest.mark.asyncio
+async def test_new_logic_dah_2362_production_layout_gives_uid_47_seventy_percent(
+    burn_service, monkeypatch, mock_settings, create_neuron_info
+):
+    """DAH-2362 invariant: UID 47 holds 7 slots and receives exactly 70% of burn_share,
+    while the 3 remaining burners keep 10% each."""
+    # Arrange — production NEW_BURNERS layout introduced by DAH-2362
+    monkeypatch.setattr(
+        "core.config.settings.NEW_BURNERS",
+        [187, 188, 189, 47, 47, 47, 47, 47, 47, 47],
+    )
+    miners = _make_miners(create_neuron_info, [187, 188, 189, 47])
+
+    # Act
+    scores = burn_service.calculate_burn_scores(
+        miners=miners,
+        burn_share=TOTAL_BURN_EMISSION,
+        last_mechanism_step_block=None,
+    )
+
+    # Assert — UID 47 (7 slots) gets 70%, other 3 burners get 10% each, total = burn_share
+    per_slot = TOTAL_BURN_EMISSION / 10
+    assert scores["hk_47"] == pytest.approx(per_slot * 7)
+    for uid in (187, 188, 189):
         assert scores[f"hk_{uid}"] == pytest.approx(per_slot)
     assert sum(scores.values()) == pytest.approx(TOTAL_BURN_EMISSION)
 


### PR DESCRIPTION
## Describe your changes

The rental-fee-payout coldkey (funded by burn emission routed to UID 47) has been losing balance: miner payouts nearly doubled over the last two weeks (~36 → ~70 TAO/day, 7-day avg 60.3 TAO/day as of 2026-07-07) while UID 47's inflow stayed at 50% of burn emission.

This retires burner UIDs `190` and `191` and reassigns their `NEW_BURNERS` slot weights to the aggregated payout UID `47`:

- Before: `[187, 188, 189, 190, 191, 47, 47, 47, 47, 47]` — UID 47 holds 5/10 slots (50%)
- After: `[187, 188, 189, 47, 47, 47, 47, 47, 47, 47]` — UID 47 holds 7/10 slots (70%)

Same move as DAH-2089 (#1033, → 30%) and DAH-2125 (#1040, → 50%). `BurnService._calculate_new_burn_logic` is slot-weighted, so no code change is needed; UIDs 190/191 simply stop receiving burn scores.

Tests: added a DAH-2362 production-layout invariant test (UID 47 gets 70%, remaining burners 10% each, full burn_share distributed) and a `(7, 10, 0.70)` parametrize case to the slot-aggregation test.

**Pre-deploy verification**
- [x] Full validator suite passes: 964 passed, 8 skipped
- [x] New invariant test asserts the exact production layout and 70/10/10/10 split

**Post-deploy verification**
- [ ] Validator log "New burn logic applied - slot-weighted distribution" shows `slot_weights: {47: 7, 187: 1, 188: 1, 189: 1}`
- [ ] `latestsetweights` (validator `5F7X5UpKSr26KU3jKfpLmT8kuKtBNyHhEnfS8xtxPCqCb13p`, netuid 51): UID 47 weight share rises from **0.3243** (baseline, 2026-07-07 16:25 UTC) to **≈0.454** (70% of the ~0.649 burn share) within one set-weights cycle
- [ ] +3 days: payout coldkey balance stops declining with miner payouts at current ~60-70 TAO/day levels

## Issue ticket number and link

[DAH-2362](https://app.notion.com/p/Route-2-more-burn-UIDs-emission-to-rental-fee-payout-UID-47-70-of-burn-396b8bfdbde9818eb3dcf30febfe930c)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?

Made with [Cursor](https://cursor.com)