### PR TITLE
PoC: GPU power limit throttle on rental start, restore on delete

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -138,6 +138,12 @@ _CREATE_CONTAINER_SSH_KEEPALIVE_INTERVAL_SEC = 30
 _CREATE_CONTAINER_SSH_KEEPALIVE_COUNT_MAX = 4
 _DOCKER_PULL_TIMEOUT_SECONDS = DEFAULT_DOCKER_PULL_TIMEOUT_SECONDS
 _INSPECTOR_LIFECYCLE_TIMEOUT_SECONDS = 30
+# PoC: fixed GPU power limit management, applied ONLY on the whitelisted stage
+# machine (RTX A4000, min 100W / max 140W). Lower on rental start, restore max
+# on container delete. Staging-only experiment — do not merge to prod as-is.
+_POC_POWER_LIMIT_EXECUTOR_IPS = {"149.36.1.151"}
+_POC_POWER_LIMIT_RENTED_W = 100
+_POC_POWER_LIMIT_DEFAULT_W = 140
 
 
 def _missing_rental_docker_host_key_log_text(
@@ -2695,6 +2701,40 @@ class DockerService:
                 )
             )
 
+    async def _apply_poc_power_limit(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        executor_info: ExecutorSSHInfo,
+        watts: int,
+        default_extra: dict[str, Any],
+    ) -> None:
+        # set a fixed GPU power limit on the whitelisted PoC executor; never raises
+        if executor_info.address not in _POC_POWER_LIMIT_EXECUTOR_IPS:
+            return
+        try:
+            result = await ssh_client.run(f"nvidia-smi -pl {watts}", check=True, timeout=30)
+            logger.info(
+                _m(
+                    "PoC power limit applied",
+                    extra=get_extra_info(
+                        {
+                            **default_extra,
+                            "poc_power_limit_watts": watts,
+                            "stdout": str(result.stdout).strip(),
+                        }
+                    ),
+                ),
+            )
+        except Exception as exc:
+            logger.warning(
+                _m(
+                    "PoC power limit failed (non-fatal)",
+                    extra=get_extra_info(
+                        {**default_extra, "poc_power_limit_watts": watts, "error": str(exc)}
+                    ),
+                ),
+            )
+
     async def create_container(
         self,
         payload: ContainerCreateRequest,
@@ -3387,6 +3427,12 @@ class DockerService:
                     await self.finish_stream_logs()
 
                     current_step = "finalize"
+                    await self._apply_poc_power_limit(
+                        ssh_client=ssh_client,
+                        executor_info=executor_info,
+                        watts=_POC_POWER_LIMIT_RENTED_W,
+                        default_extra=default_extra,
+                    )
                     await self.redis_service.add_rented_pod(executor_info, payload.pod_id, container_name)
                     if (
                         settings.ENABLE_INSPECTOR
@@ -3887,6 +3933,13 @@ class DockerService:
                 # in any post-container teardown step below must not fail the undeploy, or the
                 # backend retries a doomed request and penalizes the miner for a pod that is
                 # already removed. Each step is guarded individually and only logged on error.
+
+                await self._apply_poc_power_limit(
+                    ssh_client=ssh_client,
+                    executor_info=executor_info,
+                    watts=_POC_POWER_LIMIT_DEFAULT_W,
+                    default_extra=default_extra,
+                )
 
                 # DAH-2211: always-on inline cleanup of custom-build artifacts
                 # for this pod. No-op if the pod was not a custom build.


### PR DESCRIPTION
## ⚠️ PoC — not for merge

Proof of concept answering one question: **can the validator lower the GPU power limit when a rental starts and restore it when the rental ends, using only the access it already has?**

**Answer: yes.** Proven live on staging on 2026-07-07 (full experiment log below).

## What this PR does

- `create_container` (step `finalize`): runs `nvidia-smi -pl 100` on the executor.
- `delete_container` (right after container removal): runs `nvidia-smi -pl 140`.
- Both go through `_apply_poc_power_limit`, which:
  - applies **only** to the whitelisted stage machine `149.36.1.151` (1× RTX A4000, power range 100–140 W) — a blanket watt constant would hard-throttle other GPUs (L40 default is 300 W);
  - never raises — failures are logged as `PoC power limit failed (non-fatal)` and do not break the rental flow.

No new infrastructure: the command runs over the same asyncssh session the validator already opens into the executor container. That container is `privileged` with `pid: host` and `NVIDIA_DRIVER_CAPABILITIES=all` (see `neurons/executor/docker-compose.app.yml`), so `nvidia-smi -pl` there has full NVML admin rights and the change applies driver-wide (the host and every container see it).

## Why the renter can't undo it

Renter pods get `--gpus` passthrough but are **not** privileged. Verified on the stage machine:

```
$ docker run --rm --gpus all <image> nvidia-smi -i 0 -pl 120
Failed to set power management limit: Insufficient Permissions
```

The machine owner (miner) has host root, so this is a policy mechanism, not a security boundary against the miner.

## Live experiment (staging, 2026-07-07, all times UTC)

Deployed to the staging validator via [lium-io-deployment run 28881425349](https://github.com/Datura-ai/lium-io-deployment/actions/runs/28881425349); verified the running pod image was `lium-staging-validator:8c379a4` (this commit). Rental target: executor `b31775b1-e2f3-4b9c-bbb2-1c2b07cd7bc3` (`swift-fox-72`, machine `149.36.1.151`).

| Time | Event | Evidence |
|---|---|---|
| 16:20:01 | Baseline 140 W, no rental containers | ssh probe on host |
| 16:25:02 | `lium up --gpu A4000 --name poc-pl-test` → pod `7b490a63-b8c1-45e4-9ad5-ac117ba61fd3` RUNNING | staging DB |
| 16:25:21 | Host monitor flips **140 → 100 W** | 10 s ssh poll loop |
| 16:25:22 | `PoC power limit applied, watts: 100` — "set to 100.00 W from 140.00 W" | `connector` pod log (staging-subnet) |
| 16:26 | Renter view inside the pod: `NVIDIA RTX A4000, 100.00 W` | `lium exec poc-pl-test "nvidia-smi ..."` |
| 16:28:23 | `lium rm poc-pl-test` | CLI |
| 16:28:31 | `PoC power limit applied, watts: 140` — "set to 140.00 W from 100.00 W" | `connector` pod log |
| 16:28:40 | Host monitor flips **100 → 140 W** | poll loop |

Note: container create/delete is executed by the **connector** deployment (same image as the validator), so the PoC log lines appear there, not in the validator pod.

## Known gaps for a real implementation

1. **Conflict with the existing fatal check.** `GpuPowerLimitCheck` (`services/task/checks/gpu_power_limit.py`) zeroes the executor's score when `power_limit / power_default_limit < 0.9`; our 100/140 = 0.71. An executor left throttled while unrented (crashed validator, failed restore) gets score-zeroed. The policy and the check must be designed together.
2. **Per-GPU clamp.** Query `power.min_limit` / `power.default_limit` per GPU and clamp instead of constants; target GPUs by UUID (`nvidia-smi -i <uuid>`), not machine-wide.
3. **Restore on every exit path.** Also needed in `cleanup_failed_container_creation` plus a reconciliation sweep (restore default on unrented executors) to survive validator restarts.
4. **Reset semantics.** Reboot/driver reload resets the limit to default (safe direction). With persistence mode off the limit can drift back on idle; onboarding already recommends `nvidia-smi -pm 1`.

## Proposed full solution (sketch, not implemented here)

A possible shape for the production version, addressing the gaps above:

1. **Validator (machine_scrape): collect `min_power_limit`.** `machine_scrape.py` already calls `nvmlDeviceGetPowerManagementLimitConstraints(handle)` and keeps only `[1]` (max); the min is `[0]` of the same call — one extra field in `gpu_details`, flowing to the backend through the existing specs pipeline.
2. **Backend: decide the target and send it.** At rental creation the backend computes the desired `power_limit` for the executor's GPUs (clamped to `[min_power_limit, default_limit]` from the stored specs) and adds it to `ContainerCreateRequest`. Policy lives in one place — the backend — and can evolve (per-GPU-model table, per-customer, etc.) without touching the validator.
3. **Validator connector: apply what was sent.** `create_container` applies the received `power_limit` (per GPU UUID); no watt constants or IP whitelists in the subnet code.

**Handling the "baseline" power limit (the restore value):** recommend a **stateless restore** — at `delete_container` time read the GPU's own `power.default_limit` (NVML `nvmlDeviceGetPowerManagementDefaultLimit`, already collected by machine_scrape) and set that. Rationale:

- the driver itself stores the factory default, so nothing needs to be persisted per rental;
- restoring a *saved pre-rental value* is fragile — the saved value may itself be a leftover from a previous failed restore;
- `GpuPowerLimitCheck` already requires `limit ≥ 0.9 × default` for unrented machines, so the default **is** the de-facto baseline the fleet is held to;
- the same stateless rule makes the reconciliation sweep trivial: "unrented ⇒ set default_limit", idempotent and safe to run repeatedly.

Open question to settle with the incentive side: whether a *rented* machine with a deliberately lowered limit should be exempted in `GpuPowerLimitCheck` (e.g. skip when `rented=true`, or compare against the backend-requested target instead of the default).

## Current state

The PoC is deployed on the **staging** validator and is a no-op for every executor except `149.36.1.151`. Redeploy `main` to staging to drop it.