### PR TITLE
Route all burn emission to UID 47 with coldkey verification

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -155,8 +155,12 @@ class Settings(BaseSettings):
     VERSION: str = (pathlib.Path(__file__).parent / ".." / ".." / "version.txt").read_text().strip()
 
     BURNERS: list[int] = [4, 206, 207, 208]
-    # Duplicate entries are slot weights: UID 47 holds the aggregated share of 7 retired burners.
-    NEW_BURNERS: list[int] = [187, 188, 189, 47, 47, 47, 47, 47, 47, 47]
+    # All burn emission slots route to UID 47 (Datura payout key).
+    NEW_BURNERS: list[int] = [47, 47, 47, 47, 47, 47, 47, 47, 47, 47]
+    # Expected coldkeys for burner UIDs. Burn weights are withheld when coldkey mismatches.
+    BURNER_COLDKEYS: dict[int, str] = {
+        47: "5G694c15wAu1LKi9rpSQqJjpBfg4K1oiBxEm5QSVdVZAfp9f",
+    }
     ENABLE_NEW_BURN_LOGIC: bool = True
 
     ENABLE_NO_COLLATERAL: bool = True

--- a/neurons/validators/src/incentive/burn_service.py
+++ b/neurons/validators/src/incentive/burn_service.py
@@ -16,6 +16,29 @@ from services.const import BURNER_EMISSION
 logger = get_logger(__name__)
 
 
+def _burner_coldkey_matches(miner: bittensor.NeuronInfo) -> bool:
+    """Return True when the miner UID has no configured coldkey or coldkey matches."""
+    expected_coldkey = settings.BURNER_COLDKEYS.get(miner.uid)
+    if expected_coldkey is None:
+        return True
+
+    if miner.coldkey == expected_coldkey:
+        return True
+
+    logger.error(
+        _m(
+            "Burner coldkey mismatch — withholding burn weight",
+            extra={
+                "miner_uid": miner.uid,
+                "miner_hotkey": miner.hotkey,
+                "expected_coldkey": expected_coldkey,
+                "actual_coldkey": miner.coldkey,
+            },
+        )
+    )
+    return False
+
+
 class BurnService:
     """Service for calculating burn emission distribution across burner nodes.
 
@@ -104,6 +127,8 @@ class BurnService:
             slots = slot_weights.get(miner.uid, 0)
             if slots == 0:
                 continue
+            if not _burner_coldkey_matches(miner):
+                continue
 
             score = burn_score_per_slot * slots
             burn_scores[miner.hotkey] = score
@@ -179,6 +204,8 @@ class BurnService:
 
         for miner in miners:
             if miner.uid == main_burner:
+                if not _burner_coldkey_matches(miner):
+                    continue
                 burn_scores[miner.hotkey] = main_burner_score
 
                 logger.debug(
@@ -198,6 +225,8 @@ class BurnService:
                     )
                 )
             elif miner.uid in other_burners:
+                if not _burner_coldkey_matches(miner):
+                    continue
                 burn_scores[miner.hotkey] = other_burner_score
 
                 logger.debug(

--- a/neurons/validators/tests/test_burn_service.py
+++ b/neurons/validators/tests/test_burn_service.py
@@ -5,6 +5,8 @@ from incentive.burn_service import BurnService
 
 pytest_plugins = ["fixtures.incentive_fixtures"]
 
+UID_47_COLDKEY = "5G694c15wAu1LKi9rpSQqJjpBfg4K1oiBxEm5QSVdVZAfp9f"
+
 
 @pytest.fixture
 def burn_service():
@@ -131,6 +133,7 @@ async def test_new_logic_aggregates_share_proportional_to_slot_count(
     filler_uids = list(range(500, 500 + (total_slots - slot_count)))
     burner_slots = filler_uids + [target_uid] * slot_count
     monkeypatch.setattr("core.config.settings.NEW_BURNERS", burner_slots)
+    monkeypatch.setattr("core.config.settings.BURNER_COLDKEYS", {})
     miners = _make_miners(create_neuron_info, [target_uid])
 
     # Act
@@ -152,11 +155,12 @@ async def test_new_logic_dah_2089_uid_47_absorbs_retired_burner_shares(
 ):
     """DAH-2089 invariant: UID 47 holds 3 slots and receives exactly 30% of burn_share,
     while the 7 remaining burners keep 10% each."""
-    # Arrange — production NEW_BURNERS layout introduced by DAH-2089
+    # Arrange — DAH-2089 historical layout
     monkeypatch.setattr(
         "core.config.settings.NEW_BURNERS",
         [187, 188, 189, 190, 191, 192, 193, 47, 47, 47],
     )
+    monkeypatch.setattr("core.config.settings.BURNER_COLDKEYS", {})
     miners = _make_miners(
         create_neuron_info, [187, 188, 189, 190, 191, 192, 193, 47]
     )
@@ -177,16 +181,71 @@ async def test_new_logic_dah_2089_uid_47_absorbs_retired_burner_shares(
 
 
 @pytest.mark.asyncio
+async def test_new_logic_all_burn_slots_route_to_uid_47(
+    burn_service, monkeypatch, mock_settings, create_neuron_info
+):
+    """Production layout: all 10 burn slots route 100% of burn_share to UID 47."""
+    # Arrange
+    monkeypatch.setattr(
+        "core.config.settings.NEW_BURNERS",
+        [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+    )
+    monkeypatch.setattr(
+        "core.config.settings.BURNER_COLDKEYS",
+        {47: UID_47_COLDKEY},
+    )
+    miners = [
+        create_neuron_info(uid=47, hotkey="hk_47", coldkey=UID_47_COLDKEY),
+        create_neuron_info(uid=188, hotkey="hk_188", coldkey="wrong_coldkey"),
+    ]
+
+    # Act
+    scores = burn_service.calculate_burn_scores(
+        miners=miners,
+        burn_share=TOTAL_BURN_EMISSION,
+        last_mechanism_step_block=None,
+    )
+
+    # Assert — only verified UID 47 receives the full burn_share
+    assert scores == {"hk_47": pytest.approx(TOTAL_BURN_EMISSION)}
+    assert "hk_188" not in scores
+
+
+@pytest.mark.asyncio
+async def test_new_logic_withholds_burn_weight_on_coldkey_mismatch(
+    burn_service, monkeypatch, mock_settings, create_neuron_info
+):
+    """A configured burner UID with the wrong coldkey must not receive burn weight."""
+    # Arrange
+    monkeypatch.setattr("core.config.settings.NEW_BURNERS", [47, 47, 47])
+    monkeypatch.setattr(
+        "core.config.settings.BURNER_COLDKEYS",
+        {47: UID_47_COLDKEY},
+    )
+    miners = [create_neuron_info(uid=47, hotkey="hk_47", coldkey="wrong_coldkey")]
+
+    # Act
+    scores = burn_service.calculate_burn_scores(
+        miners=miners,
+        burn_share=TOTAL_BURN_EMISSION,
+        last_mechanism_step_block=None,
+    )
+
+    # Assert — coldkey mismatch withholds all burn weight for UID 47
+    assert scores == {}
+
+
+@pytest.mark.asyncio
 async def test_new_logic_dah_2362_production_layout_gives_uid_47_seventy_percent(
     burn_service, monkeypatch, mock_settings, create_neuron_info
 ):
-    """DAH-2362 invariant: UID 47 holds 7 slots and receives exactly 70% of burn_share,
-    while the 3 remaining burners keep 10% each."""
-    # Arrange — production NEW_BURNERS layout introduced by DAH-2362
+    """Historical DAH-2362 layout: UID 47 holds 7 slots and receives 70% of burn_share."""
+    # Arrange — superseded layout kept for regression coverage
     monkeypatch.setattr(
         "core.config.settings.NEW_BURNERS",
         [187, 188, 189, 47, 47, 47, 47, 47, 47, 47],
     )
+    monkeypatch.setattr("core.config.settings.BURNER_COLDKEYS", {})
     miners = _make_miners(create_neuron_info, [187, 188, 189, 47])
 
     # Act
@@ -213,6 +272,7 @@ async def test_new_logic_skips_burner_uids_that_are_not_in_miner_list(
     monkeypatch.setattr(
         "core.config.settings.NEW_BURNERS", [187, 188, 189, 47, 47, 47]
     )
+    monkeypatch.setattr("core.config.settings.BURNER_COLDKEYS", {})
     miners = _make_miners(create_neuron_info, [187, 47])
 
     # Act
@@ -286,11 +346,12 @@ async def test_old_logic_main_burner_selection_is_deterministic_per_block(
 async def test_is_burner_under_new_logic(
     uid, expected, burn_service, monkeypatch, mock_settings
 ):
-    # Arrange — DAH-2089 production layout
+    # Arrange — DAH-2089 historical layout
     monkeypatch.setattr(
         "core.config.settings.NEW_BURNERS",
         [187, 188, 189, 190, 191, 192, 193, 47, 47, 47],
     )
+    monkeypatch.setattr("core.config.settings.BURNER_COLDKEYS", {})
 
     # Act / Assert — membership matches the configured NEW_BURNERS list
     assert burn_service.is_burner(uid) is expected


### PR DESCRIPTION
## Describe your changes

- Route **all 10 burn slots** in `NEW_BURNERS` to UID 47 (removes UIDs 187/188/189 from burn allocation).
- Add `BURNER_COLDKEYS` config and verify burner coldkeys in `BurnService` before assigning burn weights.
- UID 47 expected coldkey: `5G694c15wAu1LKi9rpSQqJjpBfg4K1oiBxEm5QSVdVZAfp9f` (verified on subnet 51 metagraph at 2026-07-08 UTC).
- On coldkey mismatch, burn weight is **withheld** and an error is logged (fail-safe — prevents a UID reassignment like UID 188 from receiving burn emission).

## Issue ticket number and link

No Notion ticket provided.

## Verification evidence

**UID 47 coldkey (on-chain, finney, netuid 51):**
```
uid: 47
hotkey: 5Exx2VcedZrFCydQSBJ8ZNdWVrymUFh6yFw67FJ3vERjKZVY
coldkey: 5G694c15wAu1LKi9rpSQqJjpBfg4K1oiBxEm5QSVdVZAfp9f
```

**UID 188 incident context (why coldkey check is needed):**
```
uid: 188
hotkey: 5FbFNM1LWUTkxzj2maQ7PnBTXtSSuTzETVkBmgNCsYj9twkW
coldkey: 5D2KXEekAozzFqSpEyAFM1n5P4vN48dD1LF7U3A7GtAQZCJq  # provider edyfibrotech@gmail.com
incentive: ~6.6% (was receiving burn weight by UID alone)
```

**Manual burn-logic check (2026-07-08 UTC):** verified UID 47 with matching coldkey receives 100% of `burn_share`; wrong coldkey yields empty score map.

## Test plan

- [ ] `pytest neurons/validators/tests/test_burn_service.py` (new tests: all-slots-to-47, coldkey mismatch withholds weight)
- [ ] After deploy: confirm validator logs show burn weights only on UID 47 hotkey `5Exx2VcedZrF...`
- [ ] Confirm UIDs 187/188/189 no longer appear in burn score map

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?

Made with [Cursor](https://cursor.com)