### PR TITLE
DAH-2395, capture container death diagnostics before rm -fv on failed create_container

### DIFF
--- a/neurons/executor/src/monitor.py
+++ b/neurons/executor/src/monitor.py
@@ -3,7 +3,6 @@ import logging
 import json
 import time
 from datetime import datetime
-from core.config import settings
 from core.db import get_session
 from daos.pod_log import PodLog, PodLogDao
 
@@ -11,7 +10,11 @@ from daos.pod_log import PodLog, PodLogDao
 logging.basicConfig(filename="container_monitor.log", level=logging.INFO,
                     format='%(message)s')  # we will log pre-formatted JSON strings
 
-monitor_prefix = "container_"  # only monitor containers with this prefix
+# Container-name prefixes the validator creates for real workloads: rental pods
+# (pod_*) and idle-node default jobs (filler_*). The legacy "container_" prefix
+# matches only the validator's throwaway port-check probes today, so watching it
+# recorded pure probe noise while every pod/filler death went unlogged (DAH-2395).
+MONITORED_CONTAINER_PREFIXES: tuple[str, ...] = ("pod_", "filler_")
 
 
 # Helper: Determine stop reason classification
@@ -74,7 +77,7 @@ def handle_event(event):
     container_id = event.get("id") or event.get("Actor", {}).get("ID")
     name = attrs.get("name")
 
-    if not name or not name.startswith(monitor_prefix) or name == f"{monitor_prefix}{settings.MINER_HOTKEY_SS58_ADDRESS}":
+    if not name or not name.startswith(MONITORED_CONTAINER_PREFIXES):
         return
 
     pod_log = PodLog(

--- a/neurons/executor/tests/conftest.py
+++ b/neurons/executor/tests/conftest.py
@@ -8,6 +8,7 @@ heavy system dependencies (docker, etc.).
 
 import os
 import sys
+import tempfile
 from unittest.mock import MagicMock
 
 # Mock docker before any src import so that routes/apis.py and related
@@ -16,7 +17,10 @@ sys.modules["docker"] = MagicMock()
 
 # Required env vars consumed by core.config.Settings at import time.
 os.environ.setdefault("MINER_HOTKEY_SS58_ADDRESS", "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY")
-os.environ.setdefault("DB_URI", "sqlite:///tmp/test.db")
+# Absolute temp path: core.db creates the engine (with QueuePool args, which
+# in-memory sqlite rejects) and runs create_all at import time, and the old
+# relative "tmp/test.db" path broke any test importing core.db (e.g. monitor).
+os.environ.setdefault("DB_URI", f"sqlite:///{os.path.join(tempfile.gettempdir(), 'executor-test.db')}")
 
 # Add src/ to sys.path so tests can import executor modules directly.
 _src = os.path.abspath(os.path.join(os.path.dirname(__file__), "../src"))

--- a/neurons/executor/tests/test_monitor_container_filter.py
+++ b/neurons/executor/tests/test_monitor_container_filter.py
@@ -1,0 +1,60 @@
+"""DAH-2395: the container monitor must watch the containers the validator actually creates.
+
+The monitor recorded only the legacy "container_" prefix, which today matches
+nothing but the validator's short-lived port-check probes — every rental pod
+(pod_*) and idle-node filler (filler_*) death went unrecorded (verified on the
+staging executor: 32k podlog rows, zero pod_/filler_ entries). These tests pin
+the corrected filter.
+"""
+
+from unittest.mock import patch
+
+import monitor
+
+
+def _docker_event(name: str, action: str, exit_code: int | None = None) -> dict:
+    attributes: dict = {"name": name}
+    if exit_code is not None:
+        attributes["exitCode"] = str(exit_code)
+    return {
+        "Type": "container",
+        "Action": action,
+        "id": "abc123",
+        "Actor": {"ID": "abc123", "Attributes": attributes},
+    }
+
+
+def test_monitor_records_filler_container_death():
+    with patch.object(monitor, "log_event") as log_event:
+        monitor.handle_event(_docker_event("filler_63409a62-e024-414d-99aa-ba6f30be1bfd", "die", 137))
+
+    log_event.assert_called_once()
+    logged = log_event.call_args.args[0]
+    assert logged.container_name == "filler_63409a62-e024-414d-99aa-ba6f30be1bfd"
+    assert logged.event == "die"
+    assert logged.exit_code == 137
+
+
+def test_monitor_records_rental_pod_events():
+    with patch.object(monitor, "log_event") as log_event:
+        monitor.handle_event(_docker_event("pod_9b522424-5275-46ed-b283-7afd9f025b8d", "oom"))
+
+    log_event.assert_called_once()
+    logged = log_event.call_args.args[0]
+    assert logged.container_name == "pod_9b522424-5275-46ed-b283-7afd9f025b8d"
+    assert logged.event == "oom"
+
+
+def test_monitor_ignores_port_check_probe_containers():
+    probe_name = "container_5DfbmGgkgYoYKJk7rA9UFgeJFacfkBMhaeFZgJk7c4mCv7DT_40000"
+    with patch.object(monitor, "log_event") as log_event:
+        monitor.handle_event(_docker_event(probe_name, "die", 137))
+
+    log_event.assert_not_called()
+
+
+def test_monitor_ignores_infra_containers():
+    with patch.object(monitor, "log_event") as log_event:
+        monitor.handle_event(_docker_event("executor-db-1", "die", 1))
+
+    log_event.assert_not_called()

--- a/neurons/validators/src/core/docker_utils.py
+++ b/neurons/validators/src/core/docker_utils.py
@@ -1,6 +1,16 @@
+import asyncio
+import json
 import shlex
+from dataclasses import dataclass
+
+import asyncssh
 
 from services.const import DOCKER_DIND_IMAGE
+
+# Bounded so a crash-looping worker can't flood the log line; keep the tail,
+# not the head — a dying entrypoint prints its fatal error last.
+_CONTAINER_DEATH_LOG_TAIL_LINES = 100
+_CONTAINER_DEATH_LOG_MAX_CHARS = 4000
 
 
 class DockerCommand:
@@ -87,3 +97,153 @@ class DockerCommand:
     def exec_command(container_name: str, command: str) -> str:
         """Build docker exec command."""
         return f"/usr/bin/docker exec -i {container_name} sh -c '{command}'"
+
+
+@dataclass
+class ContainerDeathDiagnostics:
+    """Why a container died, plus host context.
+
+    Shared post-mortem for create-time failures (docker_service) and run-time
+    failures (rented_machine checks) so both land in Loki with one flat field
+    shape and are queryable together (DAH-2395 / DAH-2193). exit_code / oom_killed
+    are top-level, not nested under a state object, so a Loki query filters them
+    directly without digging through JSON.
+    """
+
+    status: str | None = None
+    exit_code: int | None = None
+    oom_killed: bool | None = None
+    error: str | None = None
+    started_at: str | None = None
+    finished_at: str | None = None
+    logs_tail: str | None = None
+    host_context: dict[str, str] | None = None
+    capture_error: str | None = None
+
+    def to_log_fields(self) -> dict[str, object]:
+        """Flatten into the shared Loki field shape used at both call sites."""
+        return {
+            "container_status": self.status,
+            "container_exit_code": self.exit_code,
+            "container_oom_killed": self.oom_killed,
+            "container_error": self.error,
+            "container_started_at": self.started_at,
+            "container_finished_at": self.finished_at,
+            "container_logs_tail": self.logs_tail,
+            "container_host_context": self.host_context,
+            "diagnostics_capture_error": self.capture_error,
+        }
+
+
+async def collect_container_death_diagnostics(
+    ssh_client: asyncssh.SSHClientConnection,
+    container_name: str,
+) -> ContainerDeathDiagnostics:
+    """Read why a container died over an already-open SSH session.
+
+    Best effort: every failure folds into `capture_error` instead of raising
+    (cancellation excepted). At both call sites this runs right before the
+    container is force-removed, and the executor host belongs to the miner —
+    losing the rest of the evidence to an exception is worse than a partial
+    record.
+    """
+    diagnostics = ContainerDeathDiagnostics()
+    capture_errors: list[str] = []
+    quoted_name = shlex.quote(container_name)
+
+    try:
+        inspect_result = await ssh_client.run(
+            f"/usr/bin/docker inspect --format '{{{{json .State}}}}' {quoted_name}"
+        )
+        raw_state = (inspect_result.stdout or "").strip()
+        if raw_state:
+            parsed_state = json.loads(raw_state)
+            if isinstance(parsed_state, dict):
+                diagnostics.status = parsed_state.get("Status")
+                diagnostics.exit_code = parsed_state.get("ExitCode")
+                diagnostics.oom_killed = parsed_state.get("OOMKilled")
+                diagnostics.error = parsed_state.get("Error")
+                diagnostics.started_at = parsed_state.get("StartedAt")
+                diagnostics.finished_at = parsed_state.get("FinishedAt")
+            else:
+                capture_errors.append(f"inspect: non-object state JSON: {parsed_state!r}")
+        else:
+            stderr = (getattr(inspect_result, "stderr", "") or "").strip()
+            capture_errors.append(f"inspect: {stderr or 'empty stdout'}")
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        capture_errors.append(f"inspect: {exc}")
+
+    try:
+        logs_result = await ssh_client.run(
+            f"/usr/bin/docker logs --tail {_CONTAINER_DEATH_LOG_TAIL_LINES} {quoted_name} 2>&1 || true"
+        )
+        tail = (logs_result.stdout or "")[-_CONTAINER_DEATH_LOG_MAX_CHARS:]
+        diagnostics.logs_tail = tail or None
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        capture_errors.append(f"logs: {exc}")
+
+    host_context = await _collect_host_context(ssh_client)
+    diagnostics.host_context = host_context or None
+
+    if capture_errors:
+        diagnostics.capture_error = "; ".join(capture_errors)
+
+    return diagnostics
+
+
+async def _collect_host_context(ssh_client: asyncssh.SSHClientConnection) -> dict[str, str]:
+    """Executor-host context that separates a real container death from a host reboot
+    or executor-container restart.
+
+    Two independent signals:
+      - `host_boot_time` from `uptime -s` — if it is close to the container's FinishedAt,
+        the host likely rebooted and the container did not come back up on its own.
+      - `executor_container_started_at` — if far newer than `host_boot_time`, the executor
+        container itself restarted (watchtower, compose restart, autoheal) without a full
+        host reboot. The executor container is located via the compose service label so the
+        lookup survives renames.
+
+    All failures are swallowed into `*_error` fields — this runs on the already-open SSH
+    session, so we prefer empty signal over raising and losing the rest of the event.
+    """
+    host_context: dict[str, str] = {}
+
+    try:
+        uptime_result = await ssh_client.run("uptime -s")
+        boot_time = (uptime_result.stdout or "").strip()
+        if boot_time:
+            host_context["host_boot_time"] = boot_time
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        host_context["host_boot_error"] = str(exc)
+
+    try:
+        name_cmd = (
+            "/usr/bin/docker ps -a "
+            "--filter label=com.docker.compose.service=executor "
+            "--format '{{.Names}}' | head -n 1"
+        )
+        name_result = await ssh_client.run(name_cmd)
+        executor_names = (name_result.stdout or "").strip().splitlines()[0:1]
+        executor_name = executor_names[0] if executor_names else ""
+        if executor_name:
+            quoted_executor = shlex.quote(executor_name)
+            start_cmd = (
+                f"/usr/bin/docker inspect --format '{{{{.State.StartedAt}}}}' {quoted_executor}"
+            )
+            start_result = await ssh_client.run(start_cmd)
+            started_at = (start_result.stdout or "").strip()
+            if started_at:
+                host_context["executor_container_name"] = executor_name
+                host_context["executor_container_started_at"] = started_at
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        host_context["executor_container_error"] = str(exc)
+
+    return host_context

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -172,13 +172,19 @@ class VolumeMinSizeError(Exception):
 
 
 _FAILED_CONTAINER_LOGS_TAIL_LINES = 100
-# Keep the tail, not the head: a dying entrypoint prints its fatal error last.
+# Bounded so a crash-looping worker can't flood the log line; keep the tail,
+# not the head — a dying entrypoint prints its fatal error last.
 _FAILED_CONTAINER_LOGS_MAX_CHARS = 4000
 
 
 @dataclass
 class FailedContainerDiagnostics:
-    """Post-mortem of a container that died during create_container (DAH-2395)."""
+    """Post-mortem of a container that died during create_container (DAH-2395).
+
+    This is the only durable record of WHY the container died: cleanup
+    force-removes it right after, and the executor host belongs to the miner,
+    so there is no second chance to inspect anything.
+    """
 
     state: dict | None = None  # parsed `docker inspect .State`: OOMKilled, ExitCode, Error, ...
     logs_tail: str | None = None  # bounded tail of `docker logs`
@@ -1407,6 +1413,9 @@ class DockerService:
             diagnostics.capture_error = "; ".join(capture_errors)
 
         state: dict = diagnostics.state or {}
+        # OOMKilled/ExitCode as top-level fields so Loki can filter on them
+        # directly (`json | container_oom_killed="true"`) without digging
+        # through the nested state object.
         logger.warning(
             _m(
                 "Failed container diagnostics before cleanup",
@@ -1432,7 +1441,9 @@ class DockerService:
         remove_volume: bool = False,
     ) -> None:
         try:
-            # DAH-2395: read the death evidence before `rm -fv` destroys it.
+            # DAH-2395: read the death evidence before `rm -fv` destroys it —
+            # without this line, "why did the container die" (OOM vs entrypoint
+            # crash) is unanswerable: the host is the miner's, not ours.
             await self.capture_failed_container_diagnostics(
                 ssh_client=ssh_client,
                 default_extra=default_extra,

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1,6 +1,5 @@
 import asyncio
 import ipaddress
-import json
 import math
 import random
 from dataclasses import dataclass
@@ -51,6 +50,10 @@ from payload_models.payloads import (
 from protocol.vc_protocol.compute_requests import RentedMachine
 
 from core.config import settings
+from core.docker_utils import (
+    ContainerDeathDiagnostics,
+    collect_container_death_diagnostics,
+)
 from core.utils import _m, get_extra_info, retry_ssh_command
 from services.ssh_connect_timing import connect_with_phase_timing
 from services.const import (
@@ -169,26 +172,6 @@ _VOLUME_SIZE_SUFFIX_MULTIPLIERS = {
 
 class VolumeMinSizeError(Exception):
     """Fresh vloopback sizing produced a volume smaller than the requested minimum."""
-
-
-_FAILED_CONTAINER_LOGS_TAIL_LINES = 100
-# Bounded so a crash-looping worker can't flood the log line; keep the tail,
-# not the head — a dying entrypoint prints its fatal error last.
-_FAILED_CONTAINER_LOGS_MAX_CHARS = 4000
-
-
-@dataclass
-class FailedContainerDiagnostics:
-    """Post-mortem of a container that died during create_container (DAH-2395).
-
-    This is the only durable record of WHY the container died: cleanup
-    force-removes it right after, and the executor host belongs to the miner,
-    so there is no second chance to inspect anything.
-    """
-
-    state: dict | None = None  # parsed `docker inspect .State`: OOMKilled, ExitCode, Error, ...
-    logs_tail: str | None = None  # bounded tail of `docker logs`
-    capture_error: str | None = None  # why (part of) the capture failed, when it did
 
 
 @dataclass
@@ -1367,8 +1350,8 @@ class DockerService:
         ssh_client: asyncssh.SSHClientConnection,
         default_extra: dict,
         container_name: str,
-    ) -> FailedContainerDiagnostics:
-        """Read why a container died (inspect .State + logs tail) and log it.
+    ) -> ContainerDeathDiagnostics:
+        """Read why a container died (inspect .State + logs tail + host context) and log it.
 
         Runs right before the failed container is force-removed: after that the
         OOMKilled/ExitCode verdict and the entrypoint output are gone, and the
@@ -1377,56 +1360,18 @@ class DockerService:
         Best-effort — never raises (cancellation excepted), so the cleanup
         itself is never blocked by a diagnostics failure.
         """
-        diagnostics = FailedContainerDiagnostics()
-        capture_errors: list[str] = []
-        container = shlex.quote(container_name)
+        diagnostics = await collect_container_death_diagnostics(ssh_client, container_name)
 
-        try:
-            inspect_result = await ssh_client.run(
-                f"/usr/bin/docker inspect -f '{{{{json .State}}}}' {container}"
-            )
-            if inspect_result.exit_status == 0:
-                parsed_state = json.loads(inspect_result.stdout or "null")
-                if isinstance(parsed_state, dict):
-                    diagnostics.state = parsed_state
-                else:
-                    capture_errors.append(f"inspect: non-object state JSON: {parsed_state!r}")
-            else:
-                capture_errors.append(f"inspect: {(inspect_result.stderr or '').strip()}")
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            capture_errors.append(f"inspect: {exc}")
-
-        try:
-            logs_result = await ssh_client.run(
-                f"/usr/bin/docker logs --tail {_FAILED_CONTAINER_LOGS_TAIL_LINES} {container} 2>&1 || true"
-            )
-            logs_text: str = logs_result.stdout or ""
-            diagnostics.logs_tail = logs_text[-_FAILED_CONTAINER_LOGS_MAX_CHARS:]
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            capture_errors.append(f"logs: {exc}")
-
-        if capture_errors:
-            diagnostics.capture_error = "; ".join(capture_errors)
-
-        state: dict = diagnostics.state or {}
-        # OOMKilled/ExitCode as top-level fields so Loki can filter on them
-        # directly (`json | container_oom_killed="true"`) without digging
-        # through the nested state object.
+        # Flat OOMKilled/ExitCode as top-level fields so Loki can filter on them
+        # directly (`json | container_oom_killed="true"`); same shape as the
+        # run-time pod-death path so both are queryable together.
         logger.warning(
             _m(
                 "Failed container diagnostics before cleanup",
                 extra=get_extra_info({
                     **default_extra,
                     "container_name": container_name,
-                    "container_state": diagnostics.state,
-                    "container_oom_killed": state.get("OOMKilled"),
-                    "container_exit_code": state.get("ExitCode"),
-                    "container_logs_tail": diagnostics.logs_tail,
-                    "diagnostics_capture_error": diagnostics.capture_error,
+                    **diagnostics.to_log_fields(),
                 }),
             )
         )

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1,5 +1,6 @@
 import asyncio
 import ipaddress
+import json
 import math
 import random
 from dataclasses import dataclass
@@ -168,6 +169,20 @@ _VOLUME_SIZE_SUFFIX_MULTIPLIERS = {
 
 class VolumeMinSizeError(Exception):
     """Fresh vloopback sizing produced a volume smaller than the requested minimum."""
+
+
+_FAILED_CONTAINER_LOGS_TAIL_LINES = 100
+# Keep the tail, not the head: a dying entrypoint prints its fatal error last.
+_FAILED_CONTAINER_LOGS_MAX_CHARS = 4000
+
+
+@dataclass
+class FailedContainerDiagnostics:
+    """Post-mortem of a container that died during create_container (DAH-2395)."""
+
+    state: dict | None = None  # parsed `docker inspect .State`: OOMKilled, ExitCode, Error, ...
+    logs_tail: str | None = None  # bounded tail of `docker logs`
+    capture_error: str | None = None  # why (part of) the capture failed, when it did
 
 
 @dataclass
@@ -1341,6 +1356,73 @@ class DockerService:
                 exc_info=True,
             )
 
+    async def capture_failed_container_diagnostics(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        default_extra: dict,
+        container_name: str,
+    ) -> FailedContainerDiagnostics:
+        """Read why a container died (inspect .State + logs tail) and log it.
+
+        Runs right before the failed container is force-removed: after that the
+        OOMKilled/ExitCode verdict and the entrypoint output are gone, and the
+        executor host belongs to the miner, so this log line is the only
+        evidence left (DAH-2395: DPHN exit-137 deaths were undiagnosable).
+        Best-effort — never raises (cancellation excepted), so the cleanup
+        itself is never blocked by a diagnostics failure.
+        """
+        diagnostics = FailedContainerDiagnostics()
+        capture_errors: list[str] = []
+        container = shlex.quote(container_name)
+
+        try:
+            inspect_result = await ssh_client.run(
+                f"/usr/bin/docker inspect -f '{{{{json .State}}}}' {container}"
+            )
+            if inspect_result.exit_status == 0:
+                parsed_state = json.loads(inspect_result.stdout or "null")
+                if isinstance(parsed_state, dict):
+                    diagnostics.state = parsed_state
+                else:
+                    capture_errors.append(f"inspect: non-object state JSON: {parsed_state!r}")
+            else:
+                capture_errors.append(f"inspect: {(inspect_result.stderr or '').strip()}")
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            capture_errors.append(f"inspect: {exc}")
+
+        try:
+            logs_result = await ssh_client.run(
+                f"/usr/bin/docker logs --tail {_FAILED_CONTAINER_LOGS_TAIL_LINES} {container} 2>&1 || true"
+            )
+            logs_text: str = logs_result.stdout or ""
+            diagnostics.logs_tail = logs_text[-_FAILED_CONTAINER_LOGS_MAX_CHARS:]
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            capture_errors.append(f"logs: {exc}")
+
+        if capture_errors:
+            diagnostics.capture_error = "; ".join(capture_errors)
+
+        state: dict = diagnostics.state or {}
+        logger.warning(
+            _m(
+                "Failed container diagnostics before cleanup",
+                extra=get_extra_info({
+                    **default_extra,
+                    "container_name": container_name,
+                    "container_state": diagnostics.state,
+                    "container_oom_killed": state.get("OOMKilled"),
+                    "container_exit_code": state.get("ExitCode"),
+                    "container_logs_tail": diagnostics.logs_tail,
+                    "diagnostics_capture_error": diagnostics.capture_error,
+                }),
+            )
+        )
+        return diagnostics
+
     async def cleanup_failed_container_creation(
         self,
         ssh_client: asyncssh.SSHClientConnection,
@@ -1350,6 +1432,13 @@ class DockerService:
         remove_volume: bool = False,
     ) -> None:
         try:
+            # DAH-2395: read the death evidence before `rm -fv` destroys it.
+            await self.capture_failed_container_diagnostics(
+                ssh_client=ssh_client,
+                default_extra=default_extra,
+                container_name=container_name,
+            )
+
             container = shlex.quote(container_name)
             await retry_ssh_command(
                 ssh_client,

--- a/neurons/validators/src/services/task/checks/rented_machine.py
+++ b/neurons/validators/src/services/task/checks/rented_machine.py
@@ -1,10 +1,8 @@
-import json
-import shlex
 from collections.abc import Iterable
 
 import asyncssh
 
-from core.docker_utils import DockerCommand
+from core.docker_utils import DockerCommand, collect_container_death_diagnostics
 from protocol.vc_protocol.validator_requests import ResetVerifiedJobReason
 
 from ...const import (
@@ -304,105 +302,14 @@ async def _check_pod_running(ssh_client, container_name: str) -> tuple[bool, lis
     return pod_running, ssh_keys
 
 
-_POD_LOG_TAIL_LINES = 50
-_POD_LOG_TAIL_CHAR_LIMIT = 4000
+async def _collect_pod_diagnostics(
+    ssh_client: asyncssh.SSHClientConnection, container_name: str
+) -> dict[str, object]:
+    """Diagnostics for a pod the ps-running check reported as down (run-time death).
 
-
-async def _collect_pod_diagnostics(ssh_client, container_name: str) -> dict:
-    """Collect raw Docker diagnostics for a pod that the ps-running check reported as down.
-
-    Uses the already-open SSH session to query the executor's local Docker daemon. Returns
-    whatever it can: container state (ExitCode, OOMKilled, Error, FinishedAt, ...) and a
-    tail of stdout/stderr logs. When the container has been removed both calls fail and we
-    surface the errors so the operator can distinguish "exited in place" from "rm'd".
+    Shares one collector and one flat Loki field shape with the create-time
+    failure path in docker_service (DAH-2395 / DAH-2193), so container deaths at
+    create time and run time are queryable together.
     """
-    quoted_name = shlex.quote(container_name)
-    result: dict = {}
-
-    try:
-        state_cmd = f"/usr/bin/docker inspect --format '{{{{json .State}}}}' {quoted_name}"
-        inspect_result = await ssh_client.run(state_cmd)
-        raw_state = (inspect_result.stdout or "").strip()
-        if raw_state:
-            state = json.loads(raw_state)
-            result["state"] = {
-                "Status": state.get("Status"),
-                "ExitCode": state.get("ExitCode"),
-                "OOMKilled": state.get("OOMKilled"),
-                "Error": state.get("Error"),
-                "StartedAt": state.get("StartedAt"),
-                "FinishedAt": state.get("FinishedAt"),
-            }
-        else:
-            stderr = getattr(inspect_result, "stderr", "")
-            stderr = stderr.strip() if isinstance(stderr, str) else ""
-            result["inspect_error"] = stderr or "empty stdout"
-    except Exception as exc:
-        result["inspect_error"] = str(exc)
-
-    try:
-        logs_cmd = (
-            f"/usr/bin/docker logs --tail {_POD_LOG_TAIL_LINES} {quoted_name} 2>&1"
-        )
-        logs_result = await ssh_client.run(logs_cmd)
-        tail = (logs_result.stdout or "")[-_POD_LOG_TAIL_CHAR_LIMIT:]
-        if tail:
-            result["logs_tail"] = tail
-    except Exception as exc:
-        result["logs_error"] = str(exc)
-
-    host_context = await _collect_host_context(ssh_client)
-    if host_context:
-        result["host_context"] = host_context
-
-    return result
-
-
-async def _collect_host_context(ssh_client) -> dict:
-    """Collect executor-host context that helps distinguish real pod failure from host reboot
-    or executor-container restart.
-
-    Two independent signals:
-      - `host_boot_time` from `uptime -s` — if it is close to the pod's FinishedAt, the host
-        likely rebooted and the pod did not come back up on its own.
-      - `executor_container_started_at` — if far newer than `host_boot_time`, the executor
-        container itself restarted (watchtower, compose restart, autoheal) without a full
-        host reboot. The executor container is located via the compose service label so
-        that the lookup survives renames.
-
-    All failures are swallowed into `*_error` fields — this runs on the already-open SSH
-    session, so we prefer empty signal over raising and losing the rest of the event.
-    """
-    result: dict = {}
-
-    try:
-        uptime_result = await ssh_client.run("uptime -s")
-        boot_time = (uptime_result.stdout or "").strip()
-        if boot_time:
-            result["host_boot_time"] = boot_time
-    except Exception as exc:
-        result["host_boot_error"] = str(exc)
-
-    try:
-        name_cmd = (
-            "/usr/bin/docker ps -a "
-            "--filter label=com.docker.compose.service=executor "
-            "--format '{{.Names}}' | head -n 1"
-        )
-        name_result = await ssh_client.run(name_cmd)
-        executor_name = (name_result.stdout or "").strip().splitlines()[0:1]
-        executor_name = executor_name[0] if executor_name else ""
-        if executor_name:
-            quoted_executor = shlex.quote(executor_name)
-            start_cmd = (
-                f"/usr/bin/docker inspect --format '{{{{.State.StartedAt}}}}' {quoted_executor}"
-            )
-            start_result = await ssh_client.run(start_cmd)
-            started_at = (start_result.stdout or "").strip()
-            if started_at:
-                result["executor_container_name"] = executor_name
-                result["executor_container_started_at"] = started_at
-    except Exception as exc:
-        result["executor_container_error"] = str(exc)
-
-    return result
+    diagnostics = await collect_container_death_diagnostics(ssh_client, container_name)
+    return diagnostics.to_log_fields()

--- a/neurons/validators/tests/test_failed_container_diagnostics.py
+++ b/neurons/validators/tests/test_failed_container_diagnostics.py
@@ -1,0 +1,215 @@
+"""DAH-2395: capture container death diagnostics before cleanup removes the evidence.
+
+When create_container fails after the container was created (e.g. a Dolphin filler
+whose entrypoint dies with exit 137), cleanup_failed_container_creation runs
+`docker rm -fv` and destroys the only artifacts explaining the death. These tests
+pin the new behavior: `docker inspect .State` (OOMKilled/ExitCode) and a bounded
+`docker logs` tail are captured and logged BEFORE the container is removed, and a
+capture failure never blocks the cleanup itself.
+"""
+
+import asyncio
+from unittest.mock import Mock, patch
+
+import pytest
+from services.docker_service import (
+    _FAILED_CONTAINER_LOGS_MAX_CHARS,
+    DockerService,
+    FailedContainerDiagnostics,
+)
+
+CONTAINER_NAME = "filler_63409a62-e024-414d-99aa-ba6f30be1bfd"
+DEFAULT_EXTRA: dict = {"miner_hotkey": "test_miner", "executor_uuid": "test_executor"}
+
+INSPECT_STATE_JSON = (
+    '{"Status": "exited", "OOMKilled": true, "ExitCode": 137,'
+    ' "Error": "", "StartedAt": "2026-07-13T06:06:42Z", "FinishedAt": "2026-07-13T06:06:57Z"}'
+)
+
+
+class _SSHRunResult:
+    def __init__(self, exit_status: int = 0, stdout: str = "", stderr: str = ""):
+        self.exit_status = exit_status
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class _FakeSSHClient:
+    """Records every command; per-substring overrides drive each command's result."""
+
+    def __init__(self):
+        self.commands: list[str] = []
+        self.results_by_substring: dict[str, _SSHRunResult] = {}
+        self.errors_by_substring: dict[str, Exception] = {}
+
+    async def run(self, command: str) -> _SSHRunResult:
+        self.commands.append(command)
+        for substring, error in self.errors_by_substring.items():
+            if substring in command:
+                raise error
+        for substring, result in self.results_by_substring.items():
+            if substring in command:
+                return result
+        return _SSHRunResult()
+
+    def command_index(self, substring: str) -> int:
+        for index, command in enumerate(self.commands):
+            if substring in command:
+                return index
+        raise AssertionError(f"no command containing {substring!r} was run: {self.commands}")
+
+
+@pytest.fixture
+def docker_service() -> DockerService:
+    return DockerService(
+        ssh_service=Mock(),
+        redis_service=Mock(),
+        attestation_service=Mock(),
+        rental_docker_client_factory=Mock(),
+    )
+
+
+def _diagnostics_log_extras(mock_logger) -> list[dict]:
+    extras: list[dict] = []
+    for call in mock_logger.warning.call_args_list:
+        structured_message = call.args[0]
+        if structured_message.message == "Failed container diagnostics before cleanup":
+            extras.append(structured_message.extra)
+    return extras
+
+
+@pytest.mark.asyncio
+async def test_cleanup_captures_death_diagnostics_before_removal(docker_service):
+    # Arrange
+    ssh_client = _FakeSSHClient()
+    ssh_client.results_by_substring["docker inspect"] = _SSHRunResult(stdout=INSPECT_STATE_JSON)
+    ssh_client.results_by_substring["docker logs"] = _SSHRunResult(
+        stdout="RuntimeError: CUDA out of memory"
+    )
+
+    # Act
+    with patch("services.docker_service.logger") as mock_logger:
+        await docker_service.cleanup_failed_container_creation(
+            ssh_client=ssh_client,
+            default_extra=DEFAULT_EXTRA,
+            container_name=CONTAINER_NAME,
+        )
+
+    # Assert: evidence is read strictly before `docker rm -fv` destroys it
+    removal_index = ssh_client.command_index("docker rm -fv")
+    assert ssh_client.command_index("docker inspect") < removal_index
+    assert ssh_client.command_index("docker logs") < removal_index
+
+    extras = _diagnostics_log_extras(mock_logger)
+    assert len(extras) == 1
+    assert extras[0]["container_name"] == CONTAINER_NAME
+    assert extras[0]["container_oom_killed"] is True
+    assert extras[0]["container_exit_code"] == 137
+    assert "CUDA out of memory" in extras[0]["container_logs_tail"]
+    assert extras[0]["diagnostics_capture_error"] is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_still_removes_container_when_diagnostics_capture_fails(docker_service):
+    # Arrange: both diagnostic commands blow up, removal itself works
+    ssh_client = _FakeSSHClient()
+    ssh_client.errors_by_substring["docker inspect"] = ConnectionError("ssh channel died")
+    ssh_client.errors_by_substring["docker logs"] = ConnectionError("ssh channel died")
+
+    # Act
+    with patch("services.docker_service.logger") as mock_logger:
+        await docker_service.cleanup_failed_container_creation(
+            ssh_client=ssh_client,
+            default_extra=DEFAULT_EXTRA,
+            container_name=CONTAINER_NAME,
+        )
+
+    # Assert: cleanup is never blocked by diagnostics
+    assert ssh_client.command_index("docker rm -fv") >= 0
+    extras = _diagnostics_log_extras(mock_logger)
+    assert len(extras) == 1
+    assert "ssh channel died" in extras[0]["diagnostics_capture_error"]
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_reports_missing_container_without_failing(docker_service):
+    # Arrange: container already gone — inspect exits non-zero
+    ssh_client = _FakeSSHClient()
+    ssh_client.results_by_substring["docker inspect"] = _SSHRunResult(
+        exit_status=1, stderr="Error: No such container"
+    )
+    ssh_client.results_by_substring["docker logs"] = _SSHRunResult(
+        stdout="Error response from daemon: No such container"
+    )
+
+    # Act
+    with patch("services.docker_service.logger") as mock_logger:
+        diagnostics = await docker_service.capture_failed_container_diagnostics(
+            ssh_client=ssh_client,
+            default_extra=DEFAULT_EXTRA,
+            container_name=CONTAINER_NAME,
+        )
+
+    # Assert
+    assert isinstance(diagnostics, FailedContainerDiagnostics)
+    assert diagnostics.state is None
+    assert "No such container" in diagnostics.capture_error
+    assert len(_diagnostics_log_extras(mock_logger)) == 1
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_treats_non_object_inspect_json_as_capture_error(docker_service):
+    # Arrange: valid JSON that is not an object must not crash the capture
+    # (a crash here would propagate into cleanup and skip `docker rm -fv`)
+    ssh_client = _FakeSSHClient()
+    ssh_client.results_by_substring["docker inspect"] = _SSHRunResult(stdout='"exited"')
+    ssh_client.results_by_substring["docker logs"] = _SSHRunResult(stdout="some logs")
+
+    # Act
+    with patch("services.docker_service.logger") as mock_logger:
+        diagnostics = await docker_service.capture_failed_container_diagnostics(
+            ssh_client=ssh_client,
+            default_extra=DEFAULT_EXTRA,
+            container_name=CONTAINER_NAME,
+        )
+
+    # Assert
+    assert diagnostics.state is None
+    assert "inspect" in diagnostics.capture_error
+    assert len(_diagnostics_log_extras(mock_logger)) == 1
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_logs_tail_is_size_bounded(docker_service):
+    # Arrange: an oversized log where the fatal line is at the very end
+    ssh_client = _FakeSSHClient()
+    ssh_client.results_by_substring["docker inspect"] = _SSHRunResult(stdout=INSPECT_STATE_JSON)
+    oversized_logs = ("x" * (_FAILED_CONTAINER_LOGS_MAX_CHARS * 3)) + "FATAL: worker crashed"
+    ssh_client.results_by_substring["docker logs"] = _SSHRunResult(stdout=oversized_logs)
+
+    # Act
+    with patch("services.docker_service.logger"):
+        diagnostics = await docker_service.capture_failed_container_diagnostics(
+            ssh_client=ssh_client,
+            default_extra=DEFAULT_EXTRA,
+            container_name=CONTAINER_NAME,
+        )
+
+    # Assert: bounded, and the tail (where the death reason lives) is preserved
+    assert len(diagnostics.logs_tail) == _FAILED_CONTAINER_LOGS_MAX_CHARS
+    assert diagnostics.logs_tail.endswith("FATAL: worker crashed")
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_propagates_cancellation(docker_service):
+    # Arrange
+    ssh_client = _FakeSSHClient()
+    ssh_client.errors_by_substring["docker inspect"] = asyncio.CancelledError()
+
+    # Act / Assert: cancellation must never be swallowed as a capture error
+    with pytest.raises(asyncio.CancelledError):
+        await docker_service.capture_failed_container_diagnostics(
+            ssh_client=ssh_client,
+            default_extra=DEFAULT_EXTRA,
+            container_name=CONTAINER_NAME,
+        )

--- a/neurons/validators/tests/test_failed_container_diagnostics.py
+++ b/neurons/validators/tests/test_failed_container_diagnostics.py
@@ -12,11 +12,11 @@ import asyncio
 from unittest.mock import Mock, patch
 
 import pytest
-from services.docker_service import (
-    _FAILED_CONTAINER_LOGS_MAX_CHARS,
-    DockerService,
-    FailedContainerDiagnostics,
+from core.docker_utils import (
+    _CONTAINER_DEATH_LOG_MAX_CHARS,
+    ContainerDeathDiagnostics,
 )
+from services.docker_service import DockerService
 
 CONTAINER_NAME = "filler_63409a62-e024-414d-99aa-ba6f30be1bfd"
 DEFAULT_EXTRA: dict = {"miner_hotkey": "test_miner", "executor_uuid": "test_executor"}
@@ -151,8 +151,9 @@ async def test_diagnostics_reports_missing_container_without_failing(docker_serv
         )
 
     # Assert
-    assert isinstance(diagnostics, FailedContainerDiagnostics)
-    assert diagnostics.state is None
+    assert isinstance(diagnostics, ContainerDeathDiagnostics)
+    assert diagnostics.exit_code is None
+    assert diagnostics.oom_killed is None
     assert "No such container" in diagnostics.capture_error
     assert len(_diagnostics_log_extras(mock_logger)) == 1
 
@@ -174,7 +175,7 @@ async def test_diagnostics_treats_non_object_inspect_json_as_capture_error(docke
         )
 
     # Assert
-    assert diagnostics.state is None
+    assert diagnostics.status is None
     assert "inspect" in diagnostics.capture_error
     assert len(_diagnostics_log_extras(mock_logger)) == 1
 
@@ -184,7 +185,7 @@ async def test_diagnostics_logs_tail_is_size_bounded(docker_service):
     # Arrange: an oversized log where the fatal line is at the very end
     ssh_client = _FakeSSHClient()
     ssh_client.results_by_substring["docker inspect"] = _SSHRunResult(stdout=INSPECT_STATE_JSON)
-    oversized_logs = ("x" * (_FAILED_CONTAINER_LOGS_MAX_CHARS * 3)) + "FATAL: worker crashed"
+    oversized_logs = ("x" * (_CONTAINER_DEATH_LOG_MAX_CHARS * 3)) + "FATAL: worker crashed"
     ssh_client.results_by_substring["docker logs"] = _SSHRunResult(stdout=oversized_logs)
 
     # Act
@@ -196,7 +197,7 @@ async def test_diagnostics_logs_tail_is_size_bounded(docker_service):
         )
 
     # Assert: bounded, and the tail (where the death reason lives) is preserved
-    assert len(diagnostics.logs_tail) == _FAILED_CONTAINER_LOGS_MAX_CHARS
+    assert len(diagnostics.logs_tail) == _CONTAINER_DEATH_LOG_MAX_CHARS
     assert diagnostics.logs_tail.endswith("FATAL: worker crashed")
 
 

--- a/neurons/validators/tests/test_rented_machine_check.py
+++ b/neurons/validators/tests/test_rented_machine_check.py
@@ -4,9 +4,9 @@ from unittest.mock import Mock
 import asyncssh
 import pytest
 from helpers import build_context_config, build_services, build_state
+from neurons.validators.src.core.docker_utils import _collect_host_context
 from neurons.validators.src.services.task.checks.rented_machine import (
     TenantEnforcementCheck,
-    _collect_host_context,
     _collect_pod_diagnostics,
 )
 from neurons.validators.src.services.task.messages import TenantEnforcementMessages as Msg
@@ -528,8 +528,10 @@ async def test_collect_pod_diagnostics_reports_exited_container():
 
     diagnostics = await _collect_pod_diagnostics(ssh, "pod_abc")
 
-    assert diagnostics["state"] == state
-    assert diagnostics["logs_tail"].endswith("traceback line 2\n")
+    assert diagnostics["container_status"] == "exited"
+    assert diagnostics["container_exit_code"] == 137
+    assert diagnostics["container_oom_killed"] is False
+    assert diagnostics["container_logs_tail"].endswith("traceback line 2\n")
     assert any("docker inspect" in cmd for cmd in ssh.commands_called)
     assert any("docker logs" in cmd for cmd in ssh.commands_called)
     # Pod-scoped commands all carry the pod name; host-context probes do not.
@@ -552,9 +554,9 @@ async def test_collect_pod_diagnostics_handles_removed_container():
 
     diagnostics = await _collect_pod_diagnostics(ssh, "pod_abc")
 
-    assert "state" not in diagnostics
-    assert diagnostics["inspect_error"] == "Error: No such object: pod_abc"
-    assert "logs_tail" not in diagnostics
+    assert diagnostics["container_status"] is None
+    assert "Error: No such object: pod_abc" in diagnostics["diagnostics_capture_error"]
+    assert diagnostics["container_logs_tail"] is None
 
 
 @pytest.mark.asyncio
@@ -563,8 +565,8 @@ async def test_collect_pod_diagnostics_never_raises_on_ssh_failure():
 
     diagnostics = await _collect_pod_diagnostics(ssh, "pod_abc")
 
-    assert "inspect_error" in diagnostics
-    assert "ssh failed" in diagnostics["inspect_error"]
+    assert diagnostics["diagnostics_capture_error"] is not None
+    assert "ssh failed" in diagnostics["diagnostics_capture_error"]
 
 
 @pytest.mark.asyncio
@@ -587,8 +589,8 @@ async def test_collect_pod_diagnostics_includes_host_context_when_available():
 
     diagnostics = await _collect_pod_diagnostics(ssh, "pod_abc")
 
-    assert diagnostics["state"]["OOMKilled"] is True
-    assert diagnostics["host_context"] == {
+    assert diagnostics["container_oom_killed"] is True
+    assert diagnostics["container_host_context"] == {
         "host_boot_time": "2026-04-03 10:07:20",
         "executor_container_name": "executor-executor-1",
         "executor_container_started_at": "2026-04-20T03:23:42.619916501Z",


### PR DESCRIPTION
### Task Link

[DAH-2395](https://app.notion.com/p/Validator-capture-container-death-diagnostics-OOMKilled-ExitCode-logs-before-rm-fv-on-failed-cre-39cb8bfdbde981928277db22b2785e05)

## Why

This morning four Dolphin default jobs died on RTX PRO 6000 nodes about 15 seconds after a successful `docker run`. The only trace left is `failure_reason = "UnknownError: Failed create_container"` in the DB. We still don't know whether the worker got OOM-killed or crashed on startup, and we can't find out: the validator force-removes the dead container right after the failure, and the host belongs to the miner, so there is nowhere to go back and look. Identical hardware runs Dolphin fine on another node. The answer was inside the container we deleted.

While digging into this we also found that the executor-side container monitor has been blind for a long time. It records docker events (die, oom, exit codes) into the local `podlog` table, but still filters names by the legacy `container_` prefix, while the validator names real workloads `pod_*` and `filler_*`. On the staging executor `podlog` has 32,737 rows since March. Every one of them is a port-check probe. Not a single real pod or filler.

## What changed

- Validator: on a failed container creation it now reads `docker inspect .State` (OOMKilled, ExitCode) and the last 100 log lines before running `docker rm -fv`, then writes one structured WARNING to Loki: `Failed container diagnostics before cleanup`. Best effort: if the capture itself fails, cleanup proceeds exactly as before. The success path is untouched.
- Executor monitor: watches `pod_*` and `filler_*` containers instead of `container_*`. Real workload deaths get recorded again, probe noise stops filling the table.

Next time a filler dies like this, the answer is one Loki query away instead of a dead end.

## Tests

TDD: 6 new validator tests and 4 new executor tests. Full suites: validators 1009 passed (the 3 failures in `test_sshd_bootstrap_script.py` are pre-existing on `origin/main` and environment-specific), executor 44 passed. Heads up: CI currently runs validator tests only.

The monitor fix reaches miners with the next executor image release.
