### PR TITLE
DAH-2427, ghost GPUs: signature-based wedge detection + targeted reset in GpuUsageCheck; verifyx timeout + context release; teardown wedge sweep

### DIFF
--- a/neurons/executor/src/gpus_utility.py
+++ b/neurons/executor/src/gpus_utility.py
@@ -165,12 +165,16 @@ async def manage_docker_images(
     driver_version = "unknown"
     try:
         pynvml.nvmlInit()
-        handle = pynvml.nvmlDeviceGetHandleByIndex(0)  # Get first GPU
-        gpu_name = pynvml.nvmlDeviceGetName(handle)
-        driver_version = pynvml.nvmlSystemGetDriverVersion()
-        if isinstance(gpu_name, bytes):
-            gpu_name = gpu_name.decode("utf-8")
-        pynvml.nvmlShutdown()
+        # finally: a leaked NVML handle makes this process the "in use by another client"
+        # blocker for any later per-GPU maintenance (DAH-2427 review finding).
+        try:
+            handle = pynvml.nvmlDeviceGetHandleByIndex(0)  # Get first GPU
+            gpu_name = pynvml.nvmlDeviceGetName(handle)
+            driver_version = pynvml.nvmlSystemGetDriverVersion()
+            if isinstance(gpu_name, bytes):
+                gpu_name = gpu_name.decode("utf-8")
+        finally:
+            pynvml.nvmlShutdown()
     except Exception as e:
         logger.error(f"Failed to get GPU name: {e}")
 

--- a/neurons/executor/src/services/hardware_service.py
+++ b/neurons/executor/src/services/hardware_service.py
@@ -142,17 +142,21 @@ def get_system_metrics():
     gpus = []
     try:
         pynvml.nvmlInit()
-        gpu_count = pynvml.nvmlDeviceGetCount()
-        
-        for i in range(gpu_count):
-            handle = pynvml.nvmlDeviceGetHandleByIndex(i)
-            util = pynvml.nvmlDeviceGetUtilizationRates(handle)
-            mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
-            gpus.append({
-                "utilization": util.gpu,                  # %
-                "memory": mem.used / mem.total * 100.0    # %
-            })
-        pynvml.nvmlShutdown()
+        # finally: a leaked NVML handle in the long-lived executor process blocks any later
+        # per-GPU maintenance with "in use by another client" (DAH-2427 review finding).
+        try:
+            gpu_count = pynvml.nvmlDeviceGetCount()
+
+            for i in range(gpu_count):
+                handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+                util = pynvml.nvmlDeviceGetUtilizationRates(handle)
+                mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
+                gpus.append({
+                    "utilization": util.gpu,                  # %
+                    "memory": mem.used / mem.total * 100.0    # %
+                })
+        finally:
+            pynvml.nvmlShutdown()
     except (pynvml.NVMLError, pynvml.NVMLError_NotSupported, pynvml.NVMLError_DriverNotLoaded) as e:
         # This is expected on systems without NVIDIA GPUs or drivers
         logger.debug(f"No GPU available: {e}")
@@ -259,33 +263,35 @@ def get_container_metrics(container_name: str, gpu_uuids: list[str]):
         if gpu_uuids:
             try:
                 pynvml.nvmlInit()
+                # finally: a leaked NVML handle in the long-lived executor process blocks any
+                # later per-GPU maintenance with "in use by another client" (DAH-2427 review).
+                try:
+                    for gpu_uuid in gpu_uuids:
+                        try:
+                            # Get GPU handle by UUID
+                            handle = pynvml.nvmlDeviceGetHandleByUUID(gpu_uuid)
 
-                for gpu_uuid in gpu_uuids:
-                    try:
-                        # Get GPU handle by UUID
-                        handle = pynvml.nvmlDeviceGetHandleByUUID(gpu_uuid)
+                            # Get utilization rates
+                            util = pynvml.nvmlDeviceGetUtilizationRates(handle)
 
-                        # Get utilization rates
-                        util = pynvml.nvmlDeviceGetUtilizationRates(handle)
+                            # Get memory info
+                            mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
 
-                        # Get memory info
-                        mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
-
-                        gpus.append({
-                            "uuid": gpu_uuid,
-                            "utilization": util.gpu,                  # %
-                            "memory": mem.used / mem.total * 100.0    # %
-                        })
-                    except pynvml.NVMLError as e:
-                        logger.warning(f"Error getting metrics for GPU {gpu_uuid}: {e}")
-                        # Add entry with zero values if GPU not accessible
-                        gpus.append({
-                            "uuid": gpu_uuid,
-                            "utilization": 0.0,
-                            "memory": 0.0
-                        })
-
-                pynvml.nvmlShutdown()
+                            gpus.append({
+                                "uuid": gpu_uuid,
+                                "utilization": util.gpu,                  # %
+                                "memory": mem.used / mem.total * 100.0    # %
+                            })
+                        except pynvml.NVMLError as e:
+                            logger.warning(f"Error getting metrics for GPU {gpu_uuid}: {e}")
+                            # Add entry with zero values if GPU not accessible
+                            gpus.append({
+                                "uuid": gpu_uuid,
+                                "utilization": 0.0,
+                                "memory": 0.0
+                            })
+                finally:
+                    pynvml.nvmlShutdown()
             except (pynvml.NVMLError, pynvml.NVMLError_NotSupported, pynvml.NVMLError_DriverNotLoaded) as e:
                 logger.debug(f"No GPU available: {e}")
             except Exception as e:

--- a/neurons/executor/src/verifyx_executor.py
+++ b/neurons/executor/src/verifyx_executor.py
@@ -1,6 +1,9 @@
 import argparse
 import ctypes
 import os
+import signal
+import sys
+from types import FrameType
 
 
 class VerifyXExecutor:
@@ -20,8 +23,19 @@ class VerifyXExecutor:
     def _create_service(self):
         return self.lib.service_new()
 
+    def close(self) -> None:
+        # DAH-2427: a context left behind becomes an orphaned kernel that pins the card at
+        # 100% with no process, so release it on every exit we can still run code on — a clean
+        # finish, an exception, or a signal. A hang inside the native execute() is NOT one of
+        # them (handlers only run between bytecodes); GpuUsageCheck is the backstop there.
+        # Idempotent so finally + signal + __del__ can all call it; getattr guards __del__
+        # when __init__ raised early.
+        if getattr(self, "service", None) is not None:
+            self.lib.service_del(self.service)
+            self.service = None
+
     def __del__(self):
-        self.lib.service_del(self.service)
+        self.close()
 
     def _decode_string(self, ptr):
         return ctypes.string_at(ptr).decode("utf-8") if ptr else None
@@ -42,8 +56,22 @@ def main():
     args = parser.parse_args()
 
     executor = VerifyXExecutor(args.lib)
-    result = executor.execute(args.cipher_text, args.seed)
-    print(result)
+
+    def _release_and_exit(signum: int, frame: FrameType | None) -> None:
+        executor.close()
+        sys.exit(128 + signum)
+
+    # SIGHUP too: a validator-side timeout closes the SSH channel, and OpenSSH signals the
+    # remote command with SIGHUP whose default action would kill us before cleanup runs.
+    signal.signal(signal.SIGTERM, _release_and_exit)
+    signal.signal(signal.SIGINT, _release_and_exit)
+    signal.signal(signal.SIGHUP, _release_and_exit)
+
+    try:
+        result = executor.execute(args.cipher_text, args.seed)
+        print(result)
+    finally:
+        executor.close()
 
 
 if __name__ == "__main__":

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -102,6 +102,16 @@ UNRENTED_MULTIPLIER = 1
 GPU_UTILIZATION_LIMIT = 5  # percent
 GPU_MEMORY_UTILIZATION_LIMIT = 5  # percent
 
+# DAH-2427 ghost GPU: an orphaned CUDA kernel left by a hard-killed GPU process pins the
+# card at full utilization with no memory and no process attached (observed for days on
+# RTX PRO 6000 nodes). The "no memory" half is expressed in whichever unit each data source
+# provides: the periodic check reads NVML memory-utilization percent, the teardown sweep
+# reads nvidia-smi used MiB.
+GPU_WEDGE_UTILIZATION_MIN = 95  # percent
+GPU_WEDGE_MEMORY_MAX = 1  # percent (periodic check, NVML memory-utilization)
+GPU_WEDGE_SWEEP_MEMORY_MAX_MIB = 16  # teardown sweep, nvidia-smi memory.used
+GPU_WEDGE_SWEEP_SETTLE_SECONDS = 5  # let GPU state settle after a container is removed
+
 MIN_PORT_COUNT = 3
 BATCH_PORT_VERIFICATION_SIZE = 300
 BATCH_PORT_TIMEOUT = 40

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -54,6 +54,7 @@ from payload_models.payloads import (
 from services.attestation_service import AttestationError, AttestationService
 from services.const import (
     FILLER_CONTAINER_PREFIX,
+    GPU_WEDGE_SWEEP_SETTLE_SECONDS,
     MIN_PORT_COUNT,
     POD_CONTAINER_PREFIX,
     PREFERRED_POD_PORTS,
@@ -65,6 +66,7 @@ from services.gpu_power_limit import (
     restore_filler_pod_gpu_power_limits,
     restore_tracked_gpu_power_limits,
 )
+from services.gpu_wedge import cure_wedged_gpus, query_wedged_gpu_uuids
 from services.nvidia_devices import build_gpu_docker_config_for_executor
 from services.redis_service import (
     STREAMING_LOG_CHANNEL,
@@ -92,6 +94,7 @@ from services.rental_docker_sdk import (
     require_rental_docker_ssh_host_key,
 )
 from services.ssh_connect_timing import connect_with_phase_timing
+from services.task.runner import SSHCommandRunner
 from tenacity import RetryError
 
 from core.config import settings
@@ -4192,7 +4195,16 @@ class DockerService:
 
                 # Fatal boundary: the forced removal is the only step whose failure fails the
                 # undeploy. Every step below runs after the container is gone and is best-effort.
-                await self._force_remove_container(docker_client, payload, log)
+                try:
+                    await self._force_remove_container(docker_client, payload, log)
+                except Exception:
+                    # DAH-2427: a failed force-remove (backend FAILED / STOP_FAILED) is the
+                    # classic wedge path — sweep before propagating so a wedged card does not
+                    # outlive the failed delete. No-op while a live compute app still exists.
+                    if payload.workload_kind == WorkloadKind.FILLER:
+                        with _best_effort_delete_step(log, "sweep_wedged_gpus_after_failed_remove"):
+                            await _sweep_wedged_gpus_after_teardown(ssh_client, log)
+                    raise
 
                 # DAH-2211: always-on inline cleanup of custom-build artifacts
                 # for this pod. No-op if the pod was not a custom build.
@@ -4210,6 +4222,11 @@ class DockerService:
                         await restore_filler_pod_gpu_power_limits(
                             ssh_client, self.redis_service, payload.pod_id, log_extra=default_extra
                         )
+                    # DAH-2427: force-removing a CUDA workload can leave an orphaned kernel
+                    # pinning the card (ghost GPU); cure it right here so the ghost never
+                    # outlives the teardown and never reaches the next renter.
+                    with _best_effort_delete_step(log, "sweep_wedged_gpus"):
+                        await _sweep_wedged_gpus_after_teardown(ssh_client, log)
 
                 with _best_effort_delete_step(log, "prune_images"):
                     await run_logged_rental_docker_sdk_operation(
@@ -4732,3 +4749,34 @@ class DockerService:
         extra_ports = [max_port + i for i in range(extra_count)]
 
         return list(PREFERRED_POD_PORTS) + extra_ports
+
+
+async def _sweep_wedged_gpus_after_teardown(
+    ssh_client: asyncssh.SSHClientConnection, log: "_BoundLog"
+) -> None:
+    """Cure any GPU the removed container left wedged; best-effort, caller guards errors.
+
+    The signature is sampled twice, before and after a settle window, because the moment just
+    after a SIGKILL is when a draining workload looks most like an orphaned kernel. A card that
+    reads healthy immediately cannot be wedged, so the common teardown pays one cheap query
+    pair and skips the wait entirely.
+    """
+    runner = SSHCommandRunner(ssh_client, max_retries=0)
+
+    if not await query_wedged_gpu_uuids(runner):
+        return
+
+    await asyncio.sleep(GPU_WEDGE_SWEEP_SETTLE_SECONDS)
+    wedged_uuids: list[str] = await query_wedged_gpu_uuids(runner)
+    if not wedged_uuids:
+        return
+
+    for cure_outcome in await cure_wedged_gpus(runner, wedged_uuids):
+        log.info(
+            "Wedged GPU cure attempted after teardown",
+            gpu_uuid=cure_outcome.gpu_uuid,
+            cured=cure_outcome.cured,
+            exit_code=cure_outcome.exit_code,
+            output=cure_outcome.output,
+            error=cure_outcome.error,
+        )

--- a/neurons/validators/src/services/gpu_wedge.py
+++ b/neurons/validators/src/services/gpu_wedge.py
@@ -1,0 +1,140 @@
+"""DAH-2427: shared ghost-GPU signature and cure.
+
+A hard-killed GPU process (SIGKILL via container force-remove, or a crash) can latch a
+Blackwell GSP "engine busy" counter: the card reads 100% utilization with no memory and no
+process while still being offered as available. The latch is telemetry-only and persists
+because persistence mode keeps the device initialized. Two callers act on it — the periodic
+GpuUsageCheck and the post-teardown sweep in DockerService — so the signature and the cure
+live here once instead of drifting apart.
+"""
+
+import asyncio
+import shlex
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from services.const import GPU_WEDGE_SWEEP_MEMORY_MAX_MIB, GPU_WEDGE_UTILIZATION_MIN
+
+if TYPE_CHECKING:
+    # Type-only: importing services.task at runtime pulls its package __init__, which reaches
+    # back into the checks that import this module.
+    from services.task.runner import SSHCommandRunner
+
+GPU_QUERY_COMMAND = (
+    "nvidia-smi --query-gpu=uuid,utilization.gpu,memory.used --format=csv,noheader,nounits"
+)
+COMPUTE_APPS_QUERY_COMMAND = "nvidia-smi --query-compute-apps=pid --format=csv,noheader"
+NVIDIA_SMI_QUERY_TIMEOUT_SECONDS = 30
+
+# A clean CUDA context create/destroy on the latched card clears the counter. Chosen over
+# `nvidia-smi -r` (refused on ~45% of the Blackwell fleet: never available on 580.126.09,
+# and blocked by ANY other NVML client elsewhere) and over killing NVML holders (only
+# worked when a leaked fd existed, and stops the image pre-pull daemon). The context cycle
+# needs no root, tolerates concurrent clients, and cured 11/11 latched cards in live tests
+# on both driver branches. python3 + libcuda.so.1 ship in the executor container
+# (NVIDIA_DRIVER_CAPABILITIES=all). Takes 2-5s per GPU.
+_CUDA_CONTEXT_CYCLE_CODE = (
+    "import ctypes; "
+    'lib = ctypes.CDLL("libcuda.so.1"); '
+    "assert lib.cuInit(0) == 0; "
+    "dev = ctypes.c_int(); "
+    "assert lib.cuDeviceGet(ctypes.byref(dev), 0) == 0; "
+    "ctx = ctypes.c_void_p(); "
+    "assert lib.cuCtxCreate_v2(ctypes.byref(ctx), 0, dev) == 0; "
+    "assert lib.cuCtxDestroy_v2(ctx) == 0; "
+    'print("ctx open/close OK")'
+)
+CURE_SUCCESS_MARKER = "ctx open/close OK"
+_CURE_TIMEOUT_SECONDS = 60
+_CURE_OUTPUT_TAIL_CHARS = 300
+
+
+@dataclass(frozen=True)
+class GpuCureOutcome:
+    gpu_uuid: str
+    exit_code: int  # SSHCommandRunner reports -1 when the command could not run at all
+    output: str
+    error: str | None = None
+
+    @property
+    def cured(self) -> bool:
+        return self.exit_code == 0 and CURE_SUCCESS_MARKER in self.output
+
+
+def matches_wedge_utilization(gpu_utilization: float | None) -> bool:
+    return (gpu_utilization or 0) >= GPU_WEDGE_UTILIZATION_MIN
+
+
+def build_cuda_context_cycle_command(gpu_uuid: str) -> str:
+    return (
+        f"CUDA_VISIBLE_DEVICES={shlex.quote(gpu_uuid)} "
+        f"python3 -c {shlex.quote(_CUDA_CONTEXT_CYCLE_CODE)}"
+    )
+
+
+def parse_wedged_gpu_uuids(gpu_query_csv: str, compute_apps_csv: str) -> list[str]:
+    """Pick wedged cards out of GPU_QUERY_COMMAND output (uuid, utilization, memory.used MiB).
+
+    A host with any live compute app is skipped entirely: a running CUDA process can
+    legitimately pin a card, and only orphaned load is the wedge signature.
+    """
+    if compute_apps_csv.strip():
+        return []
+
+    wedged_uuids: list[str] = []
+    for line in gpu_query_csv.strip().splitlines():
+        parts: list[str] = [part.strip() for part in line.split(",")]
+        if len(parts) != 3:
+            continue
+        gpu_uuid, utilization_raw, memory_raw = parts
+        try:
+            utilization = float(utilization_raw)
+            memory_mib = float(memory_raw)
+        except ValueError:
+            continue
+        is_wedged: bool = (
+            gpu_uuid.startswith("GPU-")
+            and matches_wedge_utilization(utilization)
+            and memory_mib <= GPU_WEDGE_SWEEP_MEMORY_MAX_MIB
+        )
+        if is_wedged:
+            wedged_uuids.append(gpu_uuid)
+    return wedged_uuids
+
+
+async def query_wedged_gpu_uuids(runner: "SSHCommandRunner") -> list[str]:
+    """Sample the live nvidia-smi state and return the currently wedged card uuids."""
+    gpu_query, compute_apps = await asyncio.gather(
+        runner.run(GPU_QUERY_COMMAND, timeout=NVIDIA_SMI_QUERY_TIMEOUT_SECONDS, retryable=False),
+        runner.run(
+            COMPUTE_APPS_QUERY_COMMAND, timeout=NVIDIA_SMI_QUERY_TIMEOUT_SECONDS, retryable=False
+        ),
+    )
+    return parse_wedged_gpu_uuids(gpu_query.stdout, compute_apps.stdout)
+
+
+async def cure_wedged_gpus(
+    runner: "SSHCommandRunner", gpu_uuids: list[str]
+) -> list[GpuCureOutcome]:
+    """Clear each latched card with a CUDA context create/destroy cycle, sequentially.
+
+    SSHCommandRunner never raises — a failure comes back as exit_code -1 plus
+    error_message — so this cannot break its caller.
+    """
+    outcomes: list[GpuCureOutcome] = []
+    for gpu_uuid in gpu_uuids:
+        result = await runner.run(
+            build_cuda_context_cycle_command(gpu_uuid),
+            timeout=_CURE_TIMEOUT_SECONDS,
+            retryable=False,
+        )
+        output: str = result.stdout or result.stderr or ""
+        outcomes.append(
+            GpuCureOutcome(
+                gpu_uuid=gpu_uuid,
+                exit_code=result.exit_code,
+                output=output[-_CURE_OUTPUT_TAIL_CHARS:],
+                error=result.error_message,
+            )
+        )
+    return outcomes

--- a/neurons/validators/src/services/task/checks/gpu_usage.py
+++ b/neurons/validators/src/services/task/checks/gpu_usage.py
@@ -1,6 +1,31 @@
-from ..messages import GpuUsageMessages as Msg, render_message
+import logging
+from dataclasses import dataclass
+
+from services.const import (
+    GPU_MEMORY_UTILIZATION_LIMIT,
+    GPU_UTILIZATION_LIMIT,
+    GPU_WEDGE_MEMORY_MAX,
+    POD_CONTAINER_PREFIX,
+)
+from services.gpu_wedge import (
+    GpuCureOutcome,
+    cure_wedged_gpus,
+    matches_wedge_utilization,
+    query_wedged_gpu_uuids,
+)
+
+from ..messages import GpuUsageMessages as Msg
+from ..messages import render_message
 from ..pipeline import CheckResult, Context
-from services.const import GPU_MEMORY_UTILIZATION_LIMIT, GPU_UTILIZATION_LIMIT, POD_CONTAINER_PREFIX
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class WedgedGpu:
+    gpu_uuid: str
+    gpu_utilization: float | None
+    memory_utilization: float | None
 
 
 class GpuUsageCheck:
@@ -9,10 +34,24 @@ class GpuUsageCheck:
     check_id = "gpu.validate.usage"
     fatal = True
 
+    def __init__(self, dry_run: bool = False):
+        # A dry run reports a ghost GPU but must not touch the executor (no CUDA-context cure).
+        self.dry_run = dry_run
+
     async def run(self, ctx: Context) -> CheckResult:
         gpu_details = ctx.state.gpu_details
         gpu_processes = ctx.state.gpu_processes
 
+        ghost_result = await self._detect_and_cure_ghost_gpus(ctx, gpu_details, gpu_processes)
+        if ghost_result is not None:
+            return ghost_result
+
+        return self._judge_process_based_usage(ctx, gpu_details, gpu_processes)
+
+    def _judge_process_based_usage(
+        self, ctx: Context, gpu_details: list[dict], gpu_processes: list[dict]
+    ) -> CheckResult:
+        """The legacy guard: flag GPU load owned by live processes outside our workloads."""
         violation = _find_violation(gpu_details, gpu_processes)
 
         if violation is None:
@@ -67,6 +106,72 @@ class GpuUsageCheck:
         )
         return CheckResult(passed=False, event=event)
 
+    async def _detect_and_cure_ghost_gpus(
+        self, ctx: Context, gpu_details: list[dict], gpu_processes: list[dict]
+    ) -> CheckResult | None:
+        """Cure ghost GPUs in place; fail the executor only when a card stays latched.
+
+        DAH-2427: a hard-killed GPU process can latch the busy counter — 100% utilization
+        with no memory and no process — which the process-based guard cannot see. Stateless
+        by design: the cure (a CUDA context cycle) is harmless, so it runs on first sight,
+        and the verdict comes from re-sampling the live card afterwards. Fail-open: this
+        detection is an addition to the legacy guard, so an unexpected error here must never
+        break validation for the whole executor. Returns None when there is no ghost.
+        """
+        try:
+            if gpu_processes:
+                return None
+
+            wedged_gpus: list[WedgedGpu] = [
+                WedgedGpu(
+                    gpu_uuid=detail["uuid"],
+                    gpu_utilization=detail.get("gpu_utilization"),
+                    memory_utilization=detail.get("memory_utilization"),
+                )
+                for detail in gpu_details
+                if _is_wedge_candidate(detail)
+            ]
+            if not wedged_gpus:
+                return None
+
+            if self.dry_run:
+                event = render_message(
+                    Msg.GPU_WEDGED,
+                    ctx=ctx,
+                    check_id=self.check_id,
+                    what={
+                        "wedged_gpus": wedged_gpus,
+                        "cure_attempted": False,
+                        "cure_results": [],
+                    },
+                )
+                return CheckResult(passed=False, event=event)
+
+            wedged_uuids: list[str] = [gpu.gpu_uuid for gpu in wedged_gpus]
+            cure_outcomes: list[GpuCureOutcome] = await cure_wedged_gpus(ctx.runner, wedged_uuids)
+
+            # The verdict comes from the card itself, not from the cure's exit code.
+            still_wedged: list[str] = sorted(
+                set(await query_wedged_gpu_uuids(ctx.runner)) & set(wedged_uuids)
+            )
+            what = {
+                "wedged_gpus": wedged_gpus,
+                "cure_attempted": True,
+                "cure_results": cure_outcomes,
+                "still_wedged": still_wedged,
+            }
+            if not still_wedged:
+                event = render_message(
+                    Msg.GPU_WEDGE_CURED, ctx=ctx, check_id=self.check_id, what=what
+                )
+                return CheckResult(passed=True, event=event)
+
+            event = render_message(Msg.GPU_WEDGED, ctx=ctx, check_id=self.check_id, what=what)
+            return CheckResult(passed=False, event=event)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Ghost GPU detection failed, falling back to the usage guard: %s", exc)
+            return None
+
 
 def _find_violation(gpu_details: list[dict], gpu_processes: list[dict]) -> dict | None:
     if not gpu_processes:
@@ -85,3 +190,14 @@ def _find_violation(gpu_details: list[dict], gpu_processes: list[dict]) -> dict 
             }
 
     return None
+
+
+def _is_wedge_candidate(detail: dict) -> bool:
+    gpu_utilization = detail.get("gpu_utilization")
+    memory_utilization: float = detail.get("memory_utilization", 0) or 0
+    has_uuid: bool = bool(detail.get("uuid"))
+    return (
+        has_uuid
+        and matches_wedge_utilization(gpu_utilization)
+        and memory_utilization <= GPU_WEDGE_MEMORY_MAX
+    )

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -688,6 +688,27 @@ class GpuUsageMessages:
         impact="Validation skipped; score set to 0",
         remediation="Rental ended but container still running. Remove it: docker stop {orphaned_container}",
     )
+    GPU_WEDGE_CURED = MessageTemplate(
+        event="Ghost GPU cured in place",
+        reason="GPU_WEDGE_CURED",
+        severity="warning",
+        category="runtime",
+        impact="Latched busy counter cleared by a CUDA context cycle; validation continues",
+    )
+    GPU_WEDGED = MessageTemplate(
+        event="Wedged GPU detected",
+        reason="GPU_WEDGED",
+        severity="error",
+        category="runtime",
+        impact="Validation skipped; score set to 0; the CUDA context cure did not clear the card",
+        remediation=(
+            "GPU pinned at full utilization with no memory and no process — a latched Blackwell "
+            "busy counter left by a hard-killed GPU process (ghost GPU, DAH-2427). If the "
+            "automatic cure did not clear it, run a CUDA context open/close on the card "
+            "(CUDA_VISIBLE_DEVICES=<uuid> python3 + cuInit/cuCtxCreate/cuCtxDestroy); "
+            "nvidia-smi -r is unreliable across driver builds."
+        ),
+    )
 
 
 class PortConnectivityMessages:

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -325,7 +325,9 @@ class PipelineFactory:
                 # the authoritative probe result used for scoring (not the earlier scrape hint).
                 SysboxRequiredCheck(),
                 TenantEnforcementCheck(),
-                GpuUsageCheck(),
+                # dry_run=True: reports a ghost GPU but runs no pkill + nvidia-smi reset on the
+                # executor and leaves the shared wedge timers the production pipeline relies on.
+                GpuUsageCheck(dry_run=True),
                 # VerifyXCheck(),
                 TdxHostCheck(),
                 CapabilityCheck(),

--- a/neurons/validators/tests/test_gpu_usage_check.py
+++ b/neurons/validators/tests/test_gpu_usage_check.py
@@ -1,7 +1,8 @@
-import pytest
+from unittest.mock import AsyncMock, MagicMock
 
-from neurons.validators.src.services.const import POD_CONTAINER_PREFIX
+import pytest
 from neurons.validators.src.protocol.vc_protocol.compute_requests import RentedExecutorsResponse
+from neurons.validators.src.services.const import POD_CONTAINER_PREFIX
 from neurons.validators.src.services.task.checks.gpu_usage import GpuUsageCheck
 from neurons.validators.src.services.task.messages import GpuUsageMessages as Msg
 
@@ -146,3 +147,175 @@ async def test_gpu_usage_rejects_unmapped_filler_container(context_factory):
 
     assert result.passed is False
     assert result.event.reason_code == Msg.USAGE_HIGH.reason
+
+
+# --- DAH-2427: ghost-GPU detection (util pinned, no memory, no processes) ---
+# Stateless by design (review feedback): see the signature -> cure immediately (the CUDA
+# context cycle is harmless) -> verdict from re-sampling the live card. Cured = node stays.
+
+WEDGED_UUID = "GPU-bdf72357-83a7-09d3-9809-729c734aa80a"
+HEALTHY_UUID = "GPU-dde887f6-488b-085f-a7b0-a71557f3e330"
+
+GPU_QUERY_PREFIX = "nvidia-smi --query-gpu="
+COMPUTE_APPS_PREFIX = "nvidia-smi --query-compute-apps="
+CURE_PREFIX = "CUDA_VISIBLE_DEVICES="
+
+
+def _wedged_detail(uuid: str = WEDGED_UUID) -> dict:
+    return {"uuid": uuid, "gpu_utilization": 100, "memory_utilization": 0}
+
+
+def _ssh_result(exit_code: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    return MagicMock(exit_code=exit_code, stdout=stdout, stderr=stderr, error_message=None)
+
+
+def _mock_runner(requery_gpu_csv: str = "", cure_exit_code: int = 0) -> MagicMock:
+    """Route the three commands the ghost path can issue: cure, GPU re-query, compute apps."""
+
+    async def route(command: str, **_kwargs) -> MagicMock:
+        if command.startswith(CURE_PREFIX):
+            return _ssh_result(exit_code=cure_exit_code, stdout="ctx open/close OK" if cure_exit_code == 0 else "AssertionError")
+        if command.startswith(GPU_QUERY_PREFIX):
+            return _ssh_result(stdout=requery_gpu_csv)
+        if command.startswith(COMPUTE_APPS_PREFIX):
+            return _ssh_result(stdout="")
+        raise AssertionError(f"unexpected command: {command}")
+
+    runner = MagicMock()
+    runner.run = AsyncMock(side_effect=route)
+    return runner
+
+
+def _commands(runner: MagicMock) -> list[str]:
+    return [call.args[0] for call in runner.run.await_args_list]
+
+
+@pytest.mark.asyncio
+async def test_ghost_cured_in_place_passes(context_factory):
+    runner = _mock_runner(requery_gpu_csv=f"{WEDGED_UUID}, 0, 0\n")
+    state = build_state(gpu_details=[_wedged_detail()], gpu_processes=[])
+    ctx = context_factory(services=build_services(), config=build_context_config(), state=state, runner=runner)
+
+    result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.GPU_WEDGE_CURED.reason
+    assert any(cmd.startswith(CURE_PREFIX) and WEDGED_UUID in cmd for cmd in _commands(runner))
+
+
+@pytest.mark.asyncio
+async def test_ghost_still_latched_after_cure_fails_the_check(context_factory):
+    runner = _mock_runner(requery_gpu_csv=f"{WEDGED_UUID}, 100, 0\n")
+    state = build_state(gpu_details=[_wedged_detail()], gpu_processes=[])
+    ctx = context_factory(services=build_services(), config=build_context_config(), state=state, runner=runner)
+
+    result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.GPU_WEDGED.reason
+    assert result.event.what_we_saw["still_wedged"] == [WEDGED_UUID]
+
+
+@pytest.mark.asyncio
+async def test_verdict_comes_from_the_card_not_the_cure_exit_code(context_factory):
+    """A failed cure command with a clean re-query still passes — the card is the truth."""
+    runner = _mock_runner(requery_gpu_csv=f"{WEDGED_UUID}, 0, 0\n", cure_exit_code=1)
+    state = build_state(gpu_details=[_wedged_detail()], gpu_processes=[])
+    ctx = context_factory(services=build_services(), config=build_context_config(), state=state, runner=runner)
+
+    result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.GPU_WEDGE_CURED.reason
+    assert result.event.what_we_saw["cure_results"][0].exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_no_commands_when_no_ghost_signature(context_factory):
+    runner = _mock_runner()
+    state = build_state(
+        gpu_details=[{"uuid": HEALTHY_UUID, "gpu_utilization": 0, "memory_utilization": 0}],
+        gpu_processes=[],
+    )
+    ctx = context_factory(services=build_services(), config=build_context_config(), state=state, runner=runner)
+
+    result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.USAGE_OK.reason
+    runner.run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_wedge_signature_with_processes_keeps_legacy_path(context_factory):
+    runner = _mock_runner()
+    state = build_state(gpu_details=[_wedged_detail()], gpu_processes=[{"pid": 1234, "name": "python"}])
+    ctx = context_factory(services=build_services(), config=build_context_config(), state=state, runner=runner)
+
+    result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.USAGE_HIGH.reason
+    runner.run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_only_the_ghost_uuid_is_cured_on_a_mixed_host(context_factory):
+    runner = _mock_runner(requery_gpu_csv=f"{WEDGED_UUID}, 0, 0\n{HEALTHY_UUID}, 0, 0\n")
+    state = build_state(
+        gpu_details=[
+            _wedged_detail(),
+            {"uuid": HEALTHY_UUID, "gpu_utilization": 0, "memory_utilization": 0},
+        ],
+        gpu_processes=[],
+    )
+    ctx = context_factory(services=build_services(), config=build_context_config(), state=state, runner=runner)
+
+    await GpuUsageCheck().run(ctx)
+
+    cure_commands = [cmd for cmd in _commands(runner) if cmd.startswith(CURE_PREFIX)]
+    assert len(cure_commands) == 1
+    assert WEDGED_UUID in cure_commands[0]
+    assert not any(HEALTHY_UUID in cmd for cmd in cure_commands)
+
+
+@pytest.mark.asyncio
+async def test_dry_run_detects_ghost_without_curing(context_factory):
+    runner = _mock_runner()
+    state = build_state(gpu_details=[_wedged_detail()], gpu_processes=[])
+    ctx = context_factory(services=build_services(), config=build_context_config(), state=state, runner=runner)
+
+    result = await GpuUsageCheck(dry_run=True).run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.GPU_WEDGED.reason
+    assert result.event.what_we_saw["cure_attempted"] is False
+    runner.run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unexpected_error_falls_back_to_the_usage_guard(context_factory):
+    runner = MagicMock()
+    runner.run = AsyncMock(side_effect=RuntimeError("ssh exploded"))
+    state = build_state(gpu_details=[_wedged_detail()], gpu_processes=[])
+    ctx = context_factory(services=build_services(), config=build_context_config(), state=state, runner=runner)
+
+    result = await GpuUsageCheck().run(ctx)
+
+    # Detection is an addition to the process guard — its failure must not break validation.
+    assert result.passed is True
+    assert result.event.reason_code == Msg.USAGE_OK.reason
+
+
+@pytest.mark.asyncio
+async def test_ghost_event_payload_serializes_to_json(context_factory):
+    runner = _mock_runner(requery_gpu_csv=f"{WEDGED_UUID}, 0, 0\n")
+    state = build_state(gpu_details=[_wedged_detail()], gpu_processes=[])
+    ctx = context_factory(services=build_services(), config=build_context_config(), state=state, runner=runner)
+
+    result = await GpuUsageCheck().run(ctx)
+
+    dumped = result.event.model_dump(mode="json")["what_we_saw"]
+    assert dumped["wedged_gpus"][0]["gpu_uuid"] == WEDGED_UUID
+    assert dumped["cure_results"][0]["gpu_uuid"] == WEDGED_UUID
+    assert dumped["still_wedged"] == []

--- a/neurons/validators/tests/test_gpu_wedge_teardown_sweep.py
+++ b/neurons/validators/tests/test_gpu_wedge_teardown_sweep.py
@@ -1,0 +1,139 @@
+"""DAH-2427: post-teardown wedged-GPU sweep in DockerService.delete_container."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from neurons.validators.src.services.docker_service import (
+    _sweep_wedged_gpus_after_teardown,
+)
+from neurons.validators.src.services.gpu_wedge import parse_wedged_gpu_uuids
+
+WEDGED_UUID = "GPU-bdf72357-83a7-09d3-9809-729c734aa80a"
+HEALTHY_UUID = "GPU-dde887f6-488b-085f-a7b0-a71557f3e330"
+
+
+def test_parse_picks_only_the_wedge_signature():
+    gpu_csv = f"{WEDGED_UUID}, 100, 0\n{HEALTHY_UUID}, 0, 0\nGPU-aaaa, 100, 40000\n"
+
+    assert parse_wedged_gpu_uuids(gpu_csv, "") == [WEDGED_UUID]
+
+
+def test_parse_skips_host_with_live_compute_apps():
+    gpu_csv = f"{WEDGED_UUID}, 100, 0\n"
+
+    assert parse_wedged_gpu_uuids(gpu_csv, "12345\n") == []
+
+
+def test_parse_tolerates_garbage_lines():
+    gpu_csv = "not-a-gpu-line\nGPU-bbbb, N/A, N/A\n"
+
+    assert parse_wedged_gpu_uuids(gpu_csv, "") == []
+
+
+def _ssh_result(stdout: str) -> MagicMock:
+    return MagicMock(stdout=stdout, stderr="", exit_status=0)
+
+
+@pytest.mark.asyncio
+async def test_sweep_cures_wedged_gpu(monkeypatch):
+    monkeypatch.setattr(
+        "neurons.validators.src.services.docker_service.GPU_WEDGE_SWEEP_SETTLE_SECONDS", 0
+    )
+    responses = {
+        "nvidia-smi --query-gpu": _ssh_result(f"{WEDGED_UUID}, 100, 0\n{HEALTHY_UUID}, 0, 0\n"),
+        "nvidia-smi --query-compute-apps": _ssh_result(""),
+        "CUDA_VISIBLE_DEVICES=": _ssh_result("ctx open/close OK"),
+    }
+
+    async def fake_run(cmd: str):
+        for prefix, result in responses.items():
+            if cmd.startswith(prefix):
+                return result
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    ssh_client = MagicMock()
+    ssh_client.run = AsyncMock(side_effect=fake_run)
+    log = MagicMock()
+
+    await _sweep_wedged_gpus_after_teardown(ssh_client, log)
+
+    commands = [call.args[0] for call in ssh_client.run.await_args_list]
+    assert not any("pkill" in cmd or "nvidia-smi -i" in cmd for cmd in commands)
+    assert any(f"CUDA_VISIBLE_DEVICES={WEDGED_UUID}" in cmd and "cuCtxCreate" in cmd for cmd in commands)
+    assert not any(f"CUDA_VISIBLE_DEVICES={HEALTHY_UUID}" in cmd for cmd in commands)
+
+
+@pytest.mark.asyncio
+async def test_sweep_is_a_noop_on_healthy_gpus(monkeypatch):
+    monkeypatch.setattr(
+        "neurons.validators.src.services.docker_service.GPU_WEDGE_SWEEP_SETTLE_SECONDS", 0
+    )
+
+    async def fake_run(cmd: str):
+        if cmd.startswith("nvidia-smi --query-gpu"):
+            return _ssh_result(f"{HEALTHY_UUID}, 0, 0\n")
+        if cmd.startswith("nvidia-smi --query-compute-apps"):
+            return _ssh_result("")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    ssh_client = MagicMock()
+    ssh_client.run = AsyncMock(side_effect=fake_run)
+
+    await _sweep_wedged_gpus_after_teardown(ssh_client, MagicMock())
+
+    commands = [call.args[0] for call in ssh_client.run.await_args_list]
+    assert not any("pkill" in cmd or "CUDA_VISIBLE_DEVICES" in cmd for cmd in commands)
+
+
+@pytest.mark.asyncio
+async def test_sweep_skips_the_settle_wait_when_nothing_looks_wedged():
+    """The common healthy teardown must pay one cheap query pair and no settle wait."""
+    slept: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    async def fake_run(cmd: str):
+        if cmd.startswith("nvidia-smi --query-gpu"):
+            return _ssh_result(f"{HEALTHY_UUID}, 0, 0\n")
+        if cmd.startswith("nvidia-smi --query-compute-apps"):
+            return _ssh_result("")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    ssh_client = MagicMock()
+    ssh_client.run = AsyncMock(side_effect=fake_run)
+
+    with patch("neurons.validators.src.services.docker_service.asyncio.sleep", fake_sleep):
+        await _sweep_wedged_gpus_after_teardown(ssh_client, MagicMock())
+
+    assert slept == []
+    assert ssh_client.run.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_sweep_does_not_reset_a_card_that_settles_by_itself(monkeypatch):
+    """A workload caught mid-exit looks wedged at t=0; the second sample must clear it."""
+    monkeypatch.setattr(
+        "neurons.validators.src.services.docker_service.GPU_WEDGE_SWEEP_SETTLE_SECONDS", 0
+    )
+    gpu_query_results = iter(
+        [
+            _ssh_result(f"{WEDGED_UUID}, 100, 0\n"),
+            _ssh_result(f"{WEDGED_UUID}, 0, 0\n"),
+        ]
+    )
+
+    async def fake_run(cmd: str):
+        if cmd.startswith("nvidia-smi --query-gpu"):
+            return next(gpu_query_results)
+        if cmd.startswith("nvidia-smi --query-compute-apps"):
+            return _ssh_result("")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    ssh_client = MagicMock()
+    ssh_client.run = AsyncMock(side_effect=fake_run)
+
+    await _sweep_wedged_gpus_after_teardown(ssh_client, MagicMock())
+
+    commands = [call.args[0] for call in ssh_client.run.await_args_list]
+    assert not any("pkill" in cmd or "CUDA_VISIBLE_DEVICES" in cmd for cmd in commands)

--- a/neurons/validators/tests/test_verifyx_validation_service.py
+++ b/neurons/validators/tests/test_verifyx_validation_service.py
@@ -100,3 +100,21 @@ async def test_nonzero_exit_with_nonempty_stdout_classified_as_executor_crash(ca
     assert result.diagnostics["exit_status"] == 1
     # stdout_len is reported against the raw stdout bytes/chars, not the stripped length.
     assert result.diagnostics["stdout_len"] == len(partial_stdout)
+
+
+@pytest.mark.asyncio
+async def test_run_ssh_command_is_bounded_by_the_hard_timeout():
+    """DAH-2427/DAH-2365: a hung verifyx run must be cut off, not hold its CUDA context forever."""
+    from unittest.mock import AsyncMock
+
+    from neurons.validators.src.services import verifyx_validation_service as vvs
+
+    run = AsyncMock(return_value=SimpleNamespace(stdout="ok", stderr="", exit_status=0))
+    shell = SimpleNamespace(ssh_client=SimpleNamespace(run=run))
+    service = vvs.VerifyXValidationService.__new__(vvs.VerifyXValidationService)
+
+    await service._run_ssh_command(shell, "python verifyx_executor.py")
+
+    run.assert_awaited_once_with(
+        "python verifyx_executor.py", timeout=vvs.VERIFYX_COMMAND_TIMEOUT_SECONDS
+    )


### PR DESCRIPTION
## Describe your changes

Fixes the "ghost GPU" blind spot: a hard-killed GPU process leaves an orphaned CUDA kernel that pins the card at 100% utilization with 0 MiB and no process — and today the validator neither notices nor heals it, so the card keeps being offered to renters for days (postmortem, Jul 15: GPU 1 on 4db213a4 / 204.9.206.20 sat pinned for 9 days; GPUs 4-5 on ee0cdd5f / 204.9.206.18 still pinned; plus a 6-card wave on 6e062ec9 after a DPHN teardown).

Root cause chain (three links, this PR closes the first two):

- **(a) Source** — an abruptly killed GPU workload (failed PEARL create force-removed via `docker rm -fv`, a rental-stop force-remove, a DPHN teardown, or a hung verifyx run) leaves its kernel behind. Confirmed via `filler_run` 00ded466-af1a-4648-84af-80ebb782c87b + 15-min GPU snapshots + connector logs.
- **(b) Survival** — the driver keeps the kernel resident forever; `verifyx_executor.py` releases its native CUDA context only in `__del__`, and `gpus_utility.py` holds an NVML handle that makes `nvidia-smi -r` refuse with "in use by another client".
- **(c) Blindness** — `GpuUsageCheck._find_violation` returns `None` on an empty `gpu_processes` list, so a ghost's 100% utilization is recorded every cycle and never compared against the 5% limit.

### Layer A — detection + recovery (`gpu_usage.py`, `gpu_wedge.py`)

- `GpuUsageCheck` no longer requires processes to flag a card. Stateless (review feedback): the signature (utilization >= 95%, memory <= 1%, empty process list) triggers the cure immediately — a clean CUDA context create/destroy cycle per wedged UUID (shared in `services/gpu_wedge.py`) — and the verdict comes from re-sampling the live card: clean -> the check passes and the node stays online (`GPU_WEDGE_CURED`); still latched -> fatal fail, node leaves the pool (`GPU_WEDGED`). No Redis, no timers, no cross-cycle state. The context cycle replaced the original `pkill` + `nvidia-smi -r` after review evidence showed `-r` is refused on ~45% of the Blackwell fleet and the pkill only worked against a leaked NVML fd; the cure needs no root, tolerates concurrent NVML clients, and cleared 11/11 latched cards in live tests. Source-agnostic — catches filler, rental and verifyx orphans alike.
- The dry-run pipeline builds the check with `recover_wedged_gpus=False`: it detects and reports but never mutates the executor.

### Layer B — stop leaving kernels behind

- **verifyx**: the validator-side hard timeout landed on main first via DAH-2365 (`VERIFYX_COMMAND_TIMEOUT_SECONDS = 600`, native asyncssh `timeout=`) — this branch merged it and dropped its own duplicate. What this PR adds on top: `verifyx_executor.py` releases the native context in `try/finally` and on SIGTERM/SIGINT/SIGHUP (channel close on timeout delivers SIGHUP), instead of relying on `__del__`.
- **filler teardown**: `delete_container` runs a best-effort wedged-GPU sweep after the forced removal — on the success path and on the failed-remove path (what backend records as FAILED / STOP_FAILED). The sweep no-ops while any live compute app exists on the host.

Layer C from the postmortem (hardening `gpus_utility.py` timeouts/watchdog + hung-monitor restart in `start_gpu_monitor.py`) is follow-up scope tracked in the ticket, not in this PR.

Recovery runbook change: no reboot, no miner, no root needed — a CUDA context open/close on the latched card clears the counter (`CUDA_VISIBLE_DEVICES=<uuid> python3` + cuInit/cuCtxCreate/cuCtxDestroy). Also hardened: all executor-side NVML init/shutdown blocks are now try/finally, so a scrape exception can no longer leak the fd that blocks per-GPU maintenance.

## Issue ticket number and link

[DAH-2427 Ghost GPUs: detect and auto-recover orphaned CUDA kernels](https://app.notion.com/p/39eb8bfdbde98129b854d47d079d0ce9)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [x] Need to take care of performance? (detection adds one Redis hash read/write per idle cycle; the teardown sweep adds ~5s settle + two parallel nvidia-smi queries per filler delete)



