### PR TITLE
DAH-2265 - Make the cached-template check fatal

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -138,10 +138,9 @@ class Settings(BaseSettings):
     # unrented executor that has not pre-pulled the recommended default image, or holds stale
     # content under the same tag, fails verification early (score 0, reason surfaced to the
     # provider). Fails open: an unmeasured signal (None) is never penalised.
-    # TODO(2026-07-14): restore datetime(2026, 7, 9, 12, 0, 0). Cutoff deferred one day to keep
-    # the check advisory during the DAH-2380 Docker Hub digest rollout. The gate is ALSO held
-    # off by fatal=False on CachedTemplateVerificationCheck (see the TODO there) — re-enable both
-    # together tomorrow.
+    # The cutoff has elapsed and CachedTemplateVerificationCheck is fatal again, so the gate is
+    # live: unrented executors are enforced, rented ones are exempt (the check runs after the
+    # tenant short-circuit).
     CACHED_TEMPLATE_CUTOFF: datetime = datetime(2026, 7, 14, 12, 0, 0)
 
     # Minimum NVIDIA driver requirement. Compared as a dotted version tuple against the

--- a/neurons/validators/src/services/task/checks/cached_template_verification.py
+++ b/neurons/validators/src/services/task/checks/cached_template_verification.py
@@ -57,11 +57,10 @@ class CachedTemplateVerificationCheck:
     """
 
     check_id = "executor.validate.cached_template"
-    # TODO(2026-07-14): restore `fatal = True` to enable this gate. Temporarily False so that a
-    # `passed=False` result (NOT_CACHED / DIGEST_MISMATCH on/after the cutoff) does NOT halt the
-    # pipeline — the check stays advisory during the DAH-2380 digest rollout. Pairs with
-    # CACHED_TEMPLATE_CUTOFF (deferred to 2026-07-14 12:00 UTC in core/config.py); flip both back.
-    fatal = False
+    # The DAH-2380 digest rollout is done, so the gate is live: a `passed=False` result
+    # (NOT_CACHED / DIGEST_MISMATCH on/after CACHED_TEMPLATE_CUTOFF) halts the pipeline and the
+    # executor scores 0. Every uncertainty still fails open inside run() (passed=True).
+    fatal = True
 
     async def run(self, ctx: Context) -> CheckResult:
         gpu_model = ctx.state.gpu_model

--- a/neurons/validators/tests/test_cached_template_verification.py
+++ b/neurons/validators/tests/test_cached_template_verification.py
@@ -81,10 +81,8 @@ def _set_cutoff(monkeypatch, *, active: bool) -> None:
 
 
 def test_check_is_fatal():
-    # TODO(2026-07-14): restore `assert CachedTemplateVerificationCheck.fatal is True`.
-    # DAH-2380 rollout: the check is temporarily fatal=False so a passed=False result never halts
-    # the pipeline (run() still returns passed=False after the cutoff — only the halt is off).
-    assert CachedTemplateVerificationCheck.fatal is False
+    # The gate is live: a passed=False result on/after the cutoff halts the pipeline (score 0).
+    assert CachedTemplateVerificationCheck.fatal is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Describe your changes

Restores the cached-template gate that the DAH-2380 digest rollout was holding off. `CachedTemplateVerificationCheck.fatal` goes back to `True`.

Today the check already computes `passed=False` on/after `CACHED_TEMPLATE_CUTOFF` and emits `severity: error` with *"Score set to 0 — recommended default image must be pre-pulled and current"* — but `fatal=False` meant the pipeline never halted, so the message was a promise the validator did not keep. This makes it real.

- **What gates**: `NOT_CACHED` (recommended default image not pre-pulled) and `DIGEST_MISMATCH` (stale content under an unchanged tag). Both halt the pipeline → executor scores 0, reason surfaced to the provider via `log_text`.
- **What never gates**: every uncertainty still fails open inside `run()` — unknown GPU/driver, backend unreachable, empty recommendation, SSH error all return `passed=True`.
- **Who is exempt**: the check runs after the tenant short-circuit, so it only ever gates **unrented** executors. An active customer rental is never failed by it.
- `CACHED_TEMPLATE_CUTOFF` is unchanged (2026-07-14 12:00 UTC — already elapsed); only the `fatal` flag and the stale TODOs move.

## Current status — what this gates, per job cycle

Measured from prod validator logs (8h to 2026-07-14 14:30 UTC, 32 job cycles ~15 min apart). Counts are **distinct executors per cycle**, not events — every failing executor below was `rented: false`, as expected (the check runs after the tenant short-circuit, so rented nodes never reach it).

| job cycle | checked | MATCH | DIGEST_MISMATCH | NOT_CACHED | gated (unrented) |
|---|---|---|---|---|---|
| 06:40 → 12:57 (26 cycles) | 43–86 | — | **0 in every cycle** | 0–4 | 0–4 |
| **13:12** (image re-push) | 45 | 5 | **40** | 0 | **40** |
| 13:27 | 44 | 39 | 2 | 3 | 5 |
| 13:42 | 43 | 37 | 3 | 3 | 6 |
| 13:57 | 43 | 37 | 4 | 2 | 6 |
| 14:12 | 42 | 38 | 4 | 0 | 4 |
| 14:27 | 30 | 27 | 3 | 0 | 3 |

**Steady state: ~3 executors per cycle mismatch on digest, ~2 are not cached — about 5 unrented executors gated per cycle out of ~40 checked.** That is the ongoing cost of arming the gate, and it is the intended behaviour: those nodes genuinely do not hold the current recommended image.

**The sharp edge is an image re-push, not the steady state.** `daturaai/pytorch:2.12.0-py3.12-cuda13.0.2-devel-ubuntu24.04-dind` was re-pushed at ~13:20 UTC on 2026-07-14: the validator's Docker Hub digest snapshot flips cleanly from `2d19c94c…` to `70bd5fa6…`, and in the very next cycle **40 of 45 checked executors (89%) mismatched at once** — the whole unrented fleet went stale simultaneously, through no fault of the providers. With `fatal=True` that single cycle scores all 40 at 0.

It recovered in **one cycle** (~15 min) as the executor pre-pull caught up: 40 → 2 → 3 → 4 → 4 → 3. So the exposure is a short, sharp spike per re-push rather than a sustained outage.

Because the check compares against the **live registry tag**, there is no grace window — every future re-push of a default image repeats that spike. Note also that the backend's `DOCKER_IMAGES` constant still pins the *old* digest `2d19c94c…` for that tag, so the backend's pinned digest and the live tag currently disagree.

Merging this accepts both: ~5 unrented executors gated per cycle in steady state, and a one-cycle fleet-wide spike on every default-image re-push. If the spike is not acceptable, the options are to gate on `NOT_CACHED` only, or to give `DIGEST_MISMATCH` a grace window (accept the previous digest for N hours, or compare against the backend's pinned digest instead of the live tag).

**Files**
- `neurons/validators/src/services/task/checks/cached_template_verification.py` — `fatal = True`, TODO removed.
- `neurons/validators/src/core/config.py` — stale cutoff TODO removed (value unchanged).
- `neurons/validators/tests/test_cached_template_verification.py` — `test_check_is_fatal` asserts `fatal is True` again.

**Tests**: full validator suite — 1066 passed, 8 skipped. The existing cutoff-enforcement tests (`NOT_CACHED` / `DIGEST_MISMATCH` after cutoff → fail; every fail-open path → pass) already cover the gated behaviour and are unchanged.

## Issue ticket number and link

DAH-2265

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance? No — flag flip only, no new work on the verification path.
