### PR TITLE
DAH-2365, bound matrix/verifyx SSH runs and emit GPU_VERIFY_TIMEOUT

### DIFF
--- a/neurons/validators/src/services/matrix_validation_service.py
+++ b/neurons/validators/src/services/matrix_validation_service.py
@@ -1,14 +1,24 @@
+import asyncio
 import time
 import random
 import logging
 import json
 import os
+import shlex
 import uuid as uuid4
 from dataclasses import dataclass
+
+import asyncssh
+
 from core.utils import _m, get_extra_info
 from ctypes import CDLL, c_longlong, POINTER, c_void_p, c_char_p
 
 logger = logging.getLogger(__name__)
+
+# Hard cap on the remote matmul run. Real runs finish in 4-27s; without a cap a wedged
+# GPU (e.g. VRAM held by an orphaned container, DAH-2364) hangs the whole pipeline until
+# the outer JOB_TIME_OUT cancellation, which dies silently without a reason_code (DAH-2365).
+MATRIX_VERIFY_TIMEOUT_SECONDS = 120
 
 
 class DMCompVerifyWrapper:
@@ -135,6 +145,7 @@ class ValidationResult:
     stderr: str = ""
     error_message: str = ""
     metrics: dict | None = None
+    timed_out: bool = False
 
     def __bool__(self) -> bool:
         """Allow using ValidationResult in boolean context for backward compatibility."""
@@ -195,6 +206,18 @@ class ValidationService:
         max_dim_k = max_elements // (2 * dim_n) - dim_n
 
         return max_dim_k
+
+    async def _kill_remote_matmul(self, ssh_client, script_path: str, log_extra: dict) -> None:
+        # best-effort kill of the leaked matmul process so it stops holding GPU memory
+        try:
+            await ssh_client.run(f"pkill -f {shlex.quote(script_path)}", timeout=10)
+        except Exception as e:
+            logger.warning(
+                _m(
+                    f"Failed to kill remote matmul process: {e}",
+                    extra=get_extra_info(log_extra),
+                )
+            )
 
     async def validate_gpu_model_and_process_job(
         self,
@@ -283,7 +306,21 @@ class ValidationService:
 
             # Run the script
             try:
-                result = await ssh_client.run(command)
+                result = await ssh_client.run(command, timeout=MATRIX_VERIFY_TIMEOUT_SECONDS)
+            except (asyncssh.TimeoutError, asyncio.TimeoutError):
+                # asyncssh's timeout only abandons the local wait — the remote process keeps
+                # running and holding GPU memory, so it must be killed explicitly.
+                error_msg = (
+                    f"Matrix multiplication timed out after {MATRIX_VERIFY_TIMEOUT_SECONDS}s"
+                )
+                logger.error(_m(error_msg, extra=get_extra_info(log_extra)))
+                await self._kill_remote_matmul(ssh_client, script_path, log_extra)
+                return ValidationResult(
+                    success=False,
+                    expected_uuid=verifier_params.uuid,
+                    error_message=error_msg,
+                    timed_out=True,
+                )
             except Exception as e:
                 error_msg = f"Failed to execute SSH command: {str(e)}"
                 logger.error(_m(error_msg, extra=get_extra_info(log_extra)))

--- a/neurons/validators/src/services/matrix_validation_service.py
+++ b/neurons/validators/src/services/matrix_validation_service.py
@@ -210,7 +210,9 @@ class ValidationService:
     async def _kill_remote_matmul(self, ssh_client, script_path: str, log_extra: dict) -> None:
         # best-effort kill of the leaked matmul process so it stops holding GPU memory
         try:
-            await ssh_client.run(f"pkill -f {shlex.quote(script_path)}", timeout=10)
+            # SIGKILL: a SIGTERM can be ignored/slow on a wedged process; -9 is strictly
+            # more reliable outside pure D-state (where no signal lands anyway)
+            await ssh_client.run(f"pkill -9 -f {shlex.quote(script_path)}", timeout=10)
         except Exception as e:
             logger.warning(
                 _m(

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -311,11 +311,8 @@ class MinerService:
                         for executor_info in msg.executors
                     ]
 
-                    results = [
-                        result
-                        for result in await asyncio.gather(*tasks, return_exceptions=True)
-                        if result and not isinstance(result, Exception) and not isinstance(result, BaseException)
-                    ]
+                    raw_results = await asyncio.gather(*tasks, return_exceptions=True)
+                    results = self._filter_task_results(msg.executors, raw_results, default_extra)
 
                     logger.info(
                         _m(
@@ -427,6 +424,30 @@ class MinerService:
                 payload,
                 str(e),
             )
+
+    def _filter_task_results(self, executors, raw_results, default_extra: dict) -> list:
+        # keep successful JobResults; log every executor whose task ended in an
+        # exception/timeout/empty result instead of silently dropping it (DAH-2365)
+        results = []
+        for executor_info, result in zip(executors, raw_results):
+            if result and not isinstance(result, BaseException):
+                results.append(result)
+                continue
+            logger.warning(
+                _m(
+                    "Executor task dropped without result",
+                    extra=get_extra_info(
+                        {
+                            **default_extra,
+                            "executor_uuid": str(executor_info.uuid),
+                            "executor_ip_address": executor_info.address,
+                            "error_type": type(result).__name__ if result is not None else None,
+                            "error": str(result) if result is not None else "empty result",
+                        }
+                    ),
+                ),
+            )
+        return results
 
     def _build_failed_job_result(self, payload: MinerJobRequestPayload, reason: str):
         executor_info = ExecutorSSHInfo(
@@ -1543,11 +1564,8 @@ class MinerService:
                     for executor_info in msg.executors
                 ]
 
-                results = [
-                    result
-                    for result in await asyncio.gather(*tasks, return_exceptions=True)
-                    if result and not isinstance(result, Exception) and not isinstance(result, BaseException)
-                ]
+                raw_results = await asyncio.gather(*tasks, return_exceptions=True)
+                results = self._filter_task_results(msg.executors, raw_results, default_extra)
 
                 logger.info(
                     _m(

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -425,14 +425,26 @@ class MinerService:
                 str(e),
             )
 
-    def _filter_task_results(self, executors, raw_results, default_extra: dict) -> list:
+    def _filter_task_results(
+        self,
+        executors: list[ExecutorSSHInfo],
+        raw_results: list,
+        default_extra: dict,
+    ) -> list[JobResult]:
         # keep successful JobResults; log every executor whose task ended in an
         # exception/timeout/empty result instead of silently dropping it (DAH-2365)
-        results = []
+        results: list[JobResult] = []
         for executor_info, result in zip(executors, raw_results):
             if result and not isinstance(result, BaseException):
                 results.append(result)
                 continue
+            if result is None:
+                error_type = None
+                error = "empty result"
+            else:
+                error_type = type(result).__name__
+                # str(TimeoutError()) is "", so fall back to the type name to avoid an empty error
+                error = str(result) or error_type
             logger.warning(
                 _m(
                     "Executor task dropped without result",
@@ -441,8 +453,8 @@ class MinerService:
                             **default_extra,
                             "executor_uuid": str(executor_info.uuid),
                             "executor_ip_address": executor_info.address,
-                            "error_type": type(result).__name__ if result is not None else None,
-                            "error": str(result) if result is not None else "empty result",
+                            "error_type": error_type,
+                            "error": error,
                         }
                     ),
                 ),

--- a/neurons/validators/src/services/task/checks/capability.py
+++ b/neurons/validators/src/services/task/checks/capability.py
@@ -80,8 +80,9 @@ class CapabilityCheck:
         elif failure_reason:
             failure_details = {"error": failure_reason}
 
+        template = Msg.VERIFY_TIMEOUT if result is not None and result.timed_out else Msg.VERIFY_FAILED
         event = render_message(
-            Msg.VERIFY_FAILED,
+            template,
             ctx=ctx,
             check_id=self.check_id,
             what=failure_details,

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -877,6 +877,17 @@ class CapabilityMessages:
         impact="Score set to 0",
         remediation="Run Docker GPU diagnostics (nvidia-smi) and ensure containers can access GPUs.",
     )
+    VERIFY_TIMEOUT = MessageTemplate(
+        event="GPU capability verification timed out",
+        reason="GPU_VERIFY_TIMEOUT",
+        severity="error",
+        category="env",
+        impact="Score set to 0",
+        remediation=(
+            "The matrix-multiplication probe did not finish in time. Check nvidia-smi for "
+            "stuck processes or leftover containers holding VRAM on the executor."
+        ),
+    )
 
 
 class ScoreMessages:

--- a/neurons/validators/src/services/verifyx_validation_service.py
+++ b/neurons/validators/src/services/verifyx_validation_service.py
@@ -24,6 +24,11 @@ MIN_CIPHER_LEN = 64
 # Cap on stderr bytes captured per failure. Last 2 KB is kept when longer.
 STDERR_TAIL_BYTES = 2048
 
+# Hard cap on the remote verifyx run. Memory/storage/network probes can legitimately take
+# minutes, so this is generous — it only cuts true hangs (same silent-hang class as the
+# matrix check, DAH-2365) instead of blocking until the outer JOB_TIME_OUT cancellation.
+VERIFYX_COMMAND_TIMEOUT_SECONDS = 600
+
 
 class VerifyXFailureClass(str, Enum):
     SSH_TRANSPORT = "SSH_TRANSPORT"
@@ -244,7 +249,7 @@ class VerifyXValidationService:
     async def _run_ssh_command(self, shell, command: str) -> SSHCapture:
         """Run SSH command; on transport failure populate `transport_error`, else the payload fields."""
         try:
-            result = await shell.ssh_client.run(command)
+            result = await shell.ssh_client.run(command, timeout=VERIFYX_COMMAND_TIMEOUT_SECONDS)
         except Exception as e:
             return SSHCapture(transport_error=f"{type(e).__name__}: {e}")
 

--- a/neurons/validators/tests/test_capability_check.py
+++ b/neurons/validators/tests/test_capability_check.py
@@ -17,6 +17,7 @@ class DummyValidationService:
         should_raise: bool = False,
         error_message: str = "",
         metrics: dict | None = None,
+        timed_out: bool = False,
     ):
         """
         Args:
@@ -24,11 +25,13 @@ class DummyValidationService:
             should_raise: Whether to raise an exception instead of returning
             error_message: The exception message if should_raise=True or error in ValidationResult
             metrics: Optional FP32 TFLOPS metrics dict to surface on the ValidationResult
+            timed_out: Whether the returned ValidationResult reports an SSH-run timeout
         """
         self.success = success
         self.should_raise = should_raise
         self.error_message = error_message
         self.metrics = metrics
+        self.timed_out = timed_out
         # Track what parameters the check called us with
         self.called_with: dict | None = None
 
@@ -62,6 +65,7 @@ class DummyValidationService:
             stderr="",
             error_message="" if self.success else self.error_message or "Validation failed",
             metrics=self.metrics,
+            timed_out=self.timed_out,
         )
 
 
@@ -118,6 +122,27 @@ async def test_capability_check(
         assert validation_service.called_with is not None
         assert validation_service.called_with["machine_spec"] == specs
         assert validation_service.called_with["executor_info"] == ctx.executor
+
+
+@pytest.mark.asyncio
+async def test_capability_check_timeout_emits_verify_timeout_reason(context_factory):
+    # Arrange: validation reports an SSH-run timeout (wedged GPU, DAH-2365)
+    validation_service = DummyValidationService(
+        success=False,
+        error_message="Matrix multiplication timed out after 120s",
+        timed_out=True,
+    )
+    services = build_services(validation=validation_service)
+    state = build_state(specs={"gpu": {"count": 2}})
+    ctx = context_factory(services=services, state=state)
+
+    # Act
+    result = await CapabilityCheck().run(ctx)
+
+    # Assert: failure is reported with the dedicated timeout reason_code
+    assert result.passed is False
+    assert result.event.reason_code == Msg.VERIFY_TIMEOUT.reason
+    assert result.event.what_we_saw["error"] == "Matrix multiplication timed out after 120s"
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_matrix_validation_service_precheck.py
+++ b/neurons/validators/tests/test_matrix_validation_service_precheck.py
@@ -245,7 +245,7 @@ async def test_ssh_timeout_returns_timed_out_result_and_kills_remote(service_wit
     # second SSH call is the best-effort kill of the leaked matmul process
     assert run_mock.await_count == 2
     pkill_cmd = run_mock.await_args_list[1].args[0]
-    assert "pkill -f" in pkill_cmd
+    assert "pkill -9 -f" in pkill_cmd
     assert "decrypt_challenge.py" in pkill_cmd
 
 

--- a/neurons/validators/tests/test_matrix_validation_service_precheck.py
+++ b/neurons/validators/tests/test_matrix_validation_service_precheck.py
@@ -11,6 +11,7 @@ executors alike. What remains tested here:
 """
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -205,3 +206,60 @@ async def test_non_string_uuid_in_result_json_falls_back(service_with_mock_wrapp
     assert result.success is True
     assert result.returned_uuid == _FIXED_UUID
     assert result.metrics is None  # untrusted metrics from the malformed line are dropped
+
+
+# --- SSH-run timeout → timed_out result + remote process kill (DAH-2365) ----
+@pytest.mark.asyncio
+async def test_matmul_run_is_bounded_by_timeout(service_with_mock_wrapper):
+    """The matmul SSH run must carry an explicit timeout so a wedged GPU can't hang the pipeline."""
+    svc, _ = service_with_mock_wrapper
+    ssh = SimpleNamespace(
+        run=AsyncMock(return_value=SimpleNamespace(stdout="UUID: foo", stderr=""))
+    )
+    await svc.validate_gpu_model_and_process_job(
+        ssh_client=ssh,
+        executor_info=_executor_info(),
+        default_extra={},
+        machine_spec=_machine_spec(),
+    )
+    assert ssh.run.await_args_list[0].kwargs["timeout"] == mvs.MATRIX_VERIFY_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_ssh_timeout_returns_timed_out_result_and_kills_remote(service_with_mock_wrapper):
+    """On timeout the result reports timed_out=True and the leaked remote process is pkill'ed."""
+    svc, _ = service_with_mock_wrapper
+    run_mock = AsyncMock(
+        side_effect=[asyncio.TimeoutError(), SimpleNamespace(stdout="", stderr="")]
+    )
+    ssh = SimpleNamespace(run=run_mock)
+    result = await svc.validate_gpu_model_and_process_job(
+        ssh_client=ssh,
+        executor_info=_executor_info(),
+        default_extra={},
+        machine_spec=_machine_spec(),
+    )
+    assert result.success is False
+    assert result.timed_out is True
+    assert "timed out" in result.error_message
+    # second SSH call is the best-effort kill of the leaked matmul process
+    assert run_mock.await_count == 2
+    pkill_cmd = run_mock.await_args_list[1].args[0]
+    assert "pkill -f" in pkill_cmd
+    assert "decrypt_challenge.py" in pkill_cmd
+
+
+@pytest.mark.asyncio
+async def test_ssh_timeout_kill_failure_still_returns_timed_out(service_with_mock_wrapper):
+    """A failing pkill (dead connection) must not mask the timed-out result."""
+    svc, _ = service_with_mock_wrapper
+    run_mock = AsyncMock(side_effect=[asyncio.TimeoutError(), RuntimeError("connection lost")])
+    ssh = SimpleNamespace(run=run_mock)
+    result = await svc.validate_gpu_model_and_process_job(
+        ssh_client=ssh,
+        executor_info=_executor_info(),
+        default_extra={},
+        machine_spec=_machine_spec(),
+    )
+    assert result.success is False
+    assert result.timed_out is True


### PR DESCRIPTION
## Describe your changes

Bounds the previously unbounded SSH runs in the validation pipeline and makes a hung GPU check produce an explicit, observable result instead of a silent executor drop:

- `matrix_validation_service`: matmul run is now bounded by `MATRIX_VERIFY_TIMEOUT_SECONDS = 120`. On timeout the validator emits a new reason code `GPU_VERIFY_TIMEOUT` (score 0) and best-effort kills the leaked remote `decrypt_challenge.py` via `pkill`.
- `verifyx_validation_service`: SSH commands bounded by `VERIFYX_COMMAND_TIMEOUT_SECONDS = 600` (timeout folds into the existing `SSH_TRANSPORT` classification).
- `miner_service` (WS + REST paths): `asyncio.gather` results are now filtered through `_filter_task_results`, which logs a warning with executor uuid/address when a task is dropped without a result (previously exceptions were filtered out silently).

Context: on the wedged 8xB200 node (ticket-0258) the matmul hung forever, the executor's pipeline died only at the outer 780s `wait_for`, produced no reason code, and the stale sweep later flipped the executor inactive with zero operator-visible signal.

Notes from review (accepted, not regressions):
- `pkill -f <script_path>` could in principle hit a concurrent legitimate matmul run on the same executor; runs are per-executor and serialized per validator cycle, so the overlap window is negligible.
- Worst case verifyx (600s) + matmul (120s) leaves ~60s of the 780s outer budget for other checks; both steps were previously unbounded, so this only makes failures more graceful.

## Issue ticket number and link

[DAH-2365 Matrix multiplication GPU check: emit explicit timeout result and clean up remote process](https://app.notion.com/p/Matrix-multiplication-GPU-check-emit-explicit-timeout-result-and-clean-up-remote-process-397b8bfdbde981d88bd9ff8b47f02ba9)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [x] Need to take care of performance? (no extra work on the happy path; timeout only bounds already-hung runs)