### PR TITLE
DAH-2364, graceful docker stop before forced container removal

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -3971,17 +3971,28 @@ class DockerService:
                 # DAH-2364: graceful stop first (SIGTERM + grace window) so the workload
                 # can exit cleanly before the forced removal below. Applies to customer
                 # rentals and fillers alike. Any stop failure is swallowed — the forced
-                # removal stays the single source of truth for deletion success.
+                # removal stays the single source of truth for deletion success. The stop
+                # is called directly (not via run_logged_rental_docker_sdk_operation) so an
+                # expected failure — chiefly an already-absent container — is not logged at
+                # ERROR and does not raise a false failed-deletion alert (DAH-2364).
+                stop_started = time.monotonic()
                 try:
-                    await run_logged_rental_docker_sdk_operation(
-                        operation="stop_container",
-                        log_extra=default_extra,
-                        call=lambda: docker_client.stop(
-                            container_name=payload.container_name,
-                            timeout=CONTAINER_STOP_GRACE_SECONDS,
-                        ),
+                    await docker_client.stop(
                         container_name=payload.container_name,
-                        stop_grace_seconds=CONTAINER_STOP_GRACE_SECONDS,
+                        timeout=CONTAINER_STOP_GRACE_SECONDS,
+                    )
+                    logger.info(
+                        _m(
+                            "Graceful container stop completed",
+                            extra=get_extra_info(
+                                {
+                                    **default_extra,
+                                    "container_name": payload.container_name,
+                                    "stop_grace_seconds": CONTAINER_STOP_GRACE_SECONDS,
+                                    "duration_ms": int((time.monotonic() - stop_started) * 1000),
+                                }
+                            ),
+                        ),
                     )
                 except Exception as exc:
                     if _is_missing_docker_container_error(exc):

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -112,6 +112,12 @@ LOG_STREAM_INTERVAL = 0.5  # 500ms — keeps build-log p95 emit→publish under 
 # would violate the SSE latency requirement.
 IN_CONTAINER_SSH_BOOTSTRAP_PATH = "/tmp/lium-ssh-bootstrap.sh"
 
+# DAH-2364: SIGTERM grace window (docker stop -t semantics) given to a container before
+# forced removal. SIGKILL-only removal of GPU-heavy workloads repeatedly wedged
+# containerd/sysbox ("could not kill container ... did not receive an exit event"),
+# leaving orphaned containers that hold GPUs and brick the executor.
+CONTAINER_STOP_GRACE_SECONDS = 30
+
 DOCKER_VOLUME_PLUGINS = {
     "s3fs": "mochoa/s3fs-volume-plugin"
 }
@@ -3962,6 +3968,48 @@ class DockerService:
                     private_key=private_key,
                 ) as docker_client,
             ):
+                # DAH-2364: graceful stop first (SIGTERM + grace window) so the workload
+                # can exit cleanly before the forced removal below. Applies to customer
+                # rentals and fillers alike. Any stop failure is swallowed — the forced
+                # removal stays the single source of truth for deletion success.
+                try:
+                    await run_logged_rental_docker_sdk_operation(
+                        operation="stop_container",
+                        log_extra=default_extra,
+                        call=lambda: docker_client.stop(
+                            container_name=payload.container_name,
+                            timeout=CONTAINER_STOP_GRACE_SECONDS,
+                        ),
+                        container_name=payload.container_name,
+                        stop_grace_seconds=CONTAINER_STOP_GRACE_SECONDS,
+                    )
+                except Exception as exc:
+                    if _is_missing_docker_container_error(exc):
+                        logger.info(
+                            _m(
+                                "Graceful stop skipped: container is already absent",
+                                extra=get_extra_info(
+                                    {
+                                        **default_extra,
+                                        "container_name": payload.container_name,
+                                    }
+                                ),
+                            ),
+                        )
+                    else:
+                        logger.warning(
+                            _m(
+                                "Graceful container stop failed; proceeding to forced removal",
+                                extra=get_extra_info(
+                                    {
+                                        **default_extra,
+                                        "container_name": payload.container_name,
+                                        "error": str(exc),
+                                    }
+                                ),
+                            ),
+                        )
+
                 try:
                     await run_logged_rental_docker_sdk_operation(
                         operation="remove_container",

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -175,14 +175,16 @@ class _BoundLog:
     def _message(self, message: str, **fields):
         return _m(message, extra=get_extra_info({**self.base_extra, **fields}))
 
+    # stacklevel=2 keeps the logged file/function/line pointing at the call site
+    # rather than at this wrapper
     def info(self, message: str, **fields) -> None:
-        logger.info(self._message(message, **fields))
+        logger.info(self._message(message, **fields), stacklevel=2)
 
     def warning(self, message: str, **fields) -> None:
-        logger.warning(self._message(message, **fields))
+        logger.warning(self._message(message, **fields), stacklevel=2)
 
     def error(self, message: str, *, exc_info: bool = False, **fields) -> None:
-        logger.error(self._message(message, **fields), exc_info=exc_info)
+        logger.error(self._message(message, **fields), exc_info=exc_info, stacklevel=2)
 
 
 def _delete_container_log_extra(

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -115,9 +115,10 @@ LOG_STREAM_INTERVAL = 0.5  # 500ms — keeps build-log p95 emit→publish under 
 IN_CONTAINER_SSH_BOOTSTRAP_PATH = "/tmp/lium-ssh-bootstrap.sh"
 
 # DAH-2364: SIGTERM grace window (docker stop -t semantics) given to a container before
-# forced removal. SIGKILL-only removal of GPU-heavy workloads repeatedly wedged
-# containerd/sysbox ("could not kill container ... did not receive an exit event"),
-# leaving orphaned containers that hold GPUs and brick the executor.
+# forced removal. SIGKILL-only removal of GPU-heavy workloads repeatedly triggered a
+# containerd/sysbox wedge ("could not kill container ... did not receive an exit event";
+# root cause: sysbox-fs FUSE deadlock, fixed separately), leaving orphaned containers
+# that hold GPUs and brick the executor.
 CONTAINER_STOP_GRACE_SECONDS = 30
 
 DOCKER_VOLUME_PLUGINS = {

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import ipaddress
 import logging
 import math
@@ -164,6 +165,64 @@ def _missing_rental_docker_host_key_log_text(
         "Missing executor SSH host key for rental Docker SDK operation",
         extra=get_extra_info({**default_extra, **HOST_KEY_REQUIRED_EXTRA, "error": str(exc)}),
     )
+
+
+class _BoundLog:
+    # structured logger bound to a default_extra, so a call site stays one line
+    def __init__(self, base_extra: dict):
+        self.base_extra = base_extra
+
+    def _message(self, message: str, **fields):
+        return _m(message, extra=get_extra_info({**self.base_extra, **fields}))
+
+    def info(self, message: str, **fields) -> None:
+        logger.info(self._message(message, **fields))
+
+    def warning(self, message: str, **fields) -> None:
+        logger.warning(self._message(message, **fields))
+
+    def error(self, message: str, *, exc_info: bool = False, **fields) -> None:
+        logger.error(self._message(message, **fields), exc_info=exc_info)
+
+
+def _delete_container_log_extra(
+    payload: ContainerDeleteRequest,
+    executor_info: ExecutorSSHInfo,
+) -> dict:
+    return {
+        "miner_hotkey": payload.miner_hotkey,
+        "executor_uuid": payload.executor_id,
+        "pod_id": payload.pod_id,
+        "workload_kind": payload.workload_kind.value,
+        "executor_ip_address": executor_info.address,
+        "executor_port": executor_info.port,
+        "executor_ssh_username": executor_info.ssh_username,
+        "executor_ssh_port": executor_info.ssh_port,
+    }
+
+
+def _validate_delete_volume_names(payload: ContainerDeleteRequest) -> None:
+    # raise ValueError on an unsafe volume name; the quoted result is unused, these names
+    # reach the Docker SDK rather than a shell
+    if payload.local_volume:
+        _quote_safe_docker_volume_name(payload.local_volume, field_name="local_volume")
+    if payload.external_volume:
+        _quote_safe_docker_volume_name(payload.external_volume, field_name="external_volume")
+
+
+@contextlib.contextmanager
+def _best_effort(log: _BoundLog, step: str, **fields):
+    # swallow a post-removal teardown failure: the container is already gone, so failing the
+    # request here would make the backend retry a doomed undeploy and penalize the miner
+    try:
+        yield
+    except Exception as exc:
+        log.error(
+            "delete_container post-teardown step failed (non-fatal)",
+            step=step,
+            error=str(exc),
+            **fields,
+        )
 
 
 # DAH-2183: fresh vloopback sizing — compute effective volume/storage limits
@@ -3861,6 +3920,94 @@ class DockerService:
                 error_code=FailedContainerErrorCodes.UnknownError,
             )
 
+    def _container_deleted(self, payload: ContainerDeleteRequest) -> ContainerDeleted:
+        return ContainerDeleted(
+            miner_hotkey=payload.miner_hotkey,
+            executor_id=payload.executor_id,
+            pod_id=payload.pod_id,
+            workload_kind=payload.workload_kind,
+        )
+
+    def _failed_delete(self, payload: ContainerDeleteRequest, msg: str) -> FailedContainerRequest:
+        return FailedContainerRequest(
+            miner_hotkey=payload.miner_hotkey,
+            executor_id=payload.executor_id,
+            pod_id=payload.pod_id,
+            workload_kind=payload.workload_kind,
+            msg=msg,
+            error_type=FailedContainerErrorTypes.ContainerDeletionFailed,
+            error_code=FailedContainerErrorCodes.UnknownError,
+        )
+
+    async def _stop_container_gracefully(
+        self,
+        docker_client: RentalDockerSdkClient,
+        payload: ContainerDeleteRequest,
+        log: _BoundLog,
+    ) -> None:
+        # DAH-2364: SIGTERM plus a grace window, so the workload exits cleanly before the forced
+        # removal. Never fatal — the forced removal stays the single source of truth for deletion.
+        # Called directly rather than through run_logged_rental_docker_sdk_operation so that an
+        # expected failure — chiefly an already-absent container — is not logged at ERROR and does
+        # not raise a false failed-deletion alert.
+        stop_started = time.monotonic()
+        try:
+            await docker_client.stop(
+                container_name=payload.container_name,
+                timeout=CONTAINER_STOP_GRACE_SECONDS,
+            )
+        except Exception as exc:
+            if _is_missing_docker_container_error(exc):
+                log.info(
+                    "Graceful stop skipped: container is already absent",
+                    container_name=payload.container_name,
+                )
+            else:
+                log.warning(
+                    "Graceful container stop failed; proceeding to forced removal",
+                    container_name=payload.container_name,
+                    error=str(exc),
+                )
+            return
+
+        log.info(
+            "Graceful container stop completed",
+            container_name=payload.container_name,
+            stop_grace_seconds=CONTAINER_STOP_GRACE_SECONDS,
+            duration_ms=int((time.monotonic() - stop_started) * 1000),
+        )
+
+    async def _force_remove_container(
+        self,
+        docker_client: RentalDockerSdkClient,
+        payload: ContainerDeleteRequest,
+        log: _BoundLog,
+    ) -> None:
+        # DAH-2345: deletion is idempotent for every workload kind — a container that is already
+        # gone (e.g. removed by failed-create cleanup) must not fail the delete, or the backend
+        # retries a doomed request until force-removal and penalizes the miner.
+        try:
+            await run_logged_rental_docker_sdk_operation(
+                operation="remove_container",
+                log_extra=log.base_extra,
+                call=lambda: docker_client.remove_container(
+                    container_name=payload.container_name,
+                    force=True,
+                    remove_volumes=True,
+                ),
+                container_name=payload.container_name,
+                force=True,
+                remove_volumes=True,
+            )
+        except Exception as exc:
+            if not _is_missing_docker_container_error(exc):
+                raise
+            log.info(
+                "Container is already absent",
+                container_name=payload.container_name,
+                error=str(exc),
+            )
+
     async def delete_container(
         self,
         payload: ContainerDeleteRequest,
@@ -3868,55 +4015,20 @@ class DockerService:
         keypair: bittensor.Keypair,
         private_key: str,
     ):
-        default_extra = {
-            "miner_hotkey": payload.miner_hotkey,
-            "executor_uuid": payload.executor_id,
-            "pod_id": payload.pod_id,
-            "workload_kind": payload.workload_kind.value,
-            "executor_ip_address": executor_info.address,
-            "executor_port": executor_info.port,
-            "executor_ssh_username": executor_info.ssh_username,
-            "executor_ssh_port": executor_info.ssh_port,
-        }
+        default_extra = _delete_container_log_extra(payload, executor_info)
+        log = _BoundLog(default_extra)
 
-        logger.info(
-            _m(
-                "Deleting Docker Container",
-                extra=get_extra_info({**default_extra, "payload": str(payload)}),
-            ),
-        )
+        log.info("Deleting Docker Container", payload=str(payload))
 
         try:
-            if payload.local_volume:
-                _quote_safe_docker_volume_name(
-                    payload.local_volume,
-                    field_name="local_volume",
-                )
-            if payload.external_volume:
-                _quote_safe_docker_volume_name(
-                    payload.external_volume,
-                    field_name="external_volume",
-                )
+            _validate_delete_volume_names(payload)
         except ValueError as exc:
-            log_text = _m(
-                "Invalid Docker volume name",
-                extra=get_extra_info({**default_extra, "error": str(exc)}),
-            )
-            logger.error(log_text)
-            return FailedContainerRequest(
-                miner_hotkey=payload.miner_hotkey,
-                executor_id=payload.executor_id,
-                pod_id=payload.pod_id,
-                workload_kind=payload.workload_kind,
-                msg=str(log_text),
-                error_type=FailedContainerErrorTypes.ContainerDeletionFailed,
-                error_code=FailedContainerErrorCodes.UnknownError,
-            )
+            log.error("Invalid Docker volume name", error=str(exc))
+            return self._failed_delete(payload, msg="Invalid Docker volume name")
 
         private_key = self.ssh_service.decrypt_payload(keypair.ss58_address, private_key)
         pkey = asyncssh.import_private_key(private_key)
 
-        known_hosts_policy: asyncssh.SSHKnownHosts | None = None
         try:
             known_hosts_policy = await self._prepare_known_hosts_policy(
                 executor_info,
@@ -3924,35 +4036,15 @@ class DockerService:
                 default_extra,
             )
         except AttestationError as exc:
-            log_text = _m(
-                "Attestation failed",
-                extra=get_extra_info({**default_extra, "error": str(exc)}),
-            )
-            logger.error(log_text)
-            return FailedContainerRequest(
-                miner_hotkey=payload.miner_hotkey,
-                executor_id=payload.executor_id,
-                pod_id=payload.pod_id,
-                workload_kind=payload.workload_kind,
-                msg=str(log_text),
-                error_type=FailedContainerErrorTypes.ContainerDeletionFailed,
-                error_code=FailedContainerErrorCodes.UnknownError,
-            )
+            log.error("Attestation failed", error=str(exc))
+            return self._failed_delete(payload, msg="Attestation failed")
 
         try:
             require_rental_docker_ssh_host_key(executor_info)
         except RentalDockerConnectionError as exc:
             log_text = _missing_rental_docker_host_key_log_text(default_extra, exc)
             logger.error(log_text)
-            return FailedContainerRequest(
-                miner_hotkey=payload.miner_hotkey,
-                executor_id=payload.executor_id,
-                pod_id=payload.pod_id,
-                workload_kind=payload.workload_kind,
-                msg=str(log_text),
-                error_type=FailedContainerErrorTypes.ContainerDeletionFailed,
-                error_code=FailedContainerErrorCodes.UnknownError,
-            )
+            return self._failed_delete(payload, msg=str(log_text))
 
         try:
             async with (
@@ -3968,96 +4060,11 @@ class DockerService:
                     private_key=private_key,
                 ) as docker_client,
             ):
-                # DAH-2364: graceful stop first (SIGTERM + grace window) so the workload
-                # can exit cleanly before the forced removal below. Applies to customer
-                # rentals and fillers alike. Any stop failure is swallowed — the forced
-                # removal stays the single source of truth for deletion success. The stop
-                # is called directly (not via run_logged_rental_docker_sdk_operation) so an
-                # expected failure — chiefly an already-absent container — is not logged at
-                # ERROR and does not raise a false failed-deletion alert (DAH-2364).
-                stop_started = time.monotonic()
-                try:
-                    await docker_client.stop(
-                        container_name=payload.container_name,
-                        timeout=CONTAINER_STOP_GRACE_SECONDS,
-                    )
-                    logger.info(
-                        _m(
-                            "Graceful container stop completed",
-                            extra=get_extra_info(
-                                {
-                                    **default_extra,
-                                    "container_name": payload.container_name,
-                                    "stop_grace_seconds": CONTAINER_STOP_GRACE_SECONDS,
-                                    "duration_ms": int((time.monotonic() - stop_started) * 1000),
-                                }
-                            ),
-                        ),
-                    )
-                except Exception as exc:
-                    if _is_missing_docker_container_error(exc):
-                        logger.info(
-                            _m(
-                                "Graceful stop skipped: container is already absent",
-                                extra=get_extra_info(
-                                    {
-                                        **default_extra,
-                                        "container_name": payload.container_name,
-                                    }
-                                ),
-                            ),
-                        )
-                    else:
-                        logger.warning(
-                            _m(
-                                "Graceful container stop failed; proceeding to forced removal",
-                                extra=get_extra_info(
-                                    {
-                                        **default_extra,
-                                        "container_name": payload.container_name,
-                                        "error": str(exc),
-                                    }
-                                ),
-                            ),
-                        )
+                await self._stop_container_gracefully(docker_client, payload, log)
 
-                try:
-                    await run_logged_rental_docker_sdk_operation(
-                        operation="remove_container",
-                        log_extra=default_extra,
-                        call=lambda: docker_client.remove_container(
-                            container_name=payload.container_name,
-                            force=True,
-                            remove_volumes=True,
-                        ),
-                        container_name=payload.container_name,
-                        force=True,
-                        remove_volumes=True,
-                    )
-                except Exception as exc:
-                    # DAH-2345: deletion is idempotent for every workload kind — a container
-                    # that is already gone (e.g. removed by failed-create cleanup) must not
-                    # fail the delete, or the backend retries a doomed request until
-                    # force-removal and penalizes the miner.
-                    if not _is_missing_docker_container_error(exc):
-                        raise
-                    logger.info(
-                        _m(
-                            "Container is already absent",
-                            extra=get_extra_info(
-                                {
-                                    **default_extra,
-                                    "container_name": payload.container_name,
-                                    "error": str(exc),
-                                }
-                            ),
-                        ),
-                    )
-
-                # DAH-2345: the container is gone once remove_container succeeds; a failure
-                # in any post-container teardown step below must not fail the undeploy, or the
-                # backend retries a doomed request and penalizes the miner for a pod that is
-                # already removed. Each step is guarded individually and only logged on error.
+                # Fatal boundary: the forced removal is the only step whose failure fails the
+                # undeploy. Every step below runs after the container is gone and is best-effort.
+                await self._force_remove_container(docker_client, payload, log)
 
                 # DAH-2211: always-on inline cleanup of custom-build artifacts
                 # for this pod. No-op if the pod was not a custom build.
@@ -4071,28 +4078,20 @@ class DockerService:
                 # DAH-2356: restore the pre-cap GPU power limits after a Lium PEARL filler is
                 # removed, so the next rental gets the machine at its original power.
                 if payload.workload_kind == WorkloadKind.FILLER:
-                    await restore_filler_pod_gpu_power_limits(
-                        ssh_client, self.redis_service, payload.pod_id, log_extra=default_extra
-                    )
+                    with _best_effort(log, "restore_filler_gpu_power"):
+                        await restore_filler_pod_gpu_power_limits(
+                            ssh_client, self.redis_service, payload.pod_id, log_extra=default_extra
+                        )
 
-                try:
+                with _best_effort(log, "prune_images"):
                     await run_logged_rental_docker_sdk_operation(
                         operation="prune_images",
                         log_extra=default_extra,
                         call=docker_client.prune_images,
                     )
-                except Exception as exc:
-                    logger.error(
-                        _m(
-                            "delete_container post-teardown step failed (non-fatal)",
-                            extra=get_extra_info(
-                                {**default_extra, "step": "prune_images", "error": str(exc)}
-                            ),
-                        ),
-                    )
 
                 if payload.local_volume:
-                    try:
+                    with _best_effort(log, "remove_volume_local", volume_name=payload.local_volume):
                         await run_logged_rental_docker_sdk_operation(
                             operation="remove_volume",
                             log_extra=default_extra,
@@ -4102,23 +4101,11 @@ class DockerService:
                             volume_name=payload.local_volume,
                             volume_role="local",
                         )
-                    except Exception as exc:
-                        logger.error(
-                            _m(
-                                "delete_container post-teardown step failed (non-fatal)",
-                                extra=get_extra_info(
-                                    {
-                                        **default_extra,
-                                        "step": "remove_volume_local",
-                                        "volume_name": payload.local_volume,
-                                        "error": str(exc),
-                                    }
-                                ),
-                            ),
-                        )
 
                 if payload.external_volume:
-                    try:
+                    with _best_effort(
+                        log, "remove_volume_external", volume_name=payload.external_volume
+                    ):
                         await run_logged_rental_docker_sdk_operation(
                             operation="remove_volume",
                             log_extra=default_extra,
@@ -4129,49 +4116,20 @@ class DockerService:
                             volume_role="external",
                         )
                         await self.disable_s3fs_volume_plugin(ssh_client)
-                    except Exception as exc:
-                        logger.error(
-                            _m(
-                                "delete_container post-teardown step failed (non-fatal)",
-                                extra=get_extra_info(
-                                    {
-                                        **default_extra,
-                                        "step": "remove_volume_external",
-                                        "volume_name": payload.external_volume,
-                                        "error": str(exc),
-                                    }
-                                ),
-                            ),
-                        )
 
-                logger.info(
-                    _m(
-                        "Remove rented machine from redis",
-                        extra=get_extra_info(
-                            {
-                                **default_extra,
-                                "container_name": payload.container_name,
-                                "local_volume": payload.local_volume,
-                                "external_volume": payload.external_volume,
-                            }
-                        ),
-                    ),
+                log.info(
+                    "Remove rented machine from redis",
+                    container_name=payload.container_name,
+                    local_volume=payload.local_volume,
+                    external_volume=payload.external_volume,
                 )
-
-                try:
-                    await self.redis_service.remove_rented_machine(executor_info, payload.container_name)
-                except Exception as exc:
-                    logger.error(
-                        _m(
-                            "delete_container post-teardown step failed (non-fatal)",
-                            extra=get_extra_info(
-                                {**default_extra, "step": "remove_rented_machine", "error": str(exc)}
-                            ),
-                        ),
+                with _best_effort(log, "remove_rented_machine"):
+                    await self.redis_service.remove_rented_machine(
+                        executor_info, payload.container_name
                     )
 
                 # Stop inspector only after the last customer pod leaves this executor.
-                try:
+                with _best_effort(log, "inspector_stop"):
                     if (
                         settings.ENABLE_INSPECTOR
                         and payload.workload_kind != WorkloadKind.FILLER
@@ -4186,48 +4144,17 @@ class DockerService:
                                 "container_name": payload.container_name,
                             },
                         )
-                except Exception as exc:
-                    logger.error(
-                        _m(
-                            "delete_container post-teardown step failed (non-fatal)",
-                            extra=get_extra_info(
-                                {**default_extra, "step": "inspector_stop", "error": str(exc)}
-                            ),
-                        ),
-                    )
 
                 # Port release now handled by backend
 
-                logger.info(
-                    _m(
-                        "Deleted Docker Container",
-                        extra=get_extra_info({**default_extra, "payload": str(payload)}),
-                    ),
-                )
+                log.info("Deleted Docker Container", payload=str(payload))
 
-                return ContainerDeleted(
-                    miner_hotkey=payload.miner_hotkey,
-                    executor_id=payload.executor_id,
-                    pod_id=payload.pod_id,
-                    workload_kind=payload.workload_kind,
-                )
+                return self._container_deleted(payload)
         except Exception as e:
-            log_text = _m(
-                "Unknown Error delete_container",
-                extra=get_extra_info({**default_extra, "error": str(e)}),
-            )
-            logger.error(log_text, exc_info=True)
+            log.error("Unknown Error delete_container", error=str(e), exc_info=True)
 
-            return FailedContainerRequest(
-                miner_hotkey=payload.miner_hotkey,
-                executor_id=payload.executor_id,
-                pod_id=payload.pod_id,
-                workload_kind=payload.workload_kind,
-                # str(log_text) drops extra, hiding the cause from the backend
-                msg=f"Unknown Error delete_container: {e}",
-                error_type=FailedContainerErrorTypes.ContainerDeletionFailed,
-                error_code=FailedContainerErrorCodes.UnknownError,
-            )
+            # str(log_text) drops extra, hiding the cause from the backend
+            return self._failed_delete(payload, msg=f"Unknown Error delete_container: {e}")
 
     async def install_jupyter_server(
         self,

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -8,6 +8,7 @@ import re
 import secrets
 import shlex
 import time
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Any
@@ -94,7 +95,7 @@ from services.ssh_connect_timing import connect_with_phase_timing
 from tenacity import RetryError
 
 from core.config import settings
-from core.utils import _m, get_extra_info, retry_ssh_command
+from core.utils import _m, _StructuredMessage, get_extra_info, retry_ssh_command
 from services.ssh_service import SSHService
 
 logger = logging.getLogger(__name__)
@@ -169,28 +170,28 @@ def _missing_rental_docker_host_key_log_text(
 
 class _BoundLog:
     # structured logger bound to a default_extra, so a call site stays one line
-    def __init__(self, base_extra: dict):
+    def __init__(self, base_extra: dict[str, Any]):
         self.base_extra = base_extra
 
-    def _message(self, message: str, **fields):
+    def _message(self, message: str, **fields: Any) -> _StructuredMessage:
         return _m(message, extra=get_extra_info({**self.base_extra, **fields}))
 
     # stacklevel=2 keeps the logged file/function/line pointing at the call site
     # rather than at this wrapper
-    def info(self, message: str, **fields) -> None:
+    def info(self, message: str, **fields: Any) -> None:
         logger.info(self._message(message, **fields), stacklevel=2)
 
-    def warning(self, message: str, **fields) -> None:
+    def warning(self, message: str, **fields: Any) -> None:
         logger.warning(self._message(message, **fields), stacklevel=2)
 
-    def error(self, message: str, *, exc_info: bool = False, **fields) -> None:
+    def error(self, message: str, *, exc_info: bool = False, **fields: Any) -> None:
         logger.error(self._message(message, **fields), exc_info=exc_info, stacklevel=2)
 
 
 def _delete_container_log_extra(
     payload: ContainerDeleteRequest,
     executor_info: ExecutorSSHInfo,
-) -> dict:
+) -> dict[str, Any]:
     return {
         "miner_hotkey": payload.miner_hotkey,
         "executor_uuid": payload.executor_id,
@@ -213,7 +214,7 @@ def _validate_delete_volume_names(payload: ContainerDeleteRequest) -> None:
 
 
 @contextlib.contextmanager
-def _best_effort(log: _BoundLog, step: str, **fields):
+def _best_effort_delete_step(log: _BoundLog, step: str, **fields: Any) -> Iterator[None]:
     # swallow a post-removal teardown failure: the container is already gone, so failing the
     # request here would make the backend retry a doomed undeploy and penalize the miner
     try:
@@ -3952,11 +3953,19 @@ class DockerService:
         # Called directly rather than through run_logged_rental_docker_sdk_operation so that an
         # expected failure — chiefly an already-absent container — is not logged at ERROR and does
         # not raise a false failed-deletion alert.
+        if payload.workload_kind == WorkloadKind.FILLER:
+            # The backend preempts a filler before a customer rent with a 30s total budget
+            # (FILLER_STOP_WAIT_TIMEOUT_SECONDS) and starts the rent anyway on timeout. A grace
+            # window equal to that budget lets a SIGTERM-ignoring filler burn all of it inside
+            # docker stop, so the customer pod would land on GPUs the filler still holds.
+            # Fillers keep the pre-DAH-2364 SIGKILL-only removal.
+            return
+
         stop_started = time.monotonic()
         try:
             await docker_client.stop(
                 container_name=payload.container_name,
-                timeout=CONTAINER_STOP_GRACE_SECONDS,
+                stop_grace_seconds=CONTAINER_STOP_GRACE_SECONDS,
             )
         except Exception as exc:
             if _is_missing_docker_container_error(exc):
@@ -4080,12 +4089,12 @@ class DockerService:
                 # DAH-2356: restore the pre-cap GPU power limits after a Lium PEARL filler is
                 # removed, so the next rental gets the machine at its original power.
                 if payload.workload_kind == WorkloadKind.FILLER:
-                    with _best_effort(log, "restore_filler_gpu_power"):
+                    with _best_effort_delete_step(log, "restore_filler_gpu_power"):
                         await restore_filler_pod_gpu_power_limits(
                             ssh_client, self.redis_service, payload.pod_id, log_extra=default_extra
                         )
 
-                with _best_effort(log, "prune_images"):
+                with _best_effort_delete_step(log, "prune_images"):
                     await run_logged_rental_docker_sdk_operation(
                         operation="prune_images",
                         log_extra=default_extra,
@@ -4093,7 +4102,9 @@ class DockerService:
                     )
 
                 if payload.local_volume:
-                    with _best_effort(log, "remove_volume_local", volume_name=payload.local_volume):
+                    with _best_effort_delete_step(
+                        log, "remove_volume_local", volume_name=payload.local_volume
+                    ):
                         await run_logged_rental_docker_sdk_operation(
                             operation="remove_volume",
                             log_extra=default_extra,
@@ -4105,7 +4116,7 @@ class DockerService:
                         )
 
                 if payload.external_volume:
-                    with _best_effort(
+                    with _best_effort_delete_step(
                         log, "remove_volume_external", volume_name=payload.external_volume
                     ):
                         await run_logged_rental_docker_sdk_operation(
@@ -4125,13 +4136,13 @@ class DockerService:
                     local_volume=payload.local_volume,
                     external_volume=payload.external_volume,
                 )
-                with _best_effort(log, "remove_rented_machine"):
+                with _best_effort_delete_step(log, "remove_rented_machine"):
                     await self.redis_service.remove_rented_machine(
                         executor_info, payload.container_name
                     )
 
                 # Stop inspector only after the last customer pod leaves this executor.
-                with _best_effort(log, "inspector_stop"):
+                with _best_effort_delete_step(log, "inspector_stop"):
                     if (
                         settings.ENABLE_INSPECTOR
                         and payload.workload_kind != WorkloadKind.FILLER

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -236,11 +236,14 @@ class RentalDockerSdkClient:
             api_method=self._api_client.start,
         )
 
-    async def stop(self, *, container_name: str) -> None:
+    async def stop(self, *, container_name: str, timeout: int | None = None) -> None:
+        # timeout is the SIGTERM grace window: dockerd waits this many seconds for the
+        # container to exit before escalating to SIGKILL (docker stop -t semantics)
         await self._call_api(
             container_name,
             operation_label="stop",
             api_method=self._api_client.stop,
+            timeout=timeout,
         )
 
     async def remove_container(

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -236,14 +236,15 @@ class RentalDockerSdkClient:
             api_method=self._api_client.start,
         )
 
-    async def stop(self, *, container_name: str, timeout: int | None = None) -> None:
-        # timeout is the SIGTERM grace window: dockerd waits this many seconds for the
-        # container to exit before escalating to SIGKILL (docker stop -t semantics)
+    async def stop(self, *, container_name: str, stop_grace_seconds: int | None = None) -> None:
+        # stop_grace_seconds is the SIGTERM grace window: dockerd waits this many seconds for
+        # the container to exit before escalating to SIGKILL (docker stop -t semantics). Named
+        # distinctly because `timeout` on this class means the HTTP client timeout (create_volume).
         await self._call_api(
             container_name,
             operation_label="stop",
             api_method=self._api_client.stop,
-            timeout=timeout,
+            timeout=stop_grace_seconds,
         )
 
     async def remove_container(

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -1231,6 +1231,12 @@ async def test_delete_filler_skips_graceful_stop(
     monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
     monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
 
+    restore_filler_power = AsyncMock(return_value=0)
+    monkeypatch.setattr(
+        "services.docker_service.restore_filler_pod_gpu_power_limits",
+        restore_filler_power,
+    )
+
     docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
     docker_service.redis_service.remove_rented_machine = AsyncMock()
 
@@ -1265,6 +1271,9 @@ async def test_delete_filler_skips_graceful_stop(
     client = docker_service.rental_docker_client_factory.client
     assert client.stopped_containers == []
     assert client.container_call_order == [("remove", payload.container_name)]
+    # DAH-2356 still restores the filler's GPU power caps even though the graceful stop is skipped
+    restore_filler_power.assert_awaited_once()
+    assert restore_filler_power.await_args.args[2] == payload.pod_id
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -57,8 +57,10 @@ class _FakeRentalDockerClient:
         self.exec_specs = []
         self.started_containers = []
         self.stopped_containers = []
-        self.stop_timeouts = []
+        self.stop_grace_seconds_calls = []
         self.removed_containers = []
+        # (operation, container_name) tuples shared by stop/remove, so tests can assert ordering
+        self.container_call_order = []
         self.created_volumes = []
         self.removed_volumes = []
         self.pruned_images = 0
@@ -96,9 +98,10 @@ class _FakeRentalDockerClient:
         if self.start_error is not None:
             raise self.start_error
 
-    async def stop(self, *, container_name: str, timeout: int | None = None) -> None:
+    async def stop(self, *, container_name: str, stop_grace_seconds: int | None = None) -> None:
         self.stopped_containers.append(container_name)
-        self.stop_timeouts.append(timeout)
+        self.stop_grace_seconds_calls.append(stop_grace_seconds)
+        self.container_call_order.append(("stop", container_name))
         if self.stop_error is not None:
             raise self.stop_error
 
@@ -116,6 +119,7 @@ class _FakeRentalDockerClient:
                 "remove_volumes": remove_volumes,
             }
         )
+        self.container_call_order.append(("remove", container_name))
         if self.remove_error is not None:
             raise self.remove_error
 
@@ -1017,8 +1021,11 @@ async def test_delete_container_stops_gracefully_before_forced_removal(
     # Assert: graceful stop with the grace window happened, then the forced removal
     assert isinstance(result, ContainerDeleted)
     client = docker_service.rental_docker_client_factory.client
-    assert client.stopped_containers == [payload.container_name]
-    assert client.stop_timeouts == [CONTAINER_STOP_GRACE_SECONDS]
+    assert client.container_call_order == [
+        ("stop", payload.container_name),
+        ("remove", payload.container_name),
+    ]
+    assert client.stop_grace_seconds_calls == [CONTAINER_STOP_GRACE_SECONDS]
     assert client.removed_containers == [
         {
             "container_name": payload.container_name,
@@ -1142,6 +1149,122 @@ async def test_delete_container_stop_failure_still_removes(
             "remove_volumes": True,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_delete_container_stop_missing_container_logs_info_and_removes(
+    docker_service,
+    monkeypatch,
+    caplog,
+):
+    # Arrange: the container is already gone when the graceful stop runs — must log info
+    # (not warning/error, which would raise a false failed-deletion alert) and still remove
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.remove_rented_machine = AsyncMock()
+    docker_service.rental_docker_client_factory.client.stop_error = Exception(
+        "Docker SDK stop failed: 404 Client Error: No such container: pod_stop_absent"
+    )
+
+    payload = ContainerDeleteRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_stop_absent",
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
+    )
+
+    # Act
+    with caplog.at_level(logging.INFO, logger="services.docker_service"):
+        result = await docker_service.delete_container(
+            payload=payload,
+            executor_info=executor_info,
+            keypair=Mock(ss58_address="validator-hotkey"),
+            private_key="encrypted",
+        )
+
+    # Assert: absent container on stop is info-level only, forced removal still runs
+    assert isinstance(result, ContainerDeleted)
+    client = docker_service.rental_docker_client_factory.client
+    assert client.container_call_order == [
+        ("stop", payload.container_name),
+        ("remove", payload.container_name),
+    ]
+    stop_records = [r for r in caplog.records if "Graceful stop skipped" in str(r.msg)]
+    assert [r.levelno for r in stop_records] == [logging.INFO]
+    assert not any(
+        "Graceful container stop failed" in str(r.msg) for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_filler_skips_graceful_stop(
+    docker_service,
+    monkeypatch,
+):
+    # Arrange: FILLER teardown races the backend's FILLER_STOP_WAIT_TIMEOUT_SECONDS budget,
+    # so it must keep the SIGKILL-only path with no graceful stop
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.remove_rented_machine = AsyncMock()
+
+    payload = ContainerDeleteRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        workload_kind=WorkloadKind.FILLER,
+        container_name="filler_no_grace",
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
+    )
+
+    # Act
+    result = await docker_service.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    # Assert: no graceful stop, straight to forced removal
+    assert isinstance(result, ContainerDeleted)
+    client = docker_service.rental_docker_client_factory.client
+    assert client.stopped_containers == []
+    assert client.container_call_order == [("remove", payload.container_name)]
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -7,6 +7,7 @@ import pytest_asyncio
 from tenacity import Future, RetryError
 
 from services.docker_service import (
+    CONTAINER_STOP_GRACE_SECONDS,
     DockerService,
     VolumeMinSizeError,
     _parse_volume_size_to_bytes,
@@ -55,6 +56,7 @@ class _FakeRentalDockerClient:
         self.exec_specs = []
         self.started_containers = []
         self.stopped_containers = []
+        self.stop_timeouts = []
         self.removed_containers = []
         self.created_volumes = []
         self.removed_volumes = []
@@ -93,8 +95,9 @@ class _FakeRentalDockerClient:
         if self.start_error is not None:
             raise self.start_error
 
-    async def stop(self, *, container_name: str) -> None:
+    async def stop(self, *, container_name: str, timeout: int | None = None) -> None:
         self.stopped_containers.append(container_name)
+        self.stop_timeouts.append(timeout)
         if self.stop_error is not None:
             raise self.stop_error
 
@@ -963,6 +966,126 @@ async def test_delete_customer_rental_treats_missing_container_as_deleted(
         executor_info,
         payload.container_name,
     )
+
+
+@pytest.mark.asyncio
+async def test_delete_container_stops_gracefully_before_forced_removal(
+    docker_service,
+    monkeypatch,
+):
+    # Arrange: healthy teardown path (DAH-2364 — SIGTERM grace before force removal)
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.remove_rented_machine = AsyncMock()
+
+    payload = ContainerDeleteRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_graceful",
+        local_volume="volume_graceful",
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
+    )
+
+    # Act
+    result = await docker_service.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    # Assert: graceful stop with the grace window happened, then the forced removal
+    assert isinstance(result, ContainerDeleted)
+    client = docker_service.rental_docker_client_factory.client
+    assert client.stopped_containers == [payload.container_name]
+    assert client.stop_timeouts == [CONTAINER_STOP_GRACE_SECONDS]
+    assert client.removed_containers == [
+        {
+            "container_name": payload.container_name,
+            "force": True,
+            "remove_volumes": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_container_stop_failure_still_removes(
+    docker_service,
+    monkeypatch,
+):
+    # Arrange: the graceful stop fails (e.g. wedged runtime) — removal must proceed
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.remove_rented_machine = AsyncMock()
+    docker_service.rental_docker_client_factory.client.stop_error = Exception(
+        "Docker SDK stop failed: 500 Server Error"
+    )
+
+    payload = ContainerDeleteRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_stop_fails",
+        local_volume="volume_stop_fails",
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
+    )
+
+    # Act
+    result = await docker_service.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    # Assert: stop failure is swallowed, forced removal still runs and succeeds
+    assert isinstance(result, ContainerDeleted)
+    client = docker_service.rental_docker_client_factory.client
+    assert client.stopped_containers == [payload.container_name]
+    assert client.removed_containers == [
+        {
+            "container_name": payload.container_name,
+            "force": True,
+            "remove_volumes": True,
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -1268,6 +1268,63 @@ async def test_delete_filler_skips_graceful_stop(
 
 
 @pytest.mark.asyncio
+async def test_delete_container_redis_failures_still_deleted(
+    docker_service,
+    retry_ssh_mock,
+    monkeypatch,
+):
+    # Arrange: redis is down — rented-machine cleanup and the inspector lookup both raise;
+    # the container is already removed, so the undeploy must still succeed (DAH-2345)
+    monkeypatch.setattr("services.docker_service.settings.ENABLE_INSPECTOR", True)
+    _patch_delete_container_connect(docker_service, monkeypatch, retry_ssh_mock)
+    docker_service.redis_service.remove_rented_machine = AsyncMock(
+        side_effect=Exception("redis down")
+    )
+    monkeypatch.setattr(
+        docker_service,
+        "_has_rented_customer_containers",
+        AsyncMock(side_effect=Exception("redis down")),
+    )
+
+    payload = ContainerDeleteRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_redis_down",
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
+    )
+
+    # Act
+    result = await docker_service.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    # Assert: both failures are non-fatal, container removal happened, undeploy succeeded
+    assert isinstance(result, ContainerDeleted)
+    client = docker_service.rental_docker_client_factory.client
+    assert client.removed_containers == [
+        {
+            "container_name": payload.container_name,
+            "force": True,
+            "remove_volumes": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_delete_container_failure_msg_includes_underlying_error(
     docker_service,
     monkeypatch,

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import AsyncMock, Mock, MagicMock, patch
 from uuid import uuid4, UUID
 from datetime import datetime
@@ -1025,6 +1026,61 @@ async def test_delete_container_stops_gracefully_before_forced_removal(
             "remove_volumes": True,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_delete_container_logs_point_at_the_call_site(
+    docker_service,
+    monkeypatch,
+    caplog,
+):
+    # Arrange: the bound logger must keep file/function/line on the caller, not on itself
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.remove_rented_machine = AsyncMock()
+
+    payload = ContainerDeleteRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_call_site",
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
+    )
+
+    # Act
+    with caplog.at_level(logging.INFO, logger="services.docker_service"):
+        await docker_service.delete_container(
+            payload=payload,
+            executor_info=executor_info,
+            keypair=Mock(ss58_address="validator-hotkey"),
+            private_key="encrypted",
+        )
+
+    # Assert
+    functions = {
+        record.funcName
+        for record in caplog.records
+        if str(record.msg) in ("Deleting Docker Container", "Deleted Docker Container")
+    }
+    assert functions == {"delete_container"}
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -108,7 +108,7 @@ class RecordingRentalDockerClient:
     async def start(self, *, container_name: str) -> None:
         self.started_containers.append(container_name)
 
-    async def stop(self, *, container_name: str) -> None:
+    async def stop(self, *, container_name: str, timeout: int | None = None) -> None:
         self.stopped_containers.append(container_name)
 
     async def remove_container(
@@ -733,7 +733,9 @@ async def test_lifecycle_operations_pass_container_names_as_sdk_data(
         ["CONTAINER_MARKER"],
     )
     assert docker_client.started_containers == [HOSTILE_CONTAINER_NAME]
-    assert docker_client.stopped_containers == [HOSTILE_CONTAINER_NAME]
+    # two stops: the explicit stop_container call + the graceful stop inside
+    # delete_container (DAH-2364)
+    assert docker_client.stopped_containers == [HOSTILE_CONTAINER_NAME, HOSTILE_CONTAINER_NAME]
     assert docker_client.removed_containers == [
         {
             "container_name": HOSTILE_CONTAINER_NAME,

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -108,7 +108,7 @@ class RecordingRentalDockerClient:
     async def start(self, *, container_name: str) -> None:
         self.started_containers.append(container_name)
 
-    async def stop(self, *, container_name: str, timeout: int | None = None) -> None:
+    async def stop(self, *, container_name: str, stop_grace_seconds: int | None = None) -> None:
         self.stopped_containers.append(container_name)
 
     async def remove_container(

--- a/neurons/validators/tests/test_rental_docker_sdk.py
+++ b/neurons/validators/tests/test_rental_docker_sdk.py
@@ -80,6 +80,7 @@ class FakeApiClient:
         self.host_config_kwargs = None
         self.created_container = None
         self.started = []
+        self.stopped = []
         self.exec_created = []
         self.exec_started = []
         self.exec_inspected = []
@@ -113,6 +114,9 @@ class FakeApiClient:
 
     def start(self, container_name):
         self.started.append(container_name)
+
+    def stop(self, container_name, timeout=None):
+        self.stopped.append({"container_name": container_name, "timeout": timeout})
 
     def exec_create(self, **kwargs):
         self.events.append("exec_create")
@@ -394,6 +398,34 @@ async def test_image_exists_returns_false_for_missing_image():
     assert await client.image_exists(image="registry.example/missing:tag") is False
 
     assert api_client.inspected_images == ["registry.example/missing:tag"]
+
+
+@pytest.mark.asyncio
+async def test_stop_forwards_grace_as_docker_py_timeout():
+    # Arrange: the SIGTERM grace must cross into docker-py as its `timeout` kwarg —
+    # every delete test fakes this client, so this seam is the only place it's verified
+    api_client = FakeApiClient()
+    client = RentalDockerSdkClient(api_client)
+
+    # Act
+    await client.stop(container_name="pod_stop", stop_grace_seconds=30)
+
+    # Assert
+    assert api_client.stopped == [{"container_name": "pod_stop", "timeout": 30}]
+
+
+@pytest.mark.asyncio
+async def test_stop_without_grace_keeps_docker_py_default():
+    # Arrange: callers that pass no grace (e.g. pause-pod stop_container) must keep
+    # docker-py's timeout=None, i.e. the daemon default grace
+    api_client = FakeApiClient()
+    client = RentalDockerSdkClient(api_client)
+
+    # Act
+    await client.stop(container_name="pod_stop_default")
+
+    # Assert
+    assert api_client.stopped == [{"container_name": "pod_stop_default", "timeout": None}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Describe your changes

Adds a graceful `docker stop` (SIGTERM + 30s grace window, `CONTAINER_STOP_GRACE_SECONDS`) via the Docker SDK before the existing forced `remove_container(force=True)` in `DockerService.delete_container`.

Context: on wedged sysbox/containerd nodes (ticket-0258, 8xB200 at 23.153.44.21), the SIGKILL-only removal path fails with `could not kill container: ... did not receive an exit event`, the backend retries 4x, then deletes the pod row and the running container becomes an orphan holding all GPUs. A SIGTERM-first stop lets the workload (e.g. sglang) shut down cleanly and avoids triggering the containerd desync.

Behavior guarantees:
- **FILLER workloads skip the graceful stop entirely** and keep the pre-PR SIGKILL-only removal: the backend preempts a filler before a customer rent with a 30s total budget (`FILLER_STOP_WAIT_TIMEOUT_SECONDS`) and starts the rent anyway on timeout, so a grace window equal to that budget would let a SIGTERM-ignoring filler hold the GPUs into the customer rent.
- Stop failures are swallowed and logged (missing container -> info, anything else -> warning) and never change `delete_container`'s result.
- Forced removal path, absent-container tolerance for every workload kind (DAH-2345) and post-teardown steps are unchanged.
- docker-py extends the HTTP read timeout by the stop timeout, so the 30s grace cannot cause a read-timeout.

## Issue ticket number and link

[DAH-2364 Graceful container teardown + escalation and alerting for failed pod deletions](https://app.notion.com/p/Graceful-container-teardown-escalation-and-alerting-for-failed-pod-deletions-397b8bfdbde9813eb8f6e27119b95912)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [x] Need to take care of performance? (adds up to 30s to pod deletion only when the workload ignores SIGTERM; deletion is async fire-and-forget on the WS path)
