### PR TITLE
DAH-2420, include failing step's error in create_container failure message

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -3593,12 +3593,11 @@ class DockerService:
             await self.redis_service.remove_pending_pod(payload.miner_hotkey, payload.executor_id, payload.pod_id)
 
             # Port release now handled by backend
-            failure_msg = str(log_text)
-            if (
-                current_step == "docker_sdk_ssh_host_key"
-                and isinstance(e, RentalDockerConnectionError)
-            ):
-                failure_msg = f"{failure_msg}: {e}"
+            # Carry the failing step's exception text into the returned message so the backend stores
+            # the real cause instead of a bare "Failed create_container" (capped to keep it small; the
+            # full traceback stays in the exc_info log above). failure_step already rides the response.
+            error_text = (str(e) or e.__class__.__name__)[:500]
+            failure_msg = f"{str(log_text)}: {error_text}"
 
             return FailedContainerRequest(
                 miner_hotkey=payload.miner_hotkey,

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -1507,6 +1507,57 @@ async def test_create_filler_skips_inspector_collector_start(docker_service, mon
 
 
 @pytest.mark.asyncio
+async def test_create_container_failure_msg_includes_step_and_error(docker_service, monkeypatch):
+    # A create failure must carry the failing step + the underlying error into the returned message,
+    # so the backend stores the real cause instead of a bare "Failed create_container".
+    _patch_create_container_happy_path(docker_service, monkeypatch)
+    monkeypatch.setattr(
+        docker_service,
+        "add_environment_variables_with_rental_docker",
+        AsyncMock(side_effect=RuntimeError("Failed to set environment variables")),
+    )
+
+    payload = ContainerCreateRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        workload_kind=WorkloadKind.FILLER,
+        docker_image="daturaai/dlph:test",
+        user_public_keys=["ssh-ed25519 test-key"],
+        gpu_uuids=["GPU-test"],
+        cpu_count=1,
+        memory_gb=1,
+        volume_limit_gb=2,
+        storage_limit_gb=1,
+        available_ports=[PayloadPortMapping(internal_port=20020, external_port=20020)],
+        pod_mapping=[],
+        active_container_names=[],
+        active_volume_names=[],
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
+    )
+
+    result = await docker_service.create_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    assert isinstance(result, FailedContainerRequest)
+    assert result.failure_step == "set_environment"
+    assert "Failed to set environment variables" in result.msg
+
+
+@pytest.mark.asyncio
 async def test_delete_last_customer_rental_stops_inspector_collector(
     docker_service,
     retry_ssh_mock,


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2420](https://app.notion.com/p/Default-Job-filler-create-failures-hide-the-real-cause-capture-failure_step-error-text-39eb8bfdbde9817d85a6f09cb564f7a3)

---

## Problem

`create_container` failures returned only the message `"Failed create_container"`, so the backend stored a bare `"UnknownError: Failed create_container"` with no cause. The failing step's real error (e.g. `set_environment` → `409 container is not running`, i.e. the workload exited at boot) was written only to the exc_info log line and never made it into the stored reason / alerts.

## Solution

Append the failing step's (capped) exception text to the returned `FailedContainerRequest.msg`. `failure_step` already rides the response.

## Changes

- `create_container` except block: `failure_msg = f"{message}: {error_text[:500]}"` for every failure (subsumes the old `docker_sdk_ssh_host_key`-only special case).
- Test that a create failure carries `failure_step` + the underlying error in `msg`.

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review

## Other PRs

Backend counterpart: [lium-io-backend#766](https://github.com/Datura-ai/lium-io-backend/pull/766) — surfaces `failure_step` in the filler's stored reason + alert.

## Risks

- Low. Only the text of the failure message changes (an error suffix is appended). No flow/behaviour change; secrets aren't in exception strings for these paths. Full docker_service suite green (144).

## Test Cases

### Test Case 1
**Actions**: create_container fails at the `set_environment` step.
**Expected Output**: `FailedContainerRequest.failure_step == "set_environment"` and `msg` contains the underlying error text.

## Checklist

- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
