### PR TITLE
DAH-2364: reduced graceful stop window for fillers instead of skipping

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -121,6 +121,15 @@ IN_CONTAINER_SSH_BOOTSTRAP_PATH = "/tmp/lium-ssh-bootstrap.sh"
 # that hold GPUs and brick the executor.
 CONTAINER_STOP_GRACE_SECONDS = 30
 
+# Fillers get a shorter grace window than customer workloads. The backend preempts a filler
+# before a customer rent with a total budget of FILLER_STOP_WAIT_TIMEOUT_SECONDS (30s in
+# compute-app) and starts the rent anyway on timeout. This grace must stay strictly below that
+# budget with room for the forced removal and the stopped-callback, so a SIGTERM-ignoring filler
+# can never burn the whole budget inside docker stop and hold the GPUs into the customer rent.
+# Half the budget leaves ~15s of headroom while still letting a well-behaved filler exit cleanly
+# and avoid the containerd/sysbox wedge. Keep in sync with compute-app FILLER_STOP_WAIT_TIMEOUT_SECONDS.
+FILLER_CONTAINER_STOP_GRACE_SECONDS = 15
+
 DOCKER_VOLUME_PLUGINS = {
     "s3fs": "mochoa/s3fs-volume-plugin"
 }
@@ -3954,19 +3963,19 @@ class DockerService:
         # Called directly rather than through run_logged_rental_docker_sdk_operation so that an
         # expected failure — chiefly an already-absent container — is not logged at ERROR and does
         # not raise a false failed-deletion alert.
-        if payload.workload_kind == WorkloadKind.FILLER:
-            # The backend preempts a filler before a customer rent with a 30s total budget
-            # (FILLER_STOP_WAIT_TIMEOUT_SECONDS) and starts the rent anyway on timeout. A grace
-            # window equal to that budget lets a SIGTERM-ignoring filler burn all of it inside
-            # docker stop, so the customer pod would land on GPUs the filler still holds.
-            # Fillers keep the pre-DAH-2364 SIGKILL-only removal.
-            return
+        # Fillers use a shorter grace window (see FILLER_CONTAINER_STOP_GRACE_SECONDS) so a
+        # SIGTERM-ignoring filler cannot outlast the backend's preemption budget.
+        stop_grace_seconds = (
+            FILLER_CONTAINER_STOP_GRACE_SECONDS
+            if payload.workload_kind == WorkloadKind.FILLER
+            else CONTAINER_STOP_GRACE_SECONDS
+        )
 
         stop_started = time.monotonic()
         try:
             await docker_client.stop(
                 container_name=payload.container_name,
-                stop_grace_seconds=CONTAINER_STOP_GRACE_SECONDS,
+                stop_grace_seconds=stop_grace_seconds,
             )
         except Exception as exc:
             if _is_missing_docker_container_error(exc):
@@ -3985,7 +3994,7 @@ class DockerService:
         log.info(
             "Graceful container stop completed",
             container_name=payload.container_name,
-            stop_grace_seconds=CONTAINER_STOP_GRACE_SECONDS,
+            stop_grace_seconds=stop_grace_seconds,
             duration_ms=int((time.monotonic() - stop_started) * 1000),
         )
 

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -9,6 +9,7 @@ from tenacity import Future, RetryError
 
 from services.docker_service import (
     CONTAINER_STOP_GRACE_SECONDS,
+    FILLER_CONTAINER_STOP_GRACE_SECONDS,
     DockerService,
     VolumeMinSizeError,
     _parse_volume_size_to_bytes,
@@ -1216,12 +1217,13 @@ async def test_delete_container_stop_missing_container_logs_info_and_removes(
 
 
 @pytest.mark.asyncio
-async def test_delete_filler_skips_graceful_stop(
+async def test_delete_filler_stops_with_reduced_grace(
     docker_service,
     monkeypatch,
 ):
     # Arrange: FILLER teardown races the backend's FILLER_STOP_WAIT_TIMEOUT_SECONDS budget,
-    # so it must keep the SIGKILL-only path with no graceful stop
+    # so it gets a shorter grace window than a customer rental — but still a graceful stop
+    # so a well-behaved filler exits cleanly and avoids the containerd/sysbox wedge
     ssh_client = AsyncMock()
     ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
     monkeypatch.setattr(
@@ -1266,12 +1268,16 @@ async def test_delete_filler_skips_graceful_stop(
         private_key="encrypted",
     )
 
-    # Assert: no graceful stop, straight to forced removal
+    # Assert: graceful stop with the reduced filler grace window, then the forced removal
     assert isinstance(result, ContainerDeleted)
     client = docker_service.rental_docker_client_factory.client
-    assert client.stopped_containers == []
-    assert client.container_call_order == [("remove", payload.container_name)]
-    # DAH-2356 still restores the filler's GPU power caps even though the graceful stop is skipped
+    assert client.container_call_order == [
+        ("stop", payload.container_name),
+        ("remove", payload.container_name),
+    ]
+    assert client.stop_grace_seconds_calls == [FILLER_CONTAINER_STOP_GRACE_SECONDS]
+    assert FILLER_CONTAINER_STOP_GRACE_SECONDS < CONTAINER_STOP_GRACE_SECONDS
+    # DAH-2356 still restores the filler's GPU power caps after the graceful stop
     restore_filler_power.assert_awaited_once()
     assert restore_filler_power.await_args.args[2] == payload.pod_id
 


### PR DESCRIPTION
## Describe your changes

Follow-up to #1121. Instead of **skipping** the graceful `docker stop` for FILLER workloads entirely (the SIGKILL-only path), fillers now get a graceful stop too, but with a **shorter grace window** — `FILLER_CONTAINER_STOP_GRACE_SECONDS = 15`, half of the customer `CONTAINER_STOP_GRACE_SECONDS = 30`.

### Why

The reason fillers were excluded was the preemption race: the backend preempts a filler before a customer rent with a total budget of `FILLER_STOP_WAIT_TIMEOUT_SECONDS = 30` (`compute-app`), polls the filler's stopped-status every 0.25s, and **starts the rent anyway on timeout**. A grace window equal to that whole budget would let a SIGTERM-ignoring filler burn all 30s inside `docker stop`, so the customer pod could land on GPUs the filler still holds.

A grace window **strictly below** that budget removes the race while still giving well-behaved fillers a clean SIGTERM exit — which is the whole point of #1121: a clean exit avoids the containerd/sysbox wedge that leaves orphaned containers holding GPUs.

### Timeline with the 15s window

| Case | Timeline | Result |
|------|----------|--------|
| Filler **respects** SIGTERM (typical sglang/PEARL/miner) | exits cleanly in 1–3s → forced removal is instant → `STOPPED` ~t=3, backend sees it within 0.25s | GPU free well before 30s; **no containerd/sysbox wedge** |
| Filler **ignores** SIGTERM (rare) | SIGKILL at t≈15 → forced removal ~t=16 → `STOPPED` ~t=17 | GPU free by ~17s, ~13s of headroom inside the 30s budget, no collision |

The one double-rare case — a wedged node **and** a SIGTERM-ignoring filler — is no worse than today (the pre-#1121 SIGKILL-only path already failed there), and the common SIGTERM-respecting filler on a wedged node is now actively helped.

`docker-py` already extends the HTTP read timeout by the stop timeout (from #1121), so the 15s grace cannot cause a read-timeout.

### Cross-repo invariant

`FILLER_CONTAINER_STOP_GRACE_SECONDS` (validator) must stay strictly below `FILLER_STOP_WAIT_TIMEOUT_SECONDS` (compute-app backend) with room for the forced removal and the stopped-callback. Documented in a comment next to the constant.

## Issue ticket number and link

[DAH-2364 Graceful container teardown + escalation and alerting for failed pod deletions](https://app.notion.com/p/Graceful-container-teardown-escalation-and-alerting-for-failed-pod-deletions-397b8bfdbde9813eb8f6e27119b95912)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests (rewrote `test_delete_filler_skips_graceful_stop` → `test_delete_filler_stops_with_reduced_grace`; full `test_docker_service.py` + `test_rental_docker_sdk.py` = 170 passed)
- [x] Need to take care of performance? (adds up to 15s to filler teardown only when the filler ignores SIGTERM; deletion is async fire-and-forget on the WS path)
