### PR TITLE
DAH-2379: surface Docker deletion in progress

### DIFF
--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -596,6 +596,7 @@ class FailedContainerErrorCodes(enum.Enum):
     UnknownError = "UnknownError"
     NoSshKeys = "NoSshKeys"
     ContainerNotRunning = "ContainerNotRunning"
+    DeletionInProgress = "DeletionInProgress"
     NoPortMappings = "NoPortMappings"
     InvalidExecutorId = "InvalidExecutorId"
     ExceptionError = "ExceptionError"

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -194,6 +194,7 @@ _LOCAL_VOLUME_TIMEOUT_GB_PER_SEC = 10
 _LOCAL_VOLUME_TIMEOUT_MAX_SEC = 180
 _FILLER_EXTERNAL_PORT_OFFSET = 20
 _DOCKER_NO_SUCH_CONTAINER_PHRASE = "No such container"
+_DOCKER_REMOVAL_IN_PROGRESS_PHRASES = ("409", "removal", "already in progress")
 HOST_KEY_REQUIRED_EXTRA = {
     "ssh_host_key_missing": True,
     "docker_sdk_host_key_required": True,
@@ -321,16 +322,24 @@ def _parse_volume_size_to_bytes(value: str | None) -> int | None:
     return int(float(number) * _VOLUME_SIZE_SUFFIX_MULTIPLIERS[suffix.lower()])
 
 
-def _is_missing_docker_container_error(exc: Exception) -> bool:
-    if _DOCKER_NO_SUCH_CONTAINER_PHRASE in str(exc):
-        return True
+def _exception_texts(exc: Exception) -> list[str]:
+    texts = [str(exc)]
     if isinstance(exc, RetryError):
         last_exception = exc.last_attempt.exception()
-        return (
-            last_exception is not None
-            and _DOCKER_NO_SUCH_CONTAINER_PHRASE in str(last_exception)
-        )
-    return False
+        if last_exception is not None:
+            texts.append(str(last_exception))
+    return texts
+
+
+def _is_missing_docker_container_error(exc: Exception) -> bool:
+    return any(_DOCKER_NO_SUCH_CONTAINER_PHRASE in text for text in _exception_texts(exc))
+
+
+def _is_docker_container_removal_in_progress_error(exc: Exception) -> bool:
+    return any(
+        all(phrase in text.lower() for phrase in _DOCKER_REMOVAL_IN_PROGRESS_PHRASES)
+        for text in _exception_texts(exc)
+    )
 
 
 def _is_stale_vloopback_mountpoint_error(exc: Exception) -> bool:
@@ -4580,10 +4589,7 @@ class DockerService:
         docker_client: RentalDockerSdkClient,
         payload: ContainerDeleteRequest,
         log: _BoundLog,
-    ) -> None:
-        # DAH-2345: deletion is idempotent for every workload kind — a container that is already
-        # gone (e.g. removed by failed-create cleanup) must not fail the delete, or the backend
-        # retries a doomed request until force-removal and penalizes the miner.
+    ) -> FailedContainerRequest | None:
         try:
             await run_logged_rental_docker_sdk_operation(
                 operation="remove_container",
@@ -4598,6 +4604,29 @@ class DockerService:
                 remove_volumes=True,
             )
         except Exception as exc:
+            if _is_docker_container_removal_in_progress_error(exc):
+                # Docker is still processing the original force-remove request;
+                # let the backend keep polling without treating this as terminal.
+                error_msg = str(exc)
+                log.info(
+                    "Container deletion is still in progress",
+                    container_name=payload.container_name,
+                    error=error_msg,
+                )
+                return FailedContainerRequest(
+                    miner_hotkey=payload.miner_hotkey,
+                    executor_id=payload.executor_id,
+                    pod_id=payload.pod_id,
+                    workload_kind=payload.workload_kind,
+                    msg=error_msg,
+                    error_type=FailedContainerErrorTypes.ContainerDeletionFailed,
+                    error_code=FailedContainerErrorCodes.DeletionInProgress,
+                )
+
+            # DAH-2345: deletion is idempotent for every workload kind — a container
+            # that is already gone (e.g. removed by failed-create cleanup) must not
+            # fail the delete, or the backend retries a doomed request until
+            # force-removal and penalizes the miner.
             if not _is_missing_docker_container_error(exc):
                 raise
             log.info(
@@ -4605,6 +4634,7 @@ class DockerService:
                 container_name=payload.container_name,
                 error=str(exc),
             )
+        return None
 
     async def delete_container(
         self,
@@ -4663,7 +4693,9 @@ class DockerService:
                 # Fatal boundary: the forced removal is the only step whose failure fails the
                 # undeploy. Every step below runs after the container is gone and is best-effort.
                 try:
-                    await self._force_remove_container(docker_client, payload, log)
+                    removal_failure = await self._force_remove_container(docker_client, payload, log)
+                    if removal_failure is not None:
+                        return removal_failure
                 except Exception:
                     # DAH-2427: a failed force-remove (backend FAILED / STOP_FAILED) is the
                     # classic wedge path — sweep before propagating so a wedged card does not

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -24,6 +24,7 @@ from payload_models.payloads import (
     ContainerStartRequest,
     ContainerStopRequest,
     FailedContainerErrorTypes,
+    FailedContainerErrorCodes,
     FailedContainerRequest,
     PayloadPortMapping,
     ProfilerStepName,
@@ -1388,6 +1389,55 @@ async def test_delete_container_failure_msg_includes_underlying_error(
     assert isinstance(result, FailedContainerRequest)
     assert result.error_type == FailedContainerErrorTypes.ContainerDeletionFailed
     assert "500 Server Error: daemon exploded" in result.msg
+
+
+@pytest.mark.asyncio
+async def test_delete_container_removal_in_progress_returns_soft_failure(
+    docker_service,
+    monkeypatch,
+):
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.remove_rented_machine = AsyncMock()
+    remove_error = (
+        "Docker SDK remove container failed: 409 Client Error: Conflict "
+        '("removal of container pod_stuck is already in progress")'
+    )
+    docker_service.rental_docker_client_factory.client.remove_error = Exception(remove_error)
+
+    payload = ContainerDeleteRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_stuck",
+        local_volume="volume_stuck",
+    )
+    executor_info = _delete_container_executor_info(payload.executor_id)
+    keypair = Mock(ss58_address="validator-hotkey")
+
+    result = await docker_service.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=keypair,
+        private_key="encrypted",
+    )
+
+    assert isinstance(result, FailedContainerRequest)
+    assert result.error_type == FailedContainerErrorTypes.ContainerDeletionFailed
+    assert result.error_code == FailedContainerErrorCodes.DeletionInProgress
+    assert result.msg == remove_error
+    assert docker_service.rental_docker_client_factory.client.pruned_images == 0
+    assert docker_service.rental_docker_client_factory.client.removed_volumes == []
+    docker_service.redis_service.remove_rented_machine.assert_not_awaited()
 
 
 def _delete_container_executor_info(executor_id: str) -> ExecutorSSHInfo:

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, Mock, MagicMock, patch
 from uuid import uuid4, UUID
 from datetime import datetime
 
+from docker.errors import APIError
 import pytest
 import pytest_asyncio
 from tenacity import Future, RetryError
@@ -12,9 +13,15 @@ from services.docker_service import (
     FILLER_CONTAINER_STOP_GRACE_SECONDS,
     DockerService,
     VolumeMinSizeError,
+    _is_docker_container_removal_in_progress_error,
     _parse_volume_size_to_bytes,
 )
-from services.rental_docker_sdk import ContainerExecResult, build_gpu_docker_config
+from services.rental_docker_sdk import (
+    ContainerExecResult,
+    RentalDockerOperationError,
+    _wrap_error_message,
+    build_gpu_docker_config,
+)
 from payload_models.payloads import (
     AddSshPublicKeyRequest,
     ContainerCreateRequest,
@@ -846,6 +853,25 @@ def _make_retry_error(exc: Exception) -> RetryError:
     future = Future(1)
     future.set_exception(exc)
     return RetryError(future)
+
+
+def test_docker_container_removal_in_progress_detection_covers_docker_py_api_error():
+    exc = APIError(
+        "409 Client Error for http+docker://ssh/v1.52/containers/pod_stuck: "
+        'Conflict ("removal of container pod_stuck is already in progress")'
+    )
+    wrapped = RentalDockerOperationError(_wrap_error_message("Docker SDK remove container failed", exc))
+
+    assert _is_docker_container_removal_in_progress_error(exc)
+    assert _is_docker_container_removal_in_progress_error(wrapped)
+    assert _is_docker_container_removal_in_progress_error(_make_retry_error(exc))
+    assert _is_docker_container_removal_in_progress_error(_make_retry_error(wrapped))
+    assert not _is_docker_container_removal_in_progress_error(
+        APIError(
+            "409 Client Error for http+docker://ssh/v1.52/containers/pod_stuck: "
+            'Conflict ("container name is already in use")'
+        )
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Describe your changes

Handle Docker `409 removal already in progress` during container deletion as a soft/non-terminal delete state.

When Docker reports that removal is already in progress, the validator now returns `FailedContainerRequest` with `error_code=DeletionInProgress` and passes the exact raw Docker exception string through `msg`. The backend companion PR uses that code to avoid treating the retry collision as a provider-impacting delete failure.

This keeps normal delete failures unchanged, still treats missing containers as successful idempotent deletes, and preserves the existing graceful-stop-before-force-remove delete flow from `main`.

Deploy order: deploy the backend companion PR first, because older backend code strictly parses the enum and needs to understand `DeletionInProgress` before validators can send it.

Tests run:

- `pdm run pytest tests/test_docker_service.py::test_docker_container_removal_in_progress_detection_covers_docker_py_api_error tests/test_docker_service.py::test_delete_container_removal_in_progress_returns_soft_failure tests/test_docker_service.py::test_delete_container_failure_msg_includes_underlying_error tests/test_docker_service.py::test_delete_customer_rental_treats_missing_container_as_deleted tests/test_docker_service.py::test_delete_filler_container_treats_missing_container_as_deleted tests/test_docker_service.py::test_delete_container_stops_gracefully_before_forced_removal tests/test_docker_service.py::test_delete_container_stop_failure_still_removes`
- `python -m py_compile neurons/validators/src/services/docker_service.py neurons/validators/tests/test_docker_service.py`
- `git diff --check -- neurons/validators/src/services/docker_service.py neurons/validators/tests/test_docker_service.py neurons/validators/src/payload_models/payloads.py`

## Issue ticket number and link

[DAH-2379](https://app.notion.com/p/398b8bfdbde9816298f7fb8607610971)

Backend companion PR: https://github.com/Datura-ai/lium-io-backend/pull/753

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?
