### PR TITLE
DAH-2431, executor auto-cure for ghost GPU util latch (Blackwell)

### DIFF
--- a/neurons/executor/src/gpu_ghost_cure.py
+++ b/neurons/executor/src/gpu_ghost_cure.py
@@ -1,0 +1,211 @@
+"""Ghost GPU cure: clear the Blackwell GSP "engine busy" utilization latch (DAH-2431).
+
+A ghost GPU reads 100% utilization with ~0 MiB used and zero compute processes
+after a process died while a CUDA kernel was executing. The latch is
+telemetry-only (no performance impact for renters) but it makes idle Blackwell
+GPUs look busy for days. It is cleared by opening and cleanly closing a CUDA
+context on the affected GPU from a fresh process.
+
+This module is self-contained (stdlib + libcuda.so via ctypes, no nvcc, no
+pynvml): the trivial kernel ships as PTX and is JIT-compiled by the driver, so
+the same file works on any GPU architecture and can also be copied to a host
+and run standalone.
+
+Usage:
+- as a script: detects ghost GPUs via nvidia-smi and cures each one
+  (each cure runs in a child process — the clean process exit is part of
+  the verified cure recipe);
+- as a subprocess payload: GHOST_CURE_UUID=<gpu-uuid> python3 gpu_ghost_cure.py
+- from code (executor watchdog): detect_ghosts() + spawn_cure(uuid).
+
+Env knobs (testing):
+- GHOST_CURE_MODE=ctx|kernel  (default kernel; ctx = context create/destroy only)
+- GHOST_CURE_SECONDS=2.0      (wall-clock of kernel activity)
+"""
+
+import ctypes
+import logging
+import os
+import subprocess
+import sys
+import time
+
+logger = logging.getLogger(__name__)
+
+CUDA_SUCCESS = 0
+GHOST_UTIL_MIN = 99
+GHOST_MEM_MIB_MAX = 8
+CURE_KERNEL_SECONDS_DEFAULT = 2.0
+
+# Trivial FMA spin kernel as PTX (sm_75 baseline, JIT-compiled forward by the driver).
+_SPIN_PTX = b"""
+.version 7.0
+.target sm_75
+.address_size 64
+
+.visible .entry spin(
+    .param .u64 pbuf,
+    .param .u32 iters
+)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<4>;
+    .reg .f32 %f<3>;
+    .reg .b64 %rd<3>;
+
+    ld.param.u64 %rd1, [pbuf];
+    cvta.to.global.u64 %rd2, %rd1;
+    ld.param.u32 %r1, [iters];
+    mov.u32 %r2, 0;
+    mov.f32 %f1, 0f3F800000;
+
+$L__loop:
+    fma.rn.f32 %f1, %f1, 0f3F7FFFF0, 0f3DCCCCCD;
+    add.s32 %r2, %r2, 1;
+    setp.lt.u32 %p1, %r2, %r1;
+    @%p1 bra $L__loop;
+
+    st.global.f32 [%rd2], %f1;
+    ret;
+}
+\x00"""
+
+
+class CudaError(RuntimeError):
+    pass
+
+
+def _check(lib: ctypes.CDLL, res: int, what: str) -> None:
+    if res != CUDA_SUCCESS:
+        msg = ctypes.c_char_p()
+        lib.cuGetErrorString(res, ctypes.byref(msg))
+        detail = msg.value.decode() if msg.value else "?"
+        raise CudaError(f"{what} failed: CUresult={res} ({detail})")
+
+
+def _cuda_device_by_uuid(lib: ctypes.CDLL, gpu_uuid: str) -> int:
+    # resolve an NVML-style uuid ("GPU-8c6b85ff-...") to a CUDA device ordinal
+    want = gpu_uuid.lower().removeprefix("gpu-").replace("-", "")
+    count = ctypes.c_int()
+    _check(lib, lib.cuDeviceGetCount(ctypes.byref(count)), "cuDeviceGetCount")
+    for i in range(count.value):
+        dev = ctypes.c_int()
+        _check(lib, lib.cuDeviceGet(ctypes.byref(dev), i), "cuDeviceGet")
+        raw = (ctypes.c_ubyte * 16)()
+        _check(lib, lib.cuDeviceGetUuid(ctypes.byref(raw), dev), "cuDeviceGetUuid")
+        if bytes(raw).hex() == want:
+            return dev.value
+    raise CudaError(f"no CUDA device with uuid {gpu_uuid}")
+
+
+def cure_gpu(
+    gpu_uuid: str, mode: str = "kernel", seconds: float = CURE_KERNEL_SECONDS_DEFAULT
+) -> None:
+    # open a clean CUDA context on the latched GPU, optionally spin a kernel, tear down cleanly
+    lib = ctypes.CDLL("libcuda.so.1")
+    _check(lib, lib.cuInit(0), "cuInit")
+    dev = _cuda_device_by_uuid(lib, gpu_uuid)
+
+    ctx = ctypes.c_void_p()
+    _check(lib, lib.cuCtxCreate_v2(ctypes.byref(ctx), 0, dev), "cuCtxCreate_v2")
+    try:
+        if mode == "kernel":
+            module = ctypes.c_void_p()
+            _check(
+                lib,
+                lib.cuModuleLoadData(ctypes.byref(module), ctypes.c_char_p(_SPIN_PTX)),
+                "cuModuleLoadData",
+            )
+            func = ctypes.c_void_p()
+            _check(lib, lib.cuModuleGetFunction(ctypes.byref(func), module, b"spin"), "cuModuleGetFunction")
+
+            dptr = ctypes.c_uint64()
+            _check(lib, lib.cuMemAlloc_v2(ctypes.byref(dptr), 16 * 1024 * 1024), "cuMemAlloc_v2")
+
+            iters = ctypes.c_uint32(500_000)
+            params = (ctypes.c_void_p * 2)(
+                ctypes.cast(ctypes.byref(dptr), ctypes.c_void_p),
+                ctypes.cast(ctypes.byref(iters), ctypes.c_void_p),
+            )
+            deadline = time.monotonic() + seconds
+            launches = 0
+            while time.monotonic() < deadline:
+                _check(
+                    lib,
+                    lib.cuLaunchKernel(func, 2048, 1, 1, 256, 1, 1, 0, None, params, None),
+                    "cuLaunchKernel",
+                )
+                _check(lib, lib.cuCtxSynchronize(), "cuCtxSynchronize")
+                launches += 1
+            logger.info("cure kernel done: %d launches in %.1fs", launches, seconds)
+
+            _check(lib, lib.cuMemFree_v2(dptr), "cuMemFree_v2")
+            _check(lib, lib.cuModuleUnload(module), "cuModuleUnload")
+    finally:
+        _check(lib, lib.cuCtxDestroy_v2(ctx), "cuCtxDestroy_v2")
+
+
+def _smi(args: list[str]) -> list[list[str]]:
+    out = subprocess.run(
+        ["nvidia-smi", *args, "--format=csv,noheader,nounits"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=True,
+    ).stdout
+    return [
+        [cell.strip() for cell in line.split(",")] for line in out.strip().splitlines() if line.strip()
+    ]
+
+
+def detect_ghosts() -> list[str]:
+    # ghost = util pinned at >=99% with (almost) no memory and zero compute processes on that GPU
+    gpus = _smi(["--query-gpu=uuid,utilization.gpu,memory.used"])
+    busy_uuids = {row[0] for row in _smi(["--query-compute-apps=gpu_uuid"]) if row}
+    return [
+        uuid
+        for uuid, util, mem in gpus
+        if int(util) >= GHOST_UTIL_MIN and int(mem) <= GHOST_MEM_MIB_MAX and uuid not in busy_uuids
+    ]
+
+
+def spawn_cure(gpu_uuid: str, timeout: float = 30.0) -> bool:
+    # run the cure in a child process (clean process exit is part of the verified recipe),
+    # then re-check whether the GPU is still a ghost
+    env = os.environ | {"GHOST_CURE_UUID": gpu_uuid}
+    proc = subprocess.run(
+        [sys.executable, os.path.abspath(__file__)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        logger.error("cure subprocess failed for %s: %s", gpu_uuid, proc.stderr.strip())
+        return False
+    time.sleep(3)
+    return gpu_uuid not in detect_ghosts()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    mode = os.environ.get("GHOST_CURE_MODE", "kernel")
+    seconds = float(os.environ.get("GHOST_CURE_SECONDS", str(CURE_KERNEL_SECONDS_DEFAULT)))
+
+    payload_uuid = os.environ.get("GHOST_CURE_UUID")
+    if payload_uuid:
+        cure_gpu(payload_uuid, mode=mode, seconds=seconds)
+        return
+
+    ghosts = detect_ghosts()
+    if not ghosts:
+        logger.info("no ghost GPUs detected")
+        return
+    for uuid in ghosts:
+        logger.info("ghost GPU detected: %s — running cure (mode=%s)", uuid, mode)
+        cured = spawn_cure(uuid)
+        logger.info("cure result for %s: %s", uuid, "CLEARED" if cured else "STILL LATCHED")
+
+
+if __name__ == "__main__":
+    main()

--- a/neurons/executor/src/gpus_utility.py
+++ b/neurons/executor/src/gpus_utility.py
@@ -1,16 +1,20 @@
 import asyncio
 import logging
-import time
 import subprocess
+import time
+
 import aiohttp
 import click
-import pynvml
+import gpu_ghost_cure
 import psutil
-
+import pynvml
 from services.pull_lock import cache_pull_lock
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+GHOST_CONSECUTIVE_SAMPLES = 3
+GHOST_CURE_COOLDOWN_SECONDS = 600
 
 
 class GPUMetricsTracker:
@@ -286,6 +290,35 @@ async def manage_docker_images(
                 await asyncio.sleep(first_interval)
 
 
+async def ghost_watchdog(interval: int = 60):
+    # cure GPUs stuck in the Blackwell GSP utilization latch ("ghost GPU"): util pinned
+    # at 100% with ~0 MiB and zero processes, sustained across samples -> run a clean
+    # CUDA context open/close in a child process (see gpu_ghost_cure.py, DAH-2431)
+    streak: dict[str, int] = {}
+    last_cure: dict[str, float] = {}
+
+    while True:
+        try:
+            ghosts = await asyncio.to_thread(gpu_ghost_cure.detect_ghosts)
+            streak = {uuid: streak.get(uuid, 0) + 1 for uuid in ghosts}
+            for uuid, samples in streak.items():
+                if samples < GHOST_CONSECUTIVE_SAMPLES:
+                    continue
+                if time.time() - last_cure.get(uuid, 0.0) < GHOST_CURE_COOLDOWN_SECONDS:
+                    continue
+                logger.warning(
+                    f"Ghost GPU {uuid}: util latched for {samples} samples, running cure"
+                )
+                last_cure[uuid] = time.time()
+                cured = await asyncio.to_thread(gpu_ghost_cure.spawn_cure, uuid)
+                logger.warning(
+                    f"Ghost GPU {uuid}: cure result: {'CLEARED' if cured else 'STILL LATCHED'}"
+                )
+        except Exception as e:
+            logger.error(f"Ghost watchdog error: {e}")
+        await asyncio.sleep(interval)
+
+
 @click.command()
 @click.option("--program_id", prompt="Program ID", help="Program ID for monitoring")
 @click.option("--signature", prompt="Signature", help="Signature for verification")
@@ -306,7 +339,8 @@ def main(
             # scrape_gpu_metrics(
             #     interval, program_id, signature, executor_id, validator_hotkey, compute_rest_app_url
             # ),
-            manage_docker_images(compute_rest_app_url)
+            manage_docker_images(compute_rest_app_url),
+            ghost_watchdog(),
         )
 
     asyncio.run(run_all())

--- a/neurons/executor/tests/test_ghost_gpu_cure.py
+++ b/neurons/executor/tests/test_ghost_gpu_cure.py
@@ -1,0 +1,147 @@
+"""Ghost GPU auto-cure (DAH-2431): detection signature and watchdog behavior.
+
+A "ghost" GPU reads 100% utilization with ~0 MiB used and zero compute
+processes (Blackwell GSP latch). The watchdog must cure only a sustained
+ghost signature and must never touch a GPU that owns processes or memory.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import gpu_ghost_cure
+import gpus_utility
+
+GHOST_UUID = "GPU-8c6b85ff-2c93-6b26-8802-8b3e93a9b1f5"
+BUSY_UUID = "GPU-1f6f4c6e-9b6a-4a0e-b1c2-3d4e5f607182"
+IDLE_UUID = "GPU-aa11bb22-cc33-dd44-ee55-ff6677889900"
+
+
+def _fake_smi(gpu_rows, compute_app_rows):
+    def fake(args):
+        if args[0].startswith("--query-gpu"):
+            return gpu_rows
+        return compute_app_rows
+
+    return fake
+
+
+def test_detect_ghosts_flags_pinned_idle_gpu(monkeypatch):
+    # Arrange: one latched GPU, one genuinely idle GPU, no compute processes
+    gpu_rows = [[GHOST_UUID, "100", "1"], [IDLE_UUID, "0", "1"]]
+    monkeypatch.setattr(gpu_ghost_cure, "_smi", _fake_smi(gpu_rows, []))
+
+    # Act
+    ghosts = gpu_ghost_cure.detect_ghosts()
+
+    # Assert
+    assert ghosts == [GHOST_UUID]
+
+
+def test_detect_ghosts_ignores_gpu_with_compute_processes(monkeypatch):
+    # Arrange: 100% util and low memory, but a compute process owns the GPU
+    gpu_rows = [[BUSY_UUID, "100", "2"]]
+    monkeypatch.setattr(gpu_ghost_cure, "_smi", _fake_smi(gpu_rows, [[BUSY_UUID]]))
+
+    # Act
+    ghosts = gpu_ghost_cure.detect_ghosts()
+
+    # Assert
+    assert ghosts == []
+
+
+def test_detect_ghosts_ignores_gpu_with_memory_in_use(monkeypatch):
+    # Arrange: 100% util but real memory allocated (a working GPU, not a ghost)
+    gpu_rows = [[BUSY_UUID, "100", "40321"]]
+    monkeypatch.setattr(gpu_ghost_cure, "_smi", _fake_smi(gpu_rows, []))
+
+    # Act
+    ghosts = gpu_ghost_cure.detect_ghosts()
+
+    # Assert
+    assert ghosts == []
+
+
+def test_spawn_cure_reports_failure_when_child_exits_nonzero(monkeypatch):
+    # Arrange: the cure child process fails
+    monkeypatch.setattr(
+        gpu_ghost_cure.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=1, stderr="cuInit failed"),
+    )
+
+    # Act
+    cured = gpu_ghost_cure.spawn_cure(GHOST_UUID)
+
+    # Assert
+    assert cured is False
+
+
+def test_spawn_cure_rechecks_ghost_signature_after_child_success(monkeypatch):
+    # Arrange: child succeeds, re-check no longer sees the ghost
+    captured = {}
+
+    def fake_run(cmd, env=None, **kwargs):
+        captured["uuid"] = env["GHOST_CURE_UUID"]
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr(gpu_ghost_cure.subprocess, "run", fake_run)
+    monkeypatch.setattr(gpu_ghost_cure.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(gpu_ghost_cure, "detect_ghosts", lambda: [])
+
+    # Act
+    cured = gpu_ghost_cure.spawn_cure(GHOST_UUID)
+
+    # Assert
+    assert cured is True
+    assert captured["uuid"] == GHOST_UUID
+
+
+def _drive_watchdog(monkeypatch, tick_results, ticks_wanted):
+    # run ghost_watchdog with interval=0, feeding detect_ghosts one canned result per
+    # tick (last result repeats), until ticks_wanted samples were consumed;
+    # returns cure calls as (uuid, tick_number)
+    ticks = []
+    cures = []
+
+    def fake_detect():
+        result = tick_results[min(len(ticks), len(tick_results) - 1)]
+        ticks.append(result)
+        return result
+
+    def fake_cure(uuid):
+        cures.append((uuid, len(ticks)))
+        return True
+
+    monkeypatch.setattr(gpus_utility.gpu_ghost_cure, "detect_ghosts", fake_detect)
+    monkeypatch.setattr(gpus_utility.gpu_ghost_cure, "spawn_cure", fake_cure)
+
+    async def run():
+        task = asyncio.create_task(gpus_utility.ghost_watchdog(interval=0))
+        while len(ticks) < ticks_wanted:
+            await asyncio.sleep(0.01)
+        task.cancel()
+
+    asyncio.run(run())
+    return cures
+
+
+def test_ghost_watchdog_cures_only_after_sustained_signature(monkeypatch):
+    # Arrange: the ghost signature holds for 3 consecutive samples, then the cure clears it
+    tick_results = [[GHOST_UUID], [GHOST_UUID], [GHOST_UUID], []]
+
+    # Act
+    cures = _drive_watchdog(monkeypatch, tick_results, ticks_wanted=6)
+
+    # Assert: cure fired exactly once, on the third consecutive ghost sample
+    assert cures == [(GHOST_UUID, gpus_utility.GHOST_CONSECUTIVE_SAMPLES)]
+
+
+def test_ghost_watchdog_resets_streak_when_signature_clears(monkeypatch):
+    # Arrange: the signature never holds for 3 consecutive samples
+    tick_results = [[GHOST_UUID], [GHOST_UUID], [], [GHOST_UUID], [GHOST_UUID], []]
+
+    # Act
+    cures = _drive_watchdog(monkeypatch, tick_results, ticks_wanted=6)
+
+    # Assert
+    assert cures == []


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2431](https://www.notion.so/39fb8bfdbde9816893aae0ff4fc8718d)

---

## Problem

Blackwell GPUs (RTX PRO 6000 SE, RTX 5090, B200) can latch their reported utilization at 100% while fully idle: 0 MiB used, zero processes, ~100 W draw. The latch happens when a process dies while a CUDA kernel is executing (GSP "engine busy" counter latch, reproduced with ~86% hit rate on a test rig). It is silent (no Xid/dmesg), survives for days under persistence mode, and affects every driver branch we run (580.95 through 595.71).

Consequences in prod: idle GPUs look permanently busy, validators flag the node, and default-job gating (`KNOWN_GPU_DRIVER_WEDGES`) takes whole machines out of rotation. 9 wedged GPUs in prod as of 2026-07-16. Graceful container stop (DAH-2364) does not prevent it — any abrupt process death mid-kernel triggers it, including renter-side kills.

## Solution

Executor-side self-cure. The latch is telemetry-only and is cleared by opening and cleanly closing a CUDA context on the affected GPU from a fresh process — verified 9/9 on a rented RTX PRO 6000 SE rig (including a ctx-only open/close with no kernel).

A `ghost_watchdog()` loop in `gpus_utility.py` (already launched on every executor by the validator's `StartGpuMonitorCheck`) samples once a minute. If a GPU holds the ghost signature — util ≥ 99%, ≤ 8 MiB used, zero compute processes — for 3 consecutive samples, it runs the cure in a child process on that GPU (by UUID) and re-checks the result. 10-minute per-GPU cooldown.

False positives are structurally excluded: a real workload always owns processes/memory on the GPU, so a rented busy GPU can never match the signature.

## Changes

- New `neurons/executor/src/gpu_ghost_cure.py`: detection + cure, stdlib + ctypes on `libcuda.so.1` (PTX JIT, no nvcc/pynvml). Also runnable standalone on a host for manual cleanup.
- `neurons/executor/src/gpus_utility.py`: `ghost_watchdog()` coroutine added to `run_all()`.
- `neurons/executor/tests/test_ghost_gpu_cure.py`: detection signature, cure spawn/re-check, watchdog streak/cooldown behavior.

## Deployment Steps

Use GitHub Action. Ships with the next `executor-v*` tag; no config changes (executor compose already sets `NVIDIA_DRIVER_CAPABILITIES=all`, so `libcuda` is visible in the container).

## Review Request

- [x] Just code review

## Other PRs

None (validator-side ghost detection fix will be a separate PR).

## Risks

- The cure occupies the target GPU for ~2 s with a trivial kernel — only ever on GPUs matching the ghost signature (zero processes), so renters are unaffected.
- Watchdog overhead: two `nvidia-smi` queries per minute.
- A failed cure retries at most once per 10 minutes per GPU (cooldown), logged at WARN with the full GPU UUID for fleet-wide observability.

## Test Cases

### Test Case 1 — unit

**Actions**

`cd neurons/executor && pdm run pytest tests/ -v`

**Expected Output**

56 passed (7 new: detection signature, spawn/re-check semantics, watchdog fires only after 3 consecutive ghost samples, streak resets when the signature clears).

### Test Case 2 — live latch/cure (test rig)

**Actions**

On a rented RTX PRO 6000 Blackwell SE: latch the GPU by SIGKILL-ing a CUDA burn process mid-kernel, then run `python3 gpu_ghost_cure.py`.

**Expected Output**

Ghost detected by signature, cure child process runs, utilization returns to 0% (P8/~29 W) within seconds. Observed 9/9 across ctx-only, kernel-mode, and script self-detection trials.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
