### PR TITLE
DAH-2375, remove anonymous volumes in failed-create cleanup and prune dangling orphans

### DIFF
--- a/neurons/validators/src/core/docker_utils.py
+++ b/neurons/validators/src/core/docker_utils.py
@@ -69,7 +69,6 @@ class DockerCommand:
         """Build docker volume ls command listing dangling volume names."""
         return "/usr/bin/docker volume ls -qf dangling=true"
 
-
     @staticmethod
     def inspect_created_timestamp(container_id: str) -> str:
         """Build docker inspect command to get creation timestamp in seconds."""

--- a/neurons/validators/src/core/docker_utils.py
+++ b/neurons/validators/src/core/docker_utils.py
@@ -33,11 +33,6 @@ class DockerCommand:
         )
 
     @staticmethod
-    def remove(name: str) -> str:
-        """Build docker rm command."""
-        return f"/usr/bin/docker rm -f {name}"
-
-    @staticmethod
     def remove_with_volumes(name: str) -> str:
         """Build docker rm command that also removes anonymous volumes."""
         return f"/usr/bin/docker rm -fv {name}"
@@ -64,34 +59,16 @@ class DockerCommand:
         return f"/usr/bin/docker inspect {container_id} --format '{{{{.State.ExitCode}}}}' 2>&1"
 
     @staticmethod
-    def volume_prune() -> str:
-        """Build docker volume prune command."""
-        return "/usr/bin/docker volume prune -af"
-
-    @staticmethod
-    def volume_remove(volume_name: str) -> str:
-        """Build docker volume rm command."""
-        return f"/usr/bin/docker volume rm {volume_name} 2>/dev/null || true"
+    def volume_remove(*volume_names: str) -> str:
+        """Build docker volume rm command, tolerating per-volume failures."""
+        names = " ".join(shlex.quote(name) for name in volume_names)
+        return f"/usr/bin/docker volume rm {names} 2>/dev/null || true"
 
     @staticmethod
     def volume_ls_dangling() -> str:
         """Build docker volume ls command listing dangling volume names."""
         return "/usr/bin/docker volume ls -qf dangling=true"
 
-    @staticmethod
-    def volume_inspect_created(volume_names: list[str]) -> str:
-        """Build docker volume inspect command printing name and creation time per line."""
-        names = " ".join(shlex.quote(name) for name in volume_names)
-        return (
-            "/usr/bin/docker volume inspect "
-            f"--format '{{{{.Name}}}} {{{{.CreatedAt}}}}' {names} 2>/dev/null"
-        )
-
-    @staticmethod
-    def volume_remove_batch(volume_names: list[str]) -> str:
-        """Build docker volume rm command for multiple volumes, tolerating per-volume failures."""
-        names = " ".join(shlex.quote(name) for name in volume_names)
-        return f"/usr/bin/docker volume rm {names} 2>/dev/null || true"
 
     @staticmethod
     def inspect_created_timestamp(container_id: str) -> str:

--- a/neurons/validators/src/core/docker_utils.py
+++ b/neurons/validators/src/core/docker_utils.py
@@ -74,6 +74,26 @@ class DockerCommand:
         return f"/usr/bin/docker volume rm {volume_name} 2>/dev/null || true"
 
     @staticmethod
+    def volume_ls_dangling() -> str:
+        """Build docker volume ls command listing dangling volume names."""
+        return "/usr/bin/docker volume ls -qf dangling=true"
+
+    @staticmethod
+    def volume_inspect_created(volume_names: list[str]) -> str:
+        """Build docker volume inspect command printing name and creation time per line."""
+        names = " ".join(shlex.quote(name) for name in volume_names)
+        return (
+            "/usr/bin/docker volume inspect "
+            f"--format '{{{{.Name}}}} {{{{.CreatedAt}}}}' {names} 2>/dev/null"
+        )
+
+    @staticmethod
+    def volume_remove_batch(volume_names: list[str]) -> str:
+        """Build docker volume rm command for multiple volumes, tolerating per-volume failures."""
+        names = " ".join(shlex.quote(name) for name in volume_names)
+        return f"/usr/bin/docker volume rm {names} 2>/dev/null || true"
+
+    @staticmethod
     def inspect_created_timestamp(container_id: str) -> str:
         """Build docker inspect command to get creation timestamp in seconds."""
         return (

--- a/neurons/validators/src/services/container_cleanup.py
+++ b/neurons/validators/src/services/container_cleanup.py
@@ -123,27 +123,27 @@ class ContainerCleanup:
         # reap orphaned anonymous volumes left behind by container removals without -v
         extra = {"executor_uuid": executor_uuid}
         try:
-            volumes = await self.get_dangling_anonymous_volumes(ssh_client)
-            if volumes is None:
+            dangling_anonymous = await self.get_dangling_anonymous_volumes(ssh_client)
+            if dangling_anonymous is None:
                 logger.warning(_m("Listing dangling volumes failed", extra=extra))
                 return 0
 
-            volumes = volumes[:VOLUME_RM_MAX_PER_PASS]
-            if not volumes:
+            to_remove = dangling_anonymous[:VOLUME_RM_MAX_PER_PASS]
+            if not to_remove:
                 return 0
 
             if self.dry_run:
                 logger.info(
                     _m(
-                        f"[DRY RUN] Would remove {len(volumes)} dangling anonymous volume(s)",
-                        extra=extra | {"volumes": volumes, "dry_run": True},
+                        f"[DRY RUN] Would remove {len(to_remove)} dangling anonymous volume(s)",
+                        extra=extra | {"volumes": to_remove, "dry_run": True},
                     )
                 )
                 return 0
 
-            await ssh_client.run(DockerCommand.volume_remove(*volumes))
-            logger.info(_m(f"Removed {len(volumes)} dangling anonymous volume(s)", extra=extra))
-            return len(volumes)
+            await ssh_client.run(DockerCommand.volume_remove(*to_remove))
+            logger.info(_m(f"Removed {len(to_remove)} dangling anonymous volume(s)", extra=extra))
+            return len(to_remove)
 
         except Exception as e:
             logger.warning(

--- a/neurons/validators/src/services/container_cleanup.py
+++ b/neurons/validators/src/services/container_cleanup.py
@@ -123,27 +123,33 @@ class ContainerCleanup:
         # reap orphaned anonymous volumes left behind by container removals without -v
         extra = {"executor_uuid": executor_uuid}
         try:
-            dangling_anonymous = await self.get_dangling_anonymous_volumes(ssh_client)
-            if dangling_anonymous is None:
+            dangling_anonymous_volumes: list[str] = await self.get_dangling_anonymous_volumes(ssh_client)
+            if dangling_anonymous_volumes is None:
                 logger.warning(_m("Listing dangling volumes failed", extra=extra))
                 return 0
 
-            to_remove = dangling_anonymous[:VOLUME_RM_MAX_PER_PASS]
-            if not to_remove:
+            volumes_to_remove = dangling_anonymous_volumes[:VOLUME_RM_MAX_PER_PASS]
+            if not volumes_to_remove:
                 return 0
 
             if self.dry_run:
                 logger.info(
                     _m(
-                        f"[DRY RUN] Would remove {len(to_remove)} dangling anonymous volume(s)",
-                        extra=extra | {"volumes": to_remove, "dry_run": True},
+                        f"[DRY RUN] Would remove {len(volumes_to_remove)} dangling anonymous volume(s)",
+                        extra=extra | {"volumes": volumes_to_remove, "dry_run": True},
                     )
                 )
                 return 0
 
-            await ssh_client.run(DockerCommand.volume_remove(*to_remove))
-            logger.info(_m(f"Removed {len(to_remove)} dangling anonymous volume(s)", extra=extra))
-            return len(to_remove)
+            await ssh_client.run(DockerCommand.volume_remove(*volumes_to_remove))
+            logger.info(
+                _m(
+                    f"Removed {len(volumes_to_remove)} of {len(dangling_anonymous_volumes)} "
+                    "dangling anonymous volume(s)",
+                    extra=extra,
+                )
+            )
+            return len(volumes_to_remove)
 
         except Exception as e:
             logger.warning(

--- a/neurons/validators/src/services/container_cleanup.py
+++ b/neurons/validators/src/services/container_cleanup.py
@@ -123,7 +123,7 @@ class ContainerCleanup:
         # reap orphaned anonymous volumes left behind by container removals without -v
         extra = {"executor_uuid": executor_uuid}
         try:
-            dangling_anonymous_volumes: list[str] = await self.get_dangling_anonymous_volumes(ssh_client)
+            dangling_anonymous_volumes: Optional[list[str]] = await self.get_dangling_anonymous_volumes(ssh_client)
             if dangling_anonymous_volumes is None:
                 logger.warning(_m("Listing dangling volumes failed", extra=extra))
                 return 0

--- a/neurons/validators/src/services/container_cleanup.py
+++ b/neurons/validators/src/services/container_cleanup.py
@@ -1,6 +1,5 @@
 import logging
 import re
-from dataclasses import dataclass
 from typing import Optional
 
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
@@ -17,16 +16,9 @@ logger = logging.getLogger(__name__)
 # Anonymous docker volumes are named with a 64-char hex hash.
 ANON_VOLUME_NAME_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
-
-@dataclass
-class DanglingVolumesResult:
-    success: bool
-    volumes: list[str]
-
-
-def filter_unnamed_volumes_only(volumes: list[str]) -> list[str]:
-    # anonymous volumes carry a docker-generated 64-hex name; named ones never match
-    return [name for name in volumes if ANON_VOLUME_NAME_PATTERN.match(name)]
+# Cap names per `docker volume rm` so a large historical backlog can't overflow
+# the shell argument length limit and fail the whole removal.
+VOLUME_RM_BATCH_SIZE = 200
 
 
 class ContainerCleanup:
@@ -131,50 +123,55 @@ class ContainerCleanup:
         # reap orphaned anonymous volumes left behind by container removals without -v
         extra = {"executor_uuid": executor_uuid}
         try:
-            dangling_volumes: DanglingVolumesResult = await self.get_dangling_volumes(ssh_client)
-
-            if not dangling_volumes.success:
+            volumes = await self.get_dangling_anonymous_volumes(ssh_client)
+            if volumes is None:
                 logger.warning(_m("Listing dangling volumes failed", extra=extra))
                 return 0
-
-            dangling_unnamed_volumes: list[str] = filter_unnamed_volumes_only(dangling_volumes.volumes)
-            if not dangling_unnamed_volumes:
+            if not volumes:
                 return 0
 
             if self.dry_run:
                 logger.info(
                     _m(
-                        f"[DRY RUN] Would remove {len(dangling_unnamed_volumes)} dangling anonymous volume(s)",
-                        extra={**extra, "volumes": dangling_unnamed_volumes, "dry_run": True},
+                        f"[DRY RUN] Would remove {len(volumes)} dangling anonymous volume(s)",
+                        extra=extra | {"volumes": volumes, "dry_run": True},
                     )
                 )
                 return 0
 
-            await ssh_client.run(DockerCommand.volume_remove(*dangling_unnamed_volumes))
+            # Remove in batches (arg-length safe) and count what docker actually
+            # reaped — it prints one removed volume name per stdout line — rather
+            # than assuming every requested name was removed.
+            removed = 0
+            for start in range(0, len(volumes), VOLUME_RM_BATCH_SIZE):
+                batch = volumes[start:start + VOLUME_RM_BATCH_SIZE]
+                result = await ssh_client.run(DockerCommand.volume_remove(*batch))
+                removed += sum(1 for line in (result.stdout or "").splitlines() if line.strip())
+
             logger.info(
                 _m(
-                    f"Removed {len(dangling_unnamed_volumes)} dangling anonymous volume(s)",
-                    extra={**extra, "volumes": dangling_unnamed_volumes},
+                    f"Removed {removed} dangling anonymous volume(s)",
+                    extra=extra | {"requested": len(volumes)},
                 )
             )
-            return len(dangling_unnamed_volumes)
+            return removed
 
         except Exception as e:
             logger.warning(
                 _m(
                     "Dangling anonymous volume prune failed",
-                    extra={**extra, "error": str(e)},
+                    extra=extra | {"error": str(e)},
                 )
             )
             return 0
 
-    async def get_dangling_volumes(self, ssh_client) -> "DanglingVolumesResult":
-        # names of volumes referenced by no container (anonymous AND named)
+    async def get_dangling_anonymous_volumes(self, ssh_client) -> Optional[list[str]]:
+        # anonymous (64-hex) volumes referenced by no container; None if listing failed
         result = await ssh_client.run(DockerCommand.volume_ls_dangling())
         if result.exit_status != 0:
-            return DanglingVolumesResult(success=False, volumes=[])
-        volumes = [line.strip() for line in (result.stdout or "").split("\n") if line.strip()]
-        return DanglingVolumesResult(success=True, volumes=volumes)
+            return None
+        names = [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
+        return [name for name in names if ANON_VOLUME_NAME_PATTERN.match(name)]
 
     async def force_remove_health_checks(
         self,

--- a/neurons/validators/src/services/container_cleanup.py
+++ b/neurons/validators/src/services/container_cleanup.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from dataclasses import dataclass
 from typing import Optional
 
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
@@ -15,6 +16,17 @@ logger = logging.getLogger(__name__)
 
 # Anonymous docker volumes are named with a 64-char hex hash.
 ANON_VOLUME_NAME_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+@dataclass
+class DanglingVolumesResult:
+    success: bool
+    volumes: list[str]
+
+
+def filter_unnamed_volumes_only(volumes: list[str]) -> list[str]:
+    # anonymous volumes carry a docker-generated 64-hex name; named ones never match
+    return [name for name in volumes if ANON_VOLUME_NAME_PATTERN.match(name)]
 
 
 class ContainerCleanup:
@@ -119,38 +131,33 @@ class ContainerCleanup:
         # reap orphaned anonymous volumes left behind by container removals without -v
         extra = {"executor_uuid": executor_uuid}
         try:
-            result = await ssh_client.run(DockerCommand.volume_ls_dangling())
-            if result.exit_status != 0:
+            dangling_volumes: DanglingVolumesResult = await self.get_dangling_volumes(ssh_client)
+
+            if not dangling_volumes.success:
+                logger.warning(_m("Listing dangling volumes failed", extra=extra))
                 return 0
 
-            # A dangling volume is referenced by no container, and an anonymous
-            # one cannot be legitimately reclaimed later — safe to remove.
-            # Named volumes (volume_<pod_id> etc.) never match the hex pattern.
-            stale_volumes = [
-                name
-                for name in (line.strip() for line in (result.stdout or "").split("\n"))
-                if ANON_VOLUME_NAME_PATTERN.match(name)
-            ]
-            if not stale_volumes:
+            dangling_unnamed_volumes: list[str] = filter_unnamed_volumes_only(dangling_volumes.volumes)
+            if not dangling_unnamed_volumes:
                 return 0
 
             if self.dry_run:
                 logger.info(
                     _m(
-                        f"[DRY RUN] Would remove {len(stale_volumes)} dangling anonymous volume(s)",
-                        extra={**extra, "volumes": stale_volumes, "dry_run": True},
+                        f"[DRY RUN] Would remove {len(dangling_unnamed_volumes)} dangling anonymous volume(s)",
+                        extra={**extra, "volumes": dangling_unnamed_volumes, "dry_run": True},
                     )
                 )
                 return 0
 
-            await ssh_client.run(DockerCommand.volume_remove(*stale_volumes))
+            await ssh_client.run(DockerCommand.volume_remove(*dangling_unnamed_volumes))
             logger.info(
                 _m(
-                    f"Removed {len(stale_volumes)} dangling anonymous volume(s)",
-                    extra={**extra, "volumes": stale_volumes},
+                    f"Removed {len(dangling_unnamed_volumes)} dangling anonymous volume(s)",
+                    extra={**extra, "volumes": dangling_unnamed_volumes},
                 )
             )
-            return len(stale_volumes)
+            return len(dangling_unnamed_volumes)
 
         except Exception as e:
             logger.warning(
@@ -160,6 +167,14 @@ class ContainerCleanup:
                 )
             )
             return 0
+
+    async def get_dangling_volumes(self, ssh_client) -> "DanglingVolumesResult":
+        # names of volumes referenced by no container (anonymous AND named)
+        result = await ssh_client.run(DockerCommand.volume_ls_dangling())
+        if result.exit_status != 0:
+            return DanglingVolumesResult(success=False, volumes=[])
+        volumes = [line.strip() for line in (result.stdout or "").split("\n") if line.strip()]
+        return DanglingVolumesResult(success=True, volumes=volumes)
 
     async def force_remove_health_checks(
         self,

--- a/neurons/validators/src/services/container_cleanup.py
+++ b/neurons/validators/src/services/container_cleanup.py
@@ -16,9 +16,9 @@ logger = logging.getLogger(__name__)
 # Anonymous docker volumes are named with a 64-char hex hash.
 ANON_VOLUME_NAME_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
-# Cap names per `docker volume rm` so a large historical backlog can't overflow
-# the shell argument length limit and fail the whole removal.
-VOLUME_RM_BATCH_SIZE = 200
+# Remove at most this many per pass; GC runs each cycle, so a backlog drains
+# over a few passes without a huge `docker volume rm` command.
+VOLUME_RM_MAX_PER_PASS = 200
 
 
 class ContainerCleanup:
@@ -127,6 +127,8 @@ class ContainerCleanup:
             if volumes is None:
                 logger.warning(_m("Listing dangling volumes failed", extra=extra))
                 return 0
+
+            volumes = volumes[:VOLUME_RM_MAX_PER_PASS]
             if not volumes:
                 return 0
 
@@ -139,22 +141,9 @@ class ContainerCleanup:
                 )
                 return 0
 
-            # Remove in batches (arg-length safe) and count what docker actually
-            # reaped — it prints one removed volume name per stdout line — rather
-            # than assuming every requested name was removed.
-            removed = 0
-            for start in range(0, len(volumes), VOLUME_RM_BATCH_SIZE):
-                batch = volumes[start:start + VOLUME_RM_BATCH_SIZE]
-                result = await ssh_client.run(DockerCommand.volume_remove(*batch))
-                removed += sum(1 for line in (result.stdout or "").splitlines() if line.strip())
-
-            logger.info(
-                _m(
-                    f"Removed {removed} dangling anonymous volume(s)",
-                    extra=extra | {"requested": len(volumes)},
-                )
-            )
-            return removed
+            await ssh_client.run(DockerCommand.volume_remove(*volumes))
+            logger.info(_m(f"Removed {len(volumes)} dangling anonymous volume(s)", extra=extra))
+            return len(volumes)
 
         except Exception as e:
             logger.warning(

--- a/neurons/validators/src/services/container_cleanup.py
+++ b/neurons/validators/src/services/container_cleanup.py
@@ -1,4 +1,6 @@
 import logging
+import re
+from datetime import datetime, timezone
 from typing import Optional
 
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
@@ -11,6 +13,13 @@ from services.const import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Protects the small window where a fresh anonymous volume exists
+# before/while its container is being created.
+ANON_VOLUME_MIN_AGE_MINUTES = 60
+
+# Anonymous docker volumes are named with a 64-char hex hash.
+ANON_VOLUME_NAME_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
 
 class ContainerCleanup:
@@ -41,6 +50,8 @@ class ContainerCleanup:
             # Get all containers with rental prefixes.
             all_containers = await self._get_all_rental_containers(ssh_client)
             if not all_containers:
+                # Still sweep orphaned anonymous volumes on idle executors.
+                await self.prune_dangling_anonymous_volumes(ssh_client, executor_uuid)
                 return 0, []
 
             extra["total_containers"] = len(all_containers)
@@ -104,7 +115,104 @@ class ContainerCleanup:
                 )
             )
 
+        # DAH-2375: reap anonymous volumes orphaned by historical `docker rm`
+        # without -v. Best-effort — never raises, never changes this return.
+        await self.prune_dangling_anonymous_volumes(ssh_client, executor_uuid)
+
         return len(removed_names), removed_names
+
+    async def prune_dangling_anonymous_volumes(
+        self,
+        ssh_client,
+        executor_uuid: str,
+    ) -> int:
+        # reap orphaned anonymous volumes left behind by container removals without -v
+        extra = {"executor_uuid": executor_uuid}
+        try:
+            result = await ssh_client.run(DockerCommand.volume_ls_dangling())
+            if result.exit_status != 0:
+                return 0
+
+            candidates = [
+                name.strip()
+                for name in (result.stdout or "").strip().split("\n")
+                if ANON_VOLUME_NAME_PATTERN.match(name.strip())
+            ]
+            if not candidates:
+                return 0
+
+            # docker volume inspect may exit non-zero if a candidate vanished
+            # between ls and inspect — parse whatever stdout it produced.
+            inspect_result = await ssh_client.run(
+                DockerCommand.volume_inspect_created(candidates)
+            )
+            now = datetime.now(timezone.utc)
+            stale_volumes = []
+            for line in (inspect_result.stdout or "").strip().split("\n"):
+                parts = line.strip().split(maxsplit=1)
+                if len(parts) != 2:
+                    continue
+                name, created_raw = parts
+                created_at = self._parse_volume_created_at(created_raw)
+                if created_at is None:
+                    continue
+                age_minutes = (now - created_at).total_seconds() / 60
+                if age_minutes > ANON_VOLUME_MIN_AGE_MINUTES:
+                    stale_volumes.append(name)
+
+            if not stale_volumes:
+                return 0
+
+            if self.dry_run:
+                logger.info(
+                    _m(
+                        f"[DRY RUN] Would remove {len(stale_volumes)} dangling anonymous volume(s)",
+                        extra={
+                            **extra,
+                            "volume_count": len(stale_volumes),
+                            "volumes": stale_volumes,
+                            "dry_run": True,
+                        },
+                    )
+                )
+                return 0
+
+            await ssh_client.run(DockerCommand.volume_remove_batch(stale_volumes))
+            logger.info(
+                _m(
+                    f"Removed {len(stale_volumes)} dangling anonymous volume(s)",
+                    extra={
+                        **extra,
+                        "removed_count": len(stale_volumes),
+                        "removed_volumes": stale_volumes,
+                    },
+                )
+            )
+            return len(stale_volumes)
+
+        except Exception as e:
+            logger.warning(
+                _m(
+                    "Dangling anonymous volume prune failed",
+                    extra={**extra, "error": str(e)},
+                )
+            )
+            return 0
+
+    def _parse_volume_created_at(self, raw: str) -> Optional[datetime]:
+        # parse docker's RFC3339 CreatedAt, tolerating nanoseconds and 'Z' suffix
+        try:
+            value = raw.strip()
+            if value.endswith("Z"):
+                value = value[:-1] + "+00:00"
+            # trim fractional seconds beyond microseconds (Go emits nanoseconds)
+            value = re.sub(r"\.(\d{6})\d+", r".\1", value)
+            parsed = datetime.fromisoformat(value)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed
+        except (ValueError, TypeError):
+            return None
 
     async def force_remove_health_checks(
         self,

--- a/neurons/validators/src/services/container_cleanup.py
+++ b/neurons/validators/src/services/container_cleanup.py
@@ -1,6 +1,5 @@
 import logging
 import re
-from datetime import datetime, timezone
 from typing import Optional
 
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
@@ -13,10 +12,6 @@ from services.const import (
 )
 
 logger = logging.getLogger(__name__)
-
-# Protects the small window where a fresh anonymous volume exists
-# before/while its container is being created.
-ANON_VOLUME_MIN_AGE_MINUTES = 60
 
 # Anonymous docker volumes are named with a 64-char hex hash.
 ANON_VOLUME_NAME_PATTERN = re.compile(r"^[0-9a-f]{64}$")
@@ -49,11 +44,6 @@ class ContainerCleanup:
         try:
             # Get all containers with rental prefixes.
             all_containers = await self._get_all_rental_containers(ssh_client)
-            if not all_containers:
-                # Still sweep orphaned anonymous volumes on idle executors.
-                await self.prune_dangling_anonymous_volumes(ssh_client, executor_uuid)
-                return 0, []
-
             extra["total_containers"] = len(all_containers)
 
             # Get currently rented containers for this executor
@@ -133,33 +123,14 @@ class ContainerCleanup:
             if result.exit_status != 0:
                 return 0
 
-            candidates = [
-                name.strip()
-                for name in (result.stdout or "").strip().split("\n")
-                if ANON_VOLUME_NAME_PATTERN.match(name.strip())
+            # A dangling volume is referenced by no container, and an anonymous
+            # one cannot be legitimately reclaimed later — safe to remove.
+            # Named volumes (volume_<pod_id> etc.) never match the hex pattern.
+            stale_volumes = [
+                name
+                for name in (line.strip() for line in (result.stdout or "").split("\n"))
+                if ANON_VOLUME_NAME_PATTERN.match(name)
             ]
-            if not candidates:
-                return 0
-
-            # docker volume inspect may exit non-zero if a candidate vanished
-            # between ls and inspect — parse whatever stdout it produced.
-            inspect_result = await ssh_client.run(
-                DockerCommand.volume_inspect_created(candidates)
-            )
-            now = datetime.now(timezone.utc)
-            stale_volumes = []
-            for line in (inspect_result.stdout or "").strip().split("\n"):
-                parts = line.strip().split(maxsplit=1)
-                if len(parts) != 2:
-                    continue
-                name, created_raw = parts
-                created_at = self._parse_volume_created_at(created_raw)
-                if created_at is None:
-                    continue
-                age_minutes = (now - created_at).total_seconds() / 60
-                if age_minutes > ANON_VOLUME_MIN_AGE_MINUTES:
-                    stale_volumes.append(name)
-
             if not stale_volumes:
                 return 0
 
@@ -167,25 +138,16 @@ class ContainerCleanup:
                 logger.info(
                     _m(
                         f"[DRY RUN] Would remove {len(stale_volumes)} dangling anonymous volume(s)",
-                        extra={
-                            **extra,
-                            "volume_count": len(stale_volumes),
-                            "volumes": stale_volumes,
-                            "dry_run": True,
-                        },
+                        extra={**extra, "volumes": stale_volumes, "dry_run": True},
                     )
                 )
                 return 0
 
-            await ssh_client.run(DockerCommand.volume_remove_batch(stale_volumes))
+            await ssh_client.run(DockerCommand.volume_remove(*stale_volumes))
             logger.info(
                 _m(
                     f"Removed {len(stale_volumes)} dangling anonymous volume(s)",
-                    extra={
-                        **extra,
-                        "removed_count": len(stale_volumes),
-                        "removed_volumes": stale_volumes,
-                    },
+                    extra={**extra, "volumes": stale_volumes},
                 )
             )
             return len(stale_volumes)
@@ -198,21 +160,6 @@ class ContainerCleanup:
                 )
             )
             return 0
-
-    def _parse_volume_created_at(self, raw: str) -> Optional[datetime]:
-        # parse docker's RFC3339 CreatedAt, tolerating nanoseconds and 'Z' suffix
-        try:
-            value = raw.strip()
-            if value.endswith("Z"):
-                value = value[:-1] + "+00:00"
-            # trim fractional seconds beyond microseconds (Go emits nanoseconds)
-            value = re.sub(r"\.(\d{6})\d+", r".\1", value)
-            parsed = datetime.fromisoformat(value)
-            if parsed.tzinfo is None:
-                parsed = parsed.replace(tzinfo=timezone.utc)
-            return parsed
-        except (ValueError, TypeError):
-            return None
 
     async def force_remove_health_checks(
         self,
@@ -234,7 +181,7 @@ class ContainerCleanup:
         """
         try:
             result = await ssh_client.run(
-                "docker ps -q --filter 'name=^health_check_' | xargs -r docker rm -f"
+                "docker ps -q --filter 'name=^health_check_' | xargs -r docker rm -fv"
             )
             removed = [
                 line for line in (result.stdout or "").strip().split("\n")

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1147,7 +1147,7 @@ class DockerService:
                 "/usr/bin/docker ps -q "
                 f"--filter {container_filter} "
                 f"--filter {health_check_filter} "
-                "| xargs -r /usr/bin/docker rm -f"
+                "| xargs -r /usr/bin/docker rm -fv"
             )
             await client.run(remove_cmd)
 
@@ -1837,7 +1837,7 @@ class DockerService:
                     raise_exception=True,
                 )
             finally:
-                command = f"/usr/bin/docker rm -f {temp_container_name}"
+                command = f"/usr/bin/docker rm -fv {temp_container_name}"
                 await self.execute_and_stream_logs(
                     ssh_client=ssh_client,
                     command=command,

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -375,7 +375,7 @@ class DockerService:
         container holding `pod_<id>`, and the next same-command attempt would
         otherwise collide with "container name already in use". Between
         attempts (after the backoff sleep, just before the next `docker run`)
-        we issue `docker rm -f <container_name>` so the rm→run window stays
+        we issue `docker rm -fv <container_name>` so the rm→run window stays
         tight. Cleanup failures are warning-logged but do not abort the loop.
 
         DAH-2133: if Docker fails to mount an existing vloopback volume because
@@ -547,11 +547,11 @@ class DockerService:
                 call=lambda: docker_client.remove_container(
                     container_name=container_name,
                     force=True,
-                    remove_volumes=False,
+                    remove_volumes=True,
                 ),
                 container_name=container_name,
                 force=True,
-                remove_volumes=False,
+                remove_volumes=True,
             )
         except asyncio.CancelledError:
             raise
@@ -628,8 +628,9 @@ class DockerService:
         warning_event: str,
     ) -> None:
         try:
-            # Remove only the failed container object; named volumes stay intact.
-            await ssh_client.run(f"/usr/bin/docker rm -f {shlex.quote(container_name)}")
+            # Reap the failed container together with its anonymous volumes (dind
+            # images declare VOLUME /var/lib/docker); named volumes are unaffected by -v.
+            await ssh_client.run(f"/usr/bin/docker rm -fv {shlex.quote(container_name)}")
         except asyncio.CancelledError:
             raise
         except Exception as rm_exc:
@@ -2657,7 +2658,7 @@ class DockerService:
                 )
         try:
             await ssh_client.run(
-                f"/usr/bin/docker rm -f {shlex.quote(dind_name)} 2>/dev/null || true",
+                f"/usr/bin/docker rm -fv {shlex.quote(dind_name)} 2>/dev/null || true",
                 check=False,
             )
         except Exception as exc:  # noqa: BLE001 — best-effort
@@ -3205,7 +3206,7 @@ class DockerService:
                 # same verified-port pool the rental allocated. Reuse the open
                 # ssh_client so we don't pay for a second connect (and don't widen
                 # the TOCTOU gap). No wait — the rental takes priority; the
-                # port-allocated retry loop + `docker rm -f` are the backstop for
+                # port-allocated retry loop + `docker rm -fv` are the backstop for
                 # any residual race.
                 current_step = "port_check_wait"
                 wait_ok, wait_msg = await self.wait_for_port_check_containers(

--- a/neurons/validators/src/services/executor_connectivity/container_runner.py
+++ b/neurons/validators/src/services/executor_connectivity/container_runner.py
@@ -64,4 +64,4 @@ class ContainerRunner:
 
     async def cleanup(self, ssh_client: SSHClientConnection, name: str):
         """Remove container."""
-        await ssh_client.run(DockerCommand.remove(name))
+        await ssh_client.run(DockerCommand.remove_with_volumes(name))

--- a/neurons/validators/src/services/executor_connectivity/dind_probe.py
+++ b/neurons/validators/src/services/executor_connectivity/dind_probe.py
@@ -43,7 +43,7 @@ class DindVerifier:
             if result.exit_status != 0:
                 error_msg = result.stderr.strip() if result.stderr and isinstance(result.stderr, str) else "unknown error"
                 logger.error(_m("DinD creation failed", extra=get_extra_info({**log_ctx, "error": error_msg})))
-                await ssh_client.run(DockerCommand.remove(name))
+                await ssh_client.run(DockerCommand.remove_with_volumes(name))
                 return DindProbeResult(
                     success=False,
                     log_text=f"dind: check failed port={port.internal}",
@@ -96,7 +96,7 @@ class DindVerifier:
                     else:
                         logger.info(_m("Sysbox check ok", extra=get_extra_info(log_ctx)))
 
-            await ssh_client.run(DockerCommand.remove(name))
+            await ssh_client.run(DockerCommand.remove_with_volumes(name))
             logger.info(_m("DinD check ok", extra=get_extra_info({**log_ctx, "sysbox_result": sysbox})))
 
             return DindProbeResult(
@@ -111,7 +111,7 @@ class DindVerifier:
                 _m("DinD check failed", extra=get_extra_info({**log_ctx, "error": str(e)})),
                 exc_info=True,
             )
-            await ssh_client.run(DockerCommand.remove(name))
+            await ssh_client.run(DockerCommand.remove_with_volumes(name))
             return DindProbeResult(
                 success=False,
                 log_text=f"dind: check failed port={port.internal}",

--- a/neurons/validators/src/services/task/checks/custom_build_orphan_sweep.py
+++ b/neurons/validators/src/services/task/checks/custom_build_orphan_sweep.py
@@ -153,7 +153,7 @@ class CustomBuildOrphanSweepCheck:
         # Defensive — only act on names matching our prefix.
         if not name.startswith(BUILD_DIND_PREFIX):
             return False
-        cmd = f'/usr/bin/docker rm -f {name} 2>/dev/null || true'
+        cmd = f'/usr/bin/docker rm -fv {name} 2>/dev/null || true'
         try:
             await ssh.run(cmd, check=False)
             return True

--- a/neurons/validators/tests/test_container_cleanup.py
+++ b/neurons/validators/tests/test_container_cleanup.py
@@ -2,7 +2,11 @@
 
 DAH-1991: cleanup must pick up `health_check_*` in addition to `pod_*` and
 `container_*` so a stale backend probe cannot hold the rental port range.
+
+DAH-2375: prune_dangling_anonymous_volumes must reap orphaned anonymous
+volumes left behind by historical `docker rm` without `-v`.
 """
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -324,3 +328,168 @@ async def test_force_remove_health_checks_swallows_exceptions():
     count = await cleanup.force_remove_health_checks(ssh_client=ssh, executor_uuid=EXECUTOR_UUID)
 
     assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# DAH-2375: prune_dangling_anonymous_volumes — reap anonymous volumes orphaned
+# by container removals without -v.
+# ---------------------------------------------------------------------------
+
+ANON_VOLUME_OLD = "a" * 64
+ANON_VOLUME_YOUNG = "b" * 64
+ANON_VOLUME_BAD_TS = "c" * 64
+
+
+def _created_at(age_minutes: float) -> str:
+    """RFC3339 CreatedAt string with nanoseconds, age_minutes in the past."""
+    created = datetime.now(timezone.utc) - timedelta(minutes=age_minutes)
+    return created.strftime("%Y-%m-%dT%H:%M:%S") + ".123456789Z"
+
+
+def _volume_ssh_mock(dangling: list[str], created_by_name: dict[str, str]):
+    """Build an ssh mock simulating docker volume ls / inspect / rm."""
+    rm_calls: list[str] = []
+
+    async def handler(cmd, *args, **kwargs):
+        if "docker volume ls" in cmd:
+            return MagicMock(exit_status=0, stdout="\n".join(dangling), stderr="")
+        if "docker volume inspect" in cmd:
+            lines = [
+                f"{name} {created}"
+                for name, created in created_by_name.items()
+                if name in cmd
+            ]
+            return MagicMock(exit_status=0, stdout="\n".join(lines), stderr="")
+        if "docker volume rm" in cmd:
+            rm_calls.append(cmd)
+            return MagicMock(exit_status=0, stdout="", stderr="")
+        return MagicMock(exit_status=0, stdout="", stderr="")
+
+    ssh = AsyncMock()
+    ssh.run = AsyncMock(side_effect=handler)
+    return ssh, rm_calls
+
+
+@pytest.mark.asyncio
+async def test_prune_removes_old_dangling_anonymous_volume():
+    ssh, rm_calls = _volume_ssh_mock(
+        dangling=[ANON_VOLUME_OLD],
+        created_by_name={ANON_VOLUME_OLD: _created_at(age_minutes=120)},
+    )
+    cleanup = ContainerCleanup()
+
+    removed = await cleanup.prune_dangling_anonymous_volumes(ssh, EXECUTOR_UUID)
+
+    assert removed == 1
+    assert any("docker volume rm" in c and ANON_VOLUME_OLD in c for c in rm_calls)
+
+
+@pytest.mark.asyncio
+async def test_prune_keeps_named_volumes_even_if_dangling():
+    ssh, rm_calls = _volume_ssh_mock(
+        dangling=["volume_abc", "hc_x", "executor_db_data", "pod_123"],
+        created_by_name={},
+    )
+    cleanup = ContainerCleanup()
+
+    removed = await cleanup.prune_dangling_anonymous_volumes(ssh, EXECUTOR_UUID)
+
+    assert removed == 0
+    assert not rm_calls
+    # No inspect either — nothing matched the anonymous 64-hex pattern.
+    issued = [call.args[0] for call in ssh.run.await_args_list]
+    assert not any("docker volume inspect" in cmd for cmd in issued)
+
+
+@pytest.mark.asyncio
+async def test_prune_keeps_young_anonymous_volume():
+    ssh, rm_calls = _volume_ssh_mock(
+        dangling=[ANON_VOLUME_YOUNG],
+        created_by_name={ANON_VOLUME_YOUNG: _created_at(age_minutes=5)},
+    )
+    cleanup = ContainerCleanup()
+
+    removed = await cleanup.prune_dangling_anonymous_volumes(ssh, EXECUTOR_UUID)
+
+    assert removed == 0
+    assert not rm_calls
+
+
+@pytest.mark.asyncio
+async def test_prune_keeps_volume_with_unparseable_created_at():
+    ssh, rm_calls = _volume_ssh_mock(
+        dangling=[ANON_VOLUME_BAD_TS],
+        created_by_name={ANON_VOLUME_BAD_TS: "not-a-timestamp"},
+    )
+    cleanup = ContainerCleanup()
+
+    removed = await cleanup.prune_dangling_anonymous_volumes(ssh, EXECUTOR_UUID)
+
+    assert removed == 0
+    assert not rm_calls
+
+
+@pytest.mark.asyncio
+async def test_prune_removes_old_but_keeps_young_and_named_mixed():
+    ssh, rm_calls = _volume_ssh_mock(
+        dangling=[ANON_VOLUME_OLD, ANON_VOLUME_YOUNG, "volume_pod1"],
+        created_by_name={
+            ANON_VOLUME_OLD: _created_at(age_minutes=90),
+            ANON_VOLUME_YOUNG: _created_at(age_minutes=10),
+        },
+    )
+    cleanup = ContainerCleanup()
+
+    removed = await cleanup.prune_dangling_anonymous_volumes(ssh, EXECUTOR_UUID)
+
+    assert removed == 1
+    assert len(rm_calls) == 1
+    assert ANON_VOLUME_OLD in rm_calls[0]
+    assert ANON_VOLUME_YOUNG not in rm_calls[0]
+    assert "volume_pod1" not in rm_calls[0]
+
+
+@pytest.mark.asyncio
+async def test_prune_never_raises_on_ssh_failure():
+    ssh = AsyncMock()
+    ssh.run = AsyncMock(side_effect=Exception("ssh broken"))
+    cleanup = ContainerCleanup()
+
+    removed = await cleanup.prune_dangling_anonymous_volumes(ssh, EXECUTOR_UUID)
+
+    assert removed == 0
+
+
+@pytest.mark.asyncio
+async def test_prune_dry_run_skips_removal():
+    ssh, rm_calls = _volume_ssh_mock(
+        dangling=[ANON_VOLUME_OLD],
+        created_by_name={ANON_VOLUME_OLD: _created_at(age_minutes=120)},
+    )
+    cleanup = ContainerCleanup(dry_run=True)
+
+    removed = await cleanup.prune_dangling_anonymous_volumes(ssh, EXECUTOR_UUID)
+
+    assert removed == 0
+    assert not rm_calls
+
+
+@pytest.mark.asyncio
+async def test_cleanup_invokes_volume_prune():
+    """cleanup() must trigger the dangling-volume sweep at the end."""
+    ssh, rm_calls = _volume_ssh_mock(
+        dangling=[ANON_VOLUME_OLD],
+        created_by_name={ANON_VOLUME_OLD: _created_at(age_minutes=120)},
+    )
+    cleanup = ContainerCleanup(stale_threshold_minutes=15)
+
+    removed_count, removed_names = await cleanup.cleanup(
+        ssh_client=ssh,
+        rented_data=None,
+        executor_uuid=EXECUTOR_UUID,
+    )
+
+    # Container return contract unchanged; the volume was still pruned.
+    assert removed_count == 0
+    assert removed_names == []
+    assert any("docker volume rm" in c and ANON_VOLUME_OLD in c for c in rm_calls)

--- a/neurons/validators/tests/test_container_cleanup.py
+++ b/neurons/validators/tests/test_container_cleanup.py
@@ -6,7 +6,6 @@ DAH-1991: cleanup must pick up `health_check_*` in addition to `pod_*` and
 DAH-2375: prune_dangling_anonymous_volumes must reap orphaned anonymous
 volumes left behind by historical `docker rm` without `-v`.
 """
-from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -335,77 +334,29 @@ async def test_force_remove_health_checks_swallows_exceptions():
 # by container removals without -v.
 # ---------------------------------------------------------------------------
 
-ANON_VOLUME_OLD = "a" * 64
-ANON_VOLUME_YOUNG = "b" * 64
-ANON_VOLUME_BAD_TS = "c" * 64
+ANON_VOLUME_A = "a" * 64
+ANON_VOLUME_B = "b" * 64
 
 
-def _created_at(age_minutes: float) -> str:
-    """RFC3339 CreatedAt string with nanoseconds, age_minutes in the past."""
-    created = datetime.now(timezone.utc) - timedelta(minutes=age_minutes)
-    return created.strftime("%Y-%m-%dT%H:%M:%S") + ".123456789Z"
-
-
-def _volume_ssh_mock(dangling: list[str], created_by_name: dict[str, str]):
-    """Build an ssh mock simulating docker volume ls / inspect / rm."""
+def _volume_ssh_mock(dangling: list[str]):
+    """Build an ssh mock simulating docker volume ls / rm."""
     rm_calls: list[str] = []
 
     async def handler(cmd, *args, **kwargs):
         if "docker volume ls" in cmd:
             return MagicMock(exit_status=0, stdout="\n".join(dangling), stderr="")
-        if "docker volume inspect" in cmd:
-            lines = [
-                f"{name} {created}"
-                for name, created in created_by_name.items()
-                if name in cmd
-            ]
-            return MagicMock(exit_status=0, stdout="\n".join(lines), stderr="")
         if "docker volume rm" in cmd:
             rm_calls.append(cmd)
             return MagicMock(exit_status=0, stdout="", stderr="")
         return MagicMock(exit_status=0, stdout="", stderr="")
 
-    ssh = AsyncMock()
-    ssh.run = AsyncMock(side_effect=handler)
-    return ssh, rm_calls
-
-
-@pytest.mark.asyncio
-async def test_prune_removes_old_dangling_anonymous_volume():
-    ssh, rm_calls = _volume_ssh_mock(
-        dangling=[ANON_VOLUME_OLD],
-        created_by_name={ANON_VOLUME_OLD: _created_at(age_minutes=120)},
-    )
-    cleanup = ContainerCleanup()
-
-    removed = await cleanup.prune_dangling_anonymous_volumes(ssh, EXECUTOR_UUID)
-
-    assert removed == 1
-    assert any("docker volume rm" in c and ANON_VOLUME_OLD in c for c in rm_calls)
+    return _ssh_mock_from_calls(handler), rm_calls
 
 
 @pytest.mark.asyncio
 async def test_prune_keeps_named_volumes_even_if_dangling():
     ssh, rm_calls = _volume_ssh_mock(
         dangling=["volume_abc", "hc_x", "executor_db_data", "pod_123"],
-        created_by_name={},
-    )
-    cleanup = ContainerCleanup()
-
-    removed = await cleanup.prune_dangling_anonymous_volumes(ssh, EXECUTOR_UUID)
-
-    assert removed == 0
-    assert not rm_calls
-    # No inspect either — nothing matched the anonymous 64-hex pattern.
-    issued = [call.args[0] for call in ssh.run.await_args_list]
-    assert not any("docker volume inspect" in cmd for cmd in issued)
-
-
-@pytest.mark.asyncio
-async def test_prune_keeps_young_anonymous_volume():
-    ssh, rm_calls = _volume_ssh_mock(
-        dangling=[ANON_VOLUME_YOUNG],
-        created_by_name={ANON_VOLUME_YOUNG: _created_at(age_minutes=5)},
     )
     cleanup = ContainerCleanup()
 
@@ -416,36 +367,18 @@ async def test_prune_keeps_young_anonymous_volume():
 
 
 @pytest.mark.asyncio
-async def test_prune_keeps_volume_with_unparseable_created_at():
+async def test_prune_removes_anonymous_keeps_named_mixed():
     ssh, rm_calls = _volume_ssh_mock(
-        dangling=[ANON_VOLUME_BAD_TS],
-        created_by_name={ANON_VOLUME_BAD_TS: "not-a-timestamp"},
+        dangling=[ANON_VOLUME_A, ANON_VOLUME_B, "volume_pod1"],
     )
     cleanup = ContainerCleanup()
 
     removed = await cleanup.prune_dangling_anonymous_volumes(ssh, EXECUTOR_UUID)
 
-    assert removed == 0
-    assert not rm_calls
-
-
-@pytest.mark.asyncio
-async def test_prune_removes_old_but_keeps_young_and_named_mixed():
-    ssh, rm_calls = _volume_ssh_mock(
-        dangling=[ANON_VOLUME_OLD, ANON_VOLUME_YOUNG, "volume_pod1"],
-        created_by_name={
-            ANON_VOLUME_OLD: _created_at(age_minutes=90),
-            ANON_VOLUME_YOUNG: _created_at(age_minutes=10),
-        },
-    )
-    cleanup = ContainerCleanup()
-
-    removed = await cleanup.prune_dangling_anonymous_volumes(ssh, EXECUTOR_UUID)
-
-    assert removed == 1
+    assert removed == 2
     assert len(rm_calls) == 1
-    assert ANON_VOLUME_OLD in rm_calls[0]
-    assert ANON_VOLUME_YOUNG not in rm_calls[0]
+    assert ANON_VOLUME_A in rm_calls[0]
+    assert ANON_VOLUME_B in rm_calls[0]
     assert "volume_pod1" not in rm_calls[0]
 
 
@@ -462,10 +395,7 @@ async def test_prune_never_raises_on_ssh_failure():
 
 @pytest.mark.asyncio
 async def test_prune_dry_run_skips_removal():
-    ssh, rm_calls = _volume_ssh_mock(
-        dangling=[ANON_VOLUME_OLD],
-        created_by_name={ANON_VOLUME_OLD: _created_at(age_minutes=120)},
-    )
+    ssh, rm_calls = _volume_ssh_mock(dangling=[ANON_VOLUME_A])
     cleanup = ContainerCleanup(dry_run=True)
 
     removed = await cleanup.prune_dangling_anonymous_volumes(ssh, EXECUTOR_UUID)
@@ -477,10 +407,7 @@ async def test_prune_dry_run_skips_removal():
 @pytest.mark.asyncio
 async def test_cleanup_invokes_volume_prune():
     """cleanup() must trigger the dangling-volume sweep at the end."""
-    ssh, rm_calls = _volume_ssh_mock(
-        dangling=[ANON_VOLUME_OLD],
-        created_by_name={ANON_VOLUME_OLD: _created_at(age_minutes=120)},
-    )
+    ssh, rm_calls = _volume_ssh_mock(dangling=[ANON_VOLUME_A])
     cleanup = ContainerCleanup(stale_threshold_minutes=15)
 
     removed_count, removed_names = await cleanup.cleanup(
@@ -492,4 +419,4 @@ async def test_cleanup_invokes_volume_prune():
     # Container return contract unchanged; the volume was still pruned.
     assert removed_count == 0
     assert removed_names == []
-    assert any("docker volume rm" in c and ANON_VOLUME_OLD in c for c in rm_calls)
+    assert any("docker volume rm" in c and ANON_VOLUME_A in c for c in rm_calls)

--- a/neurons/validators/tests/test_container_cleanup.py
+++ b/neurons/validators/tests/test_container_cleanup.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 import pytest_asyncio
 
-from services.container_cleanup import ContainerCleanup
+from services.container_cleanup import VOLUME_RM_BATCH_SIZE, ContainerCleanup
 
 
 def _ssh_mock_from_calls(call_handler):
@@ -347,7 +347,9 @@ def _volume_ssh_mock(dangling: list[str]):
             return MagicMock(exit_status=0, stdout="\n".join(dangling), stderr="")
         if "docker volume rm" in cmd:
             rm_calls.append(cmd)
-            return MagicMock(exit_status=0, stdout="", stderr="")
+            # docker prints one removed volume name per line to stdout
+            echoed = "\n".join(name for name in dangling if name in cmd)
+            return MagicMock(exit_status=0, stdout=echoed, stderr="")
         return MagicMock(exit_status=0, stdout="", stderr="")
 
     return _ssh_mock_from_calls(handler), rm_calls
@@ -380,6 +382,40 @@ async def test_prune_removes_anonymous_keeps_named_mixed():
     assert ANON_VOLUME_A in rm_calls[0]
     assert ANON_VOLUME_B in rm_calls[0]
     assert "volume_pod1" not in rm_calls[0]
+
+
+@pytest.mark.asyncio
+async def test_prune_batches_large_backlog_and_counts_actual_removals():
+    """A backlog larger than VOLUME_RM_BATCH_SIZE is removed in several `rm`
+    calls, and the returned count reflects what docker actually reaped."""
+    backlog = [f"{i:064x}" for i in range(VOLUME_RM_BATCH_SIZE + 50)]
+    ssh, rm_calls = _volume_ssh_mock(dangling=backlog)
+    cleanup = ContainerCleanup()
+
+    removed = await cleanup.prune_dangling_anonymous_volumes(ssh, EXECUTOR_UUID)
+
+    assert removed == len(backlog)
+    assert len(rm_calls) == 2  # 200 + 50
+
+
+@pytest.mark.asyncio
+async def test_prune_reports_actual_removals_not_requested():
+    """If docker reaps fewer than requested (e.g. one raced back into use),
+    the count reflects reality, not the input length."""
+    ssh = AsyncMock()
+
+    async def run(cmd, *args, **kwargs):
+        if "docker volume ls" in cmd:
+            return MagicMock(exit_status=0, stdout=f"{ANON_VOLUME_A}\n{ANON_VOLUME_B}", stderr="")
+        # docker removed only A; B stayed (in use) and was silently skipped
+        return MagicMock(exit_status=0, stdout=ANON_VOLUME_A, stderr="")
+
+    ssh.run = AsyncMock(side_effect=run)
+    cleanup = ContainerCleanup()
+
+    removed = await cleanup.prune_dangling_anonymous_volumes(ssh, EXECUTOR_UUID)
+
+    assert removed == 1
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_container_cleanup.py
+++ b/neurons/validators/tests/test_container_cleanup.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 import pytest_asyncio
 
-from services.container_cleanup import VOLUME_RM_BATCH_SIZE, ContainerCleanup
+from services.container_cleanup import VOLUME_RM_MAX_PER_PASS, ContainerCleanup
 
 
 def _ssh_mock_from_calls(call_handler):
@@ -347,9 +347,7 @@ def _volume_ssh_mock(dangling: list[str]):
             return MagicMock(exit_status=0, stdout="\n".join(dangling), stderr="")
         if "docker volume rm" in cmd:
             rm_calls.append(cmd)
-            # docker prints one removed volume name per line to stdout
-            echoed = "\n".join(name for name in dangling if name in cmd)
-            return MagicMock(exit_status=0, stdout=echoed, stderr="")
+            return MagicMock(exit_status=0, stdout="", stderr="")
         return MagicMock(exit_status=0, stdout="", stderr="")
 
     return _ssh_mock_from_calls(handler), rm_calls
@@ -385,37 +383,16 @@ async def test_prune_removes_anonymous_keeps_named_mixed():
 
 
 @pytest.mark.asyncio
-async def test_prune_batches_large_backlog_and_counts_actual_removals():
-    """A backlog larger than VOLUME_RM_BATCH_SIZE is removed in several `rm`
-    calls, and the returned count reflects what docker actually reaped."""
-    backlog = [f"{i:064x}" for i in range(VOLUME_RM_BATCH_SIZE + 50)]
+async def test_prune_caps_removals_per_pass():
+    """A backlog larger than the cap only removes the first VOLUME_RM_MAX_PER_PASS."""
+    backlog = [f"{i:064x}" for i in range(VOLUME_RM_MAX_PER_PASS + 50)]
     ssh, rm_calls = _volume_ssh_mock(dangling=backlog)
     cleanup = ContainerCleanup()
 
     removed = await cleanup.prune_dangling_anonymous_volumes(ssh, EXECUTOR_UUID)
 
-    assert removed == len(backlog)
-    assert len(rm_calls) == 2  # 200 + 50
-
-
-@pytest.mark.asyncio
-async def test_prune_reports_actual_removals_not_requested():
-    """If docker reaps fewer than requested (e.g. one raced back into use),
-    the count reflects reality, not the input length."""
-    ssh = AsyncMock()
-
-    async def run(cmd, *args, **kwargs):
-        if "docker volume ls" in cmd:
-            return MagicMock(exit_status=0, stdout=f"{ANON_VOLUME_A}\n{ANON_VOLUME_B}", stderr="")
-        # docker removed only A; B stayed (in use) and was silently skipped
-        return MagicMock(exit_status=0, stdout=ANON_VOLUME_A, stderr="")
-
-    ssh.run = AsyncMock(side_effect=run)
-    cleanup = ContainerCleanup()
-
-    removed = await cleanup.prune_dangling_anonymous_volumes(ssh, EXECUTOR_UUID)
-
-    assert removed == 1
+    assert removed == VOLUME_RM_MAX_PER_PASS
+    assert len(rm_calls) == 1
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_custom_build_orphan_sweep.py
+++ b/neurons/validators/tests/test_custom_build_orphan_sweep.py
@@ -94,7 +94,7 @@ async def test_sweep_removes_orphan_dind_container():
     result = await check.run(ctx)
     assert result.passed is True
 
-    dind_rm_calls = [c for c in calls if "docker rm -f lium-dind-build-" in c]
+    dind_rm_calls = [c for c in calls if "docker rm -fv lium-dind-build-" in c]
     assert any("lium-dind-build-POD-DEAD" in c for c in dind_rm_calls)
     assert not any("lium-dind-build-POD-ALIVE" in c for c in dind_rm_calls)
 

--- a/neurons/validators/tests/test_custom_dockerfile_build.py
+++ b/neurons/validators/tests/test_custom_dockerfile_build.py
@@ -635,7 +635,7 @@ async def test_A13_egress_failure_aborts_before_build(svc, monkeypatch):
     # The build must NOT run when egress filtering can't be guaranteed.
     assert not any("docker build" in c for c in esl.seen)
     # But the DinD container is still torn down.
-    assert any(f"docker rm -f" in c and f"lium-dind-build-{payload.pod_id}" in c
+    assert any(f"docker rm -fv" in c and f"lium-dind-build-{payload.pod_id}" in c
                for c in ssh_client.calls)
 
 
@@ -659,7 +659,7 @@ async def test_A14_dind_container_always_torn_down(svc, monkeypatch):
     )
     assert ok is True and step is None
     assert any(
-        "docker rm -f" in c and f"lium-dind-build-{payload.pod_id}" in c
+        "docker rm -fv" in c and f"lium-dind-build-{payload.pod_id}" in c
         for c in ssh_client.calls
     ), ssh_client.calls
 

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -3449,7 +3449,7 @@ async def test_wait_for_port_check_does_not_block_other_miner(docker_service):
 
 # ---------------------------------------------------------------------------
 # DAH-2018: container-name conflict — between port-allocated retries we
-# `docker rm -f <container_name>` to release the name Docker reserved during
+# `docker rm -fv <container_name>` to release the name Docker reserved during
 # the prior `docker run` parse. Cleanup runs AFTER the backoff sleep so the
 # rm→run window stays tight; cleanup failures warn-log but never abort.
 # ---------------------------------------------------------------------------
@@ -3459,7 +3459,7 @@ async def test_wait_for_port_check_does_not_block_other_miner(docker_service):
 async def test_create_container_removes_stale_container_between_port_retries(
     docker_service, monkeypatch,
 ):
-    """Between port-allocated retries: sleep first, then docker rm -f, then re-run.
+    """Between port-allocated retries: sleep first, then docker rm -fv, then re-run.
 
     Pins both the rm command itself and the ordering vs the backoff sleep, so
     the rm→run window stays as tight as possible.
@@ -3501,7 +3501,7 @@ async def test_create_container_removes_stale_container_between_port_retries(
     assert events == [
         ("execute", 1),
         ("sleep", 5),
-        ("ssh_run", "/usr/bin/docker rm -f pod_test"),
+        ("ssh_run", "/usr/bin/docker rm -fv pod_test"),
         ("execute", 2),
     ]
 
@@ -3510,7 +3510,7 @@ async def test_create_container_removes_stale_container_between_port_retries(
 async def test_port_retry_continues_when_rm_cleanup_fails(
     docker_service, monkeypatch,
 ):
-    """A failing `docker rm -f` must warning-log but not abort the retry loop."""
+    """A failing `docker rm -fv` must warning-log but not abort the retry loop."""
     calls = {"n": 0}
 
     async def fake_execute(*, ssh_client, command, log_tag, log_text, log_extra, timeout):
@@ -3556,9 +3556,34 @@ async def test_port_retry_continues_when_rm_cleanup_fails(
 
     assert calls["n"] == 2
     # rm was attempted exactly once (between the two execute attempts).
-    assert rm_calls == ["/usr/bin/docker rm -f pod_test"]
+    assert rm_calls == ["/usr/bin/docker rm -fv pod_test"]
     # And the failure was warning-logged with the documented tag.
     assert any("PORT_RETRY_STALE_RM_FAILED" in m for m in warning_msgs)
+
+
+@pytest.mark.asyncio
+async def test_remove_failed_rental_container_for_retry_removes_anonymous_volumes(
+    docker_service,
+):
+    """DAH-2375: SDK failed-create cleanup passes remove_volumes=True so anonymous
+    volumes (dind images declare VOLUME /var/lib/docker) don't leak; named volumes
+    are never removed by it."""
+    docker_client = _FakeRentalDockerClient()
+
+    await docker_service._remove_failed_rental_container_for_retry(
+        docker_client=docker_client,
+        container_name="pod_test",
+        default_extra={},
+        warning_event="PORT_RETRY_STALE_RM_FAILED",
+    )
+
+    assert docker_client.removed_containers == [
+        {
+            "container_name": "pod_test",
+            "force": True,
+            "remove_volumes": True,
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2375](https://www.notion.so/398b8bfdbde981709269d4f2f5682f22)

---

## Problem

Executor nodes slowly fill their disk with orphaned anonymous docker volumes. Dind-based rental images (`daturaai/pytorch:*-dind`, `daturaai/dind`) declare `VOLUME /var/lib/docker`, so docker creates one anonymous volume per container. The happy-path delete removes containers with `-v` and reaps them, but the failed-create/retry cleanup paths remove containers WITHOUT `-v`, orphaning the anonymous volume on every failed create / port retry. Nothing ever prunes them (`volume_prune()` helper existed but was never called), so orphans accumulate forever — observed 1345 volumes / ~32GB on the staging A4000, pushing the disk to 84% and silently blocking the PEARL fit check.

## Solution

Two-part fix:

1. **Stop the leak** — all container-removal paths now also remove the container's anonymous volumes (`docker rm -fv` / `remove_volumes=True`). This is safe for retry data: the `-v` flag (Docker API `v=1`) removes only anonymous volumes and never touches named volumes such as `volume_<pod_id>`.
2. **Garbage-collect the backlog** — `ContainerCleanup.prune_dangling_anonymous_volumes()` runs on every executor each validation cycle (via `StaleContainerCleanupCheck`) and removes volumes that are dangling AND have a 64-hex anonymous name. Named volumes are excluded by the name filter; in-use volumes are excluded twice over — the `dangling=true` filter never lists a volume referenced by any container (running or stopped), and `docker volume rm` itself refuses to remove a volume that raced back into use. It removes at most `VOLUME_RM_MAX_PER_PASS = 200` per pass so the `docker volume rm` command stays small; since GC runs every cycle, any larger backlog drains over a few passes. Best-effort: never raises, never changes the check verdict.

The dangerous `DockerCommand.volume_prune()` (`prune -af` would delete unused NAMED volumes) was removed entirely.

## Changes

- `docker_service.py`: `_remove_failed_rental_container_for_retry` → `remove_volumes=True`; `_remove_failed_container_for_retry` → `docker rm -fv` (+ fixed misleading comment); custom-build dind teardown → `-fv`; stale doc comments updated
- `custom_build_orphan_sweep.py`: orphaned build-dind removal → `-fv`
- `container_cleanup.py`: new `prune_dangling_anonymous_volumes()` + `get_dangling_anonymous_volumes()` wired into `cleanup()` (including the idle-executor path, whose early return was dropped so the sweep still runs); constants `ANON_VOLUME_NAME_PATTERN`, `VOLUME_RM_MAX_PER_PASS = 200`
- `docker_utils.py`: new command builders `volume_ls_dangling()` and variadic `volume_remove(*names)`; removed the now-unused `remove()` and dangerous `volume_prune()`
- Tests: updated exact-command assertions to `-fv`; new test for the SDK retry path; new tests for the volume GC (filter keeps named volumes, removes anonymous, caps removals per pass, swallows SSH failures, respects `dry_run`, and is invoked by `cleanup()`)

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

None.

## Risks

- Volume GC runs a couple extra SSH commands per executor per validation cycle (cheap: `volume ls` + one capped `rm`).
- A dangling volume is by definition referenced by no container (running or stopped), so no rental can be using it; if one races back into use between the `ls` and the `rm`, `docker volume rm` refuses it and it is silently skipped.
- Named volumes (`volume_<pod_id>`) are protected twice: `-v`/`v=1` never removes named volumes, and the GC only matches bare 64-hex anonymous names.

## Test Cases

### Test Case 1: full validator test suite

**Actions**

`cd neurons/validators && pdm run pytest`

**Expected Output**

Green, apart from the 3 pre-existing failures in `test_sshd_bootstrap_script.py` that reproduce on clean `origin/main` and are unrelated.

### Test Case 2: volume GC unit coverage

**Actions**

`pdm run pytest tests/test_container_cleanup.py -q`

**Expected Output**

Removes bare 64-hex dangling volumes; keeps named ones (`volume_*`, `hc_*`, `pod_*`, `executor_db_data`) even when dangling; caps removals at `VOLUME_RM_MAX_PER_PASS` per pass; returns 0 without raising on SSH failure; respects `dry_run`; `cleanup()` return contract unchanged.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
