### PR TITLE
DAH-2391: isolate metrics collection from executor event loop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,14 @@ on:
     branches: [main, dev]
     paths:
       - 'neurons/validators/**'
+      - 'neurons/executor/**'
       - 'datura/**'
       - '.github/workflows/test.yml'
   push:
     branches: [main]
     paths:
       - 'neurons/validators/**'
+      - 'neurons/executor/**'
       - 'datura/**'
 
 permissions:
@@ -53,3 +55,33 @@ jobs:
           ENABLE_TDX_ATTESTATION: True
           TDX_VERIFIER_URL: http://localhost:8000/verify
         run: pdm run pytest tests/ -v --tb=short --strict-markers
+
+  executor:
+    name: Executor Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    defaults:
+      run:
+        working-directory: neurons/executor
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11.11'
+
+      - name: Install pdm
+        uses: pdm-project/setup-pdm@v4
+        with:
+          cache: true
+          cache-dependency-path: neurons/executor/pdm.lock
+
+      - name: Install dependencies
+        run: pdm install
+
+      - name: Run tests
+        run: mkdir -p tmp && pdm run pytest tests/ -v --tb=short

--- a/neurons/executor/src/routes/apis.py
+++ b/neurons/executor/src/routes/apis.py
@@ -5,9 +5,10 @@ import os
 import threading
 import time
 import tomllib
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional
 
 import bittensor
 import docker
@@ -54,7 +55,7 @@ _metrics_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="metric
 _metrics_semaphore = asyncio.Semaphore(METRICS_MAX_CONCURRENT)
 
 
-async def _run_in_metrics_pool(label: str, func, timeout: float | None = None):
+async def _run_in_metrics_pool(label: str, func: Callable[[], Any], timeout: float | None = None) -> Any:
     # run one blocking call in the dedicated pool, bounded by a timeout read at call time
     if timeout is None:
         timeout = METRICS_TIMEOUT_SECONDS
@@ -71,7 +72,7 @@ async def _run_in_metrics_pool(label: str, func, timeout: float | None = None):
         raise HTTPException(status_code=503, detail="Executor busy, metrics collection timed out")
 
 
-async def _run_metrics_call(label: str, func):
+async def _run_metrics_call(label: str, func: Callable[[], Any]) -> Any:
     # reject immediately when all metrics slots are busy instead of queueing on the event loop
     if _metrics_semaphore.locked():
         logger.warning(

--- a/neurons/executor/src/routes/apis.py
+++ b/neurons/executor/src/routes/apis.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import logging
 import os
 import threading
@@ -39,6 +40,50 @@ _container_log_stream_executor = ThreadPoolExecutor(
 )
 _active_follow_log_streams = 0
 _active_follow_log_streams_lock = asyncio.Lock()
+
+METRICS_MAX_CONCURRENT = 3
+METRICS_TIMEOUT_SECONDS = 8.0
+CONTAINER_LOOKUP_TIMEOUT_SECONDS = 5.0
+
+# Dedicated pool for blocking metrics/docker work: psutil, pynvml and docker-py
+# calls must never run on the event loop (a single hung call there blocks /ping
+# and /upload_ssh_key for its whole duration). A separate pool also isolates
+# leaked threads: wait_for cancels the coroutine but cannot kill a stuck thread,
+# so a wedged docker daemon degrades metrics only, never the whole agent.
+_metrics_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="metrics")
+_metrics_semaphore = asyncio.Semaphore(METRICS_MAX_CONCURRENT)
+
+
+async def _run_in_metrics_pool(label: str, func, timeout: float | None = None):
+    # run one blocking call in the dedicated pool, bounded by a timeout read at call time
+    if timeout is None:
+        timeout = METRICS_TIMEOUT_SECONDS
+    loop = asyncio.get_running_loop()
+    try:
+        return await asyncio.wait_for(loop.run_in_executor(_metrics_executor, func), timeout=timeout)
+    except TimeoutError:
+        logger.warning(
+            "%s timed out after %.1fs in the metrics pool, returning 503 "
+            "(worker thread may be leaked)",
+            label,
+            timeout,
+        )
+        raise HTTPException(status_code=503, detail="Executor busy, metrics collection timed out")
+
+
+async def _run_metrics_call(label: str, func):
+    # reject immediately when all metrics slots are busy instead of queueing on the event loop
+    if _metrics_semaphore.locked():
+        logger.warning(
+            "%s rejected: %d concurrent metrics calls already running",
+            label,
+            METRICS_MAX_CONCURRENT,
+        )
+        raise HTTPException(
+            status_code=503, detail="Executor busy, too many concurrent metrics requests"
+        )
+    async with _metrics_semaphore:
+        return await _run_in_metrics_pool(label, func)
 
 
 def _normalize_log_tail(tail: Optional[int]) -> int:
@@ -233,7 +278,7 @@ async def hardware_utilization(
     Returns:
         dict: Hardware utilization metrics including CPU, memory, storage, and GPU
     """
-    return get_system_metrics()
+    return await _run_metrics_call("hardware_utilization", get_system_metrics)
 
 
 @apis_router.post("/containers/{container_name}")
@@ -253,7 +298,10 @@ async def container_hardware_utilization(
     Returns:
         dict: Container-specific hardware utilization metrics
     """
-    return get_container_metrics(container_name, payload.gpu_uuids)
+    return await _run_metrics_call(
+        f"container_utilization:{container_name}",
+        functools.partial(get_container_metrics, container_name, payload.gpu_uuids),
+    )
 
 
 @apis_router.post("/ping")
@@ -314,9 +362,16 @@ async def stream_container_logs(
         if not reserved_follow_stream:
             raise HTTPException(status_code=429, detail="Too many active live log streams")
 
-    try:
+    def _lookup_container():
         client = docker.from_env()
-        container = client.containers.get(container_name)
+        return client.containers.get(container_name)
+
+    try:
+        container = await _run_in_metrics_pool(
+            f"container_logs_lookup:{container_name}",
+            _lookup_container,
+            timeout=CONTAINER_LOOKUP_TIMEOUT_SECONDS,
+        )
     except Exception:
         if reserved_follow_stream:
             await _release_follow_log_stream()

--- a/neurons/executor/src/services/hardware_service.py
+++ b/neurons/executor/src/services/hardware_service.py
@@ -68,8 +68,9 @@ def _get_filesystem_usage(container_name: str, mount_point: str) -> dict:
 
     Runs `docker exec ... df -k` as a subprocess instead of docker-py exec_run:
     df against a dead FUSE mount hangs in uninterruptible D-state forever, and a
-    docker-py call stuck on it can never be reclaimed, while a subprocess is
-    killed on timeout.
+    docker-py call stuck on it can never be reclaimed. As a subprocess the
+    `docker exec` client is killed on timeout, which frees the executor's pool
+    thread (the `df` inside the container stays wedged, but the agent is not).
 
     Args:
         container_name: Name of the Docker container
@@ -85,7 +86,7 @@ def _get_filesystem_usage(container_name: str, mount_point: str) -> dict:
             "stale": bool         # Present and True when collection timed out
         }
     """
-    empty = {"total": 0, "used": 0, "available": 0, "utilization": 0.0, "mount_point": mount_point}
+    zero_usage = {"total": 0, "used": 0, "available": 0, "utilization": 0.0, "mount_point": mount_point}
     try:
         result = subprocess.run(
             ["docker", "exec", "-u", "root", container_name, "df", "-k", mount_point],
@@ -97,19 +98,19 @@ def _get_filesystem_usage(container_name: str, mount_point: str) -> dict:
             f"df -k {mount_point} in {container_name} timed out after {DF_TIMEOUT_SECONDS}s, "
             "returning stale zeros"
         )
-        return {**empty, "stale": True}
+        return {**zero_usage, "stale": True}
     except Exception as e:
         logger.warning(f"Error getting filesystem usage for {mount_point}: {e}")
-        return empty
+        return zero_usage
 
     if result.returncode != 0:
         logger.warning(
             f"Failed to get filesystem usage for {mount_point}: "
             f"{result.stderr.decode('utf-8', errors='replace')}"
         )
-        return empty
+        return zero_usage
 
-    parsed = _parse_df_output(result.stdout.decode("utf-8"))
+    parsed = _parse_df_output(result.stdout.decode("utf-8", errors="replace"))
     parsed["mount_point"] = mount_point
     return parsed
 

--- a/neurons/executor/src/services/hardware_service.py
+++ b/neurons/executor/src/services/hardware_service.py
@@ -1,9 +1,27 @@
+import subprocess
+import threading
+
 import psutil
 import pynvml
 import docker
 from core.logger import get_logger
 
 logger = get_logger(__name__)
+
+DF_TIMEOUT_SECONDS = 5.0
+DOCKER_CLIENT_TIMEOUT_SECONDS = 5.0
+
+_docker_client = None
+_docker_client_lock = threading.Lock()
+
+
+def _get_docker_client():
+    # one shared client with a bounded API timeout, so a wedged docker daemon cannot hold a call forever
+    global _docker_client
+    with _docker_client_lock:
+        if _docker_client is None:
+            _docker_client = docker.from_env(timeout=DOCKER_CLIENT_TIMEOUT_SECONDS)
+        return _docker_client
 
 
 def _parse_df_output(df_output: str) -> dict:
@@ -44,14 +62,19 @@ def _parse_df_output(df_output: str) -> dict:
         return {"total": 0, "used": 0, "available": 0, "utilization": 0.0}
 
 
-def _get_filesystem_usage(container, mount_point: str) -> dict:
+def _get_filesystem_usage(container_name: str, mount_point: str) -> dict:
     """
     Get filesystem usage for a specific mount point inside the container.
-    
+
+    Runs `docker exec ... df -k` as a subprocess instead of docker-py exec_run:
+    df against a dead FUSE mount hangs in uninterruptible D-state forever, and a
+    docker-py call stuck on it can never be reclaimed, while a subprocess is
+    killed on timeout.
+
     Args:
-        container: Docker container object
+        container_name: Name of the Docker container
         mount_point: Mount point path (e.g., "/", "/root")
-    
+
     Returns:
         dict: {
             "total": int,  # Total size in KB
@@ -59,22 +82,36 @@ def _get_filesystem_usage(container, mount_point: str) -> dict:
             "available": int,  # Available size in KB
             "utilization": float  # Utilization percentage
             "mount_point": str    # Mount point path
+            "stale": bool         # Present and True when collection timed out
         }
     """
+    empty = {"total": 0, "used": 0, "available": 0, "utilization": 0.0, "mount_point": mount_point}
     try:
-        # Execute df -k inside the container to get metrics in KB
-        exec_result = container.exec_run(f"df -k {mount_point}", user="root")
-        if exec_result.exit_code != 0:
-            logger.warning(f"Failed to get filesystem usage for {mount_point}: {exec_result.output.decode()}")
-            return {"total": 0, "used": 0, "available": 0, "utilization": 0.0, "mount_point": mount_point}
-        
-        output = exec_result.output.decode('utf-8')
-        result = _parse_df_output(output)
-        result["mount_point"] = mount_point
-        return result
+        result = subprocess.run(
+            ["docker", "exec", "-u", "root", container_name, "df", "-k", mount_point],
+            capture_output=True,
+            timeout=DF_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            f"df -k {mount_point} in {container_name} timed out after {DF_TIMEOUT_SECONDS}s, "
+            "returning stale zeros"
+        )
+        return {**empty, "stale": True}
     except Exception as e:
         logger.warning(f"Error getting filesystem usage for {mount_point}: {e}")
-        return {"total": 0, "used": 0, "available": 0, "utilization": 0.0, "mount_point": mount_point}
+        return empty
+
+    if result.returncode != 0:
+        logger.warning(
+            f"Failed to get filesystem usage for {mount_point}: "
+            f"{result.stderr.decode('utf-8', errors='replace')}"
+        )
+        return empty
+
+    parsed = _parse_df_output(result.stdout.decode("utf-8"))
+    parsed["mount_point"] = mount_point
+    return parsed
 
 
 def get_system_metrics():
@@ -174,7 +211,7 @@ def get_container_metrics(container_name: str, gpu_uuids: list[str]):
     """
     try:
         # Get Docker client
-        client = docker.from_env()
+        client = _get_docker_client()
         container = client.containers.get(container_name)
 
         # Get container stats (non-streaming, single sample)
@@ -203,7 +240,7 @@ def get_container_metrics(container_name: str, gpu_uuids: list[str]):
             memory_utilization = round((memory_usage / memory_limit) * 100.0, 2)
 
         # Get actual filesystem usage from inside the container
-        storage_metrics = _get_filesystem_usage(container, "/")
+        storage_metrics = _get_filesystem_usage(container_name, "/")
         
         # Get volume metrics if there's a vloopback volume
         volume_metrics = None
@@ -213,7 +250,7 @@ def get_container_metrics(container_name: str, gpu_uuids: list[str]):
             if mount.get("Driver", "").startswith("vloopback"):
                 mount_point = mount.get("Destination", "")
                 if mount_point:
-                    volume_metrics = _get_filesystem_usage(container, mount_point)
+                    volume_metrics = _get_filesystem_usage(container_name, mount_point)
                     break
 
         # Get GPU metrics for specified UUIDs only

--- a/neurons/executor/src/services/hardware_service.py
+++ b/neurons/executor/src/services/hardware_service.py
@@ -15,7 +15,7 @@ _docker_client = None
 _docker_client_lock = threading.Lock()
 
 
-def _get_docker_client():
+def _get_docker_client() -> docker.DockerClient:
     # one shared client with a bounded API timeout, so a wedged docker daemon cannot hold a call forever
     global _docker_client
     with _docker_client_lock:

--- a/neurons/executor/tests/test_metrics_loop_isolation.py
+++ b/neurons/executor/tests/test_metrics_loop_isolation.py
@@ -1,0 +1,148 @@
+"""Event-loop isolation for metrics endpoints (DAH-2391).
+
+A hung or slow metrics collection (psutil / pynvml / docker stats / df inside a
+renter container) must never block the event loop: /ping has to stay fast, and
+excess concurrent metrics calls have to be rejected instead of piling up.
+"""
+
+import subprocess
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from dependencies.auth import verify_allowed_hotkey_signature, verify_ping_signature
+from routes import apis
+from routes.apis import apis_router
+from services import hardware_service
+
+
+@pytest.fixture()
+def client():
+    app = FastAPI()
+    app.include_router(apis_router)
+    app.dependency_overrides[verify_allowed_hotkey_signature] = lambda: None
+    app.dependency_overrides[verify_ping_signature] = lambda: None
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_ping_stays_fast_while_metrics_call_is_slow(client, monkeypatch):
+    # Arrange: a metrics collection that blocks its worker thread for seconds
+    release = threading.Event()
+
+    def slow_metrics():
+        release.wait(5.0)
+        return {"cpu": 0.0}
+
+    monkeypatch.setattr(apis, "get_system_metrics", slow_metrics)
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        metrics_future = pool.submit(client.post, "/hardware_utilization")
+        time.sleep(0.3)  # let the metrics request reach the worker thread
+
+        # Act: ping while the metrics call is still blocked
+        started = time.monotonic()
+        response = client.post("/ping")
+        elapsed = time.monotonic() - started
+
+        release.set()
+        metrics_response = metrics_future.result()
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == {"status": "pong"}
+    assert elapsed < 1.0
+    assert metrics_response.status_code == 200
+
+
+def test_metrics_requests_over_limit_are_rejected_with_503(client, monkeypatch):
+    # Arrange: fill every metrics slot with a blocked collection
+    release = threading.Event()
+    entered = threading.Semaphore(0)
+
+    def blocking_metrics():
+        entered.release()
+        release.wait(10.0)
+        return {"cpu": 0.0}
+
+    monkeypatch.setattr(apis, "get_system_metrics", blocking_metrics)
+
+    with ThreadPoolExecutor(max_workers=apis.METRICS_MAX_CONCURRENT) as pool:
+        futures = [
+            pool.submit(client.post, "/hardware_utilization")
+            for _ in range(apis.METRICS_MAX_CONCURRENT)
+        ]
+        for _ in range(apis.METRICS_MAX_CONCURRENT):
+            assert entered.acquire(timeout=5)
+
+        # Act: one request over the limit
+        response = client.post("/hardware_utilization")
+
+        release.set()
+        occupied = [future.result() for future in futures]
+
+    # Assert
+    assert response.status_code == 503
+    assert all(r.status_code == 200 for r in occupied)
+
+
+def test_metrics_call_timeout_returns_503(client, monkeypatch):
+    # Arrange: collection outlives the (shrunk) timeout
+    monkeypatch.setattr(apis, "METRICS_TIMEOUT_SECONDS", 0.2)
+    monkeypatch.setattr(apis, "get_system_metrics", lambda: time.sleep(2.0))
+
+    # Act
+    response = client.post("/hardware_utilization")
+
+    # Assert
+    assert response.status_code == 503
+
+
+def test_filesystem_usage_df_timeout_returns_stale_zeros(monkeypatch):
+    # Arrange: df subprocess never returns within the timeout
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="docker exec", timeout=hardware_service.DF_TIMEOUT_SECONDS)
+
+    monkeypatch.setattr(hardware_service.subprocess, "run", fake_run)
+
+    # Act
+    result = hardware_service._get_filesystem_usage("container_x", "/")
+
+    # Assert
+    assert result == {
+        "total": 0,
+        "used": 0,
+        "available": 0,
+        "utilization": 0.0,
+        "mount_point": "/",
+        "stale": True,
+    }
+
+
+def test_filesystem_usage_parses_df_output(monkeypatch):
+    # Arrange: a successful df -k run
+    captured = {}
+
+    class FakeResult:
+        returncode = 0
+        stdout = b"Filesystem 1K-blocks Used Available Use% Mounted on\noverlay 100 40 60 40% /\n"
+        stderr = b""
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["timeout"] = kwargs.get("timeout")
+        return FakeResult()
+
+    monkeypatch.setattr(hardware_service.subprocess, "run", fake_run)
+
+    # Act
+    result = hardware_service._get_filesystem_usage("container_x", "/")
+
+    # Assert
+    assert result == {"total": 100, "used": 40, "available": 60, "utilization": 40.0, "mount_point": "/"}
+    assert captured["cmd"] == ["docker", "exec", "-u", "root", "container_x", "df", "-k", "/"]
+    assert captured["timeout"] == hardware_service.DF_TIMEOUT_SECONDS


### PR DESCRIPTION
## Problem

The executor agent is a single-process, single-event-loop FastAPI app. `/hardware_utilization` and `/containers/{name}` call sync psutil / pynvml / docker-py — including `exec_run("df -k ...")` into the renter's container — directly on the event loop with no timeouts. Any hang (dead FUSE mount: 61s block reproduced on staging) or a burst of ordinary renter polling (10 concurrent calls serialize to 19.2s) blocks `/ping` and `/upload_ssh_key`, producing false-offline flips, `EXECUTOR_INACTIVE_MID_RENTAL` penalties, and failed rental starts while the node is actually healthy.

Investigation: see DAH-2391.

## Changes

- **Dedicated `ThreadPoolExecutor(4)` for metrics** — blocking collection never runs on the event loop; `wait_for(8s)` bounds every call. A leaked thread (stuck docker daemon) degrades metrics only, never `/ping`.
- **`Semaphore(3)` with immediate 503** — excess concurrent metrics requests are rejected, not queued, so polling bursts cannot pile up.
- **`df` via killable subprocess** — `docker exec ... df -k` with a 5s timeout replaces docker-py `exec_run`: a `df` stuck in D-state on a dead FUSE mount kills the subprocess instead of permanently leaking a pool thread; the response carries `"stale": true` zeros.
- **Single module-level docker client** with `timeout=5` instead of `docker.from_env()` per request.
- **Container lookup in `/containers/{name}/logs`** offloaded to the pool with a 5s bound (was a raw docker call on the loop).
- **CI**: executor test suite now runs on PRs (`test.yml` had no executor job at all).

`sr25519` verification deliberately stays sync on the loop (~1ms; offloading it to a shared pool would queue pings behind slow metrics calls).

## Rollout note

Do not roll out to the fleet (runner image rebuild) before backend PR #755 (3-consecutive-miss offline debounce) is live: a fleet-wide watchtower restart can exceed the single 10s ping window.

## Tests

5 new tests in `tests/test_metrics_loop_isolation.py`: ping stays <1s while a metrics call blocks its worker; over-limit request gets 503 while in-flight ones finish; timeout returns 503; df timeout returns stale zeros; df success parses and passes the timeout.
`pdm run pytest` — 45 passed.