### PR TITLE
DAH-2392 - Disable SSH connect debug logging by default

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -175,17 +175,16 @@ class Settings(BaseSettings):
     DRY_RUN: bool = Field(env="DRY_RUN", default=False, description="Run validation without publishing scores/weights")
     CONTAINER_CLEANUP_DRY_RUN: bool = Field(env="CONTAINER_CLEANUP_DRY_RUN", default=False, description="Dry run mode for stale container cleanup")
 
-    # DAH-2272: raise the asyncssh logger to DEBUG (debug level 2) so the SSH
-    # handshake (banner / key exchange / auth) is logged per connection. Enabled
-    # by default while DAH-2272 is under investigation, so the handshake trace is
-    # captured whenever the rare slow-connect transient hits; set
-    # SSH_DEBUG_LOGGING=false (env) to silence it without a deploy. Lives on the
-    # main settings (not DebugSettings, which is local-dev only) so it is
-    # configurable in staging/prod where the real slow connects happen.
-    # TODO(DAH-2272): flip default back to False once the slow-connect
-    # investigation is closed — debug-level handshake logging shouldn't ship on
-    # by default long-term.
-    SSH_DEBUG_LOGGING: bool = Field(env="SSH_DEBUG_LOGGING", default=True, description="Enable verbose asyncssh SSH handshake debug logging")
+    # DAH-2272: when on, raise the asyncssh logger to DEBUG (debug level 2) so the
+    # SSH handshake (banner / key exchange / auth) is logged per connection, and
+    # emit the per-connect ``ssh_connect_phase_timing`` breakdown (see
+    # ``services.ssh_connect_timing``). Off by default now that the slow-connect
+    # investigation is closed — this instrumentation is kept in the tree so it can
+    # be re-enabled without a code change by setting SSH_DEBUG_LOGGING=true (env)
+    # for a future investigation. Lives on the main settings (not DebugSettings,
+    # which is local-dev only) so it is configurable in staging/prod where the
+    # real slow connects happen.
+    SSH_DEBUG_LOGGING: bool = Field(env="SSH_DEBUG_LOGGING", default=False, description="Enable verbose asyncssh SSH handshake debug logging and per-connect phase timing")
 
     # DAH-2250 — unrented incentive soft price limit. When True, an unrented executor
     # whose price_per_gpu exceeds market p90 * SOFT_LIMIT_PRICE_RATE loses the unrented

--- a/neurons/validators/src/services/ssh_connect_timing.py
+++ b/neurons/validators/src/services/ssh_connect_timing.py
@@ -4,8 +4,9 @@ Splits a single ``asyncssh.connect`` into its phases **without changing how the
 connection is established** — so we can attribute a slow connect to the network,
 the remote sshd, or the validator. It does this by attaching an observation-only
 ``SSHClient`` (a documented asyncssh extension point) that timestamps the
-connection lifecycle callbacks, then emits one structured
-``ssh_connect_phase_timing`` log line per connect.
+connection lifecycle callbacks, then — when ``SSH_DEBUG_LOGGING`` is enabled
+(off by default; DAH-2272) — emits one structured ``ssh_connect_phase_timing``
+log line per connect.
 
 Phases (each the gap between two asyncssh ``SSHClient`` callbacks):
 
@@ -46,6 +47,7 @@ from typing import AsyncIterator
 
 import asyncssh
 
+from core.config import settings
 from core.utils import _m, get_extra_info
 from payload_models.payloads import now_ms
 
@@ -152,31 +154,36 @@ async def connect_with_phase_timing(
         client_factory=lambda: _PhaseTimingSSHClient(marks, log_extra, host),
         **connect_kwargs,
     ) as conn:
-        end = now_ms()
-        tcp_done = marks.get("tcp_done_ms")
-        auth_begin = marks.get("auth_begin_ms")
-        auth_done = marks.get("auth_done_ms")
+        # DAH-2272: the per-connect phase-timing line is diagnostic-only and off by
+        # default (SSH_DEBUG_LOGGING). Skip building/emitting it when the flag is
+        # off so normal operation stays quiet; the abnormal ``ssh_connection_lost``
+        # warning in the client callback still fires regardless.
+        if settings.SSH_DEBUG_LOGGING:
+            end = now_ms()
+            tcp_done = marks.get("tcp_done_ms")
+            auth_begin = marks.get("auth_begin_ms")
+            auth_done = marks.get("auth_done_ms")
 
-        def _delta(a, b):
-            return (b - a) if (a is not None and b is not None) else None
+            def _delta(a, b):
+                return (b - a) if (a is not None and b is not None) else None
 
-        extra = {
-            **log_extra,
-            "host": host,
-            "port": connect_kwargs.get("port"),
-            "tcp_connect_ms": _delta(t0, tcp_done),
-            "ssh_handshake_ms": _delta(tcp_done, auth_begin),  # banner + KEX
-            "ssh_auth_ms": _delta(auth_begin, auth_done),      # authentication
-            "ssh_login_ms": _delta(tcp_done, auth_done),       # robust combined
-            "total_connect_ms": end - t0,
-            "server_version": _safe_extra(conn, "server_version"),
-            "cipher": _safe_extra(conn, "recv_cipher"),
-            "mac": _safe_extra(conn, "recv_mac"),
-        }
-        if marks.get("auth_banner"):
-            extra["auth_banner"] = marks["auth_banner"]
-        if marks.get("server_debug_msgs"):
-            extra["server_debug_msgs"] = marks["server_debug_msgs"]
+            extra = {
+                **log_extra,
+                "host": host,
+                "port": connect_kwargs.get("port"),
+                "tcp_connect_ms": _delta(t0, tcp_done),
+                "ssh_handshake_ms": _delta(tcp_done, auth_begin),  # banner + KEX
+                "ssh_auth_ms": _delta(auth_begin, auth_done),      # authentication
+                "ssh_login_ms": _delta(tcp_done, auth_done),       # robust combined
+                "total_connect_ms": end - t0,
+                "server_version": _safe_extra(conn, "server_version"),
+                "cipher": _safe_extra(conn, "recv_cipher"),
+                "mac": _safe_extra(conn, "recv_mac"),
+            }
+            if marks.get("auth_banner"):
+                extra["auth_banner"] = marks["auth_banner"]
+            if marks.get("server_debug_msgs"):
+                extra["server_debug_msgs"] = marks["server_debug_msgs"]
 
-        logger.info(_m("ssh_connect_phase_timing", extra=get_extra_info(extra)))
+            logger.info(_m("ssh_connect_phase_timing", extra=get_extra_info(extra)))
         yield conn

--- a/neurons/validators/tests/test_ssh_connect_timing.py
+++ b/neurons/validators/tests/test_ssh_connect_timing.py
@@ -83,6 +83,16 @@ def _record(caplog, message):
     return None
 
 
+@pytest.fixture(autouse=True)
+def _ssh_debug_logging_on(monkeypatch):
+    """DAH-2272: the phase-timing line is off by default (SSH_DEBUG_LOGGING=False).
+
+    These tests exercise the instrumentation itself, so enable it. The
+    suppression test overrides this back to False.
+    """
+    monkeypatch.setattr(sct.settings, "SSH_DEBUG_LOGGING", True)
+
+
 @pytest.mark.asyncio
 async def test_logs_three_way_phase_split(monkeypatch, caplog):
     """connection_made/begin_auth/auth_completed → tcp / handshake / auth split."""
@@ -187,6 +197,28 @@ async def test_clean_connection_lost_is_silent(monkeypatch, caplog):
             pass
 
     assert _record(caplog, "ssh_connection_lost") is None
+
+
+@pytest.mark.asyncio
+async def test_phase_timing_suppressed_when_flag_off(monkeypatch, caplog):
+    """DAH-2272: with SSH_DEBUG_LOGGING off the per-connect line is NOT emitted,
+    but the connection is still established/closed and abnormal drops still warn."""
+    monkeypatch.setattr(sct.settings, "SSH_DEBUG_LOGGING", False)
+    conn = _fake_conn()
+    _clock(monkeypatch, [1000, 1100, 1300, 1400, 1450])
+    exc = ConnectionResetError("keepalive timeout")
+    monkeypatch.setattr(sct.asyncssh, "connect", _connect_returning(conn, lost_exc=exc))
+
+    with caplog.at_level(logging.INFO, logger=MODULE_LOGGER):
+        async with connect_with_phase_timing(host="h", port=22) as client:
+            assert client is conn
+
+    # The per-connection phase-timing line is gated off ...
+    assert _record(caplog, "ssh_connect_phase_timing") is None
+    # ... but the abnormal-drop warning is independent of the flag and still fires.
+    assert _record(caplog, "ssh_connection_lost") is not None
+    conn.close.assert_called_once()
+    conn.wait_closed.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Describe your changes

Follow-up to DAH-2272. The SSH connect phase-timing instrumentation added to investigate the slow-connect / "Started in subnet" stall shipped **enabled by default**. That investigation is now closed, so this turns the debug logging off by default while keeping the tooling in the tree (re-enablable via env for any future investigation).

**What was noisy**
- **Layer 1 — per-connection phase timing:** `neurons/validators/src/services/ssh_connect_timing.py` emitted a `ssh_connect_phase_timing` info line on **every** `asyncssh.connect`. This was a hard `logger.info` **not gated by any flag** — so `SSH_DEBUG_LOGGING=false` alone did *not* silence it.
- **Layer 2 — asyncssh handshake DEBUG:** `neurons/validators/src/core/utils.py` raised the `asyncssh` logger to DEBUG (debug level 2) per connection when `SSH_DEBUG_LOGGING` was on — and the flag defaulted to `True`.

**How it's fixed**
- `core/config.py` — `SSH_DEBUG_LOGGING` default flipped `True → False` (off everywhere by default; set `SSH_DEBUG_LOGGING=true` per env to re-enable).
- `services/ssh_connect_timing.py` — the per-connect `ssh_connect_phase_timing` block is now gated behind `settings.SSH_DEBUG_LOGGING`, so the flag actually controls both layers.
- The abnormal `ssh_connection_lost` warning is intentionally left **ungated** — it only fires on abnormal drops (keepalive timeout / mid-deploy reset), so it's a low-volume signal, not per-connection noise.
- The two `docker_service.py` callsites are unchanged; they use `connect_with_phase_timing` purely as a context manager, so connects behave identically — just without the per-connection log when off.

**Tests**
- `tests/test_ssh_connect_timing.py`: an autouse fixture enables the flag for the existing emission tests, plus a new `test_phase_timing_suppressed_when_flag_off` proving the line is silent when off while the connection is still established/closed and abnormal drops still warn.
- `pytest tests/test_ssh_connect_timing.py` → **10 passed**.
- `ruff@0.5.1` clean on the changed lines (two pre-existing findings in `ssh_connect_timing.py`, `I001`/`UP035`, predate this branch and are left untouched per repo convention).

## Issue ticket number and link

[DAH-2392 — Disable DAH-2272 SSH connect debug logging by default](https://app.notion.com/p/Disable-DAH-2272-SSH-connect-debug-logging-by-default-399b8bfdbde981f8aeecfd2c1036b00f)

### Verification (from the spec)

**Pre-deploy**
- [x] `pytest neurons/validators/tests/test_ssh_connect_timing.py` passes (10 passed).
- [x] With `SSH_DEBUG_LOGGING` unset (new default False): `connect_with_phase_timing` does **not** emit `ssh_connect_phase_timing`, and the asyncssh logger stays at WARNING (covered by the suppression test + `test_apply_asyncssh_log_level_off`).
- [x] With `SSH_DEBUG_LOGGING=true`: the phase-timing line and asyncssh DEBUG still appear (tooling re-enablable) — covered by the emission tests + `test_apply_asyncssh_log_level_on`.
- [x] `ruff` clean on changed lines.

**Post-deploy** (whoever deploys the validator re-runs):
- Query validator logs (Loki) for `ssh_connect_phase_timing` and confirm the per-connection line has stopped appearing.
- Confirm no `asyncssh` DEBUG handshake spam.
- Confirm the validator still verifies executors normally (SSH connects still succeed).

> No read-only baseline probe applies here — the "bug" is log noise from deployed validators, not a reproducible functional defect. Coverage is via unit tests; the post-deploy Loki check above is the confirmation.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?
