### PR TITLE
DAH-2380 - Resolve default template digests from Docker Hub in validator

### DIFF
--- a/neurons/validators/pdm.lock
+++ b/neurons/validators/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:0e13325f43f515589be5eab46a17afce732d011a151de8cb7d05e9ca9d3552fb"
+content_hash = "sha256:8ee9e62b9269e48f4d7b901bd7f92c568d55b76297e33c521776f1019c3e9c5f"
 
 [[metadata.targets]]
 requires_python = ">=3.11,<3.13"

--- a/neurons/validators/pyproject.toml
+++ b/neurons/validators/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "celium-collateral==1.2.0",
     "databases>=0.9.0",
     "datura @ file:///${PROJECT_ROOT}/../../datura",
-    "lium-core>=0.1.4",
+    "lium-core>=0.1.6",
     "fastapi>=0.110.3",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.10.1",

--- a/neurons/validators/src/cli.py
+++ b/neurons/validators/src/cli.py
@@ -10,6 +10,7 @@ from datura.requests.miner_requests import ExecutorSSHInfo
 from core.utils import configure_logs_of_other_modules, _m, get_extra_info, get_logger
 from core.validator import Validator
 from clients.subtensor_client import SubtensorClient
+from services.default_docker_image_digest_service import fetch_default_image_digests
 from services.ioc import ioc
 from services.miner_service import MinerService
 from services.docker_service import DockerService
@@ -147,6 +148,7 @@ async def _request_job_to_miner(miner_hotkey: str):
             ),
             encrypted_files=encrypted_files,
             rented_data=RentedExecutorsResponse(executors={}),
+            default_docker_image_digests=await fetch_default_image_digests(),
         )
         print('job_result:', result)
     finally:

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -138,7 +138,11 @@ class Settings(BaseSettings):
     # unrented executor that has not pre-pulled the recommended default image, or holds stale
     # content under the same tag, fails verification early (score 0, reason surfaced to the
     # provider). Fails open: an unmeasured signal (None) is never penalised.
-    CACHED_TEMPLATE_CUTOFF: datetime = datetime(2026, 7, 9, 12, 0, 0)
+    # TODO(2026-07-14): restore datetime(2026, 7, 9, 12, 0, 0). Cutoff deferred one day to keep
+    # the check advisory during the DAH-2380 Docker Hub digest rollout. The gate is ALSO held
+    # off by fatal=False on CachedTemplateVerificationCheck (see the TODO there) — re-enable both
+    # together tomorrow.
+    CACHED_TEMPLATE_CUTOFF: datetime = datetime(2026, 7, 14, 12, 0, 0)
 
     # Minimum NVIDIA driver requirement. Compared as a dotted version tuple against the
     # executor's reported gpu.driver (e.g. "580.95.05"). 580.65.06 is the r580 floor that

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -139,6 +139,10 @@ class Settings(BaseSettings):
     # content under the same tag, fails verification early (score 0, reason surfaced to the
     # provider). Fails open: an unmeasured signal (None) is never penalised.
     CACHED_TEMPLATE_CUTOFF: datetime = datetime(2026, 7, 9, 12, 0, 0)
+    # DAH-2380: how often the validator re-fetches default cache-template digests from Docker Hub.
+    DEFAULT_DOCKER_IMAGE_DIGEST_REFRESH_SECONDS: int = Field(
+        env="DEFAULT_DOCKER_IMAGE_DIGEST_REFRESH_SECONDS", default=3600
+    )
 
     # Minimum NVIDIA driver requirement. Compared as a dotted version tuple against the
     # executor's reported gpu.driver (e.g. "580.95.05"). 580.65.06 is the r580 floor that

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -139,10 +139,6 @@ class Settings(BaseSettings):
     # content under the same tag, fails verification early (score 0, reason surfaced to the
     # provider). Fails open: an unmeasured signal (None) is never penalised.
     CACHED_TEMPLATE_CUTOFF: datetime = datetime(2026, 7, 9, 12, 0, 0)
-    # DAH-2380: how often the validator re-fetches default cache-template digests from Docker Hub.
-    DEFAULT_DOCKER_IMAGE_DIGEST_REFRESH_SECONDS: int = Field(
-        env="DEFAULT_DOCKER_IMAGE_DIGEST_REFRESH_SECONDS", default=3600
-    )
 
     # Minimum NVIDIA driver requirement. Compared as a dotted version tuple against the
     # executor's reported gpu.driver (e.g. "580.95.05"). 580.65.06 is the r580 floor that

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -74,10 +74,6 @@ class Validator:
             keypair=keypair,
         )
         self.default_docker_image_digest_service = get_default_docker_image_digest_service()
-        # Retain the task ref so the background refresh loop isn't garbage-collected mid-run.
-        self._digest_refresh_task = asyncio.create_task(
-            self.default_docker_image_digest_service.run_refresh_loop()
-        )
 
         port_tester = PortTester()
         runner = ContainerRunner()
@@ -220,6 +216,19 @@ class Validator:
             if current_block - self.last_job_run_blocks >= settings.BLOCKS_FOR_JOB:
                 job_block = (current_block // settings.BLOCKS_FOR_JOB) * settings.BLOCKS_FOR_JOB
                 job_batch_id = await self.subtensor_client.get_time_from_block(job_block)
+
+                # DAH-2380: refresh default cache-template digests from Docker Hub at the
+                # start of each job cycle, so verification compares executors against the
+                # current tags. Fail-open — a Docker Hub hiccup must never block the cycle.
+                try:
+                    await self.default_docker_image_digest_service.refresh()
+                except Exception as exc:
+                    logger.error(
+                        _m(
+                            "[sync] default docker image digest refresh failed; using last cache",
+                            extra=get_extra_info({**self.default_extra, "error": str(exc)}),
+                        ),
+                    )
 
                 # Fetch all rented executors from backend API
                 rented_executors = await self.backend_client.get_all_rented_executors()

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -3,35 +3,34 @@ import json
 import os
 import time
 
-from payload_models.payloads import MinerJobRequestPayload
 from clients.backend_client import BackendClient
-
-from core.config import settings
+from clients.subtensor_client import SubtensorClient
 from incentive.eligibility import is_missing_discord_after_cutoff
 from incentive.factory import IncentiveFactory
 from incentive.rental_price import precompute_all_estimates
-from core.utils import _m, get_extra_info, get_logger
-from clients.subtensor_client import SubtensorClient
+from payload_models.payloads import MinerJobRequestPayload
+from services.attestation_service import AttestationService
+from services.collateral_contract_service import CollateralContractService
+from services.default_docker_image_digest_service import get_default_docker_image_digest_service
 from services.docker_service import DockerService
 from services.executor_connectivity.container_runner import ContainerRunner
 from services.executor_connectivity.dind_probe import DindProbe, DindVerifier
+from services.executor_connectivity.orchestrator import ConnectivityOrchestrator
 from services.executor_connectivity.port_probe import PortProbe
 from services.executor_connectivity.port_selector import PortSelector
 from services.executor_connectivity.port_tester import PortTester
 from services.executor_connectivity.port_verifiers import BatchVerifier, FallbackVerifier
-from services.executor_connectivity.orchestrator import ConnectivityOrchestrator
 from services.executor_connectivity_service import ExecutorConnectivityService
 from services.file_encrypt_service import FileEncryptService
+from services.matrix_validation_service import ValidationService
 from services.miner_service import MinerService
 from services.redis_service import GPU_ESTIMATES_CHANNEL, PENDING_PODS_PREFIX, RedisService
-from services.ssh_service import SSHService
-from services.task_service import TaskService, JobResult
-from services.matrix_validation_service import ValidationService
+from services.task_service import JobResult, TaskService
 from services.verifyx_validation_service import VerifyXValidationService
-from services.collateral_contract_service import CollateralContractService
-from services.attestation_service import AttestationService
-from services.const import IS_NOT_DEPOSITED_SCORE_MULTIPLIER
 
+from core.config import settings
+from core.utils import _m, get_extra_info, get_logger
+from services.ssh_service import SSHService
 
 logger = get_logger(__name__)
 
@@ -74,6 +73,8 @@ class Validator:
             base_url=settings.COMPUTE_REST_API_URL or "",
             keypair=keypair,
         )
+        self.default_docker_image_digest_service = get_default_docker_image_digest_service()
+        asyncio.create_task(self.default_docker_image_digest_service.run_refresh_loop())
 
         port_tester = PortTester()
         runner = ContainerRunner()
@@ -97,6 +98,7 @@ class Validator:
             executor_connectivity_service=self.executor_connectivity_service,
             backend_client=self.backend_client,
             attestation_service=self.attestation_service,
+            default_docker_image_digest_service=self.default_docker_image_digest_service,
         )
         self.docker_service = DockerService(
             ssh_service=ssh_service,

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -11,7 +11,7 @@ from incentive.rental_price import precompute_all_estimates
 from payload_models.payloads import MinerJobRequestPayload
 from services.attestation_service import AttestationService
 from services.collateral_contract_service import CollateralContractService
-from services.default_docker_image_digest_service import get_default_docker_image_digest_service
+from services.default_docker_image_digest_service import fetch_default_image_digests
 from services.docker_service import DockerService
 from services.executor_connectivity.container_runner import ContainerRunner
 from services.executor_connectivity.dind_probe import DindProbe, DindVerifier
@@ -73,8 +73,6 @@ class Validator:
             base_url=settings.COMPUTE_REST_API_URL or "",
             keypair=keypair,
         )
-        self.default_docker_image_digest_service = get_default_docker_image_digest_service()
-
         port_tester = PortTester()
         runner = ContainerRunner()
         self.executor_connectivity_service = ExecutorConnectivityService(
@@ -97,7 +95,6 @@ class Validator:
             executor_connectivity_service=self.executor_connectivity_service,
             backend_client=self.backend_client,
             attestation_service=self.attestation_service,
-            default_docker_image_digest_service=self.default_docker_image_digest_service,
         )
         self.docker_service = DockerService(
             ssh_service=ssh_service,
@@ -217,15 +214,17 @@ class Validator:
                 job_block = (current_block // settings.BLOCKS_FOR_JOB) * settings.BLOCKS_FOR_JOB
                 job_batch_id = await self.subtensor_client.get_time_from_block(job_block)
 
-                # DAH-2380: refresh default cache-template digests from Docker Hub at the
+                # DAH-2380: fetch default cache-template digests from Docker Hub at the
                 # start of each job cycle, so verification compares executors against the
-                # current tags. Fail-open — a Docker Hub hiccup must never block the cycle.
+                # current tags. Fail-open — a Docker Hub hiccup must never block the cycle;
+                # an empty snapshot makes the digest check skip (never penalizes a miner).
                 try:
-                    await self.default_docker_image_digest_service.refresh()
+                    default_image_digests = await fetch_default_image_digests()
                 except Exception as exc:
+                    default_image_digests = {}
                     logger.error(
                         _m(
-                            "[sync] default docker image digest refresh failed; using last cache",
+                            "[sync] default docker image digest fetch failed; digest checks skip this cycle",
                             extra=get_extra_info({**self.default_extra, "error": str(exc)}),
                         ),
                     )
@@ -274,6 +273,7 @@ class Validator:
                             ),
                             encrypted_files=encrypted_files,
                             rented_data=rented_executors,
+                            default_docker_image_digests=default_image_digests,
                         )
                     )
                     for miner in miners

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -74,7 +74,10 @@ class Validator:
             keypair=keypair,
         )
         self.default_docker_image_digest_service = get_default_docker_image_digest_service()
-        asyncio.create_task(self.default_docker_image_digest_service.run_refresh_loop())
+        # Retain the task ref so the background refresh loop isn't garbage-collected mid-run.
+        self._digest_refresh_task = asyncio.create_task(
+            self.default_docker_image_digest_service.run_refresh_loop()
+        )
 
         port_tester = PortTester()
         runner = ContainerRunner()

--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -132,9 +132,9 @@ class DefaultDockerImage(BaseModel, extra="allow"):
     docker_image: str
     docker_image_tag: str
     docker_image_size: int | None = None
-    # DAH-2265: bare manifest-list digest ("sha256:…") the backend says is current for this
-    # image. None when the backend has no recorded digest. Compared against the executor's
-    # local RepoDigest to flag stale content cached under an unchanged tag.
+    # DAH-2380: bare manifest-list digest ("sha256:…") the validator fetches from Docker Hub.
+    # Kept on the model for backward compatibility with older responses; no longer populated
+    # by the backend.
     docker_image_digest: str | None = None
 
     @property

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -272,10 +272,3 @@ TDX_WHITELIST = {
         },
     }
 }
-
-# Default cache-template images whose digests the validator pre-fetches from Docker Hub
-# (DAH-2380). Keep in sync with lium-io-backend `DOCKER_IMAGES`.
-DEFAULT_DOCKER_IMAGE_REFS: tuple[str, ...] = (
-    "daturaai/pytorch:2.12.0-py3.12-cuda12.8-devel-ubuntu24.04-dind",
-    "daturaai/pytorch:2.12.0-py3.12-cuda13.0.2-devel-ubuntu24.04-dind",
-)

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -272,3 +272,10 @@ TDX_WHITELIST = {
         },
     }
 }
+
+# Default cache-template images whose digests the validator pre-fetches from Docker Hub
+# (DAH-2380). Keep in sync with lium-io-backend `DOCKER_IMAGES`.
+DEFAULT_DOCKER_IMAGE_REFS: tuple[str, ...] = (
+    "daturaai/pytorch:2.12.0-py3.12-cuda12.8-devel-ubuntu24.04-dind",
+    "daturaai/pytorch:2.12.0-py3.12-cuda13.0.2-devel-ubuntu24.04-dind",
+)

--- a/neurons/validators/src/services/default_docker_image_digest_service.py
+++ b/neurons/validators/src/services/default_docker_image_digest_service.py
@@ -2,6 +2,8 @@
 
 The validator resolves the recommended image from the backend (image + tag only) and
 compares the executor's local RepoDigest against a digest map built here from Docker Hub.
+The set of default images is read from the backend shared config (``SharedConfig``),
+whose source of truth is the backend ``DOCKER_IMAGES`` list — no hardcoded copy here.
 Uses the manifest-list media type so the digest matches what `docker pull` records in
 RepoDigests on amd64 GPU nodes.
 """
@@ -13,7 +15,6 @@ import logging
 from functools import lru_cache
 
 import aiohttp
-from services.const import DEFAULT_DOCKER_IMAGE_REFS
 
 from core.config import settings
 
@@ -25,6 +26,18 @@ _MANIFEST_ACCEPT = (
 )
 _REGISTRY_AUTH_URL = "https://auth.docker.io/token"
 _REGISTRY_API = "https://registry-1.docker.io/v2"
+
+
+def _shared_config_image_refs() -> tuple[str, ...]:
+    """Default cache-template image refs served by the backend via shared config.
+
+    The single source of truth is the backend ``DOCKER_IMAGES`` list, published on
+    ``/v1/shared-config``; ``SharedConfigClient`` falls back to the packaged lium-core
+    default when the backend is unreachable, so the returned tuple is always valid.
+    """
+    from core.config import shared_client
+
+    return tuple(shared_client.config.default_docker_image_refs)
 
 
 def _bare_digest(digest: str | None) -> str | None:
@@ -70,9 +83,12 @@ class DefaultDockerImageDigestService:
 
     def __init__(
         self,
-        image_refs: tuple[str, ...] = DEFAULT_DOCKER_IMAGE_REFS,
+        image_refs: tuple[str, ...] | None = None,
         refresh_seconds: int | None = None,
     ) -> None:
+        # None → resolve the current list from shared config on each refresh, so a new
+        # backend template is picked up without a validator restart. An explicit tuple
+        # pins the list (used by tests).
         self._image_refs = image_refs
         self._refresh_seconds = (
             refresh_seconds
@@ -86,6 +102,11 @@ class DefaultDockerImageDigestService:
         """Bare ``sha256:…`` for a previously refreshed ``repo:tag``, or None."""
         return self._digests.get(image_ref)
 
+    def _resolve_image_refs(self) -> tuple[str, ...]:
+        if self._image_refs is not None:
+            return self._image_refs
+        return _shared_config_image_refs()
+
     async def refresh(self) -> None:
         """Pull current digests for every configured default image ref.
 
@@ -95,10 +116,11 @@ class DefaultDockerImageDigestService:
         a false ``DIGEST_MISMATCH`` against a re-pushed tag and zero an honest
         miner's score (DAH-2380).
         """
+        image_refs = self._resolve_image_refs()
         updated: dict[str, str] = {}
         timeout = aiohttp.ClientTimeout(total=30)
         async with aiohttp.ClientSession(timeout=timeout) as session:
-            for image_ref in self._image_refs:
+            for image_ref in image_refs:
                 digest = await fetch_registry_digest(session, image_ref)
                 if digest:
                     updated[image_ref] = digest
@@ -106,7 +128,7 @@ class DefaultDockerImageDigestService:
         async with self._lock:
             self._digests = updated
 
-        failed = [ref for ref in self._image_refs if ref not in updated]
+        failed = [ref for ref in image_refs if ref not in updated]
         if failed:
             logger.warning(
                 "Dropped %d default docker image digest(s) after a failed refresh "

--- a/neurons/validators/src/services/default_docker_image_digest_service.py
+++ b/neurons/validators/src/services/default_docker_image_digest_service.py
@@ -87,7 +87,14 @@ class DefaultDockerImageDigestService:
         return self._digests.get(image_ref)
 
     async def refresh(self) -> None:
-        """Pull current digests for every configured default image ref."""
+        """Pull current digests for every configured default image ref.
+
+        Replaces the cache wholesale: a ref whose fetch fails this round is
+        *dropped* rather than left pointing at a stale digest. A missing digest
+        makes the verification check fail open (skip); a stale one would produce
+        a false ``DIGEST_MISMATCH`` against a re-pushed tag and zero an honest
+        miner's score (DAH-2380).
+        """
         updated: dict[str, str] = {}
         timeout = aiohttp.ClientTimeout(total=30)
         async with aiohttp.ClientSession(timeout=timeout) as session:
@@ -97,15 +104,21 @@ class DefaultDockerImageDigestService:
                     updated[image_ref] = digest
 
         async with self._lock:
-            self._digests.update(updated)
+            self._digests = updated
 
+        failed = [ref for ref in self._image_refs if ref not in updated]
+        if failed:
+            logger.warning(
+                "Dropped %d default docker image digest(s) after a failed refresh "
+                "(check fails open for these): %s",
+                len(failed),
+                ", ".join(failed),
+            )
         if updated:
             logger.info(
                 "Refreshed %d default docker image digest(s) from Docker Hub",
                 len(updated),
             )
-        else:
-            logger.warning("Default docker image digest refresh returned no digests")
 
     async def run_refresh_loop(self) -> None:
         """Background loop: refresh on boot, then every ``refresh_seconds``."""

--- a/neurons/validators/src/services/default_docker_image_digest_service.py
+++ b/neurons/validators/src/services/default_docker_image_digest_service.py
@@ -1,0 +1,125 @@
+"""Fetch and cache manifest digests for default cache-template docker images (DAH-2380).
+
+The validator resolves the recommended image from the backend (image + tag only) and
+compares the executor's local RepoDigest against a digest map built here from Docker Hub.
+Uses the manifest-list media type so the digest matches what `docker pull` records in
+RepoDigests on amd64 GPU nodes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from functools import lru_cache
+
+import aiohttp
+from services.const import DEFAULT_DOCKER_IMAGE_REFS
+
+from core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_MANIFEST_ACCEPT = (
+    "application/vnd.docker.distribution.manifest.list.v2+json,"
+    " application/vnd.docker.distribution.manifest.v2+json"
+)
+_REGISTRY_AUTH_URL = "https://auth.docker.io/token"
+_REGISTRY_API = "https://registry-1.docker.io/v2"
+
+
+def _bare_digest(digest: str | None) -> str | None:
+    if not digest:
+        return None
+    return digest.rpartition("@")[2] or digest
+
+
+async def fetch_registry_digest(session: aiohttp.ClientSession, image_ref: str) -> str | None:
+    """Return the registry manifest digest for ``repository:tag``, or None on any error."""
+    repository, _, tag = image_ref.partition(":")
+    if not repository or not tag:
+        return None
+    try:
+        async with session.get(
+            _REGISTRY_AUTH_URL,
+            params={
+                "service": "registry.docker.io",
+                "scope": f"repository:{repository}:pull",
+            },
+        ) as token_response:
+            token_response.raise_for_status()
+            token = (await token_response.json()).get("token")
+        if not token:
+            return None
+
+        async with session.head(
+            f"{_REGISTRY_API}/{repository}/manifests/{tag}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": _MANIFEST_ACCEPT,
+            },
+        ) as manifest_response:
+            manifest_response.raise_for_status()
+            return _bare_digest(manifest_response.headers.get("Docker-Content-Digest"))
+    except Exception as exc:
+        logger.warning("Failed to fetch registry digest for %s: %s", image_ref, exc)
+        return None
+
+
+class DefaultDockerImageDigestService:
+    """In-memory image_ref → bare sha256 digest map, refreshed from Docker Hub."""
+
+    def __init__(
+        self,
+        image_refs: tuple[str, ...] = DEFAULT_DOCKER_IMAGE_REFS,
+        refresh_seconds: int | None = None,
+    ) -> None:
+        self._image_refs = image_refs
+        self._refresh_seconds = (
+            refresh_seconds
+            if refresh_seconds is not None
+            else settings.DEFAULT_DOCKER_IMAGE_DIGEST_REFRESH_SECONDS
+        )
+        self._digests: dict[str, str] = {}
+        self._lock = asyncio.Lock()
+
+    def get_digest(self, image_ref: str) -> str | None:
+        """Bare ``sha256:…`` for a previously refreshed ``repo:tag``, or None."""
+        return self._digests.get(image_ref)
+
+    async def refresh(self) -> None:
+        """Pull current digests for every configured default image ref."""
+        updated: dict[str, str] = {}
+        timeout = aiohttp.ClientTimeout(total=30)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            for image_ref in self._image_refs:
+                digest = await fetch_registry_digest(session, image_ref)
+                if digest:
+                    updated[image_ref] = digest
+
+        async with self._lock:
+            self._digests.update(updated)
+
+        if updated:
+            logger.info(
+                "Refreshed %d default docker image digest(s) from Docker Hub",
+                len(updated),
+            )
+        else:
+            logger.warning("Default docker image digest refresh returned no digests")
+
+    async def run_refresh_loop(self) -> None:
+        """Background loop: refresh on boot, then every ``refresh_seconds``."""
+        while True:
+            try:
+                await self.refresh()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.error("Unexpected error refreshing default image digests: %s", exc)
+            await asyncio.sleep(self._refresh_seconds)
+
+
+@lru_cache
+def get_default_docker_image_digest_service() -> DefaultDockerImageDigestService:
+    """Process-wide singleton used by the validator and FastAPI DI."""
+    return DefaultDockerImageDigestService()

--- a/neurons/validators/src/services/default_docker_image_digest_service.py
+++ b/neurons/validators/src/services/default_docker_image_digest_service.py
@@ -16,8 +16,6 @@ from functools import lru_cache
 
 import aiohttp
 
-from core.config import settings
-
 logger = logging.getLogger(__name__)
 
 _MANIFEST_ACCEPT = (
@@ -81,20 +79,11 @@ async def fetch_registry_digest(session: aiohttp.ClientSession, image_ref: str) 
 class DefaultDockerImageDigestService:
     """In-memory image_ref → bare sha256 digest map, refreshed from Docker Hub."""
 
-    def __init__(
-        self,
-        image_refs: tuple[str, ...] | None = None,
-        refresh_seconds: int | None = None,
-    ) -> None:
+    def __init__(self, image_refs: tuple[str, ...] | None = None) -> None:
         # None → resolve the current list from shared config on each refresh, so a new
-        # backend template is picked up without a validator restart. An explicit tuple
-        # pins the list (used by tests).
+        # backend template is picked up automatically. An explicit tuple pins the list
+        # (used by tests).
         self._image_refs = image_refs
-        self._refresh_seconds = (
-            refresh_seconds
-            if refresh_seconds is not None
-            else settings.DEFAULT_DOCKER_IMAGE_DIGEST_REFRESH_SECONDS
-        )
         self._digests: dict[str, str] = {}
         self._lock = asyncio.Lock()
 
@@ -141,17 +130,6 @@ class DefaultDockerImageDigestService:
                 "Refreshed %d default docker image digest(s) from Docker Hub",
                 len(updated),
             )
-
-    async def run_refresh_loop(self) -> None:
-        """Background loop: refresh on boot, then every ``refresh_seconds``."""
-        while True:
-            try:
-                await self.refresh()
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                logger.error("Unexpected error refreshing default image digests: %s", exc)
-            await asyncio.sleep(self._refresh_seconds)
 
 
 @lru_cache

--- a/neurons/validators/src/services/default_docker_image_digest_service.py
+++ b/neurons/validators/src/services/default_docker_image_digest_service.py
@@ -29,15 +29,26 @@ _REGISTRY_API = "https://registry-1.docker.io/v2"
 
 
 def _shared_config_image_refs() -> tuple[str, ...]:
-    """Default cache-template image refs served by the backend via shared config.
+    """Default cache-template image refs derived from the backend shared config.
 
-    The single source of truth is the backend ``DOCKER_IMAGES`` list, published on
-    ``/v1/shared-config``; ``SharedConfigClient`` falls back to the packaged lium-core
-    default when the backend is unreachable, so the returned tuple is always valid.
+    The single source of truth is the backend ``DOCKER_IMAGES`` list, published
+    verbatim on ``/v1/shared-config`` as ``default_docker_images`` (full metadata
+    dicts); the ``repo:tag`` refs are derived here from the ``image``/``tag`` keys.
+    ``SharedConfigClient`` falls back to the packaged lium-core default when the
+    backend is unreachable, so the returned tuple is always valid. An entry missing
+    ``image`` or ``tag`` is skipped (fail open) rather than producing a broken ref.
     """
     from core.config import shared_client
 
-    return tuple(shared_client.config.default_docker_image_refs)
+    refs: list[str] = []
+    for entry in shared_client.config.default_docker_images:
+        image = entry.get("image")
+        tag = entry.get("tag")
+        if image and tag:
+            refs.append(f"{image}:{tag}")
+        else:
+            logger.warning("Skipping malformed default docker image entry: %r", entry)
+    return tuple(refs)
 
 
 async def fetch_registry_digest(session: aiohttp.ClientSession, image_ref: str) -> str | None:

--- a/neurons/validators/src/services/default_docker_image_digest_service.py
+++ b/neurons/validators/src/services/default_docker_image_digest_service.py
@@ -1,18 +1,20 @@
-"""Fetch and cache manifest digests for default cache-template docker images (DAH-2380).
+"""Fetch manifest digests for default cache-template docker images (DAH-2380).
 
 The validator resolves the recommended image from the backend (image + tag only) and
-compares the executor's local RepoDigest against a digest map built here from Docker Hub.
-The set of default images is read from the backend shared config (``SharedConfig``),
+compares the executor's local RepoDigest against a digest snapshot built here from Docker
+Hub. The set of default images is read from the backend shared config (``SharedConfig``),
 whose source of truth is the backend ``DOCKER_IMAGES`` list — no hardcoded copy here.
 Uses the manifest-list media type so the digest matches what `docker pull` records in
 RepoDigests on amd64 GPU nodes.
+
+``fetch_default_image_digests`` returns a plain ``dict`` snapshot for one job cycle rather
+than holding state: the validator fetches it at job-cycle start and threads it into the
+pipeline context, so there is no shared mutable cache to keep in sync.
 """
 
 from __future__ import annotations
 
-import asyncio
 import logging
-from functools import lru_cache
 
 import aiohttp
 
@@ -36,12 +38,6 @@ def _shared_config_image_refs() -> tuple[str, ...]:
     from core.config import shared_client
 
     return tuple(shared_client.config.default_docker_image_refs)
-
-
-def _bare_digest(digest: str | None) -> str | None:
-    if not digest:
-        return None
-    return digest.rpartition("@")[2] or digest
 
 
 async def fetch_registry_digest(session: aiohttp.ClientSession, image_ref: str) -> str | None:
@@ -70,69 +66,41 @@ async def fetch_registry_digest(session: aiohttp.ClientSession, image_ref: str) 
             },
         ) as manifest_response:
             manifest_response.raise_for_status()
-            return _bare_digest(manifest_response.headers.get("Docker-Content-Digest"))
+            # The Docker-Content-Digest response header is already a bare ``sha256:…``.
+            return manifest_response.headers.get("Docker-Content-Digest") or None
     except Exception as exc:
         logger.warning("Failed to fetch registry digest for %s: %s", image_ref, exc)
         return None
 
 
-class DefaultDockerImageDigestService:
-    """In-memory image_ref → bare sha256 digest map, refreshed from Docker Hub."""
+async def fetch_default_image_digests() -> dict[str, str]:
+    """Snapshot of ``image_ref -> bare sha256 digest`` for one job cycle.
 
-    def __init__(self, image_refs: tuple[str, ...] | None = None) -> None:
-        # None → resolve the current list from shared config on each refresh, so a new
-        # backend template is picked up automatically. An explicit tuple pins the list
-        # (used by tests).
-        self._image_refs = image_refs
-        self._digests: dict[str, str] = {}
-        self._lock = asyncio.Lock()
+    Fail-open per ref: a ref whose fetch fails this cycle is simply *absent* from the
+    snapshot, so the verification check finds no digest to compare against and skips
+    (rather than mismatching a re-pushed tag and zeroing an honest miner's score —
+    DAH-2380). The list of refs comes from the backend shared config.
+    """
+    image_refs = _shared_config_image_refs()
+    digests: dict[str, str] = {}
+    timeout = aiohttp.ClientTimeout(total=30)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        for image_ref in image_refs:
+            digest = await fetch_registry_digest(session, image_ref)
+            if digest:
+                digests[image_ref] = digest
 
-    def get_digest(self, image_ref: str) -> str | None:
-        """Bare ``sha256:…`` for a previously refreshed ``repo:tag``, or None."""
-        return self._digests.get(image_ref)
-
-    def _resolve_image_refs(self) -> tuple[str, ...]:
-        if self._image_refs is not None:
-            return self._image_refs
-        return _shared_config_image_refs()
-
-    async def refresh(self) -> None:
-        """Pull current digests for every configured default image ref.
-
-        Replaces the cache wholesale: a ref whose fetch fails this round is
-        *dropped* rather than left pointing at a stale digest. A missing digest
-        makes the verification check fail open (skip); a stale one would produce
-        a false ``DIGEST_MISMATCH`` against a re-pushed tag and zero an honest
-        miner's score (DAH-2380).
-        """
-        image_refs = self._resolve_image_refs()
-        updated: dict[str, str] = {}
-        timeout = aiohttp.ClientTimeout(total=30)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
-            for image_ref in image_refs:
-                digest = await fetch_registry_digest(session, image_ref)
-                if digest:
-                    updated[image_ref] = digest
-
-        async with self._lock:
-            self._digests = updated
-
-        failed = [ref for ref in image_refs if ref not in updated]
-        if failed:
-            logger.warning(
-                "Dropped %d default docker image digest(s) after a failed refresh "
-                "(check fails open for these): %s",
-                len(failed),
-                ", ".join(failed),
-            )
-        if updated:
-            logger.info(
-                "Refreshed %d default docker image digest(s) from Docker Hub",
-                len(updated),
-            )
-
-
-@lru_cache
-def get_default_docker_image_digest_service() -> DefaultDockerImageDigestService:
-    """Process-wide singleton used by the validator and FastAPI DI."""
-    return DefaultDockerImageDigestService()
+    failed = [ref for ref in image_refs if ref not in digests]
+    if failed:
+        logger.warning(
+            "No default docker image digest for %d ref(s) this cycle "
+            "(check fails open for these): %s",
+            len(failed),
+            ", ".join(failed),
+        )
+    if digests:
+        logger.info(
+            "Fetched %d default docker image digest(s) from Docker Hub",
+            len(digests),
+        )
+    return digests

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -185,6 +185,7 @@ class MinerService:
         payload: MinerJobRequestPayload,
         encrypted_files: MinerJobEnryptedFiles,
         rented_data: RentedExecutorsResponse,
+        default_docker_image_digests: dict[str, str],
     ):
         """Request job to miner - uses REST API if configured, otherwise WebSocket."""
         if settings.USE_REST_API:
@@ -197,7 +198,9 @@ class MinerService:
                     }),
                 ),
             )
-            return await self._request_job_to_miner(payload, encrypted_files, rented_data)
+            return await self._request_job_to_miner(
+                payload, encrypted_files, rented_data, default_docker_image_digests
+            )
         else:
             logger.info(
                 _m(
@@ -303,6 +306,7 @@ class MinerService:
                                     public_key=public_key.decode("utf-8"),
                                     encrypted_files=encrypted_files,
                                     rented_data=rented_data,
+                                    default_docker_image_digests=default_docker_image_digests,
                                     attestation_nonce=attestation_nonce,
                                 ),
                                 timeout=settings.JOB_TIME_OUT - 120
@@ -1453,6 +1457,7 @@ class MinerService:
         payload: MinerJobRequestPayload,
         encrypted_files: MinerJobEnryptedFiles,
         rented_data: RentedExecutorsResponse,
+        default_docker_image_digests: dict[str, str],
     ):
         """REST API version of request_job_to_miner."""
         my_key: bittensor.Keypair = settings.get_bittensor_wallet().get_hotkey()
@@ -1535,6 +1540,7 @@ class MinerService:
                                 public_key=public_key.decode("utf-8"),
                                 encrypted_files=encrypted_files,
                                 rented_data=rented_data,
+                                default_docker_image_digests=default_docker_image_digests,
                                 attestation_nonce=attestation_nonce,
                             ),
                             timeout=settings.JOB_TIME_OUT - 120

--- a/neurons/validators/src/services/task/checks/cached_template_verification.py
+++ b/neurons/validators/src/services/task/checks/cached_template_verification.py
@@ -38,8 +38,8 @@ class CachedTemplateVerificationCheck:
     when the image is already present. This check resolves the recommended image from the
     backend (the same ``/executors/default-docker-image`` endpoint the executor uses) and
     probes ``docker image inspect`` on the executor. The expected manifest digest comes from
-    the validator's Docker Hub digest cache (``DefaultDockerImageDigestService``), not the
-    backend response.
+    the per-cycle Docker Hub digest snapshot fetched at job-cycle start (``ctx.config``),
+    not the backend response.
 
     Two-phase by ``settings.CACHED_TEMPLATE_CUTOFF``:
       * Before the cutoff — advisory only: emits a structured event and publishes
@@ -104,7 +104,7 @@ class CachedTemplateVerificationCheck:
         image_ref = images[0].image_ref
         docker_image = images[0].docker_image
         # Bare manifest digest the validator fetched from Docker Hub for this image, if any.
-        backend_digest = ctx.services.default_docker_image_digests.get_digest(image_ref)
+        backend_digest = ctx.config.default_docker_image_digests.get(image_ref)
 
         try:
             inspect = await ctx.ssh.run(

--- a/neurons/validators/src/services/task/checks/cached_template_verification.py
+++ b/neurons/validators/src/services/task/checks/cached_template_verification.py
@@ -37,7 +37,9 @@ class CachedTemplateVerificationCheck:
     template image warm, and the rental-time DAH-1524 pull-skip turns DOCKER_PULL into a no-op
     when the image is already present. This check resolves the recommended image from the
     backend (the same ``/executors/default-docker-image`` endpoint the executor uses) and
-    probes ``docker image inspect`` on the executor.
+    probes ``docker image inspect`` on the executor. The expected manifest digest comes from
+    the validator's Docker Hub digest cache (``DefaultDockerImageDigestService``), not the
+    backend response.
 
     Two-phase by ``settings.CACHED_TEMPLATE_CUTOFF``:
       * Before the cutoff — advisory only: emits a structured event and publishes
@@ -101,10 +103,8 @@ class CachedTemplateVerificationCheck:
         # request — the same image the executor pre-pull warms first.
         image_ref = images[0].image_ref
         docker_image = images[0].docker_image
-        # Bare manifest digest the backend says is current for this image, if any. Normalize
-        # defensively so a "repo@sha256:…" paste is tolerated and only the sha is compared (M3).
-        backend_digest = getattr(images[0], "docker_image_digest", None)
-        backend_digest = (backend_digest or "").rpartition("@")[2] or None
+        # Bare manifest digest the validator fetched from Docker Hub for this image, if any.
+        backend_digest = ctx.services.default_docker_image_digests.get_digest(image_ref)
 
         try:
             inspect = await ctx.ssh.run(

--- a/neurons/validators/src/services/task/checks/cached_template_verification.py
+++ b/neurons/validators/src/services/task/checks/cached_template_verification.py
@@ -57,7 +57,11 @@ class CachedTemplateVerificationCheck:
     """
 
     check_id = "executor.validate.cached_template"
-    fatal = True
+    # TODO(2026-07-14): restore `fatal = True` to enable this gate. Temporarily False so that a
+    # `passed=False` result (NOT_CACHED / DIGEST_MISMATCH on/after the cutoff) does NOT halt the
+    # pipeline — the check stays advisory during the DAH-2380 digest rollout. Pairs with
+    # CACHED_TEMPLATE_CUTOFF (deferred to 2026-07-14 12:00 UTC in core/config.py); flip both back.
+    fatal = False
 
     async def run(self, ctx: Context) -> CheckResult:
         gpu_model = ctx.state.gpu_model

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -13,6 +13,7 @@ from clients.backend_client import BackendClient
 from services.ssh_service import SSHService
 from services.redis_service import RedisService
 from services.collateral_contract_service import CollateralContractService
+from services.default_docker_image_digest_service import DefaultDockerImageDigestService
 from services.matrix_validation_service import ValidationService
 from services.verifyx_validation_service import VerifyXValidationService
 from services.executor_connectivity_service import ExecutorConnectivityService
@@ -35,6 +36,7 @@ class ContextServices:
     shell: InteractiveShellService
     score_calculator: Callable[[str, bool, bool, str, bool, int], Tuple[float, float, str]]
     backend: BackendClient
+    default_docker_image_digests: DefaultDockerImageDigestService
     container_cleanup: ContainerCleanup
 
 

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -13,7 +13,6 @@ from clients.backend_client import BackendClient
 from services.ssh_service import SSHService
 from services.redis_service import RedisService
 from services.collateral_contract_service import CollateralContractService
-from services.default_docker_image_digest_service import DefaultDockerImageDigestService
 from services.matrix_validation_service import ValidationService
 from services.verifyx_validation_service import VerifyXValidationService
 from services.executor_connectivity_service import ExecutorConnectivityService
@@ -36,7 +35,6 @@ class ContextServices:
     shell: InteractiveShellService
     score_calculator: Callable[[str, bool, bool, str, bool, int], Tuple[float, float, str]]
     backend: BackendClient
-    default_docker_image_digests: DefaultDockerImageDigestService
     container_cleanup: ContainerCleanup
 
 
@@ -48,6 +46,9 @@ class ContextConfig:
     machine_scrape_filename: str
     machine_scrape_timeout: int
     obfuscation_keys: Any
+    # DAH-2380: per-cycle snapshot of default cache-template image_ref -> bare digest,
+    # fetched from Docker Hub at job-cycle start. Empty => digest check skips (fail-open).
+    default_docker_image_digests: dict[str, str]
     validator_keypair: Optional[Any] = None
     max_gpu_count: Optional[int] = None
     gpu_model_rates: Optional[dict[str, Any]] = None

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -16,7 +16,6 @@ from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.collateral_contract_service import CollateralContractService
 from services.const import GPU_MODEL_RATES, LIB_NVIDIA_ML_DIGESTS, MAX_GPU_COUNT
 from services.container_cleanup import ContainerCleanup
-from services.default_docker_image_digest_service import DefaultDockerImageDigestService
 from services.executor_connectivity_service import ExecutorConnectivityService
 from services.inspector_validation_service import InspectorValidationService
 from services.interactive_shell_service import InteractiveShellService
@@ -92,7 +91,6 @@ class PipelineFactory:
         collateral_contract_service: CollateralContractService,
         executor_connectivity_service: ExecutorConnectivityService,
         backend_client: BackendClient,
-        default_docker_image_digest_service: DefaultDockerImageDigestService,
     ):
         """Initialize pipeline factory with required services.
 
@@ -113,7 +111,6 @@ class PipelineFactory:
         self.collateral_contract_service = collateral_contract_service
         self.executor_connectivity_service = executor_connectivity_service
         self.backend_client = backend_client
-        self.default_docker_image_digest_service = default_docker_image_digest_service
 
         dry_run = settings.DRY_RUN or settings.CONTAINER_CLEANUP_DRY_RUN
         logger.info(f"ContainerCleanup dry_run={dry_run}")
@@ -129,6 +126,7 @@ class PipelineFactory:
         public_key: str,
         encrypted_files: MinerJobEnryptedFiles,
         rented_data: RentedExecutorsResponse,
+        default_docker_image_digests: dict[str, str],
         tdx_attestation_passed: bool = False,
         gpu_attestation_passed: bool | None = None,
     ) -> Context:
@@ -195,7 +193,6 @@ class PipelineFactory:
                 shell=shell,
                 score_calculator=calculate_scores,
                 backend=self.backend_client,
-                default_docker_image_digests=self.default_docker_image_digest_service,
                 container_cleanup=self.container_cleanup,
             ),
             config=ContextConfig(
@@ -205,6 +202,7 @@ class PipelineFactory:
                 machine_scrape_filename=encrypted_files.machine_scrape_file_name,
                 machine_scrape_timeout=JOB_LENGTH,
                 obfuscation_keys=encrypted_files.all_keys,
+                default_docker_image_digests=default_docker_image_digests,
                 validator_keypair=keypair,
                 max_gpu_count=MAX_GPU_COUNT,
                 gpu_model_rates=GPU_MODEL_RATES,

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -16,6 +16,7 @@ from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.collateral_contract_service import CollateralContractService
 from services.const import GPU_MODEL_RATES, LIB_NVIDIA_ML_DIGESTS, MAX_GPU_COUNT
 from services.container_cleanup import ContainerCleanup
+from services.default_docker_image_digest_service import DefaultDockerImageDigestService
 from services.executor_connectivity_service import ExecutorConnectivityService
 from services.inspector_validation_service import InspectorValidationService
 from services.interactive_shell_service import InteractiveShellService
@@ -91,6 +92,7 @@ class PipelineFactory:
         collateral_contract_service: CollateralContractService,
         executor_connectivity_service: ExecutorConnectivityService,
         backend_client: BackendClient,
+        default_docker_image_digest_service: DefaultDockerImageDigestService,
     ):
         """Initialize pipeline factory with required services.
 
@@ -111,6 +113,7 @@ class PipelineFactory:
         self.collateral_contract_service = collateral_contract_service
         self.executor_connectivity_service = executor_connectivity_service
         self.backend_client = backend_client
+        self.default_docker_image_digest_service = default_docker_image_digest_service
 
         dry_run = settings.DRY_RUN or settings.CONTAINER_CLEANUP_DRY_RUN
         logger.info(f"ContainerCleanup dry_run={dry_run}")
@@ -192,6 +195,7 @@ class PipelineFactory:
                 shell=shell,
                 score_calculator=calculate_scores,
                 backend=self.backend_client,
+                default_docker_image_digests=self.default_docker_image_digest_service,
                 container_cleanup=self.container_cleanup,
             ),
             config=ContextConfig(

--- a/neurons/validators/src/services/task/service.py
+++ b/neurons/validators/src/services/task/service.py
@@ -2,22 +2,26 @@ import logging
 from typing import Annotated
 
 import bittensor
+from clients.backend_client import BackendClient
 from datura.requests.miner_requests import ExecutorSSHInfo
 from fastapi import Depends
 from payload_models.payloads import MinerJobEnryptedFiles, MinerJobRequestPayload
-
-from clients.backend_client import BackendClient
-from core.config import settings
-from core.utils import _m, get_extra_info
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.attestation_service import AttestationError, AttestationNonce, AttestationService
 from services.collateral_contract_service import CollateralContractService
+from services.default_docker_image_digest_service import (
+    DefaultDockerImageDigestService,
+    get_default_docker_image_digest_service,
+)
 from services.executor_connectivity_service import ExecutorConnectivityService
 from services.interactive_shell_service import InteractiveShellService
 from services.matrix_validation_service import ValidationService
 from services.redis_service import RedisService
-from services.ssh_service import SSHService
 from services.verifyx_validation_service import VerifyXValidationService
+
+from core.config import settings
+from core.utils import _m, get_extra_info
+from services.ssh_service import SSHService
 
 from .models import JobResult
 from .pipeline_factory import PipelineFactory
@@ -35,6 +39,9 @@ class TaskService:
         collateral_contract_service: Annotated[CollateralContractService, Depends(CollateralContractService)],
         executor_connectivity_service: Annotated[ExecutorConnectivityService, Depends(ExecutorConnectivityService)],
         backend_client: Annotated[BackendClient, Depends(BackendClient)],
+        default_docker_image_digest_service: Annotated[
+            DefaultDockerImageDigestService, Depends(get_default_docker_image_digest_service)
+        ],
         attestation_service: Annotated[AttestationService, Depends(AttestationService)],
     ):
         self.ssh_service = ssh_service
@@ -51,6 +58,7 @@ class TaskService:
             collateral_contract_service=collateral_contract_service,
             executor_connectivity_service=executor_connectivity_service,
             backend_client=backend_client,
+            default_docker_image_digest_service=default_docker_image_digest_service,
         )
 
     async def create_task(

--- a/neurons/validators/src/services/task/service.py
+++ b/neurons/validators/src/services/task/service.py
@@ -9,10 +9,6 @@ from payload_models.payloads import MinerJobEnryptedFiles, MinerJobRequestPayloa
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.attestation_service import AttestationError, AttestationNonce, AttestationService
 from services.collateral_contract_service import CollateralContractService
-from services.default_docker_image_digest_service import (
-    DefaultDockerImageDigestService,
-    get_default_docker_image_digest_service,
-)
 from services.executor_connectivity_service import ExecutorConnectivityService
 from services.interactive_shell_service import InteractiveShellService
 from services.matrix_validation_service import ValidationService
@@ -39,9 +35,6 @@ class TaskService:
         collateral_contract_service: Annotated[CollateralContractService, Depends(CollateralContractService)],
         executor_connectivity_service: Annotated[ExecutorConnectivityService, Depends(ExecutorConnectivityService)],
         backend_client: Annotated[BackendClient, Depends(BackendClient)],
-        default_docker_image_digest_service: Annotated[
-            DefaultDockerImageDigestService, Depends(get_default_docker_image_digest_service)
-        ],
         attestation_service: Annotated[AttestationService, Depends(AttestationService)],
     ):
         self.ssh_service = ssh_service
@@ -58,7 +51,6 @@ class TaskService:
             collateral_contract_service=collateral_contract_service,
             executor_connectivity_service=executor_connectivity_service,
             backend_client=backend_client,
-            default_docker_image_digest_service=default_docker_image_digest_service,
         )
 
     async def create_task(
@@ -70,6 +62,7 @@ class TaskService:
         public_key: str,
         encrypted_files: MinerJobEnryptedFiles,
         rented_data: RentedExecutorsResponse,
+        default_docker_image_digests: dict[str, str],
         attestation_nonce: AttestationNonce | None = None,
     ):
         """New pipeline-based validation task implementation."""
@@ -125,6 +118,7 @@ class TaskService:
                     public_key=public_key,
                     encrypted_files=encrypted_files,
                     rented_data=rented_data,
+                    default_docker_image_digests=default_docker_image_digests,
                     tdx_attestation_passed=attestation_passed,
                     gpu_attestation_passed=gpu_attestation_passed,
                 )

--- a/neurons/validators/tests/helpers.py
+++ b/neurons/validators/tests/helpers.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from unittest.mock import Mock
-
 from datura.requests.miner_requests import ExecutorSSHInfo
 
 from neurons.validators.src.services.task.pipeline import (
@@ -40,6 +38,7 @@ def build_context_config(**overrides) -> ContextConfig:
         machine_scrape_filename="scrape.sh",
         machine_scrape_timeout=300,
         obfuscation_keys={},
+        default_docker_image_digests={},
         validator_keypair=None,
         max_gpu_count=None,
         gpu_model_rates={},
@@ -55,12 +54,6 @@ def build_context_config(**overrides) -> ContextConfig:
     return ContextConfig(**base)
 
 
-def _default_digest_service() -> Mock:
-    service = Mock()
-    service.get_digest = Mock(return_value=None)
-    return service
-
-
 def build_services(**overrides) -> ContextServices:
     base = dict(
         ssh=None,
@@ -73,7 +66,6 @@ def build_services(**overrides) -> ContextServices:
         shell=None,
         score_calculator=DummyScoreCalc(),
         backend=None,
-        default_docker_image_digests=_default_digest_service(),
         container_cleanup=None,
     )
     base.update(overrides)

--- a/neurons/validators/tests/helpers.py
+++ b/neurons/validators/tests/helpers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 from datura.requests.miner_requests import ExecutorSSHInfo
 
 from neurons.validators.src.services.task.pipeline import (
@@ -53,6 +55,12 @@ def build_context_config(**overrides) -> ContextConfig:
     return ContextConfig(**base)
 
 
+def _default_digest_service() -> Mock:
+    service = Mock()
+    service.get_digest = Mock(return_value=None)
+    return service
+
+
 def build_services(**overrides) -> ContextServices:
     base = dict(
         ssh=None,
@@ -65,6 +73,7 @@ def build_services(**overrides) -> ContextServices:
         shell=None,
         score_calculator=DummyScoreCalc(),
         backend=None,
+        default_docker_image_digests=_default_digest_service(),
         container_cleanup=None,
     )
     base.update(overrides)

--- a/neurons/validators/tests/test_cached_template_verification.py
+++ b/neurons/validators/tests/test_cached_template_verification.py
@@ -22,7 +22,7 @@ from neurons.validators.src.services.task.checks.cached_template_verification im
 from neurons.validators.src.services.task.messages import CachedTemplateMessages as Msg
 
 from protocol.vc_protocol.compute_requests import DefaultDockerImage
-from tests.helpers import build_services, build_state
+from tests.helpers import build_context_config, build_services, build_state
 
 _IMAGE = DefaultDockerImage(
     docker_image="daturaai/torch", docker_image_tag="2.4.0", docker_image_size=12_000_000_000
@@ -56,22 +56,14 @@ def _ssh(exit_status=0, stdout="", raises=False):
     return ssh
 
 
-def _digest_service(*, digest: str | None = None, by_ref: dict[str, str] | None = None):
-    service = Mock()
-    if by_ref is not None:
-        service.get_digest = Mock(side_effect=lambda ref: by_ref.get(ref))
-    else:
-        service.get_digest = Mock(return_value=digest)
-    return service
+def _services(backend_images):
+    return build_services(backend=_backend(images=backend_images))
 
 
-def _services(backend_images, digest_map: dict[str, str] | None = None):
-    return build_services(
-        backend=_backend(images=backend_images),
-        default_docker_image_digests=(
-            _digest_service(by_ref=digest_map) if digest_map is not None else _digest_service()
-        ),
-    )
+def _config_with_digests(digest_map: dict[str, str]):
+    # DAH-2380: the validator's Docker Hub digest snapshot now lives on ctx.config
+    # (a per-cycle dict), not on ctx.services.
+    return build_context_config(default_docker_image_digests=digest_map)
 
 
 @pytest.fixture(autouse=True)
@@ -221,7 +213,8 @@ async def test_digest_match_publishes_true(context_factory):
     # Branch 4: cached + local RepoDigest == validator digest cache → match True.
     ssh = _ssh(exit_status=0, stdout=_LOCAL_MATCH)
     ctx = context_factory(
-        services=_services([_IMAGE], {_IMAGE_REF: _IMAGE_DIGEST}),
+        services=_services([_IMAGE]),
+        config=_config_with_digests({_IMAGE_REF: _IMAGE_DIGEST}),
         state=build_state(gpu_model=_GPU, specs=_SPECS),
         ssh=ssh,
     )
@@ -243,7 +236,8 @@ async def test_digest_match_publishes_true(context_factory):
 async def test_digest_mismatch_publishes_false(context_factory):
     # Branch 5: cached + local RepoDigest != validator digest cache → match False (stale content).
     ctx = context_factory(
-        services=_services([_IMAGE], {_IMAGE_REF: _IMAGE_DIGEST}),
+        services=_services([_IMAGE]),
+        config=_config_with_digests({_IMAGE_REF: _IMAGE_DIGEST}),
         state=build_state(gpu_model=_GPU, specs=_SPECS),
         ssh=_ssh(exit_status=0, stdout=_LOCAL_MISMATCH),
     )
@@ -259,7 +253,8 @@ async def test_digest_mismatch_publishes_false(context_factory):
 @pytest.mark.asyncio
 async def test_digest_match_uses_validator_digest_cache(context_factory):
     ctx = context_factory(
-        services=_services([_IMAGE], {_IMAGE_REF: _IMAGE_DIGEST}),
+        services=_services([_IMAGE]),
+        config=_config_with_digests({_IMAGE_REF: _IMAGE_DIGEST}),
         state=build_state(gpu_model=_GPU, specs=_SPECS),
         ssh=_ssh(exit_status=0, stdout=_LOCAL_MATCH),
     )
@@ -298,7 +293,8 @@ async def test_digest_none_when_validator_digest_missing(context_factory):
 async def test_digest_none_when_no_repo_match(context_factory, stdout):
     # Branch 3: cached + backend digest set, but no RepoDigest for THIS repo → match None.
     ctx = context_factory(
-        services=_services([_IMAGE], {_IMAGE_REF: _IMAGE_DIGEST}),
+        services=_services([_IMAGE]),
+        config=_config_with_digests({_IMAGE_REF: _IMAGE_DIGEST}),
         state=build_state(gpu_model=_GPU, specs=_SPECS),
         ssh=_ssh(exit_status=0, stdout=stdout),
     )
@@ -316,7 +312,8 @@ async def test_digest_fails_open_on_unparseable_stdout(context_factory):
     # Branch 3 variant: cached + backend digest set, RepoDigests JSON is garbage → match None,
     # never raises.
     ctx = context_factory(
-        services=_services([_IMAGE], {_IMAGE_REF: _IMAGE_DIGEST}),
+        services=_services([_IMAGE]),
+        config=_config_with_digests({_IMAGE_REF: _IMAGE_DIGEST}),
         state=build_state(gpu_model=_GPU, specs=_SPECS),
         ssh=_ssh(exit_status=0, stdout="not json at all"),
     )
@@ -355,7 +352,8 @@ async def test_digest_mismatch_fails_after_cutoff(context_factory, monkeypatch):
     # Stale content under the same tag + after cutoff → fatal fail.
     _set_cutoff(monkeypatch, active=True)
     ctx = context_factory(
-        services=_services([_IMAGE], {_IMAGE_REF: _IMAGE_DIGEST}),
+        services=_services([_IMAGE]),
+        config=_config_with_digests({_IMAGE_REF: _IMAGE_DIGEST}),
         state=build_state(gpu_model=_GPU, specs=_SPECS),
         ssh=_ssh(exit_status=0, stdout=_LOCAL_MISMATCH),
     )
@@ -389,7 +387,8 @@ async def test_cached_passes_after_cutoff(context_factory, monkeypatch):
 async def test_digest_match_passes_after_cutoff(context_factory, monkeypatch):
     _set_cutoff(monkeypatch, active=True)
     ctx = context_factory(
-        services=_services([_IMAGE], {_IMAGE_REF: _IMAGE_DIGEST}),
+        services=_services([_IMAGE]),
+        config=_config_with_digests({_IMAGE_REF: _IMAGE_DIGEST}),
         state=build_state(gpu_model=_GPU, specs=_SPECS),
         ssh=_ssh(exit_status=0, stdout=_LOCAL_MATCH),
     )
@@ -423,7 +422,8 @@ async def test_digest_skipped_passes_after_cutoff(context_factory, monkeypatch):
     # Cached but RepoDigest unreadable for this repo → DIGEST_SKIPPED, never a fatal fail.
     _set_cutoff(monkeypatch, active=True)
     ctx = context_factory(
-        services=_services([_IMAGE], {_IMAGE_REF: _IMAGE_DIGEST}),
+        services=_services([_IMAGE]),
+        config=_config_with_digests({_IMAGE_REF: _IMAGE_DIGEST}),
         state=build_state(gpu_model=_GPU, specs=_SPECS),
         ssh=_ssh(exit_status=0, stdout="[]"),
     )

--- a/neurons/validators/tests/test_cached_template_verification.py
+++ b/neurons/validators/tests/test_cached_template_verification.py
@@ -81,8 +81,10 @@ def _set_cutoff(monkeypatch, *, active: bool) -> None:
 
 
 def test_check_is_fatal():
-    # DAH-2265: the check is fatal-capable; run() only returns passed=False after the cutoff.
-    assert CachedTemplateVerificationCheck.fatal is True
+    # TODO(2026-07-14): restore `assert CachedTemplateVerificationCheck.fatal is True`.
+    # DAH-2380 rollout: the check is temporarily fatal=False so a passed=False result never halts
+    # the pipeline (run() still returns passed=False after the cutoff — only the halt is off).
+    assert CachedTemplateVerificationCheck.fatal is False
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_cached_template_verification.py
+++ b/neurons/validators/tests/test_cached_template_verification.py
@@ -27,12 +27,8 @@ from tests.helpers import build_services, build_state
 _IMAGE = DefaultDockerImage(
     docker_image="daturaai/torch", docker_image_tag="2.4.0", docker_image_size=12_000_000_000
 )
-_IMAGE_WITH_DIGEST = DefaultDockerImage(
-    docker_image="daturaai/torch",
-    docker_image_tag="2.4.0",
-    docker_image_size=12_000_000_000,
-    docker_image_digest="sha256:aaa",
-)
+_IMAGE_REF = "daturaai/torch:2.4.0"
+_IMAGE_DIGEST = "sha256:aaa"
 _LOCAL_MATCH = '["daturaai/torch@sha256:aaa"]'
 _LOCAL_MISMATCH = '["daturaai/torch@sha256:bbb"]'
 _GPU = "NVIDIA H200"
@@ -58,6 +54,24 @@ def _ssh(exit_status=0, stdout="", raises=False):
     else:
         ssh.run = AsyncMock(return_value=Mock(exit_status=exit_status, stdout=stdout))
     return ssh
+
+
+def _digest_service(*, digest: str | None = None, by_ref: dict[str, str] | None = None):
+    service = Mock()
+    if by_ref is not None:
+        service.get_digest = Mock(side_effect=lambda ref: by_ref.get(ref))
+    else:
+        service.get_digest = Mock(return_value=digest)
+    return service
+
+
+def _services(backend_images, digest_map: dict[str, str] | None = None):
+    return build_services(
+        backend=_backend(images=backend_images),
+        default_docker_image_digests=(
+            _digest_service(by_ref=digest_map) if digest_map is not None else _digest_service()
+        ),
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -204,10 +218,10 @@ async def test_fails_open_when_inspect_raises(context_factory):
 
 @pytest.mark.asyncio
 async def test_digest_match_publishes_true(context_factory):
-    # Branch 4: cached + local RepoDigest == backend digest → match True.
+    # Branch 4: cached + local RepoDigest == validator digest cache → match True.
     ssh = _ssh(exit_status=0, stdout=_LOCAL_MATCH)
     ctx = context_factory(
-        services=build_services(backend=_backend(images=[_IMAGE_WITH_DIGEST])),
+        services=_services([_IMAGE], {_IMAGE_REF: _IMAGE_DIGEST}),
         state=build_state(gpu_model=_GPU, specs=_SPECS),
         ssh=ssh,
     )
@@ -227,9 +241,9 @@ async def test_digest_match_publishes_true(context_factory):
 
 @pytest.mark.asyncio
 async def test_digest_mismatch_publishes_false(context_factory):
-    # Branch 5: cached + local RepoDigest != backend digest → match False (stale content).
+    # Branch 5: cached + local RepoDigest != validator digest cache → match False (stale content).
     ctx = context_factory(
-        services=build_services(backend=_backend(images=[_IMAGE_WITH_DIGEST])),
+        services=_services([_IMAGE], {_IMAGE_REF: _IMAGE_DIGEST}),
         state=build_state(gpu_model=_GPU, specs=_SPECS),
         ssh=_ssh(exit_status=0, stdout=_LOCAL_MISMATCH),
     )
@@ -243,16 +257,9 @@ async def test_digest_mismatch_publishes_false(context_factory):
 
 
 @pytest.mark.asyncio
-async def test_digest_match_normalizes_repo_at_sha_backend_value(context_factory):
-    # M3: a backend digest pasted as "repo@sha256:…" must compare only on the bare sha.
-    image = DefaultDockerImage(
-        docker_image="daturaai/torch",
-        docker_image_tag="2.4.0",
-        docker_image_size=12_000_000_000,
-        docker_image_digest="daturaai/torch@sha256:aaa",
-    )
+async def test_digest_match_uses_validator_digest_cache(context_factory):
     ctx = context_factory(
-        services=build_services(backend=_backend(images=[image])),
+        services=_services([_IMAGE], {_IMAGE_REF: _IMAGE_DIGEST}),
         state=build_state(gpu_model=_GPU, specs=_SPECS),
         ssh=_ssh(exit_status=0, stdout=_LOCAL_MATCH),
     )
@@ -264,8 +271,8 @@ async def test_digest_match_normalizes_repo_at_sha_backend_value(context_factory
 
 
 @pytest.mark.asyncio
-async def test_digest_none_when_backend_digest_missing(context_factory):
-    # Branch 2: cached, but backend published no digest → match None, cached stays True.
+async def test_digest_none_when_validator_digest_missing(context_factory):
+    # Branch 2: cached, but the validator digest cache has no entry → match None, cached stays True.
     ctx = context_factory(
         services=build_services(backend=_backend(images=[_IMAGE])),
         state=build_state(gpu_model=_GPU, specs=_SPECS),
@@ -291,7 +298,7 @@ async def test_digest_none_when_backend_digest_missing(context_factory):
 async def test_digest_none_when_no_repo_match(context_factory, stdout):
     # Branch 3: cached + backend digest set, but no RepoDigest for THIS repo → match None.
     ctx = context_factory(
-        services=build_services(backend=_backend(images=[_IMAGE_WITH_DIGEST])),
+        services=_services([_IMAGE], {_IMAGE_REF: _IMAGE_DIGEST}),
         state=build_state(gpu_model=_GPU, specs=_SPECS),
         ssh=_ssh(exit_status=0, stdout=stdout),
     )
@@ -309,7 +316,7 @@ async def test_digest_fails_open_on_unparseable_stdout(context_factory):
     # Branch 3 variant: cached + backend digest set, RepoDigests JSON is garbage → match None,
     # never raises.
     ctx = context_factory(
-        services=build_services(backend=_backend(images=[_IMAGE_WITH_DIGEST])),
+        services=_services([_IMAGE], {_IMAGE_REF: _IMAGE_DIGEST}),
         state=build_state(gpu_model=_GPU, specs=_SPECS),
         ssh=_ssh(exit_status=0, stdout="not json at all"),
     )
@@ -348,7 +355,7 @@ async def test_digest_mismatch_fails_after_cutoff(context_factory, monkeypatch):
     # Stale content under the same tag + after cutoff → fatal fail.
     _set_cutoff(monkeypatch, active=True)
     ctx = context_factory(
-        services=build_services(backend=_backend(images=[_IMAGE_WITH_DIGEST])),
+        services=_services([_IMAGE], {_IMAGE_REF: _IMAGE_DIGEST}),
         state=build_state(gpu_model=_GPU, specs=_SPECS),
         ssh=_ssh(exit_status=0, stdout=_LOCAL_MISMATCH),
     )
@@ -382,7 +389,7 @@ async def test_cached_passes_after_cutoff(context_factory, monkeypatch):
 async def test_digest_match_passes_after_cutoff(context_factory, monkeypatch):
     _set_cutoff(monkeypatch, active=True)
     ctx = context_factory(
-        services=build_services(backend=_backend(images=[_IMAGE_WITH_DIGEST])),
+        services=_services([_IMAGE], {_IMAGE_REF: _IMAGE_DIGEST}),
         state=build_state(gpu_model=_GPU, specs=_SPECS),
         ssh=_ssh(exit_status=0, stdout=_LOCAL_MATCH),
     )
@@ -416,7 +423,7 @@ async def test_digest_skipped_passes_after_cutoff(context_factory, monkeypatch):
     # Cached but RepoDigest unreadable for this repo → DIGEST_SKIPPED, never a fatal fail.
     _set_cutoff(monkeypatch, active=True)
     ctx = context_factory(
-        services=build_services(backend=_backend(images=[_IMAGE_WITH_DIGEST])),
+        services=_services([_IMAGE], {_IMAGE_REF: _IMAGE_DIGEST}),
         state=build_state(gpu_model=_GPU, specs=_SPECS),
         ssh=_ssh(exit_status=0, stdout="[]"),
     )

--- a/neurons/validators/tests/test_default_docker_image_digest_service.py
+++ b/neurons/validators/tests/test_default_docker_image_digest_service.py
@@ -1,15 +1,53 @@
 """Tests for the default docker image digest snapshot (DAH-2380)."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-
 from neurons.validators.src.services.default_docker_image_digest_service import (
+    _shared_config_image_refs,
     fetch_default_image_digests,
     fetch_registry_digest,
 )
 
 _MODULE = "neurons.validators.src.services.default_docker_image_digest_service"
+
+
+def _shared_client_with(images) -> SimpleNamespace:
+    return SimpleNamespace(config=SimpleNamespace(default_docker_images=images))
+
+
+def test_shared_config_image_refs_derives_repo_tag_from_structured_entries():
+    """Refs are derived locally from the structured default_docker_images field.
+
+    The backend serves its DOCKER_IMAGES entries verbatim (full metadata); only
+    image/tag participate in the ref, extra keys are ignored.
+    """
+    images = (
+        {"image": "daturaai/pytorch", "tag": "cuda12.8-dind", "cuda": 12.8, "size": 123},
+        {"image": "daturaai/pytorch", "tag": "cuda13.0-dind", "cuda": 13.0, "size": 456},
+    )
+    with patch("core.config.shared_client", _shared_client_with(images)):
+        refs = _shared_config_image_refs()
+
+    assert refs == (
+        "daturaai/pytorch:cuda12.8-dind",
+        "daturaai/pytorch:cuda13.0-dind",
+    )
+
+
+def test_shared_config_image_refs_skips_malformed_entries():
+    """An entry missing image or tag is dropped (fail open), not a broken ref."""
+    images = (
+        {"image": "daturaai/pytorch", "tag": "cuda12.8-dind"},
+        {"image": "daturaai/pytorch"},  # no tag
+        {"tag": "orphan-tag"},  # no image
+        {},
+    )
+    with patch("core.config.shared_client", _shared_client_with(images)):
+        refs = _shared_config_image_refs()
+
+    assert refs == ("daturaai/pytorch:cuda12.8-dind",)
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_default_docker_image_digest_service.py
+++ b/neurons/validators/tests/test_default_docker_image_digest_service.py
@@ -43,10 +43,7 @@ async def test_fetch_registry_digest_returns_bare_digest():
 
 @pytest.mark.asyncio
 async def test_refresh_populates_digest_map():
-    service = DefaultDockerImageDigestService(
-        image_refs=("daturaai/pytorch:test",),
-        refresh_seconds=60,
-    )
+    service = DefaultDockerImageDigestService(image_refs=("daturaai/pytorch:test",))
 
     with patch(
         "neurons.validators.src.services.default_docker_image_digest_service.fetch_registry_digest",
@@ -64,10 +61,7 @@ async def test_refresh_drops_ref_when_fetch_fails():
     Regression for the DIGEST_MISMATCH false-positive: a stale digest kept after
     a failed fetch would mismatch a re-pushed tag and zero an honest miner.
     """
-    service = DefaultDockerImageDigestService(
-        image_refs=("daturaai/pytorch:test",),
-        refresh_seconds=60,
-    )
+    service = DefaultDockerImageDigestService(image_refs=("daturaai/pytorch:test",))
 
     with patch(
         "neurons.validators.src.services.default_docker_image_digest_service.fetch_registry_digest",
@@ -91,7 +85,7 @@ async def test_refresh_reads_image_refs_from_shared_config_when_none_provided():
     This is the DAH-2380 single-source-of-truth path: the backend serves the
     default template refs via /v1/shared-config, so no hardcoded copy lives here.
     """
-    service = DefaultDockerImageDigestService(refresh_seconds=60)  # image_refs=None
+    service = DefaultDockerImageDigestService()  # image_refs=None
 
     with (
         patch(
@@ -111,5 +105,5 @@ async def test_refresh_reads_image_refs_from_shared_config_when_none_provided():
 
 @pytest.mark.asyncio
 async def test_get_digest_returns_none_for_unknown_image():
-    service = DefaultDockerImageDigestService(image_refs=(), refresh_seconds=60)
+    service = DefaultDockerImageDigestService(image_refs=())
     assert service.get_digest("daturaai/pytorch:missing") is None

--- a/neurons/validators/tests/test_default_docker_image_digest_service.py
+++ b/neurons/validators/tests/test_default_docker_image_digest_service.py
@@ -85,6 +85,31 @@ async def test_refresh_drops_ref_when_fetch_fails():
 
 
 @pytest.mark.asyncio
+async def test_refresh_reads_image_refs_from_shared_config_when_none_provided():
+    """With no static image_refs, the service pulls the list from shared config.
+
+    This is the DAH-2380 single-source-of-truth path: the backend serves the
+    default template refs via /v1/shared-config, so no hardcoded copy lives here.
+    """
+    service = DefaultDockerImageDigestService(refresh_seconds=60)  # image_refs=None
+
+    with (
+        patch(
+            "neurons.validators.src.services.default_docker_image_digest_service"
+            "._shared_config_image_refs",
+            return_value=("daturaai/pytorch:shared",),
+        ),
+        patch(
+            "neurons.validators.src.services.default_docker_image_digest_service.fetch_registry_digest",
+            new=AsyncMock(return_value="sha256:shared"),
+        ),
+    ):
+        await service.refresh()
+
+    assert service.get_digest("daturaai/pytorch:shared") == "sha256:shared"
+
+
+@pytest.mark.asyncio
 async def test_get_digest_returns_none_for_unknown_image():
     service = DefaultDockerImageDigestService(image_refs=(), refresh_seconds=60)
     assert service.get_digest("daturaai/pytorch:missing") is None

--- a/neurons/validators/tests/test_default_docker_image_digest_service.py
+++ b/neurons/validators/tests/test_default_docker_image_digest_service.py
@@ -1,0 +1,63 @@
+"""Tests for DefaultDockerImageDigestService (DAH-2380)."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from neurons.validators.src.services.default_docker_image_digest_service import (
+    DefaultDockerImageDigestService,
+    _bare_digest,
+    fetch_registry_digest,
+)
+
+
+def test_bare_digest_strips_repo_prefix():
+    assert _bare_digest("daturaai/pytorch@sha256:abc") == "sha256:abc"
+    assert _bare_digest("sha256:abc") == "sha256:abc"
+
+
+@pytest.mark.asyncio
+async def test_fetch_registry_digest_returns_bare_digest():
+    session = AsyncMock()
+    token_response = AsyncMock()
+    token_response.raise_for_status = Mock()
+    token_response.json = AsyncMock(return_value={"token": "tok"})
+    token_cm = AsyncMock()
+    token_cm.__aenter__.return_value = token_response
+
+    manifest_response = AsyncMock()
+    manifest_response.raise_for_status = Mock()
+    manifest_response.headers = {"Docker-Content-Digest": "sha256:deadbeef"}
+    manifest_cm = AsyncMock()
+    manifest_cm.__aenter__.return_value = manifest_response
+
+    session.get = Mock(return_value=token_cm)
+    session.head = Mock(return_value=manifest_cm)
+
+    digest = await fetch_registry_digest(session, "daturaai/pytorch:1.0")
+
+    assert digest == "sha256:deadbeef"
+    session.head.assert_called_once()
+    assert "manifests/1.0" in session.head.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_refresh_populates_digest_map():
+    service = DefaultDockerImageDigestService(
+        image_refs=("daturaai/pytorch:test",),
+        refresh_seconds=60,
+    )
+
+    with patch(
+        "neurons.validators.src.services.default_docker_image_digest_service.fetch_registry_digest",
+        new=AsyncMock(return_value="sha256:abc"),
+    ):
+        await service.refresh()
+
+    assert service.get_digest("daturaai/pytorch:test") == "sha256:abc"
+
+
+@pytest.mark.asyncio
+async def test_get_digest_returns_none_for_unknown_image():
+    service = DefaultDockerImageDigestService(image_refs=(), refresh_seconds=60)
+    assert service.get_digest("daturaai/pytorch:missing") is None

--- a/neurons/validators/tests/test_default_docker_image_digest_service.py
+++ b/neurons/validators/tests/test_default_docker_image_digest_service.py
@@ -58,6 +58,33 @@ async def test_refresh_populates_digest_map():
 
 
 @pytest.mark.asyncio
+async def test_refresh_drops_ref_when_fetch_fails():
+    """A ref that fails to refresh is cleared, not left stale (fail open).
+
+    Regression for the DIGEST_MISMATCH false-positive: a stale digest kept after
+    a failed fetch would mismatch a re-pushed tag and zero an honest miner.
+    """
+    service = DefaultDockerImageDigestService(
+        image_refs=("daturaai/pytorch:test",),
+        refresh_seconds=60,
+    )
+
+    with patch(
+        "neurons.validators.src.services.default_docker_image_digest_service.fetch_registry_digest",
+        new=AsyncMock(return_value="sha256:abc"),
+    ):
+        await service.refresh()
+    assert service.get_digest("daturaai/pytorch:test") == "sha256:abc"
+
+    with patch(
+        "neurons.validators.src.services.default_docker_image_digest_service.fetch_registry_digest",
+        new=AsyncMock(return_value=None),
+    ):
+        await service.refresh()
+    assert service.get_digest("daturaai/pytorch:test") is None
+
+
+@pytest.mark.asyncio
 async def test_get_digest_returns_none_for_unknown_image():
     service = DefaultDockerImageDigestService(image_refs=(), refresh_seconds=60)
     assert service.get_digest("daturaai/pytorch:missing") is None

--- a/neurons/validators/tests/test_default_docker_image_digest_service.py
+++ b/neurons/validators/tests/test_default_docker_image_digest_service.py
@@ -1,19 +1,15 @@
-"""Tests for DefaultDockerImageDigestService (DAH-2380)."""
+"""Tests for the default docker image digest snapshot (DAH-2380)."""
 
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from neurons.validators.src.services.default_docker_image_digest_service import (
-    DefaultDockerImageDigestService,
-    _bare_digest,
+    fetch_default_image_digests,
     fetch_registry_digest,
 )
 
-
-def test_bare_digest_strips_repo_prefix():
-    assert _bare_digest("daturaai/pytorch@sha256:abc") == "sha256:abc"
-    assert _bare_digest("sha256:abc") == "sha256:abc"
+_MODULE = "neurons.validators.src.services.default_docker_image_digest_service"
 
 
 @pytest.mark.asyncio
@@ -42,68 +38,45 @@ async def test_fetch_registry_digest_returns_bare_digest():
 
 
 @pytest.mark.asyncio
-async def test_refresh_populates_digest_map():
-    service = DefaultDockerImageDigestService(image_refs=("daturaai/pytorch:test",))
-
-    with patch(
-        "neurons.validators.src.services.default_docker_image_digest_service.fetch_registry_digest",
-        new=AsyncMock(return_value="sha256:abc"),
-    ):
-        await service.refresh()
-
-    assert service.get_digest("daturaai/pytorch:test") == "sha256:abc"
-
-
-@pytest.mark.asyncio
-async def test_refresh_drops_ref_when_fetch_fails():
-    """A ref that fails to refresh is cleared, not left stale (fail open).
-
-    Regression for the DIGEST_MISMATCH false-positive: a stale digest kept after
-    a failed fetch would mismatch a re-pushed tag and zero an honest miner.
-    """
-    service = DefaultDockerImageDigestService(image_refs=("daturaai/pytorch:test",))
-
-    with patch(
-        "neurons.validators.src.services.default_docker_image_digest_service.fetch_registry_digest",
-        new=AsyncMock(return_value="sha256:abc"),
-    ):
-        await service.refresh()
-    assert service.get_digest("daturaai/pytorch:test") == "sha256:abc"
-
-    with patch(
-        "neurons.validators.src.services.default_docker_image_digest_service.fetch_registry_digest",
-        new=AsyncMock(return_value=None),
-    ):
-        await service.refresh()
-    assert service.get_digest("daturaai/pytorch:test") is None
-
-
-@pytest.mark.asyncio
-async def test_refresh_reads_image_refs_from_shared_config_when_none_provided():
-    """With no static image_refs, the service pulls the list from shared config.
-
-    This is the DAH-2380 single-source-of-truth path: the backend serves the
-    default template refs via /v1/shared-config, so no hardcoded copy lives here.
-    """
-    service = DefaultDockerImageDigestService()  # image_refs=None
-
+async def test_fetch_default_image_digests_builds_snapshot():
     with (
-        patch(
-            "neurons.validators.src.services.default_docker_image_digest_service"
-            "._shared_config_image_refs",
-            return_value=("daturaai/pytorch:shared",),
-        ),
-        patch(
-            "neurons.validators.src.services.default_docker_image_digest_service.fetch_registry_digest",
-            new=AsyncMock(return_value="sha256:shared"),
-        ),
+        patch(f"{_MODULE}._shared_config_image_refs", return_value=("daturaai/pytorch:test",)),
+        patch(f"{_MODULE}.fetch_registry_digest", new=AsyncMock(return_value="sha256:abc")),
     ):
-        await service.refresh()
+        digests = await fetch_default_image_digests()
 
-    assert service.get_digest("daturaai/pytorch:shared") == "sha256:shared"
+    assert digests == {"daturaai/pytorch:test": "sha256:abc"}
 
 
 @pytest.mark.asyncio
-async def test_get_digest_returns_none_for_unknown_image():
-    service = DefaultDockerImageDigestService(image_refs=())
-    assert service.get_digest("daturaai/pytorch:missing") is None
+async def test_fetch_default_image_digests_drops_ref_when_fetch_fails():
+    """A ref that fails to fetch is absent from the snapshot, not stale (fail open).
+
+    Regression for the DIGEST_MISMATCH false-positive: a stale digest kept after a
+    failed fetch would mismatch a re-pushed tag and zero an honest miner's score.
+    """
+    with (
+        patch(f"{_MODULE}._shared_config_image_refs", return_value=("daturaai/pytorch:test",)),
+        patch(f"{_MODULE}.fetch_registry_digest", new=AsyncMock(return_value=None)),
+    ):
+        digests = await fetch_default_image_digests()
+
+    assert digests == {}
+    # An absent ref makes the verification check find no digest to compare (skip).
+    assert digests.get("daturaai/pytorch:test") is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_default_image_digests_reads_refs_from_shared_config():
+    """The ref list is the backend single-source-of-truth via shared config.
+
+    No hardcoded copy lives in the validator: whatever ``_shared_config_image_refs``
+    returns is exactly what gets fetched and keyed in the snapshot.
+    """
+    with (
+        patch(f"{_MODULE}._shared_config_image_refs", return_value=("daturaai/pytorch:shared",)),
+        patch(f"{_MODULE}.fetch_registry_digest", new=AsyncMock(return_value="sha256:shared")),
+    ):
+        digests = await fetch_default_image_digests()
+
+    assert digests == {"daturaai/pytorch:shared": "sha256:shared"}

--- a/neurons/validators/tests/test_incentive_flow.py
+++ b/neurons/validators/tests/test_incentive_flow.py
@@ -71,7 +71,7 @@ async def _run_set_weights_and_capture(mock_subtensor_client, miners, miner_scor
 
 
 async def _run_sync_with_jobs(validator, miners, job_results_by_hotkey, *, job_batch_id="2024-01-01 00:00:00"):
-    async def request_job_side_effect(payload, encrypted_files, rented_data):
+    async def request_job_side_effect(payload, encrypted_files, rented_data, default_docker_image_digests):
         hotkey = payload.miner_hotkey
         results = job_results_by_hotkey.get(hotkey, [])
         return {

--- a/neurons/validators/tests/test_incentive_flow.py
+++ b/neurons/validators/tests/test_incentive_flow.py
@@ -85,7 +85,14 @@ async def _run_sync_with_jobs(validator, miners, job_results_by_hotkey, *, job_b
     validator.subtensor_client.get_time_from_block = AsyncMock(return_value=job_batch_id)
     validator.miner_service.request_job_to_miner = AsyncMock(side_effect=request_job_side_effect)
 
-    await validator.sync()
+    # DAH-2380: sync() fetches default docker image digests from Docker Hub at job-cycle
+    # start. Stub it here so these unit tests never hit the network (the real fetch would
+    # open aiohttp connections to auth.docker.io / registry-1.docker.io per cycle).
+    with patch(
+        "core.validator.fetch_default_image_digests",
+        new=AsyncMock(return_value={}),
+    ):
+        await validator.sync()
 
 
 # Existing test scenarios

--- a/neurons/validators/tests/test_new_rentals_pause_filter.py
+++ b/neurons/validators/tests/test_new_rentals_pause_filter.py
@@ -259,6 +259,7 @@ async def test_websocket_request_job_validates_paused_unrented_executors(monkeyp
             _payload(),
             MagicMock(),
             rented_data,
+            {},
         )
 
     assert [job.executor_info.uuid for job in result["results"]] == ["paused-executor", "available-executor"]
@@ -299,6 +300,7 @@ async def test_rest_request_job_validates_paused_unrented_executors(monkeypatch)
         _payload(),
         MagicMock(),
         rented_data,
+        {},
     )
 
     assert [job.executor_info.uuid for job in result["results"]] == ["paused-executor", "available-executor"]


### PR DESCRIPTION
## Describe your changes

- Add a stateless `fetch_default_image_digests()` that builds a fresh `repo:tag → sha256` snapshot from Docker Hub at each job-cycle start (token GET + manifest **HEAD** with the manifest-list accept header, so the digest matches `docker pull` RepoDigests on amd64 and the requests are exempt from Docker Hub pull rate limits).
- The image list comes from the backend via shared config: `SharedConfig.default_docker_images` carries the backend's `DOCKER_IMAGES` entries verbatim, and the validator **derives the `repo:tag` refs locally** from the `image`/`tag` keys (no hardcoded copy, no backend-derived refs field). Malformed entries are skipped, fail-open.
- The snapshot is threaded through the existing `rented_data`-style parameter rails into `ContextConfig`; `CachedTemplateVerificationCheck` compares the executor's local `RepoDigest` against it instead of `docker_image_digest` on the backend response.
- Fail-open by design: a ref whose fetch fails this cycle is absent from the snapshot, so the check skips rather than zeroing an honest miner on a re-pushed tag or a Docker Hub outage.
- Unit tests for ref derivation, digest fetch, snapshot fail-open, and updated cached-template verification tests.

## Issue ticket number and link

[DAH-2380 - Validator fetches default template digests from Docker Hub](https://app.notion.com/p/Validator-fetches-default-template-digests-from-Docker-Hub-398b8bfdbde98165a783e641bdc0f227)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [x] Need to take care of performance? (per-cycle: one HEAD per default image, ~2 refs)

## Other PRs (rollout ordering)

1. **lium-core#5** — adds `SharedConfig.default_docker_images` (v0.1.6, must be released to PyPI first).
2. **lium-io-backend#754** — publishes `default_docker_images` on `/v1/shared-config` and stops serving per-template digests.
3. This PR — after 0.1.6 is on PyPI, regen the lockfile here to pin it; deploy backend + validator together.

## Test plan

- [x] Full validator suite: 999 passed, 8 skipped
- [x] `uvx ruff@0.5.1` clean on changed files
- [ ] Deploy validator + backend together; confirm `recommended_image_digest_match` still populates on a node with the recommended image pre-pulled