### PR TITLE
DAH-2419: capture worker log when a Lium filler is up but not mining (non-fatal diagnostic)

### DIFF
--- a/neurons/validators/src/services/task/checks/__init__.py
+++ b/neurons/validators/src/services/task/checks/__init__.py
@@ -4,6 +4,7 @@ from .capability import CapabilityCheck
 from .collateral import CollateralCheck
 from .custom_build_orphan_sweep import CustomBuildOrphanSweepCheck
 from .duplicate_executor import DuplicateExecutorCheck
+from .filler_mining_health import FillerMiningHealthCheck
 from .finalize import FinalizeCheck
 from .gpu_count import GpuCountCheck
 from .gpu_fingerprint import GpuFingerprintCheck
@@ -34,6 +35,7 @@ __all__ = [
     "CollateralCheck",
     "CustomBuildOrphanSweepCheck",
     "DuplicateExecutorCheck",
+    "FillerMiningHealthCheck",
     "FinalizeCheck",
     "GpuCountCheck",
     "GpuFingerprintCheck",

--- a/neurons/validators/src/services/task/checks/filler_mining_health.py
+++ b/neurons/validators/src/services/task/checks/filler_mining_health.py
@@ -72,8 +72,8 @@ class FillerMiningHealthCheck:
         key = _CAPTURE_KEY.format(executor_id=ctx.executor.uuid)
         now = datetime.now(timezone.utc).timestamp()
         try:
-            last = await ctx.services.redis.get(key)
-            if last is not None and now - float(last) < _CAPTURE_COOLDOWN_SECONDS:
+            last_capture = await ctx.services.redis.get(key)
+            if last_capture is not None and now - float(last_capture) < _CAPTURE_COOLDOWN_SECONDS:
                 return False
             await ctx.services.redis.set(key, str(now))
         except Exception:
@@ -82,6 +82,4 @@ class FillerMiningHealthCheck:
 
 
 def _filler_holds_gpu(filler_container: str, gpu_processes: list[dict]) -> bool:
-    # Mining => the filler container is the process actually holding the GPU. If no GPU process belongs
-    # to it (dead worker, or a firmware-wedged card whose process is already gone), it isn't mining.
     return any(process.get("container_name") == filler_container for process in gpu_processes)

--- a/neurons/validators/src/services/task/checks/filler_mining_health.py
+++ b/neurons/validators/src/services/task/checks/filler_mining_health.py
@@ -1,0 +1,87 @@
+from datetime import datetime, timezone
+
+from core.docker_utils import collect_container_death_diagnostics
+from core.utils import _m, get_extra_info, get_logger
+
+from ..messages import FillerMiningHealthMessages as Msg
+from ..messages import render_message
+from ..pipeline import CheckResult, Context
+
+logger = get_logger(__name__)
+
+# A wedge persists for hours and collect_container_death_diagnostics SSHes into the miner host, so we
+# snap the worker log at most once per this window per executor rather than every validation cycle.
+_CAPTURE_COOLDOWN_SECONDS = 3600
+_CAPTURE_KEY = "filler_mining_health:last_capture:{executor_id}"
+
+
+class FillerMiningHealthCheck:
+    """Diagnostic (non-fatal): when a Lium filler is RUNNING but the GPU shows it isn't actually
+    mining (dead worker, or a firmware-wedged card the worker no longer holds), snap the worker's
+    `docker logs` so the in-container failure — which lives on the miner host, not in our logs — is
+    captured in Loki. NEVER fails the miner: `passed` is always True and `fatal` is False.
+    """
+
+    check_id = "filler.mining.health"
+    fatal = False
+
+    async def run(self, ctx: Context) -> CheckResult:
+        rented_data = ctx.state.rented_data
+        filler_container = rented_data.get_filler_container(ctx.executor.uuid) if rented_data else None
+        if not filler_container:
+            return CheckResult(passed=True, event=render_message(Msg.NO_FILLER, ctx=ctx, check_id=self.check_id))
+
+        if _filler_holds_gpu(filler_container, ctx.state.gpu_processes):
+            return CheckResult(passed=True, event=render_message(Msg.MINING_OK, ctx=ctx, check_id=self.check_id))
+
+        captured = await self._capture_worker_log(ctx, filler_container)
+        return CheckResult(
+            passed=True,
+            event=render_message(
+                Msg.NOT_MINING,
+                ctx=ctx,
+                check_id=self.check_id,
+                what={"filler_container": filler_container, "log_captured": captured},
+            ),
+        )
+
+    async def _capture_worker_log(self, ctx: Context, container: str) -> bool:
+        if not await self._claim_capture_slot(ctx):
+            return False
+        try:
+            diagnostics = await collect_container_death_diagnostics(ctx.ssh, container)
+        except Exception as exc:  # a diagnostics failure must never fail the pipeline
+            logger.warning(
+                _m(
+                    "Filler mining-health: worker log capture failed",
+                    extra=get_extra_info({**ctx.default_extra, "container": container, "error": str(exc)}),
+                )
+            )
+            return False
+        logger.warning(
+            _m(
+                "Filler running but not mining — worker diagnostics",
+                extra=get_extra_info({**ctx.default_extra, "container": container} | diagnostics.to_log_fields()),
+            )
+        )
+        return True
+
+    async def _claim_capture_slot(self, ctx: Context) -> bool:
+        # Rate-limit per executor via a stored timestamp (the RedisService wrapper has no TTL set). A
+        # redis hiccup must never block or fail the check, so on any error we skip the capture.
+        key = _CAPTURE_KEY.format(executor_id=ctx.executor.uuid)
+        now = datetime.now(timezone.utc).timestamp()
+        try:
+            last = await ctx.services.redis.get(key)
+            if last is not None and now - float(last) < _CAPTURE_COOLDOWN_SECONDS:
+                return False
+            await ctx.services.redis.set(key, str(now))
+        except Exception:
+            return False
+        return True
+
+
+def _filler_holds_gpu(filler_container: str, gpu_processes: list[dict]) -> bool:
+    # Mining => the filler container is the process actually holding the GPU. If no GPU process belongs
+    # to it (dead worker, or a firmware-wedged card whose process is already gone), it isn't mining.
+    return any(process.get("container_name") == filler_container for process in gpu_processes)

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -690,6 +690,31 @@ class GpuUsageMessages:
     )
 
 
+class FillerMiningHealthMessages:
+    NO_FILLER = MessageTemplate(
+        event="No Lium filler on executor",
+        reason="FILLER_MINING_HEALTH_NO_FILLER",
+        severity="info",
+        category="runtime",
+        impact="Proceed",
+    )
+    MINING_OK = MessageTemplate(
+        event="Lium filler is holding the GPU",
+        reason="FILLER_MINING_HEALTH_OK",
+        severity="info",
+        category="runtime",
+        impact="Proceed",
+    )
+    NOT_MINING = MessageTemplate(
+        event="Lium filler running but not mining",
+        reason="FILLER_MINING_HEALTH_NOT_MINING",
+        severity="warning",
+        category="runtime",
+        # Diagnostic only — never fails the miner or changes score.
+        impact="Diagnostic: worker log captured for investigation",
+    )
+
+
 class PortConnectivityMessages:
     SKIPPED_RENTED = MessageTemplate(
         event="Port connectivity skipped for rented executor",

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -35,6 +35,7 @@ from .checks import (
     DuplicateExecutorCheck,
     FinalizeCheck,
     GpuCountCheck,
+    FillerMiningHealthCheck,
     GpuFingerprintCheck,
     GpuModelValidCheck,
     GpuPowerLimitCheck,
@@ -272,6 +273,9 @@ class PipelineFactory:
                 InspectorRentedCheck(),
                 TenantEnforcementCheck(),
                 GpuUsageCheck(),
+                # DAH-2419: non-fatal diagnostic — snaps the worker log when a filler is up but not
+                # holding the GPU (dead/wedged). Never changes score; runs after GPU usage is known.
+                FillerMiningHealthCheck(),
                 VerifyXCheck(),
                 TdxHostCheck(),
                 CapabilityCheck(),
@@ -326,6 +330,9 @@ class PipelineFactory:
                 SysboxRequiredCheck(),
                 TenantEnforcementCheck(),
                 GpuUsageCheck(),
+                # DAH-2419: non-fatal diagnostic — snaps the worker log when a filler is up but not
+                # holding the GPU (dead/wedged). Never changes score; runs after GPU usage is known.
+                FillerMiningHealthCheck(),
                 # VerifyXCheck(),
                 TdxHostCheck(),
                 CapabilityCheck(),

--- a/neurons/validators/tests/test_filler_mining_health_check.py
+++ b/neurons/validators/tests/test_filler_mining_health_check.py
@@ -1,0 +1,90 @@
+"""Tests for FillerMiningHealthCheck (DAH-2419).
+
+Non-fatal diagnostic: when a Lium filler is RUNNING but not holding the GPU (dead worker / firmware
+wedge), snap the worker log. It must NEVER fail the miner and must rate-limit the SSH log capture.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from helpers import build_services, build_state, default_executor, make_context
+from neurons.validators.src.services.task.checks import FillerMiningHealthCheck, filler_mining_health
+
+from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
+
+FILLER = "filler_abc123"
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    async def get(self, key: str):
+        return self.store.get(key)
+
+    async def set(self, key: str, value: str) -> None:
+        self.store[key] = value
+
+
+def _ctx(*, gpu_processes=None, has_filler: bool = True):
+    executor = default_executor()
+    rented = RentedExecutorsResponse(
+        executors={},
+        filler_containers_by_executor={str(executor.uuid): FILLER} if has_filler else {},
+    )
+    state = build_state(rented_data=rented, gpu_processes=gpu_processes or [])
+    services = build_services(redis=FakeRedis())
+    return make_context(executor=executor, services=services, state=state, ssh="ssh-sentinel")
+
+
+def test_check_is_non_fatal() -> None:
+    assert FillerMiningHealthCheck().fatal is False
+
+
+@pytest.mark.asyncio
+async def test_no_filler_passes_without_capture(monkeypatch) -> None:
+    capture = AsyncMock()
+    monkeypatch.setattr(filler_mining_health, "collect_container_death_diagnostics", capture)
+    result = await FillerMiningHealthCheck().run(_ctx(has_filler=False))
+    assert result.passed is True
+    capture.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_filler_holding_gpu_is_ok_no_capture(monkeypatch) -> None:
+    capture = AsyncMock()
+    monkeypatch.setattr(filler_mining_health, "collect_container_death_diagnostics", capture)
+    result = await FillerMiningHealthCheck().run(_ctx(gpu_processes=[{"container_name": FILLER}]))
+    assert result.passed is True
+    capture.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_filler_not_on_gpu_captures_worker_log(monkeypatch) -> None:
+    diag = SimpleNamespace(to_log_fields=lambda: {"container_logs_tail": "OOM during model load"})
+    capture = AsyncMock(return_value=diag)
+    monkeypatch.setattr(filler_mining_health, "collect_container_death_diagnostics", capture)
+    # Nothing from the filler is on the GPU (dead / firmware-wedged) → capture, but still passes.
+    result = await FillerMiningHealthCheck().run(_ctx(gpu_processes=[]))
+    assert result.passed is True
+    capture.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_capture_is_rate_limited(monkeypatch) -> None:
+    capture = AsyncMock(return_value=SimpleNamespace(to_log_fields=lambda: {}))
+    monkeypatch.setattr(filler_mining_health, "collect_container_death_diagnostics", capture)
+    ctx = _ctx(gpu_processes=[])
+    check = FillerMiningHealthCheck()
+    await check.run(ctx)
+    await check.run(ctx)  # same executor within the cooldown → second capture suppressed
+    capture.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_failure_still_passes(monkeypatch) -> None:
+    capture = AsyncMock(side_effect=RuntimeError("ssh dropped"))
+    monkeypatch.setattr(filler_mining_health, "collect_container_death_diagnostics", capture)
+    result = await FillerMiningHealthCheck().run(_ctx(gpu_processes=[]))
+    assert result.passed is True  # a capture failure never fails the miner


### PR DESCRIPTION
## Problem

A Lium filler can be RUNNING while the GPU shows it isn't mining — a dead worker, or a firmware-wedged card the worker no longer holds (100% util, 0 MiB, no process). The **why** lives in the worker's own logs, which run in a container on the miner's host and never reach our Loki. So today we can't see the in-container failure (OOM / Triton-JIT / bad model download).

## What this adds

A new **non-fatal** pipeline check `FillerMiningHealthCheck`: when a node has a Lium filler but no GPU process belongs to that filler, it snaps the worker's `docker logs` over the already-open SSH session and logs them to Loki (`Filler running but not mining — worker diagnostics`, flat fields via `to_log_fields()`).

Reuses `collect_container_death_diagnostics` (DAH-2395) — it reads `docker inspect` + logs tail; on a **live** wedge container that tail is the worker's recent output.

## Safety (strictly diagnostic)

- `fatal = False`, `passed` **always True** — never fails a check, never changes a miner's score.
- SSH log capture is **rate-limited to once per hour per executor** (a wedge persists for hours; we must not SSH every cycle).
- Any capture/redis error folds to "skip", never raises into the pipeline.
- No-ops when there's no filler (rented nodes) — returns before any SSH.

## Scope / limitation

Detects the strategy-agnostic cases: **dead worker** and **firmware wedge** (filler present but not on the GPU). It does **not** catch a partial-load DPHN (vLLM present but only ~14 GB of the ~70 GB model loaded) — that needs the filler's strategy, which the validator doesn't receive today (`filler_containers_by_executor` carries only the container name). Follow-up: add strategy to that map to enable the per-strategy VRAM threshold.

## Relation

Same ticket as the backend self-heal (lium-io-backend#767): the backend classifies + acts on not-mining fillers; this validator side captures the *cause* from the worker log. Complements the RTX PRO 6000 firmware-wedge work (v1.238 driver gate) by surfacing the in-container failures the gate doesn't explain.

## Tests

`test_filler_mining_health_check.py` — non-fatal, no-filler no-op, filler-on-GPU OK (no capture), not-on-GPU captures, rate-limit suppresses the second capture, diagnostics failure still passes. 6 pass (+ neighbouring pipeline tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)