### PR TITLE
DAH-2385, skip port-count check on filler-occupied nodes

### DIFF
--- a/neurons/validators/src/services/task/checks/port_count.py
+++ b/neurons/validators/src/services/task/checks/port_count.py
@@ -37,6 +37,25 @@ class PortCountCheck:
         )
 
         if not is_rented and port_count < MIN_PORT_COUNT:
+            # A filler container is published with all of the executor's free ports (DAH-2385),
+            # so a low count is expected while it runs — skip instead of zeroing the score,
+            # same filler tolerance as the capability/verifyx/gpu_usage checks.
+            filler_container = _get_filler_only_container(ctx)
+            if filler_container:
+                event = render_message(
+                    Msg.FILLER_SKIPPED,
+                    ctx=ctx,
+                    check_id=self.check_id,
+                    what={
+                        "available_port_count": port_count,
+                        "filler_container": filler_container,
+                    },
+                )
+                return CheckResult(
+                    passed=True,
+                    event=event,
+                    updates={"port_count": port_count, "state": updated_state},
+                )
             event = render_message(
                 Msg.INSUFFICIENT_PORTS,
                 ctx=ctx,
@@ -63,3 +82,14 @@ class PortCountCheck:
             event=event,
             updates={"port_count": port_count, "state": updated_state},
         )
+
+
+def _get_filler_only_container(ctx: Context) -> str | None:
+    rented_data = ctx.state.rented_data
+    if not rented_data:
+        return None
+
+    filler_container = rented_data.get_filler_container(ctx.executor.uuid)
+    rented_executor = rented_data.executors.get(ctx.executor.uuid)
+    has_customer_rental = bool(rented_executor and rented_executor.pods)
+    return filler_container if filler_container and not has_customer_rental else None

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -724,6 +724,13 @@ class PortCountMessages:
         impact="Score set to 0",
         remediation="Increase port range or check port mappings configuration.",
     )
+    FILLER_SKIPPED = MessageTemplate(
+        event="Port count check skipped for active filler",
+        reason="PORT_COUNT_SKIPPED_ACTIVE_FILLER",
+        severity="info",
+        category="policy",
+        impact="Active filler publishes the executor's free ports; count recovers when the filler stops.",
+    )
 
 
 VERIFYX_DEBUG_DOC_URL = (

--- a/neurons/validators/tests/test_port_count_check.py
+++ b/neurons/validators/tests/test_port_count_check.py
@@ -65,3 +65,37 @@ async def test_port_count_insufficient_passes_when_rented(context_factory):
     assert result.passed is True
     assert result.event.reason_code == Msg.PORT_COUNT_RECORDED.reason
     assert result.updates["port_count"] == MIN_PORT_COUNT - 1
+
+
+@pytest.mark.asyncio
+async def test_port_count_insufficient_passes_when_filler_occupies_node(context_factory):
+    """A filler-only node passes: the filler container publishes the executor's free ports,
+    so a low count is expected and must not zero the score (DAH-2385)."""
+    rented_data = RentedExecutorsResponse(
+        executors={},
+        filler_containers_by_executor={"executor-123": "filler_12bc2580"},
+    )
+    ctx = context_factory(state=build_state(verified_port_count=MIN_PORT_COUNT - 1, rented_data=rented_data))
+
+    result = await PortCountCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.FILLER_SKIPPED.reason
+    assert result.updates["port_count"] == MIN_PORT_COUNT - 1
+    assert result.updates["state"].specs["available_port_count"] == MIN_PORT_COUNT - 1
+
+
+@pytest.mark.asyncio
+async def test_port_count_sufficient_records_normally_with_filler(context_factory):
+    """With a filler present but enough free ports, the check records the count as usual."""
+    rented_data = RentedExecutorsResponse(
+        executors={},
+        filler_containers_by_executor={"executor-123": "filler_12bc2580"},
+    )
+    ctx = context_factory(state=build_state(verified_port_count=MIN_PORT_COUNT + 1, rented_data=rented_data))
+
+    result = await PortCountCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.PORT_COUNT_RECORDED.reason
+    assert result.updates["port_count"] == MIN_PORT_COUNT + 1


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2385](https://www.notion.so/399b8bfdbde981828158d8fc18a6ded3)

---

## Problem

A Lium filler container (Dolphin/PEARL) is published with **all of the executor's free ports** (the shared filler launch path passes `prepare_ports_data` with the full available range), so while a filler runs, the validator's `PortCountCheck` sees fewer than `MIN_PORT_COUNT` free ports and zeroes the miner's score with `INSUFFICIENT_PORTS`.

Observed on staging during DAH-1958 Dolphin testing (H100 `185.216.21.144`, executor `4bfe9efe`): filler occupies 40000-40007 + 40009 of the 40000-40009 range → `available_port_count: 1, required: 3` → score 0. Same effect on PEARL-filled nodes — `port_count` is the only check without filler tolerance: `capability`, `verifyx`, and `gpu_usage` already skip filler-only nodes via `rented_data.get_filler_container`.

Without this fix, enabling Dolphin on prod would zero the provider's validation score on every filled node.

## Solution

Mirror the existing filler-tolerance pattern in `PortCountCheck`: when the node has an active filler container and **no customer rental**, a low port count is expected — pass the check (new `PORT_COUNT_SKIPPED_ACTIVE_FILLER` info event for Grafana) instead of failing with `INSUFFICIENT_PORTS`. The real `available_port_count` is still recorded in specs. Nodes with enough free ports, rented nodes, and filler-less nodes keep the existing behavior.

## Changes

- `checks/port_count.py`: filler-only skip before the `INSUFFICIENT_PORTS` failure; `_get_filler_only_container` helper (same private-helper idiom as `capability.py` / `verifyx.py`)
- `messages.py`: `PortCountMessages.FILLER_SKIPPED` template (`PORT_COUNT_SKIPPED_ACTIVE_FILLER`)
- `tests/test_port_count_check.py`: filler-only node with low ports passes with the skip reason; filler node with enough ports records normally

## Deployment Steps

Use GitHub Action (validator staging/prod deploy via lium-io-deployment).

## Review Request

- [x] Just code review

## Other PRs

None — backend already feeds `filler_containers_by_executor` for all filler strategies (Datura-ai/lium-io-backend `utils/rented_machines.py`).

## Risks

- Port degradation on a filler-occupied node is no longer score-penalized until the filler stops; the skip applies only when there is **no customer rental**, and the port count is still recorded + the skip is visible in logs by reason code.
- No behavior change for rented, filler-less, or healthy-port nodes.

## Test Cases

### Test Case 1
**Actions:** `PortCountCheck` with `verified_port_count = MIN_PORT_COUNT - 1` and `filler_containers_by_executor` containing the executor.
**Expected Output:** passed, reason `PORT_COUNT_SKIPPED_ACTIVE_FILLER`, real port count recorded.

### Test Case 2
**Actions:** same filler node with `MIN_PORT_COUNT + 1` free ports.
**Expected Output:** passed, normal `PORT_COUNT_RECORDED`.

### Test Case 3
**Actions:** full validator unit suite (`tests/`, 832 passed locally; remaining failures pre-exist on `main` — stale local `datura` package / TDX fixture env).
**Expected Output:** no regressions from this change.

## Checklist

- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described