### PR TITLE
DAH-2438 - Force-pass special manual rentals in the validator

### DIFF
--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -69,6 +69,18 @@ class NetworkEMA(BaseModel):
     ema_verifyx_upload_speed: float | None = None
 
 
+class ManualRentalInfo(BaseModel):
+    """Specs a special manual (bare-metal) rental is force-passed against.
+
+    A manually-rented node is never contacted, so these cannot be scraped — the backend sends
+    what the node was last verified to have, and it is the sole basis for the forced score.
+    Both fields are load-bearing: the incentive layer maps gpu_model to a total-count denominator
+    and multiplies by gpu_count, so a missing model or a zero count means zero emission.
+    """
+    gpu_model: str
+    gpu_count: int
+
+
 class RentedExecutorsResponse(BaseModel):
     """Response with executors dict and banned GUIDs."""
     executors: dict[str, RentedExecutor]  # key = executor_id
@@ -82,6 +94,10 @@ class RentedExecutorsResponse(BaseModel):
     # executor_id → "miner" | "lium"; absent = no default job. Parsed leniently as str for
     # forward-compatibility (a future owner value must not break parsing of the whole response).
     default_job_owner_by_executor: dict[str, str] = {}
+    # executor_id → specs to force-pass against. Present only for executors carrying a pod flagged
+    # as a special manual (bare-metal) rental. Defaults to empty so an older backend that omits the
+    # field force-passes nobody (fail-closed) rather than everybody.
+    manual_rental_executors: dict[str, ManualRentalInfo] = {}
 
     @field_validator("filler_containers_by_executor")
     @classmethod
@@ -97,6 +113,10 @@ class RentedExecutorsResponse(BaseModel):
 
     def get_default_job_owner(self, executor_uuid: str) -> str | None:
         return self.default_job_owner_by_executor.get(str(executor_uuid))
+
+    def get_manual_rental_info(self, executor_uuid: str) -> "ManualRentalInfo | None":
+        """Specs to force-pass this executor against, or None if it is not a manual rental."""
+        return self.manual_rental_executors.get(str(executor_uuid))
 
 
 class PodRentalActiveResponse(BaseModel):

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -62,6 +62,7 @@ from services.attestation_service import AttestationService
 from services.docker_service import DockerService
 from services.redis_service import MACHINE_SPEC_CHANNEL, RedisService
 from services.ssh_service import SSHService
+from incentive.config import BASE_GPU_MAP
 from services.task_service import TaskService, JobResult
 
 logger = logging.getLogger(__name__)
@@ -146,6 +147,11 @@ REST_SSH_SUBMIT_TIMEOUT = 30  # Timeout for SSH key submission requests
 REST_CONTAINER_OP_TIMEOUT = 30  # Timeout for container operations
 REST_POD_LOGS_TIMEOUT = 30  # Timeout for pod logs requests
 REST_SSH_REMOVE_TIMEOUT = 10  # Timeout for SSH key removal requests
+
+# Emitted instead of a validation result for an executor under a special manual (bare-metal)
+# rental. Distinct string so manual passes are greppable in Loki and can never be mistaken for a
+# node that actually passed validation -- nothing about this node was verified.
+MANUAL_RENTAL_FORCED_PASS_EVENT = "Executor force-passed as special manual rental (not validated)"
 
 
 class MinerService:
@@ -276,6 +282,17 @@ class MinerService:
                     msg = None
 
                 if msg is None:
+                    # Deliberately NOT force-passed, unlike the zero-executors case below. There we
+                    # know the miner is alive and chose to drop the executor because it could not
+                    # install our key -- exactly the manual-rental shape. Here we have no signal
+                    # from the miner at all, so we cannot distinguish "renter holds the box" from
+                    # "this miner is gone"; force-passing would pay emissions on strictly less
+                    # evidence than the case it is meant to cover. This assumes the miner neuron is
+                    # shared infrastructure independent of the rented host (CENTRAL_MODE), so that
+                    # an unreachable miner is a real fault rather than an expected consequence of
+                    # handing the box over -- CENTRAL_MODE defaults to False and confirming the
+                    # target deployment is still an open question on the plan.
+                    # Accepted for beta -- see the plan's V3 "Known limitation".
                     return self._build_failed_job_result(
                         payload,
                         "Miner did not respond after SSH key submission",
@@ -290,7 +307,13 @@ class MinerService:
                             ),
                         ),
                     )
-                    if len(msg.executors) == 0:
+                    if len(msg.executors) == 0 and not self._has_manual_rental_executors(
+                        payload, rented_data
+                    ):
+                        # Zero executors is normally a miner failure. It is the *expected* shape when
+                        # every executor this miner has is under a manual rental, though -- the miner
+                        # drops each one because it can no longer install our key. Only fail when
+                        # there is genuinely nothing to score; otherwise fall through to synthesis.
                         return self._build_failed_job_result(
                             payload,
                             "Miner returned zero executors in AcceptSSHKeyRequest",
@@ -317,6 +340,9 @@ class MinerService:
 
                     raw_results = await asyncio.gather(*tasks, return_exceptions=True)
                     results = self._filter_task_results(msg.executors, raw_results, default_extra)
+                    results.extend(
+                        self._build_manual_rental_results(payload, rented_data, existing=results)
+                    )
 
                     logger.info(
                         _m(
@@ -463,6 +489,171 @@ class MinerService:
                     ),
                 ),
             )
+        return results
+
+    def _iter_manual_rental_candidates(
+        self,
+        payload: MinerJobRequestPayload,
+        rented_data: RentedExecutorsResponse | None,
+    ):
+        """Yield (executor_uuid, info, rented_executor) for this miner's force-passable rentals.
+
+        Shared by the cheap `_has_manual_rental_executors` probe and the actual synthesis so the
+        two can never disagree about which executors qualify.
+        """
+        if not rented_data or not rented_data.manual_rental_executors:
+            return
+
+        for executor_uuid, info in rented_data.manual_rental_executors.items():
+            executor_uuid = str(executor_uuid)
+
+            rented_executor = rented_data.executors.get(executor_uuid)
+            if not rented_executor:
+                # Flagged by the backend but not listed as rented (e.g. the pod is DELETING, which
+                # get_rented_pods_with_ports excludes). Without an address there is nothing to build.
+                continue
+            if rented_executor.miner_hotkey != payload.miner_hotkey:
+                # Belongs to a different miner's job request.
+                continue
+            if info.gpu_model not in BASE_GPU_MAP:
+                # A real result can never reach the incentive layer with an unknown model --
+                # GpuModelValidCheck is fatal and halts the pipeline first. A synthetic one skips
+                # the whole pipeline, so it has to make that check itself: RentalPriceIncentive's
+                # get_base_model_for_gpu does a raising BASE_GPU_MAP[...] subscript, and it is
+                # called from calculate_mining_scores, which has no per-result try/except. An
+                # unknown model (e.g. a SKU retired from the map since the rental was created)
+                # would therefore abort weight-setting for EVERY miner on the subnet this cycle.
+                # Dropping the entry costs this one node its emission; raising costs everyone's.
+                logger.warning(
+                    _m(
+                        "Manual rental executor has a GPU model that is not in BASE_GPU_MAP; "
+                        "skipping its forced pass to protect this cycle's weight calculation",
+                        extra=get_extra_info({
+                            "job_batch_id": payload.job_batch_id,
+                            "miner_hotkey": payload.miner_hotkey,
+                            "executor_uuid": executor_uuid,
+                            "gpu_model": info.gpu_model,
+                        }),
+                    ),
+                )
+                continue
+
+            yield executor_uuid, info, rented_executor
+
+    def _has_manual_rental_executors(
+        self,
+        payload: MinerJobRequestPayload,
+        rented_data: RentedExecutorsResponse | None,
+    ) -> bool:
+        """Whether this miner has any force-passable manual rental, without building anything.
+
+        Used to decide whether a zero-executor AcceptSSHKeyRequest is a genuine miner failure or
+        the expected shape when every executor has been handed to a renter.
+        """
+        return any(self._iter_manual_rental_candidates(payload, rented_data))
+
+    def _build_manual_rental_results(
+        self,
+        payload: MinerJobRequestPayload,
+        rented_data: RentedExecutorsResponse | None,
+        existing: list[JobResult],
+    ) -> list[JobResult]:
+        """Synthesise forced-pass results for this miner's special manual (bare-metal) rentals.
+
+        A manually-rented node is handed to the renter at root level and the platform stops
+        provisioning it, so the miner can no longer install our SSH key on it. The miner silently
+        drops such an executor from AcceptSSHKeyRequest (it filters on a successful pubkey upload),
+        which means TaskService.create_task never runs for it and it would score 0. The forced pass
+        therefore has to be synthesised out here, from the backend's list, rather than short-circuited
+        inside per-executor validation.
+
+        The node is never contacted: score, gpu_model and gpu_count come entirely from the backend.
+
+        `spec` is deliberately left None. The backend skips its whole executor upsert on a null spec,
+        which is what we want -- a synthesised spec that validated but disagreed with the stored row
+        would flip the executor inactive and take billing down with it.
+        """
+        already_scored = {str(result.executor_info.uuid) for result in existing}
+        results: list[JobResult] = []
+
+        for executor_uuid, info, rented_executor in self._iter_manual_rental_candidates(
+            payload, rented_data
+        ):
+            if executor_uuid in already_scored:
+                # The node answered after all. A real result always beats a synthesised one.
+                continue
+
+            try:
+                executor_port = int(rented_executor.executor_ip_port)
+            except (TypeError, ValueError):
+                executor_port = 0
+
+            executor_info = ExecutorSSHInfo(
+                uuid=executor_uuid,
+                address=rented_executor.executor_ip_address,
+                port=executor_port,
+                # No SSH is attempted for a manual rental; these exist only to satisfy the model.
+                ssh_username="",
+                ssh_port=0,
+                python_path="",
+                root_dir="",
+            )
+
+            # Read the incentive-layer gates off rented_data exactly as ResultHandler does, rather
+            # than hardcoding them: forcing score=1.0 buys a place in the mining pool, it does not
+            # exempt the node from spot-tier or Discord exclusions.
+            is_spot = executor_uuid in (rented_data.spot_executor_ids or [])
+            discord_connected_ids = rented_data.provider_discord_connected_executor_ids
+            provider_discord_connected = (
+                True if discord_connected_ids is None else executor_uuid in discord_connected_ids
+            )
+
+            log_text = _m(
+                MANUAL_RENTAL_FORCED_PASS_EVENT,
+                extra=get_extra_info({
+                    "job_batch_id": payload.job_batch_id,
+                    "miner_hotkey": payload.miner_hotkey,
+                    "executor_uuid": executor_uuid,
+                    "executor_ip_address": rented_executor.executor_ip_address,
+                    "gpu_model": info.gpu_model,
+                    "gpu_count": info.gpu_count,
+                    "reason": "special_manual_rental",
+                }),
+            ).to_full_string()
+
+            results.append(
+                JobResult(
+                    spec=None,
+                    executor_info=executor_info,
+                    score=1.0,
+                    job_score=1.0,
+                    job_batch_id=payload.job_batch_id,
+                    log_status="success",
+                    log_text=log_text,
+                    gpu_model=info.gpu_model,
+                    gpu_count=info.gpu_count,
+                    # Rented exempts the minimum-driver gate, which we cannot measure here.
+                    is_rented=True,
+                    # Not measurable without the node; a false reading would silently cut the score.
+                    sysbox_runtime=True,
+                    is_spot=is_spot,
+                    provider_discord_connected=provider_discord_connected,
+                )
+            )
+
+        if results:
+            logger.info(
+                _m(
+                    "Forced pass for special manual rentals",
+                    extra=get_extra_info({
+                        "job_batch_id": payload.job_batch_id,
+                        "miner_hotkey": payload.miner_hotkey,
+                        "executors": len(results),
+                        "executor_uuids": [str(r.executor_info.uuid) for r in results],
+                    }),
+                ),
+            )
+
         return results
 
     def _build_failed_job_result(self, payload: MinerJobRequestPayload, reason: str):
@@ -1557,7 +1748,11 @@ class MinerService:
                         ),
                     ),
                 )
-                if len(msg.executors) == 0:
+                if len(msg.executors) == 0 and not self._has_manual_rental_executors(
+                    payload, rented_data
+                ):
+                    # See the WebSocket path: zero executors is the expected shape when every
+                    # executor is under a manual rental, so only fail when nothing can be scored.
                     return self._build_failed_job_result(
                         payload,
                         "Miner returned zero executors in AcceptSSHKeyRequest",
@@ -1584,6 +1779,9 @@ class MinerService:
 
                 raw_results = await asyncio.gather(*tasks, return_exceptions=True)
                 results = self._filter_task_results(msg.executors, raw_results, default_extra)
+                results.extend(
+                    self._build_manual_rental_results(payload, rented_data, existing=results)
+                )
 
                 logger.info(
                     _m(

--- a/neurons/validators/tests/test_manual_rental_results.py
+++ b/neurons/validators/tests/test_manual_rental_results.py
@@ -1,0 +1,377 @@
+"""Tests for MinerService._build_manual_rental_results — the synthetic forced-pass path for
+special manual (bare-metal) rentals.
+
+See .omc/plans/special-manual-rental.md sections T3, T4 and 5 for the full rationale:
+
+- T3: a manually-rented node hands root to the renter, so the miner can no longer install the
+  validator's SSH key and silently drops that executor from AcceptSSHKeyRequest.executors. The
+  validator therefore never calls create_task for it and it would score 0 unless the forced pass
+  is synthesised out-of-band, from the backend's manual_rental_executors list.
+- T4: forcing score=1.0 is necessary but not sufficient for emissions. The incentive layer keys
+  its total-count denominator off gpu_model and multiplies by gpu_count (default.py:167-174), so a
+  synthetic result missing either is worth zero despite a perfect score. is_rented/sysbox_runtime
+  avoid gate haircuts, and is_spot/provider_discord_connected must be read from rented_data rather
+  than hardcoded, because forcing score=1.0 buys a place in the mining pool -- it does not exempt
+  the node from the spot-tier or Discord-gate exclusions.
+- 5 (A7/A7b/A7c/A7d/A7e/A8/A12): the acceptance criteria this file maps to, one test per row.
+
+`_build_manual_rental_results` is a pure, non-async method (services/miner_service.py), so it is
+exercised directly here rather than by driving the full websocket/REST flow.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from datura.requests.miner_requests import ExecutorSSHInfo
+from incentive.config import BASE_GPU_MAP
+from payload_models.payloads import MinerJobRequestPayload
+from pydantic import BaseModel
+
+from protocol.vc_protocol.compute_requests import (
+    ManualRentalInfo,
+    NetworkEMA,
+    RentedExecutor,
+    RentedExecutorsResponse,
+)
+from services.miner_service import MinerService
+from services.task.models import JobResult
+
+MINER_HOTKEY = "5MinerHotkeyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+OTHER_MINER_HOTKEY = "5OtherMinerHotkeyBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+EXECUTOR_UUID = "executor-manual-rental-123"
+
+
+def make_payload(*, miner_hotkey: str = MINER_HOTKEY) -> MinerJobRequestPayload:
+    return MinerJobRequestPayload(
+        job_batch_id="batch-manual-1",
+        miner_hotkey=miner_hotkey,
+        miner_coldkey="5ColdkeyCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+        miner_address="10.0.0.5",
+        miner_port=8000,
+    )
+
+
+def make_rented_executor(*, miner_hotkey: str = MINER_HOTKEY) -> RentedExecutor:
+    return RentedExecutor(
+        miner_hotkey=miner_hotkey,
+        executor_ip_address="10.0.0.5",
+        executor_ip_port="8080",
+        pods=[],
+    )
+
+
+def make_real_job_result(*, uuid: str, score: float = 0.42) -> JobResult:
+    """A JobResult as produced by a real, reachable TaskService.create_task run -- used to prove
+    a real result beats a synthesized one (A8)."""
+    return JobResult(
+        executor_info=ExecutorSSHInfo(
+            uuid=uuid,
+            address="10.0.0.5",
+            port=8080,
+            ssh_username="root",
+            ssh_port=22,
+            python_path="/usr/bin/python3",
+            root_dir="/root/app",
+        ),
+        score=score,
+        job_score=score,
+        job_batch_id="batch-manual-1",
+        log_status="success",
+        log_text="real validation result",
+    )
+
+
+def make_miner_service() -> MinerService:
+    """MinerService.__init__ only assigns its four dependencies -- no I/O, no heavy setup -- so
+    plain Mocks are enough; _build_manual_rental_results touches none of them."""
+    return MinerService(
+        ssh_service=Mock(),
+        task_service=Mock(),
+        redis_service=Mock(),
+        attestation_service=Mock(),
+    )
+
+
+def test_manual_rental_forced_pass_synthesizes_full_scoring_result():
+    """A7: an executor absent from msg.executors (existing=[]) but present in both
+    manual_rental_executors and rented_data.executors for this miner gets exactly one
+    synthesized JobResult carrying every field the incentive layer needs (T4)."""
+    # Arrange
+    payload = make_payload()
+    rented_data = RentedExecutorsResponse(
+        executors={EXECUTOR_UUID: make_rented_executor()},
+        manual_rental_executors={
+            EXECUTOR_UUID: ManualRentalInfo(gpu_model="NVIDIA H200", gpu_count=8)
+        },
+    )
+    service = make_miner_service()
+
+    # Act
+    results = service._build_manual_rental_results(payload, rented_data, existing=[])
+
+    # Assert -- exactly one synthesized result for the one flagged executor
+    assert len(results) == 1
+    result = results[0]
+    # score/job_score=1.0 is the forced pass itself (D1)
+    assert result.score == 1.0
+    assert result.job_score == 1.0
+    # is_rented exempts the min-driver gate; sysbox_runtime avoids the sysbox haircut (T4)
+    assert result.is_rented is True
+    assert result.sysbox_runtime is True
+    # spec=None keeps save_executor_into_db a no-op on the backend (T4/V4) -- a synthetic spec
+    # that validated but disagreed with the stored row would flip the executor inactive.
+    assert result.spec is None
+    # gpu_model/gpu_count are the incentive-layer denominator and numerator (default.py:167-174);
+    # missing either means zero emission despite score=1.0.
+    assert result.gpu_model == "NVIDIA H200"
+    assert result.gpu_count == 8
+    assert result.log_status == "success"
+    assert result.executor_info.uuid == EXECUTOR_UUID
+
+
+def test_manual_rental_forced_pass_yields_no_duplicate_when_real_result_exists():
+    """A8: if the node answered after all and `existing` already contains a real JobResult for
+    it, the synthesized pass must return [] for that executor -- a real result always wins over a
+    synthetic one, and there must be exactly one JobResult per executor id overall."""
+    # Arrange
+    payload = make_payload()
+    rented_data = RentedExecutorsResponse(
+        executors={EXECUTOR_UUID: make_rented_executor()},
+        manual_rental_executors={
+            EXECUTOR_UUID: ManualRentalInfo(gpu_model="NVIDIA H200", gpu_count=8)
+        },
+    )
+    real_result = make_real_job_result(uuid=EXECUTOR_UUID)
+    service = make_miner_service()
+
+    # Act
+    synthetic_results = service._build_manual_rental_results(
+        payload, rented_data, existing=[real_result]
+    )
+
+    # Assert -- nothing new is synthesized for an executor already covered by a real result
+    assert synthetic_results == []
+    # The combined result set (as miner_service.py builds it via results.extend(...)) still has
+    # exactly one JobResult for this executor id, and it is the real one.
+    combined = [real_result] + synthetic_results
+    assert len(combined) == 1
+    assert combined[0] is real_result
+
+
+def test_manual_rental_forced_pass_skips_executor_owned_by_different_miner():
+    """A7b: an executor in manual_rental_executors whose RentedExecutor.miner_hotkey belongs to a
+    different miner than payload.miner_hotkey is not synthesized for this miner's job request."""
+    # Arrange
+    payload = make_payload(miner_hotkey=MINER_HOTKEY)
+    rented_data = RentedExecutorsResponse(
+        executors={EXECUTOR_UUID: make_rented_executor(miner_hotkey=OTHER_MINER_HOTKEY)},
+        manual_rental_executors={
+            EXECUTOR_UUID: ManualRentalInfo(gpu_model="NVIDIA H200", gpu_count=8)
+        },
+    )
+    service = make_miner_service()
+
+    # Act
+    results = service._build_manual_rental_results(payload, rented_data, existing=[])
+
+    # Assert -- this job request is for MINER_HOTKEY; the executor belongs to a different miner
+    assert results == []
+
+
+def test_manual_rental_forced_pass_skips_executor_missing_from_rented_executors():
+    """A7c: an executor id flagged in manual_rental_executors but absent from
+    rented_data.executors is skipped without raising -- there is no address/hotkey to build a
+    result from."""
+    # Arrange
+    payload = make_payload()
+    rented_data = RentedExecutorsResponse(
+        executors={},
+        manual_rental_executors={
+            EXECUTOR_UUID: ManualRentalInfo(gpu_model="NVIDIA H200", gpu_count=8)
+        },
+    )
+    service = make_miner_service()
+
+    # Act
+    results = service._build_manual_rental_results(payload, rented_data, existing=[])
+
+    # Assert -- no exception, and nothing to score without an address
+    assert results == []
+
+
+def test_manual_rental_forced_pass_skips_gpu_model_absent_from_base_gpu_map():
+    """A synthetic result must never carry a gpu_model that is missing from BASE_GPU_MAP.
+
+    A real result cannot reach the incentive layer with an unknown model -- GpuModelValidCheck is
+    fatal and halts the pipeline first. A synthetic one skips the pipeline entirely, so it has to
+    make that check itself: RentalPriceIncentive.get_base_model_for_gpu does a RAISING
+    BASE_GPU_MAP[...] subscript (rental_price.py:176), reached from calculate_mining_scores, which
+    has no per-result try/except. A manual pod whose gpu_name was frozen at rental creation and
+    later retired from the map would therefore abort weight-setting for EVERY miner on the subnet
+    for that cycle. Dropping the entry costs one node its emission; raising costs everyone's.
+    """
+    # Arrange -- a model that is deliberately not a BASE_GPU_MAP key
+    assert "NVIDIA RETIRED-SKU 9000" not in BASE_GPU_MAP
+    payload = make_payload()
+    rented_data = RentedExecutorsResponse(
+        executors={EXECUTOR_UUID: make_rented_executor()},
+        manual_rental_executors={
+            EXECUTOR_UUID: ManualRentalInfo(gpu_model="NVIDIA RETIRED-SKU 9000", gpu_count=8)
+        },
+    )
+    service = make_miner_service()
+
+    # Act
+    results = service._build_manual_rental_results(payload, rented_data, existing=[])
+
+    # Assert -- skipped rather than synthesised
+    assert results == []
+
+
+def test_manual_rental_forced_pass_gpu_model_is_a_real_base_gpu_map_key():
+    """Guard against the BASE_GPU_MAP check being so strict it rejects legitimate models --
+    a silently-empty forced pass would look identical to the feature being off."""
+    assert "NVIDIA H200" in BASE_GPU_MAP
+
+
+@pytest.mark.parametrize(
+    "rented_data",
+    [
+        pytest.param(
+            RentedExecutorsResponse(executors={EXECUTOR_UUID: make_rented_executor()}),
+            id="manual_rental_executors_empty",
+        ),
+        pytest.param(None, id="rented_data_is_none"),
+    ],
+)
+def test_manual_rental_forced_pass_returns_empty_when_nothing_flagged(rented_data):
+    """A7d: an empty/absent manual_rental_executors dict returns []; rented_data=None (e.g. the
+    backend call failed this cycle) also returns [] rather than raising."""
+    # Arrange
+    payload = make_payload()
+    service = make_miner_service()
+
+    # Act
+    results = service._build_manual_rental_results(payload, rented_data, existing=[])
+
+    # Assert -- nothing flagged, nothing synthesized
+    assert results == []
+
+
+def test_manual_rental_forced_pass_marks_spot_when_executor_in_spot_ids():
+    """A7e: the spot-tier gate is read from rented_data.spot_executor_ids, not hardcoded --
+    forcing score=1.0 puts the node in the mining pool, it does not exempt it from the spot-tier
+    exclusion applied later in the incentive layer."""
+    # Arrange
+    payload = make_payload()
+    rented_data = RentedExecutorsResponse(
+        executors={EXECUTOR_UUID: make_rented_executor()},
+        manual_rental_executors={
+            EXECUTOR_UUID: ManualRentalInfo(gpu_model="NVIDIA H200", gpu_count=8)
+        },
+        spot_executor_ids=[EXECUTOR_UUID],
+    )
+    service = make_miner_service()
+
+    # Act
+    results = service._build_manual_rental_results(payload, rented_data, existing=[])
+
+    # Assert -- executor id is in spot_executor_ids, so the synthetic result is marked spot
+    assert len(results) == 1
+    assert results[0].is_spot is True
+
+
+def test_manual_rental_forced_pass_discord_disconnected_when_excluded_from_list():
+    """A7e: when provider_discord_connected_executor_ids is a list that does NOT contain this
+    executor id, provider_discord_connected is False -- a provider without Discord connected
+    earns zero even when rented (R4), and the synthetic result must not paper over that."""
+    # Arrange
+    payload = make_payload()
+    rented_data = RentedExecutorsResponse(
+        executors={EXECUTOR_UUID: make_rented_executor()},
+        manual_rental_executors={
+            EXECUTOR_UUID: ManualRentalInfo(gpu_model="NVIDIA H200", gpu_count=8)
+        },
+        provider_discord_connected_executor_ids=["some-other-executor-id"],
+    )
+    service = make_miner_service()
+
+    # Act
+    results = service._build_manual_rental_results(payload, rented_data, existing=[])
+
+    # Assert -- executor id is absent from the connected-ids list, so the gate excludes it
+    assert len(results) == 1
+    assert results[0].provider_discord_connected is False
+
+
+def test_manual_rental_forced_pass_discord_connected_defaults_true_when_list_is_none():
+    """A7e: provider_discord_connected_executor_ids=None means the field was not populated this
+    cycle, so the synthetic result defaults provider_discord_connected to True."""
+    # Arrange
+    payload = make_payload()
+    rented_data = RentedExecutorsResponse(
+        executors={EXECUTOR_UUID: make_rented_executor()},
+        manual_rental_executors={
+            EXECUTOR_UUID: ManualRentalInfo(gpu_model="NVIDIA H200", gpu_count=8)
+        },
+        provider_discord_connected_executor_ids=None,
+    )
+    service = make_miner_service()
+
+    # Act
+    results = service._build_manual_rental_results(payload, rented_data, existing=[])
+
+    # Assert -- None means "gate not populated"; default is connected=True
+    assert len(results) == 1
+    assert results[0].provider_discord_connected is True
+
+
+class _PreManualRentalRentedExecutorsResponse(BaseModel):
+    """Mirrors RentedExecutorsResponse exactly as it looked before this feature -- every field
+    except manual_rental_executors -- to simulate an un-upgraded validator parsing a payload the
+    upgraded backend now sends."""
+
+    executors: dict[str, RentedExecutor]
+    filler_containers_by_executor: dict[str, str] = {}
+    banned_guids: list[str] = []
+    gpu_splitting_config: dict[str, int] = {}
+    network_ema: dict[str, NetworkEMA] = {}
+    spot_executor_ids: list[str] = []
+    new_rentals_paused_executor_ids: list[str] = []
+    provider_discord_connected_executor_ids: list[str] | None = None
+    default_job_owner_by_executor: dict[str, str] = {}
+
+
+def test_old_validator_model_ignores_new_manual_rental_key():
+    """A12: a payload dict containing the new manual_rental_executors key must parse without
+    raising against a model that does not declare it. RentedExecutorsResponse declares no
+    model_config, so it inherits Pydantic v2's default extra="ignore" -- an un-upgraded validator
+    silently ignores the field instead of raising a ValidationError that would skip the entire
+    validation cycle for every miner (R7/R8)."""
+    # Arrange -- payload shaped like the upgraded backend's response
+    payload_with_new_key = {
+        "executors": {},
+        "manual_rental_executors": {
+            EXECUTOR_UUID: {"gpu_model": "NVIDIA H200", "gpu_count": 8}
+        },
+    }
+
+    # Act -- parse against the OLD (pre-feature) model shape
+    old = _PreManualRentalRentedExecutorsResponse.model_validate(payload_with_new_key)
+
+    # Assert -- parses without raising, and the old model has no knowledge of the new field
+    assert not hasattr(old, "manual_rental_executors")
+
+
+def test_current_model_defaults_manual_rental_executors_to_empty_when_key_absent():
+    """A12: the CURRENT model defaults manual_rental_executors to {} when the key is absent from
+    the payload -- an old backend that has not shipped the field yet force-passes nobody
+    (fail-closed), never everybody."""
+    # Arrange -- payload shaped like an old (pre-feature) backend's response
+    payload_without_key = {"executors": {}}
+
+    # Act
+    current = RentedExecutorsResponse.model_validate(payload_without_key)
+
+    # Assert
+    assert current.manual_rental_executors == {}


### PR DESCRIPTION
## Describe your changes

Validator side of **special manual rental** — a rental where an admin hands the renter root on the bare-metal host out of band. The platform keeps charging the renter and paying the provider, but stops provisioning the node, so the validator can no longer reach it.

**Why this can't be a short-circuit inside `TaskService.create_task`:** once the platform stops provisioning, the miner can no longer install our SSH key on the host. `register_pubkey` filters on a successful pubkey upload (`neurons/miners/src/services/executor_service.py:397`), so it silently drops that executor from `AcceptSSHKeyRequest.executors` — and the validator only iterates that list. `create_task` is therefore never called for a manually-rented node, and a short-circuit inside it would be dead code. The forced pass is instead **synthesised** in `miner_service` from the backend's `manual_rental_executors` list, after `_filter_task_results`, on **both** the WebSocket and REST paths.

**What the synthetic result carries, and why:**
- `score=1.0` / `job_score=1.0` — the forced pass itself. The node is never contacted; `gpu_model`/`gpu_count` come from the backend, which is the only party that still knows what the node was verified to have.
- `spec=None` — deliberate. The backend skips its whole executor upsert on a null spec, so this is inert. A synthesised spec that validated but disagreed with the stored row would hit the specs-mismatch branch and flip the executor `active=False`, which would take billing down with it.
- `is_rented=True`, `sysbox_runtime=True` — avoid the min-driver gate and the sysbox haircut, neither of which we can measure without the node.
- `is_spot` / `provider_discord_connected` are read from `rented_data`, **not hardcoded**: forcing `score=1.0` buys a place in the mining pool, it does not exempt the node from the spot-tier or Discord exclusions.
- `gpu_model` is validated against `BASE_GPU_MAP` before synthesis. A real result can never reach the incentive layer with an unknown model (`GpuModelValidCheck` is fatal), but a synthetic one skips the pipeline — and `get_base_model_for_gpu` does a **raising** `BASE_GPU_MAP[...]` subscript reached from `calculate_mining_scores`, which has no per-result `try/except`. A model retired from the map since the rental was created would otherwise abort weight-setting **for every miner on the subnet**.

`msg is None` (miner unreachable) is deliberately **not** force-passed — that's no signal from the miner at all, strictly weaker evidence than "miner alive, deliberately dropped the executor", so force-passing there would pay emissions for a possibly-dead miner. Commented at the branch.

`manual_rental_executors` defaults to `{}`, so an un-upgraded validator ignores the field (Pydantic `extra="ignore"`) and an older backend force-passes nobody (fail-closed).

**Pairs with (must land together):** Datura-ai/lium-io-backend#779 — this PR alone is inert (the field is never populated); the backend alone bills the node without it ever earning.

## Issue ticket number and link

[DAH-2438](https://www.notion.so/DAH-2438)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?

Tests: `neurons/validators/tests/test_manual_rental_results.py` — 13 tests covering the synthesis (full field set), real-result-wins-over-synthetic, wrong-miner and missing-executor skips, the spot/Discord gates being read from `rented_data`, the `BASE_GPU_MAP` guard, and forward-compat (an old model parses a payload carrying the new key). Full validator suite: **1117 passed, 8 skipped** (was 1115 before this change; +2 net new).

Performance: unchanged. The synthesis is O(manual rentals) over an in-memory dict already fetched once per cycle, and adds no network calls — it exists precisely to avoid contacting the node.

