### PR TITLE
DAH-2382: docker_service characterization oracle (PR-1a)

### DIFF
--- a/neurons/validators/Makefile
+++ b/neurons/validators/Makefile
@@ -1,0 +1,13 @@
+# E7 differential gate (DAH-2382, decision D-B): mandatory LOCAL run against a
+# real docker daemon before each extraction PR. See tests/integration/README_E7.md.
+
+PYTEST = pdm run pytest
+E7_TESTS = tests/integration/test_docker_service_differential.py
+
+.PHONY: e7 e7-record
+
+e7:
+	RUN_RENTAL_DOCKER_SDK_INTEGRATION=1 $(PYTEST) $(E7_TESTS) -q
+
+e7-record:
+	RUN_RENTAL_DOCKER_SDK_INTEGRATION=1 $(PYTEST) $(E7_TESTS) -q --update-snapshot

--- a/neurons/validators/tests/docker_oracle/README.md
+++ b/neurons/validators/tests/docker_oracle/README.md
@@ -1,0 +1,304 @@
+# Docker service characterization oracle (DAH-2382)
+
+Characterization suites that freeze the observable boundary of
+`src/services/docker_service.py` before the docker-service-refactor extraction
+moves any code. Internal control flow is free to change; these goldens are not.
+
+- **Baseline:** lium-io `origin/main` `6be5649f` (`docker_service.py` = 4,777 lines).
+  PR-1a touches tests only — every `docker_service.py:<line>` below is valid on
+  both the baseline and this branch.
+- **Scope (PR-1a):** groups B (create success / profiler / redis), C (volumes /
+  vloopback / ports), D (delete / ssh keys / jupyter / security sinks) and
+  E (ordering / cancellation / idempotency) of the plan in
+  `openspec/changes/docker-service-refactor/characterization-oracle-DRAFT.md`.
+  Group A (the create-container failure matrix) lands in PR-1b.
+
+## Normalization rules
+
+- **Byte-for-byte** for every `msg` template and every
+  `error_type` / `error_code` / `failure_step` enum value — these are the
+  classifier and backend surface. `msg` is the bare template
+  (`_StructuredMessage.__str__` returns only `.message`); `str(exc)` lives in
+  the log extra, not in `msg`.
+- **Normalize only interpolated `str(exc)` tails.** Two places interpolate the
+  exception into `msg`: the host-key special case
+  (`current_step == "docker_sdk_ssh_host_key"` + `RentalDockerConnectionError`
+  → `"Failed create_container: {e}"`) and `delete_container`'s generic
+  `"Unknown Error delete_container: {e}"`. Assert the prefix byte-for-byte plus
+  a substring of the tail; never freeze a full interpolated string whose tail
+  is environment-dependent. When the test itself controls the raised exception
+  the full string is deterministic and MAY be pinned `==` (the D5 delete test
+  does — the SDK wrapper re-raises the original exception unwrapped).
+- **Timestamps / durations are masked.** Assert type and relation
+  (e.g. `total == sum(...)`), never literals.
+- **An absent key is not `null`.** The profiler serializer omits keys
+  (`skipped=False` is dropped; the anchor has no `duration`) — assert the exact
+  key set of wire dicts, not just values.
+- **Monkeypatch-target migration rule:** an import/patch target may move in a
+  later PR, or the asserted behavior may change — never both in the same PR
+  (exception: a module constant changing namespace, tracked in PR-4).
+
+## Repo-reality constraints
+
+- **pytest-asyncio runs in STRICT mode** — `pyproject.toml` sets no
+  `asyncio_mode`, so every async test needs an explicit `@pytest.mark.asyncio`.
+  (Do not copy a miner test: `neurons/miners` uses `asyncio_mode="auto"`.)
+- **Goldens use the repo's own `--update-snapshot` flag** (conftest.py
+  `update_snapshot` fixture) with the write-on-missing-then-byte-equal pattern
+  of `test_custom_dockerfile_build.py::test_A1_golden_snapshot_image_pull_wire`.
+  Golden files live in `tests/fixtures/docker_oracle/`. Do NOT add syrupy /
+  pytest-regressions — a second snapshot-update workflow is forbidden.
+- **One shared harness.** All suites build on
+  `tests/docker_oracle/harness.py` (`FakeRentalDockerClient`,
+  `RecordingRedisService`, `patch_create_happy_path`, `patch_delete_happy_path`,
+  `patch_rental_ssh_connect`, `make_create_request` / `make_delete_request` /
+  `make_executor_info` / `make_docker_service`). Four near-copies of the fake
+  client already existed before this package; do not add a fifth — extend the
+  harness.
+- AAA layout with explicit `# Arrange / # Act / # Assert` comments and a
+  one-line WHY comment before each assert block.
+
+## Gap analysis (2.1)
+
+Contract → coverage map. "Baseline :N" = line number at `6be5649f` (the three
+modified test files shifted a few lines on this branch; names are durable).
+
+| Oracle area | Sketches | Pinned by |
+|---|---|---|
+| create FAILURE matrix | A1–A14 | **PR-1b (pending).** Baseline already covers: `docker_pull` (test_docker_service.py baseline :2997), `set_environment` (:3077), host-key substring (:2405), custom-build `docker_build`/`build_timeout` (test_custom_dockerfile_build.py) |
+| create success / profiler / redis / DAH-2265 | B1–B9 new; B10/B11 folded; B12 dropped | `test_create_success.py` (9 tests: `test_container_created_full_golden`, `test_profiler_shape_anchor_timestamp` / `_duration_only` / `_duration_skipped`, `test_profiler_name_sequence_golden`, `test_loki_profile_steps_format`, `test_redis_operation_order_customer_rental`, `test_redis_remove_pending_for_filler`, `test_streaming_log_publish_shape`) + 2 goldens; folds in `tests/test_deploy_optimizations.py` |
+| volume sizing (C1–C9) | finer pins over an existing suite (see stale-[N] below) | `test_volume_sizing_and_ports.py::test_sizing_*` (8) + `::test_parse_volume_size_formats`; baseline DAH-2183 suite `test_docker_service.py::test_resolve_volume_sizing_*` (baseline :4281–:4458) |
+| SDK retry loop (C10–C17) | all new — live `_run_rental_docker_create_with_port_retry` had zero tests (only the dead SSH twin was tested) | `test_sdk_retry_loop.py` (11: C10–C17 as `test_sdk_*` + 3 extra: `test_sdk_partial_mount_phrases_do_not_trigger_repair`, `test_sdk_port_retry_sleeps_then_removes_then_reruns`, `test_sdk_port_retry_second_phrase_address_in_use`) |
+| port planner (C18–C20) | C18/C19 dropped (pre-covered); C20 new | `test_docker_service.py::test_min_port_count_validation` (baseline :623), `::test_generate_portMappings_offsets_filler_custom_external_port` (baseline :673); `test_volume_sizing_and_ports.py::test_ports_lock_error_returns_empty[LockError\|LockNotOwnedError]` |
+| delete flow (D1–D11) | D1, D6–D11 new; D2–D5 extended in place | `test_delete_flow.py` (7 fn / 9 items); extensions: `test_docker_service.py::test_delete_container_stops_gracefully_before_forced_removal` (D2, grace `[30]`), `::test_delete_filler_stops_with_reduced_grace` (D3, `[15]`), `::test_delete_container_stop_failure_still_removes` (D4, byte WARNING), `::test_delete_container_remove_container_error_fails_undeploy` (D5) |
+| ssh keys (D12–D17 + attestation) | D12/D13 folded; D14–D17 + attestation ×2 new | folds in `tests/test_docker_service_rental_security.py`; `test_ssh_keys_and_jupyter.py::test_add_ssh_key_no_keys` / `::test_remove_ssh_keys_no_keys` / `::test_add_ssh_key_generic_exception` / `::test_remove_ssh_keys_generic_exception` / `::test_ssh_key_methods_attestation_error_returns_addsskeyfailed[add\|remove]` |
+| jupyter (D18–D20) | all new — method had zero tests | `test_ssh_keys_and_jupyter.py::test_install_jupyter_success_url_shape` / `::test_install_jupyter_attestation_returns_failed_container_request` / `::test_install_jupyter_runtime_exception_returns_jupyter_installation_failed` |
+| argv / security (D21–D24) | D21 case 1 dropped; rest new (live builder had no unit test) | `test_startup_argv.py::test_startup_commands_argv_neutralizes_injection` / `::test_startup_commands_argv_preserves_quoted_metacharacters` / `::test_startup_commands_unbalanced_quotes_fall_back` / `::test_prepare_known_hosts_policy_fail_open_returns_none` / `::test_prepare_known_hosts_policy_fail_closed_raises_attestation_error` |
+| behavior invariants (E1–E6) | all new (E1 cleanup half is a SPEC xfail) | `test_behavior_invariants.py` (9 fn / 13 items — see Suite stats) |
+| E7 differential | harness + self-consistency test | `tests/integration/test_docker_service_differential.py::test_e7_differential_probe_self_consistency` (env-gated) + `Makefile` `e7` / `e7-record` |
+
+### §0.5 audit: sketch → fate
+
+| Sketch | Fate | Where it landed |
+|---|---|---|
+| B12 | DROP | pre-covered: `test_deploy_optimizations.py::test_ships_sshd_with_startup_commands_runs_bootstrap_and_run_jupyter` (baseline :454) |
+| C18 | DROP | `test_docker_service.py::test_min_port_count_validation` (baseline :623) |
+| C19 | DROP | `test_docker_service.py::test_generate_portMappings_offsets_filler_custom_external_port` (baseline :673) |
+| D21 case 1 | DROP case | `test_docker_service_rental_security.py::test_create_container_keeps_hostile_fields_out_of_host_shell_commands` (baseline :362, full-boundary, stronger); case 2 kept → `test_startup_argv.py::test_startup_commands_argv_neutralizes_injection` |
+| A14 | RETAG [E] → PR-1b | will extend `test_custom_dockerfile_build.py::test_A11_empty_dockerfile_content_*` (only byte `msg` + `remove_pending_pod` assert are new) |
+| B10 / B11 | FOLD | asserts added to `test_deploy_optimizations.py::test_ships_sshd_true_forwards_jupyter_password_instead_of_run_jupyter` / `::test_ships_sshd_none_with_jupyter_uses_run_jupyter` (baseline :382/:435); plus `_CREDS` so the login asserts are non-vacuous |
+| D6 | NARROW | `test_delete_flow.py::test_delete_teardown_step_failure_nonfatal` parametrized over exactly the 3 uncovered steps: `restore_filler_gpu_power`, `sweep_wedged_gpus`, `inspector_stop` |
+| D12 / D13 | FOLD | return-shape + key-echo asserts added to `test_docker_service_rental_security.py::test_add_ssh_key_writes_public_keys_as_stdin_data` / `::test_remove_ssh_key_writes_public_keys_as_stdin_data` (baseline :608/:645) |
+
+### Stale-[N] discoveries (baseline coverage the DRAFT missed)
+
+- **C1–C8 were tagged [N] but a baseline suite already existed**:
+  `test_docker_service.py` baseline :4281–:4458 (DAH-2183,
+  `test_resolve_volume_sizing_*`) covers legacy, pool-bound, storage_opt
+  unsupported, request_cap, df_guard, below-min raise, severe-shrink, fallback,
+  1 GB floor and base parse formats. The new file adds only the finer pins:
+  the exact 4-command SSH sequence + `--filter driver=` on the volume listing;
+  `docker volume inspect` skipped when no volumes exist; the byte-exact
+  `VolumeMinSizeError` msg (`"Fresh vloopback sizing produced {v}GB volume,
+  below required minimum {m}GB"`); the `capped_by` tie-break (first in
+  candidate list order); the full `None`-field set on fallback/legacy; parse
+  edge formats. C9's [E] tag was correct.
+- **B10/B11 asserts partially pre-existed**: the login-skip matrix tests at
+  `test_deploy_optimizations.py` baseline :761/:796 already asserted
+  `login_calls == []` / `DOCKER_LOGIN.skipped` — folds were needed only at
+  :382/:435.
+
+### Known uncovered, low risk (deliberate)
+
+- `_cleanup_custom_build_artifacts` failure case (delete :4208): not routed
+  through `_best_effort_delete_step` — self-guarding WARNING `"Custom build
+  artifact cleanup failed (non-fatal)"` with no `step=` key. Still non-fatal by
+  its own try/except; exercising it adds no boundary information.
+- `remove_volume_external` failure case (:4249, incl.
+  `disable_s3fs_volume_plugin`): only the hostile-name guard is covered. The
+  step uses the same `_best_effort_delete_step` wrapper whose semantics D6 pins
+  on three representative steps.
+- Retry-loop repair-returns-False branch (`repair_stale_vloopback_mountpoint`
+  → `False` → immediate propagate, once-flag already consumed): one-line
+  branch sharing the C17 propagate path.
+
+## Failure-site matrix (2.2)
+
+Scope honestly: PR-1a pins the **delete / ssh-key / jupyter** failure sites and
+the create **SUCCESS** surface. The create failure funnel step-map (5
+early-return sites + 1 funnel across 29 `current_step` labels) is **PR-1b
+group A** — below is only what PR-1a already pinned, on baseline `6be5649f`.
+
+### delete_container (`error_type=ContainerDeletionFailed`, `failure_step` always `None`)
+
+| Site (src) | Trigger | error_code / msg (byte) | Pinned by |
+|---|---|---|---|
+| volume-name guard (:4153) | hostile `local_volume`, checked BEFORE `decrypt_payload` | UnknownError / `"Invalid Docker volume name"` (wire literal; descriptive ValueError text only in the log), no SDK calls | `test_delete_flow.py::test_delete_unsafe_volume_name_rejected` (D10); complements `rental_security.py::test_delete_container_rejects_unsafe_volume_names_before_shell` (baseline :770) |
+| attestation (after decrypt/`import_private_key`, before SSH/SDK) | `attestation_service.prepare_host_policy` raises `AttestationError` | UnknownError (NOT the unused `AttestationError` enum member) / `"Attestation failed"` | `test_delete_flow.py::test_delete_attestation_failure` (D11) |
+| graceful stop, non-fatal (:4094) | `stop` raises non-missing | still ContainerDeleted; WARNING `"Graceful container stop failed; proceeding to forced removal"`, force-remove still runs | `test_docker_service.py::test_delete_container_stop_failure_still_removes` (D4) |
+| **fatal force-remove** (funnel :4296–:4299) | `_force_remove_container` (:4107) raises non-missing | UnknownError / `"Unknown Error delete_container: {e}"` (full `==` pinned — tail deterministic), `remove_rented_machine` NOT awaited | `test_docker_service.py::test_delete_container_remove_container_error_fails_undeploy` (D5) |
+| missing container (idempotency) | `"No such container"` substring (:294), incl. RetryError unwrap | swallowed → 2nd delete returns ContainerDeleted; graceful stop on missing = INFO skip (:1156) | `test_behavior_invariants.py::test_delete_container_is_idempotent_when_container_already_missing` (E3) + baseline `::test_delete_filler_container_treats_missing_container_as_deleted` / `::test_delete_customer_rental_treats_missing_container_as_deleted` (baseline :851/:917) |
+
+Post-teardown best-effort steps, in execution order. Wrapper =
+`_best_effort_delete_step` (:234–:246): swallows, logs **ERROR**
+`"delete_container post-teardown step failed (non-fatal)"` with extra keys
+`step`, `error` (+`volume_name` where applicable). Result stays
+ContainerDeleted.
+
+| # | Step (src) | Gate | Covered by |
+|---|---|---|---|
+| 1 | `sweep_wedged_gpus_after_failed_remove` (:4201) | FILLER, remove-except only, then re-raise | `test_delete_flow.py::test_delete_filler_sweeps_before_propagating_failure` (D8, was uncovered) |
+| 2 | `_cleanup_custom_build_artifacts` (:4208) | all | NOT wrapper-routed (own WARNING, no `step=`); failure case uncovered (low risk, above) |
+| 3 | `restore_filler_gpu_power` (:4217) | FILLER | `test_delete_flow.py::test_delete_teardown_step_failure_nonfatal[restore_filler_gpu_power]` (D6, was uncovered) |
+| 4 | `sweep_wedged_gpus` (:4224) | FILLER | D6 `[sweep_wedged_gpus]` + `::test_delete_filler_sweeps_wedged_gpus_on_success_nonfatal` (D7) + `::test_delete_customer_rental_does_not_sweep` (D9) — call-site only; internals stay in `test_gpu_wedge_teardown_sweep.py` |
+| 5 | `prune_images` (:4227) | all | pre-covered `test_docker_service.py::test_delete_container_prune_images_failure_still_deleted` (baseline :1507) |
+| 6 | `remove_volume_local` (:4235) | local volume | pre-covered `::test_delete_container_volume_read_timeout_still_deleted` / `::test_delete_container_missing_volume_still_deleted` (baseline :1407/:1461) |
+| 7 | `remove_volume_external` (:4249) | external volume | hostile-name guard only; failure case uncovered (low risk, above) |
+| 8 | `remove_rented_machine` (:4269) | all | pre-covered `::test_delete_container_redis_failures_still_deleted` (baseline :1286) — IS best-effort |
+| 9 | `inspector_stop` (:4275) | all | failure pre-covered (baseline :1286); D6 `[inspector_stop]` adds the `step=` log pin |
+
+FILLER gate (:4216) is ONE `if` wrapping steps 3–4. Sweep ordering (docker
+remove before sweep) pinned via the journal in D8.
+
+### add_ssh_key / remove_ssh_keys (`error_type=AddSSkeyFailed` on BOTH paths, `failure_step` always `None`)
+
+| Trigger | error_code / msg (byte, src) | Pinned by |
+|---|---|---|
+| add: empty keys | NoSshKeys / `"ssh key Add error: no public key"` (:4591) | `test_ssh_keys_and_jupyter.py::test_add_ssh_key_no_keys` (D14) |
+| remove: empty keys | NoSshKeys / `"ssh key Remove error: no public key"` (:4458) | `::test_remove_ssh_keys_no_keys` (D15) |
+| add: generic exception | UnknownError / `"Failed add_ssh_key"` (:4657) | `::test_add_ssh_key_generic_exception` (D16) |
+| remove: generic exception | UnknownError / `"Unknown Error remove_ssh_keys"` (:4525) | `::test_remove_ssh_keys_generic_exception` (D17) |
+| add/remove: `AttestationError` — the attestation gate runs BEFORE the empty-keys check | UnknownError / `"Attestation failed"` | `::test_ssh_key_methods_attestation_error_returns_addsskeyfailed[add\|remove]` |
+| success acks | `SshPubKeyAdded` / `SshPubKeyRemoved`, `user_public_keys` echoed | D12/D13 folds in `rental_security.py` (the remove ack is silently dropped by the backend — frozen anyway, DRAFT §8) |
+
+### install_jupyter_server (asymmetric two-shape failure contract)
+
+| Trigger | Result | Pinned by |
+|---|---|---|
+| success | `JupyterServerInstalled(jupyter_url="http://{executor address}:{external port}/lab?token=<32 lowercase hex>")`; token = `secrets.token_hex(16)`; `run_jupyter` receives the INTERNAL port + token | `::test_install_jupyter_success_url_shape` (D18) |
+| `AttestationError` | `FailedContainerRequest(error_type=ContainerCreationFailed` — surprising, create's type — `, UnknownError, "Attestation failed")` (:4347) | `::test_install_jupyter_attestation_returns_failed_container_request` (D19) |
+| `run_jupyter` raises | `JupyterInstallationFailed(msg="Failed install jupyter server")` — payload (payloads.py:598) carries ONLY `msg`, no error_type/error_code/failure_step fields | `::test_install_jupyter_runtime_exception_returns_jupyter_installation_failed` (D20) |
+
+### Create-side failure sites already pinned via PR-1a groups
+
+| Site | Behavior (byte values) | Pinned by |
+|---|---|---|
+| retry-loop exhaustion in `_run_rental_docker_create_with_port_retry` | deadline `time.monotonic()+90` checked `>=` after each failure; final non-retryable error logged `"Docker SDK run container failed"` ERROR `exc_info=True` + `stream_log` before re-raise; propagates to the boundary as `failure_step="docker_run"` | `test_sdk_retry_loop.py::test_sdk_port_retry_deadline_expired` / `::test_sdk_non_port_error_propagates`; boundary step + orphan cleanup: `test_behavior_invariants.py::test_create_failure_at_docker_run_cleans_up_container_and_volume` (E5) |
+| health check false after successful run | sticky step: boundary reports `failure_step="container_health_check"` (not `docker_run`); container + volume cleaned up | `::test_create_failure_at_health_check_cleans_up_container_and_volume` (E5); byte `msg` lands in PR-1b A10 |
+| `LockError` / `LockNotOwnedError` in `generate_portMappings` (:968) | `([], None)` → boundary NoPortMappings / `port_mapping` (boundary half in PR-1b A1) | `test_volume_sizing_and_ports.py::test_ports_lock_error_returns_empty[...]` (C20) |
+| `VolumeMinSizeError` from `resolve_volume_sizing` | raises with byte msg `"Fresh vloopback sizing produced {v}GB volume, below required minimum {m}GB"` → boundary `failure_step="volume_sizing"` in PR-1b A8 | `::test_sizing_below_min_raises` (C4) |
+| retry-loop log events | `VLOOPBACK_STALE_MOUNTPOINT_RETRY` (INFO); `PORT_ALREADY_ALLOCATED_RETRY` (INFO, extras `attempt`/`remaining_sec`/`sleep_seconds`/`port_allocation_phrase`) then sleep 5 s then SDK `remove_container(container_name=..., force=True, remove_volumes=True)` as operation `remove_failed_container_for_retry`; `PORT_RETRY_STALE_RM_FAILED` (WARNING, rm failure non-fatal, extras `container_name`/`rm_error`) | `test_sdk_retry_loop.py` (C10–C17 + extras) |
+
+## Observed-vs-sketch corrections
+
+Places where baseline reality differed from the DRAFT sketches. PR-1b/PR-2+
+authors: trust this list over the DRAFT, do not re-derive.
+
+1. **`"Finished create_container"` does not exist.** The Loki summary line is
+   `logger.info("Deployment profile summary")` (:3747).
+2. **`jupyter_url` host is the executor address** (`executor_info.address`,
+   :3654), for BOTH DAH-2265 branches — the sketch's `127.0.0.1` was just the
+   test executor's address.
+3. **`_sweep_wedged_gpus_after_teardown` is module-level** (:4749), not an
+   instance method — patch `services.docker_service._sweep_wedged_gpus_after_teardown`;
+   same for `restore_filler_pod_gpu_power_limits` (module import :66).
+4. **Best-effort post-teardown log is ERROR, not warning**
+   (`"delete_container post-teardown step failed (non-fatal)"`, extra keys
+   `step`, `error`, +`volume_name`).
+5. **Every attestation branch uses `error_code=UnknownError`** (delete D11,
+   add/remove keys, jupyter D19) — `FailedContainerErrorCodes.AttestationError`
+   exists but is unused on these paths (mirror of the A4 surprise).
+6. **`ContainerDeleted` has no optional fields**: exact wire =
+   `{message_type, miner_hotkey, executor_id, pod_id, workload_kind}`.
+7. **Stale-mount matching requires ALL 3 phrases** (`"VolumeDriver.Mount"`,
+   `"cannot create mount point dir"`, `"file exists"` — `all()` at :306); port
+   phrases are ANY-match, first match fills the log field.
+8. **Repair-retry does not increment the SDK-operation `attempt`** (both runs
+   log `attempt=1`; a port retry goes 1→2). Repair-retry has NO sleep and NO
+   rm; port-retry sleeps 5 s then SDK-removes the stale container.
+9. **Sizing tie-break**: winner = `min(candidates)`; on a tie the FIRST in
+   candidate list order wins — `pool` > `request_cap` > `df_guard` (pinned
+   inside C5).
+10. **Gating precedence**: `storage_limit_gb is None` →
+    `storage_opt_unsupported` is checked BEFORE `disk_share is None` → legacy.
+11. **`df_guard = max((df − 10 GiB) × 1.5, 0)`** — the clamp-to-0 was omitted
+    in the sketch; `request_cap` candidate is ABSENT when `volume_limit_gb` is
+    None.
+12. **`VolumeSizingResult` has no `warnings` field** —
+    `vloopback_fresh_sizing_fallback` surfaces only via `logger.warning`. The
+    dataclass `path` comment (:272) omits `storage_opt_unsupported`
+    (code-comment drift; fix in a later PR, not here).
+13. **C20's catch tuple is redundant**: `(LockError, LockNotOwnedError)` where
+    `LockNotOwnedError` subclasses `LockError`; `UUID(executor_id)` runs BEFORE
+    the try (:968 region).
+14. **D24 fail-closed msg interpolates `executor.port`** (the API port, e.g.
+    `8080`), NOT the ssh port: `"Unable to prepare host-key policy for executor
+    127.0.0.1:8080; refusing unpinned rental SSH"`. Fail-open returns `None` +
+    warning `"Unable to prepare known_hosts policy"`. `known_hosts_policy` is
+    unused in `add_ssh_key` (SDK path ignores it), not even assigned in
+    remove; only `install_jupyter_server` consumes it.
+15. **DAH-2265 skip_login asymmetry**: `skip_login = not has_credentials or
+    bool(ships_sshd)` (:3100) gates on `ships_sshd` ALONE — `ships_sshd` + a
+    non-blank `startup_commands` still skips docker login while falling back to
+    validator-managed bootstrap/`run_jupyter` (bootstrap skip gates on
+    `image_manages_services` :3608, `run_jupyter` skip on
+    `image_managed_jupyter` :3636).
+16. **`JUPYTER_PASSWORD` is injected into `custom_options.environment` BEFORE
+    the run-spec build** (:3279) — it travels as `docker run -e`, not
+    post-create.
+17. **E1 cancellation propagates but leaks**: `CancelledError` escapes the
+    except-Exception funnel (green test), but NO cleanup runs and the pending
+    pod leaks — documented as strict xfail ×3 seams (`docker_run`,
+    `ssh_bootstrap`, `finalize_add_rented_pod`); fix lands in PR-8. The
+    executor lock cannot leak at these seams (scoped inside
+    `generate_portMappings`, released before them).
+18. **B9 latent shape**: `handle_stream_logs` has no guard against starting
+    after `finish_stream_logs` — improbable with real I/O; candidate note for
+    PR-2 (LogStreamer). (An all-AsyncMock version of this race deadlocked the
+    B9 test until a real `await asyncio.sleep(0)` was added.)
+19. **Test-authoring trap**: a bare `Mock()` `attestation_service` makes
+    `await prepare_host_policy(...)` raise TypeError → the fail-open branch →
+    silently `None`. Stub it as AsyncMock (see harness) — PR-1b A4 must
+    override `harness.mocks["_prepare_known_hosts_policy"]`.
+20. **Live argv builder**: `build_container_command_argv` at
+    `src/services/rental_docker_sdk.py:560`, sole live call site
+    `docker_service.py:702` (`_build_rental_container_run_spec` →
+    `ContainerRunSpec.command`); `None`/empty/whitespace → `()`, shlex ValueError
+    → `()`. `build_startup_command_args` is dead (PR-3 decision, DRAFT §8).
+
+## E7 differential gate
+
+```bash
+cd neurons/validators
+make e7          # run against a real local docker daemon (byte-equal vs golden)
+make e7-record   # re-record after an INTENDED behavior change
+```
+
+D-B duty: extraction-PR authors (PR-2..PR-12) run `make e7` locally **before
+push** and record `E7: ran locally, N passed @ <sha>` in the PR description;
+snapshot drift = behavior change (fix it, or `make e7-record` + call the diff
+out in the PR). Full prerequisites, the macOS `DOCKER_HOST` gotcha, the PR-1a
+probe scope and the PR-2 old-vs-new evolution: `tests/integration/README_E7.md`.
+
+## Suite stats
+
+- **68 new tests** in `tests/docker_oracle/` — harness smoke 1,
+  `test_create_success.py` 9, `test_volume_sizing_and_ports.py` 11,
+  `test_sdk_retry_loop.py` 11, `test_delete_flow.py` 9,
+  `test_ssh_keys_and_jupyter.py` 9, `test_startup_argv.py` 5,
+  `test_behavior_invariants.py` 13 — plus **1 env-gated E7 test**
+  (`tests/integration/test_docker_service_differential.py`, skipped without
+  `RUN_RENTAL_DOCKER_SDK_INTEGRATION=1`) and assert-folds in 3 pre-existing
+  files (`test_deploy_optimizations.py`, `test_docker_service.py`,
+  `test_docker_service_rental_security.py`).
+- **The 3 xfails are by design** (strict):
+  `test_create_cancelled_midflight_runs_cleanup_and_removes_pending_pod` ×3
+  seams — the D1 deviation #1 SPEC test (cancellation cleanup, lands PR-8).
+- **Goldens** in `tests/fixtures/docker_oracle/`:
+  `container_created_success_golden.json` (durations masked `"<duration_ms>"`),
+  `profiler_name_sequence_golden.json` (the frozen 15-step sequence),
+  `e7_differential_probe_surface.json` (recorded from a real daemon). Review
+  any diff there as a behavior change, never as noise.
+- Full validators suite at PR-1a head: 1179 passed, 9 skipped, 3 xfailed;
+  3 pre-existing env-dependent failures in `test_sshd_bootstrap_script.py`
+  (unrelated to this PR).

--- a/neurons/validators/tests/docker_oracle/harness.py
+++ b/neurons/validators/tests/docker_oracle/harness.py
@@ -1,0 +1,575 @@
+"""Shared harness for the docker-service characterization oracle (DAH-2382, PR-1a).
+
+Consolidates the four near-copies of the fake rental docker client
+(test_docker_service.py, test_deploy_optimizations.py, test_custom_dockerfile_build.py,
+test_docker_service_rental_security.py) and their happy-path patchers
+(`_patch_happy`, `_patch_create_harness`) into the ONE helper every oracle suite
+builds on. Do not add a fifth ad-hoc copy — extend this module instead.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+from datura.requests.miner_requests import ExecutorSSHInfo
+from payload_models.payloads import (
+    ContainerCreateRequest,
+    ContainerDeleteRequest,
+    PayloadPortMapping,
+    WorkloadKind,
+)
+from services.docker_service import DockerService
+from services.rental_docker_sdk import (
+    ContainerExecResult,
+    ContainerExecSpec,
+    ContainerRunSpec,
+    build_gpu_docker_config,
+)
+
+from core.config import settings
+
+RecordedCall = tuple[str, dict[str, Any]]
+
+FAKE_SSH_HOST_KEY = "ssh-ed25519 AAAATESTKEY"
+DEFAULT_PORT_MAPS: list[tuple[int, int, int]] = [(22, 20001, 20001)]
+
+
+class FakeRentalDockerClient:
+    """Recording fake of RentalDockerSdkClient.
+
+    Every method appends ``(method_name, kwargs)`` to ``.calls`` in invocation
+    order (and, prefixed ``docker.``, to the shared cross-layer ``journal``)
+    before applying its configured outcome. Outcome knobs:
+
+    - ``image_exists`` is truthy when the image is in ``existing_images``.
+    - ``run_container``: ``run_errors`` is a FIFO queue raised one per call and
+      then success (retry-loop tests); ``run_error`` raises on every call.
+    - ``stop_error`` / ``remove_error`` raise on every call of their method.
+    """
+
+    def __init__(self, journal: list[RecordedCall] | None = None) -> None:
+        self.calls: list[RecordedCall] = []
+        self._journal = journal
+        self.existing_images: set[str] = set()
+        self.run_errors: list[Exception] = []
+        self.run_error: Exception | None = None
+        self.stop_error: Exception | None = None
+        self.remove_error: Exception | None = None
+
+    def _record(self, name: str, **kwargs: Any) -> None:
+        self.calls.append((name, kwargs))
+        if self._journal is not None:
+            self._journal.append((f"docker.{name}", kwargs))
+
+    def _named(self, name: str) -> list[dict[str, Any]]:
+        return [kwargs for called, kwargs in self.calls if called == name]
+
+    # -- recorded views (parity with the assertion idioms of the four legacy fakes) --
+
+    @property
+    def pulled_images(self) -> list[str]:
+        return [kwargs["image"] for kwargs in self._named("pull")]
+
+    @property
+    def run_specs(self) -> list[ContainerRunSpec]:
+        return [kwargs["spec"] for kwargs in self._named("run_container")]
+
+    @property
+    def started_containers(self) -> list[str]:
+        return [kwargs["container_name"] for kwargs in self._named("start")]
+
+    @property
+    def stopped_containers(self) -> list[str]:
+        return [kwargs["container_name"] for kwargs in self._named("stop")]
+
+    @property
+    def removed_containers(self) -> list[dict[str, Any]]:
+        return self._named("remove_container")
+
+    @property
+    def created_volumes(self) -> list[dict[str, Any]]:
+        return self._named("create_volume")
+
+    @property
+    def removed_volumes(self) -> list[dict[str, Any]]:
+        return self._named("remove_volume")
+
+    @property
+    def pruned_images(self) -> int:
+        return len(self._named("prune_images"))
+
+    # -- RentalDockerSdkClient surface --
+
+    async def login(self, *, username: str, password: str) -> None:
+        self._record("login", username=username, password=password)
+
+    async def image_exists(self, *, image: str) -> bool:
+        self._record("image_exists", image=image)
+        return image in self.existing_images
+
+    async def pull(self, *, image: str) -> None:
+        self._record("pull", image=image)
+
+    async def run_container(self, spec: ContainerRunSpec) -> None:
+        self._record("run_container", spec=spec)
+        if self.run_errors:
+            raise self.run_errors.pop(0)
+        if self.run_error is not None:
+            raise self.run_error
+
+    async def exec_in_container(self, spec: ContainerExecSpec) -> ContainerExecResult:
+        self._record("exec_in_container", spec=spec)
+        return ContainerExecResult(exit_status=0)
+
+    async def start(self, *, container_name: str) -> None:
+        self._record("start", container_name=container_name)
+
+    async def stop(self, *, container_name: str, stop_grace_seconds: int | None = None) -> None:
+        self._record("stop", container_name=container_name, stop_grace_seconds=stop_grace_seconds)
+        if self.stop_error is not None:
+            raise self.stop_error
+
+    async def remove_container(
+        self,
+        *,
+        container_name: str,
+        force: bool = True,
+        remove_volumes: bool = True,
+    ) -> None:
+        self._record(
+            "remove_container",
+            container_name=container_name,
+            force=force,
+            remove_volumes=remove_volumes,
+        )
+        if self.remove_error is not None:
+            raise self.remove_error
+
+    async def create_volume(
+        self,
+        *,
+        volume_name: str,
+        driver: str | None = None,
+        driver_opts: dict[str, str] | None = None,
+        timeout: int | None = None,
+    ) -> None:
+        self._record(
+            "create_volume",
+            volume_name=volume_name,
+            driver=driver,
+            driver_opts=driver_opts,
+            timeout=timeout,
+        )
+
+    async def remove_volume(self, *, volume_name: str, force: bool = False) -> None:
+        self._record("remove_volume", volume_name=volume_name, force=force)
+
+    async def prune_images(self) -> None:
+        self._record("prune_images")
+
+
+class FakeRentalDockerFactory:
+    def __init__(self, client: FakeRentalDockerClient) -> None:
+        self.client = client
+        self.connect_calls: list[dict[str, Any]] = []
+
+    def connect(
+        self, *, executor_info: ExecutorSSHInfo, private_key: str
+    ) -> FakeRentalDockerFactory:
+        self.connect_calls.append(
+            {"executor_info": executor_info, "private_key": private_key}
+        )
+        return self
+
+    async def __aenter__(self) -> FakeRentalDockerClient:
+        return self.client
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        return None
+
+
+class RecordingRedisService:
+    """Recording fake of RedisService for the create/delete paths.
+
+    ``.calls`` keeps the ordered cross-op sequence (the B7/E4 sketches assert
+    relative order across redis operations), ``.published`` captures pub/sub
+    messages, and get/set/delete are backed by the ``values`` dict so the
+    best-effort gpu-power reads see honest empty state instead of mock noise.
+    """
+
+    def __init__(self, journal: list[RecordedCall] | None = None) -> None:
+        self.calls: list[RecordedCall] = []
+        self._journal = journal
+        self.values: dict[str, str] = {}
+        self.published: list[tuple[str, dict[str, Any]]] = []
+        self.get_rented_machine_error: Exception | None = None
+
+    def _record(self, name: str, **kwargs: Any) -> None:
+        self.calls.append((name, kwargs))
+        if self._journal is not None:
+            self._journal.append((f"redis.{name}", kwargs))
+
+    @contextlib.asynccontextmanager
+    async def acquire_executor_lock(self, executor_id: str, **_: Any) -> AsyncIterator[None]:
+        self._record("acquire_executor_lock", executor_id=executor_id)
+        yield
+
+    async def add_pending_pod(self, miner_hotkey: str, executor_id: str, pod_id: str) -> None:
+        self._record(
+            "add_pending_pod", miner_hotkey=miner_hotkey, executor_id=executor_id, pod_id=pod_id
+        )
+
+    async def remove_pending_pod(self, miner_hotkey: str, executor_id: str, pod_id: str) -> None:
+        self._record(
+            "remove_pending_pod", miner_hotkey=miner_hotkey, executor_id=executor_id, pod_id=pod_id
+        )
+
+    async def add_rented_pod(
+        self, executor: ExecutorSSHInfo, pod_id: str, container_name: str
+    ) -> None:
+        self._record(
+            "add_rented_pod", executor=executor, pod_id=pod_id, container_name=container_name
+        )
+
+    async def remove_rented_machine(
+        self, executor: ExecutorSSHInfo, container_name: str | None = None
+    ) -> None:
+        # optional container_name mirrors the real RedisService signature
+        self._record(
+            "remove_rented_machine", executor=executor, container_name=container_name
+        )
+
+    async def get_rented_machine(self, executor: ExecutorSSHInfo) -> dict[str, Any] | None:
+        # honest empty state (no rented machine) unless a test arms the error knob
+        self._record("get_rented_machine", executor=executor)
+        if self.get_rented_machine_error is not None:
+            raise self.get_rented_machine_error
+        return None
+
+    async def publish(self, channel: str, message: dict[str, Any]) -> None:
+        self._record("publish", channel=channel, message=message)
+        self.published.append((channel, message))
+
+    async def get(self, key: str) -> str | None:
+        self._record("get", key=key)
+        return self.values.get(key)
+
+    async def set(self, key: str, value: str) -> None:
+        self._record("set", key=key, value=value)
+        self.values[key] = value
+
+    async def delete(self, key: str) -> None:
+        self._record("delete", key=key)
+        self.values.pop(key, None)
+
+
+class RecordingSSHClient:
+    """Records every host-shell command and returns a fixed result."""
+
+    def __init__(self, *, stdout: str = "", stderr: str = "", exit_status: int = 0) -> None:
+        self.commands: list[str] = []
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_status = exit_status
+
+    async def run(self, command: str, *args: Any, **kwargs: Any) -> SimpleNamespace:
+        self.commands.append(command)
+        return SimpleNamespace(
+            stdout=self.stdout,
+            stderr=self.stderr,
+            exit_status=self.exit_status,
+        )
+
+
+class _SSHConnCtx:
+    def __init__(self, ssh_client: RecordingSSHClient) -> None:
+        self.ssh_client = ssh_client
+
+    async def __aenter__(self) -> RecordingSSHClient:
+        return self.ssh_client
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        return None
+
+
+def patch_rental_ssh_connect(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    ssh_client: RecordingSSHClient | None = None,
+) -> tuple[RecordingSSHClient, Mock]:
+    # route services.docker_service.asyncssh (connect + import_private_key) to a
+    # recording client; returns (client, connect_mock) so tests can assert both
+    # the host commands and whether an SSH connection was opened at all
+    client = ssh_client if ssh_client is not None else RecordingSSHClient()
+    connect_mock = Mock(return_value=_SSHConnCtx(client))
+    monkeypatch.setattr("services.docker_service.asyncssh.connect", connect_mock)
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.import_private_key", Mock(return_value="pkey")
+    )
+    return client, connect_mock
+
+
+def make_create_request(**overrides: Any) -> ContainerCreateRequest:
+    # Small payload with a SHORT port list — the conftest sample_executor_info
+    # (1005 port_mappings) is deliberately NOT the base here.
+    base: dict[str, Any] = dict(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        docker_image="daturaai/pytorch:1.0.0",
+        user_public_keys=["ssh-ed25519 test-key"],
+        gpu_uuids=["GPU-test"],
+        cpu_count=1,
+        memory_gb=1,
+        volume_limit_gb=2,
+        storage_limit_gb=1,
+        available_ports=[PayloadPortMapping(internal_port=20001, external_port=20001)],
+        pod_mapping=[],
+        active_container_names=[],
+        active_volume_names=[],
+    )
+    base.update(overrides)
+    return ContainerCreateRequest(**base)
+
+
+def make_executor_info(payload: ContainerCreateRequest, **overrides: Any) -> ExecutorSSHInfo:
+    base: dict[str, Any] = dict(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
+    )
+    base.update(overrides)
+    return ExecutorSSHInfo(**base)
+
+
+def make_docker_service() -> DockerService:
+    # Bare-Mock dependencies; patch_create_happy_path swaps in the recording fakes.
+    return DockerService(
+        ssh_service=Mock(),
+        redis_service=Mock(),
+        attestation_service=Mock(),
+    )
+
+
+@dataclass
+class CreateContainerHarness:
+    """Seams into a patched create_container run.
+
+    ``mocks`` maps every patched name to its mock so tests can override
+    outcomes (e.g. ``harness.mocks["check_container_running"].return_value =
+    False``); ``journal`` interleaves redis and docker calls in invocation
+    order for cross-layer ordering asserts.
+    """
+
+    docker_client: FakeRentalDockerClient
+    docker_factory: FakeRentalDockerFactory
+    redis: RecordingRedisService
+    ssh_client: RecordingSSHClient
+    journal: list[RecordedCall]
+    mocks: dict[str, Any]
+    host_commands: list[str]
+
+
+def patch_create_happy_path(
+    svc: DockerService,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    port_maps: list[tuple[int, int, int]] | None = None,
+    jupyter_port_map: tuple[int, int] | None = None,
+    volume_limit_gb: int = 10,
+    storage_limit_gb: int = 20,
+    enable_inspector: bool = False,
+) -> CreateContainerHarness:
+    """Patch instance seams so create_container reaches a real ContainerCreated
+    with no SSH and no docker daemon.
+
+    Consolidates `_patch_happy` (test_deploy_optimizations.py) and
+    `_patch_create_harness` (test_docker_service_rental_security.py). Decision
+    D3: delegation is always ``self.<method>``, so seams are patched on the
+    DockerService INSTANCE; only asyncssh + the gpu-config module function are
+    patched in the services.docker_service namespace. The rental SDK layer
+    stays REAL down to the fake client — `_run_rental_docker_create_with_port_retry`,
+    run-spec building and key/environment exec injection all execute, so their
+    calls land in the fake's journal.
+    """
+    journal: list[RecordedCall] = []
+    docker_client = FakeRentalDockerClient(journal)
+    docker_factory = FakeRentalDockerFactory(docker_client)
+    redis = RecordingRedisService(journal)
+    ssh_client = RecordingSSHClient()
+    host_commands: list[str] = []
+
+    svc.rental_docker_client_factory = docker_factory
+    svc.redis_service = redis
+    svc.ssh_service.decrypt_payload = Mock(return_value="private-key")
+
+    async def _capture_streamed_command(*, command: str, **kwargs: Any) -> tuple[bool, str]:
+        host_commands.append(command)
+        return True, ""
+
+    mocks: dict[str, Any] = {
+        "generate_portMappings": AsyncMock(
+            return_value=(list(port_maps) if port_maps is not None else list(DEFAULT_PORT_MAPS),
+                          jupyter_port_map)
+        ),
+        "_prepare_known_hosts_policy": AsyncMock(return_value=None),
+        "clean_existing_containers": AsyncMock(),
+        "clean_stale_vloopback_volumes": AsyncMock(),
+        "resolve_volume_sizing": AsyncMock(
+            return_value=SimpleNamespace(
+                volume_limit_gb=volume_limit_gb, storage_limit_gb=storage_limit_gb
+            )
+        ),
+        "create_local_volume": AsyncMock(),
+        "wait_for_port_check_containers": AsyncMock(return_value=(True, "ok")),
+        "check_container_running": AsyncMock(return_value=True),
+        "install_open_ssh_server_and_start_ssh_service_with_rental_docker": AsyncMock(
+            return_value=True
+        ),
+        "run_jupyter": AsyncMock(),
+        "execute_and_stream_logs": AsyncMock(side_effect=_capture_streamed_command),
+        "stream_log": AsyncMock(),
+        "finish_stream_logs": AsyncMock(),
+        "handle_stream_logs": AsyncMock(),
+    }
+    for name, mock in mocks.items():
+        monkeypatch.setattr(svc, name, mock)
+
+    connect_mock = Mock(return_value=_SSHConnCtx(ssh_client))
+    monkeypatch.setattr("services.docker_service.asyncssh.connect", connect_mock)
+    import_private_key_mock = Mock(return_value="pkey")
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.import_private_key", import_private_key_mock
+    )
+    gpu_config_mock = AsyncMock(return_value=build_gpu_docker_config(["GPU-test"]))
+    monkeypatch.setattr(
+        "services.docker_service.build_gpu_docker_config_for_executor", gpu_config_mock
+    )
+    mocks["asyncssh.connect"] = connect_mock
+    mocks["asyncssh.import_private_key"] = import_private_key_mock
+    mocks["build_gpu_docker_config_for_executor"] = gpu_config_mock
+
+    # Pin the inspector flag: goldens must not depend on the developer's env
+    # (settings default is True; the B5/B6 sketches assume the step is skipped).
+    monkeypatch.setattr(settings, "ENABLE_INSPECTOR", enable_inspector)
+
+    return CreateContainerHarness(
+        docker_client=docker_client,
+        docker_factory=docker_factory,
+        redis=redis,
+        ssh_client=ssh_client,
+        journal=journal,
+        mocks=mocks,
+        host_commands=host_commands,
+    )
+
+
+def make_delete_request(**overrides: Any) -> ContainerDeleteRequest:
+    base: dict[str, Any] = dict(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_oracle_delete",
+    )
+    base.update(overrides)
+    return ContainerDeleteRequest(**base)
+
+
+@dataclass
+class DeleteContainerHarness:
+    """Seams into a patched delete_container run.
+
+    ``mocks`` maps each patched seam to its mock (set ``.side_effect`` to fail
+    a step); ``journal`` interleaves docker calls and the sweep in invocation
+    order for the D8 sweep-before-raise ordering assert.
+    """
+
+    docker_client: FakeRentalDockerClient
+    docker_factory: FakeRentalDockerFactory
+    redis: RecordingRedisService
+    ssh_client: RecordingSSHClient
+    journal: list[RecordedCall]
+    mocks: dict[str, Any]
+
+
+def patch_delete_happy_path(
+    svc: DockerService,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    enable_inspector: bool = False,
+) -> DeleteContainerHarness:
+    """Patch seams so delete_container reaches a real ContainerDeleted with no
+    SSH and no docker daemon.
+
+    The attestation chokepoint (``_prepare_known_hosts_policy``) runs for REAL —
+    only ``attestation_service.prepare_host_policy`` is faked, so D11 exercises
+    the actual AttestationError pass-through. ``_sweep_wedged_gpus_after_teardown``
+    and ``restore_filler_pod_gpu_power_limits`` are module-level functions on
+    baseline (NOT instance methods) and are patched in the
+    ``services.docker_service`` namespace; the sweep journals its invocation so
+    ordering against docker calls stays observable.
+    """
+    journal: list[RecordedCall] = []
+    docker_client = FakeRentalDockerClient(journal)
+    docker_factory = FakeRentalDockerFactory(docker_client)
+    redis = RecordingRedisService(journal)
+    ssh_client = RecordingSSHClient()
+
+    svc.rental_docker_client_factory = docker_factory
+    svc.redis_service = redis
+    svc.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    svc.attestation_service.prepare_host_policy = AsyncMock(
+        return_value=SimpleNamespace(known_hosts=None)
+    )
+
+    connect_mock = Mock(return_value=_SSHConnCtx(ssh_client))
+    monkeypatch.setattr("services.docker_service.asyncssh.connect", connect_mock)
+    import_key_mock = Mock(return_value="pkey")
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.import_private_key", import_key_mock
+    )
+
+    restore_power_mock = AsyncMock()
+    monkeypatch.setattr(
+        "services.docker_service.restore_filler_pod_gpu_power_limits",
+        restore_power_mock,
+    )
+
+    def _journal_sweep(*args: Any, **kwargs: Any) -> None:
+        journal.append(("sweep.teardown_sweep", {}))
+
+    sweep_mock = AsyncMock(side_effect=_journal_sweep)
+    monkeypatch.setattr(
+        "services.docker_service._sweep_wedged_gpus_after_teardown", sweep_mock
+    )
+
+    monkeypatch.setattr(settings, "ENABLE_INSPECTOR", enable_inspector)
+
+    mocks: dict[str, Any] = {
+        "asyncssh.connect": connect_mock,
+        "asyncssh.import_private_key": import_key_mock,
+        "prepare_host_policy": svc.attestation_service.prepare_host_policy,
+        "restore_filler_pod_gpu_power_limits": restore_power_mock,
+        "_sweep_wedged_gpus_after_teardown": sweep_mock,
+    }
+    return DeleteContainerHarness(
+        docker_client=docker_client,
+        docker_factory=docker_factory,
+        redis=redis,
+        ssh_client=ssh_client,
+        journal=journal,
+        mocks=mocks,
+    )

--- a/neurons/validators/tests/docker_oracle/test_behavior_invariants.py
+++ b/neurons/validators/tests/docker_oracle/test_behavior_invariants.py
@@ -1,0 +1,494 @@
+"""Behavior-class invariants for the docker-service oracle (DAH-2382 PR-1a, group E).
+
+E1-E6 of characterization-oracle-DRAFT.md §E: cancellation, concurrency,
+idempotency, side-effect ordering, orphan resources, nondeterminism control.
+Unlike groups A-D these encode INVARIANTS, not pure characterization: where
+baseline 6be5649f already upholds an invariant the test is plain green; where
+it deviates (the D1 deviation list in design.md) the test asserts the DESIRED
+behavior under ``xfail(strict=True)`` so it documents the gap and flips loudly
+when the fix lands.
+
+Observed on baseline (feeds the oracle README):
+- E1: ``CancelledError`` PROPAGATES out of ``create_container`` (both inner
+  ``except Exception`` cleanups and the outer funnel are Exception-only), but
+  NO cleanup runs and the pending pod LEAKS -> propagation is green, the
+  cleanup half is an xfail SPEC test. The executor lock cannot leak at these
+  seams: it is scoped inside ``generate_portMappings`` (patched here) and is
+  released before any E1 seam runs.
+- E2/E3/E4/E5/E6 all HOLD on baseline -> plain green.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from datura.requests.miner_requests import ExecutorSSHInfo
+from docker_oracle.harness import (
+    CreateContainerHarness,
+    RecordedCall,
+    make_create_request,
+    make_delete_request,
+    make_docker_service,
+    make_executor_info,
+    patch_create_happy_path,
+    patch_delete_happy_path,
+)
+from payload_models.payloads import (
+    ContainerCreated,
+    ContainerCreateRequest,
+    ContainerDeleted,
+    FailedContainerRequest,
+)
+from services.docker_service import DockerService
+from services.rental_docker_sdk import RentalDockerOperationError
+
+_JUPYTER_PORT_MAP: tuple[int, int] = (8888, 30888)
+
+# The three awaited seams of E1: one inside the docker-run inner try, one inside
+# the post-run provisioning inner try, one at the finalize redis write.
+_CANCEL_SEAMS: list[str] = ["docker_run", "ssh_bootstrap", "finalize_add_rented_pod"]
+
+
+async def _create(
+    svc: DockerService,
+    payload: ContainerCreateRequest,
+    executor_info: ExecutorSSHInfo,
+) -> Any:
+    return await svc.create_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+
+def _inject_cancelled_error(
+    harness: CreateContainerHarness, monkeypatch: pytest.MonkeyPatch, seam: str
+) -> None:
+    # arm exactly one awaited step of the create path to raise CancelledError when reached
+    if seam == "docker_run":
+        harness.docker_client.run_error = asyncio.CancelledError()
+    elif seam == "ssh_bootstrap":
+        harness.mocks[
+            "install_open_ssh_server_and_start_ssh_service_with_rental_docker"
+        ].side_effect = asyncio.CancelledError()
+    elif seam == "finalize_add_rented_pod":
+        monkeypatch.setattr(
+            harness.redis, "add_rented_pod", AsyncMock(side_effect=asyncio.CancelledError())
+        )
+    else:  # pragma: no cover - guards against a typo in the parametrize list
+        raise ValueError(f"unknown seam: {seam}")
+
+
+def _spy_cleanup(
+    svc: DockerService,
+    monkeypatch: pytest.MonkeyPatch,
+    journal: list[RecordedCall],
+) -> list[dict[str, Any]]:
+    # record every cleanup_failed_container_creation call (also into the shared
+    # journal for cross-layer ordering asserts) while delegating to the real method
+    calls: list[dict[str, Any]] = []
+    real_cleanup = svc.cleanup_failed_container_creation
+
+    async def _wrapped(**kwargs: Any) -> None:
+        calls.append(kwargs)
+        journal.append(("cleanup.failed_container_creation", {}))
+        await real_cleanup(**kwargs)
+
+    monkeypatch.setattr(svc, "cleanup_failed_container_creation", _wrapped)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# E1 — cancellation mid-flight
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("seam", _CANCEL_SEAMS)
+async def test_create_cancelled_midflight_propagates_cancellation(
+    monkeypatch: pytest.MonkeyPatch, seam: str
+) -> None:
+    # Arrange
+    svc = make_docker_service()
+    harness = patch_create_happy_path(svc, monkeypatch)
+    _inject_cancelled_error(harness, monkeypatch, seam)
+    payload = make_create_request()
+    executor_info = make_executor_info(payload)
+
+    # Act / Assert
+    # WHY: cancellation must never be swallowed into a FailedContainerRequest —
+    # in py3.11 CancelledError is a BaseException, so the except-Exception
+    # funnel does not catch it and it re-raises to the caller (HOLDS on baseline).
+    with pytest.raises(asyncio.CancelledError):
+        await _create(svc, payload, executor_info)
+
+    # WHY: sanity that the cancel hit AFTER the pending-pod write, i.e. the seam
+    # really was mid-flight and not an early return.
+    pending_calls = [name for name, _ in harness.redis.calls if name == "add_pending_pod"]
+    assert pending_calls == ["add_pending_pod"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("seam", _CANCEL_SEAMS)
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "D1 deviation #1: create_container has no finally/BaseException handling — a "
+        "CancelledError skips both inner except-Exception blocks AND the outer funnel, so "
+        "cleanup_failed_container_creation never runs and the pending pod leaks; fixed in "
+        "PR-8 (Compensations: LIFO on error and cancellation)"
+    ),
+)
+async def test_create_cancelled_midflight_runs_cleanup_and_removes_pending_pod(
+    monkeypatch: pytest.MonkeyPatch, seam: str
+) -> None:
+    # Arrange
+    svc = make_docker_service()
+    harness = patch_create_happy_path(svc, monkeypatch)
+    cleanup_calls = _spy_cleanup(svc, monkeypatch, harness.journal)
+    _inject_cancelled_error(harness, monkeypatch, seam)
+    payload = make_create_request()
+    executor_info = make_executor_info(payload)
+
+    # Act
+    with pytest.raises(asyncio.CancelledError):
+        await _create(svc, payload, executor_info)
+
+    # Assert
+    # WHY: cancellation midway through resource acquisition must not orphan the
+    # container/volume on the miner host nor leak the pending-pod redis entry
+    # (desired invariant — SPEC test, no compliant baseline exists).
+    assert cleanup_calls, "cleanup_failed_container_creation must run on cancellation"
+    removed = [name for name, _ in harness.redis.calls if name == "remove_pending_pod"]
+    assert removed, "remove_pending_pod must be awaited on cancellation"
+
+
+# ---------------------------------------------------------------------------
+# E2 — concurrent creates on distinct pods, one service instance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_create_distinct_pods_no_shared_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: ONE service instance, ONE harness (single shared journal). The
+    # port planner seam returns a port keyed off the executor_id ARGUMENT, so
+    # any cross-request state bleed would surface as swapped ports/names in the
+    # results; the sleep(0) forces the two creates to actually interleave.
+    svc = make_docker_service()
+    harness = patch_create_happy_path(svc, monkeypatch)
+    payload_a = make_create_request()
+    payload_b = make_create_request()
+    executor_a = make_executor_info(payload_a)
+    executor_b = make_executor_info(payload_b)
+    port_by_executor = {payload_a.executor_id: 20001, payload_b.executor_id: 20002}
+
+    async def _ports_for_request(
+        miner_hotkey: str, executor_id: str, *args: Any, **kwargs: Any
+    ) -> tuple[list[tuple[int, int, int]], None]:
+        await asyncio.sleep(0)
+        port = port_by_executor[executor_id]
+        return [(22, port, port)], None
+
+    harness.mocks["generate_portMappings"].side_effect = _ports_for_request
+
+    # Act
+    result_a, result_b = await asyncio.gather(
+        _create(svc, payload_a, executor_a),
+        _create(svc, payload_b, executor_b),
+    )
+
+    # Assert
+    # WHY: one facade instance served both requests concurrently — each result
+    # must carry ITS OWN pod identity, names and ports (no cross-talk).
+    assert isinstance(result_a, ContainerCreated)
+    assert isinstance(result_b, ContainerCreated)
+    assert result_a.pod_id == payload_a.pod_id
+    assert result_b.pod_id == payload_b.pod_id
+    assert result_a.container_name == f"pod_{payload_a.pod_id}"
+    assert result_b.container_name == f"pod_{payload_b.pod_id}"
+    assert result_a.volume_name == f"volume_{payload_a.pod_id}"
+    assert result_b.volume_name == f"volume_{payload_b.pod_id}"
+    assert result_a.port_maps == [(22, 20001)]
+    assert result_b.port_maps == [(22, 20002)]
+
+    # WHY: the shared journal must show BOTH pods' full redis lifecycle and both
+    # docker runs — neither request may swallow or overwrite the other's records.
+    pending_pod_ids = sorted(
+        kwargs["pod_id"] for name, kwargs in harness.redis.calls if name == "add_pending_pod"
+    )
+    assert pending_pod_ids == sorted([payload_a.pod_id, payload_b.pod_id])
+    rented = {
+        kwargs["pod_id"]: kwargs["container_name"]
+        for name, kwargs in harness.redis.calls
+        if name == "add_rented_pod"
+    }
+    assert rented == {
+        payload_a.pod_id: f"pod_{payload_a.pod_id}",
+        payload_b.pod_id: f"pod_{payload_b.pod_id}",
+    }
+    run_container_names = {spec.name for spec in harness.docker_client.run_specs}
+    assert run_container_names == {f"pod_{payload_a.pod_id}", f"pod_{payload_b.pod_id}"}
+
+
+# ---------------------------------------------------------------------------
+# E3 — delete idempotency (backend delivery is at-least-once)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_container_is_idempotent_when_container_already_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    svc = make_docker_service()
+    harness = patch_delete_happy_path(svc, monkeypatch)
+    payload = make_delete_request()
+    # make_executor_info only reads executor_id, shared by create/delete payloads
+    executor_info = make_executor_info(payload)
+    keypair = Mock(ss58_address="validator-hotkey")
+
+    # Act: first delete succeeds normally
+    first = await svc.delete_container(
+        payload=payload, executor_info=executor_info, keypair=keypair, private_key="encrypted"
+    )
+
+    # Arrange the retry: the container is now gone. The real SDK wraps docker-py's
+    # NotFound into RentalDockerOperationError carrying dockerd's "No such
+    # container" text (rental_docker_sdk._call_api); delete detects "missing" by
+    # that phrase (_is_missing_docker_container_error), not by exception type.
+    harness.docker_client.stop_error = RentalDockerOperationError(
+        "Docker SDK stop failed: 404 Client Error: Not Found "
+        f'("No such container: {payload.container_name}")'
+    )
+    harness.docker_client.remove_error = RentalDockerOperationError(
+        "Docker SDK remove container failed: 404 Client Error: Not Found "
+        f'("No such container: {payload.container_name}")'
+    )
+
+    # Act: second delete of the same, now-missing container
+    second = await svc.delete_container(
+        payload=payload, executor_info=executor_info, keypair=keypair, private_key="encrypted"
+    )
+
+    # Assert
+    # WHY: backend delivery is at-least-once — a retried delete of an
+    # already-removed container must be a successful no-op, never an error
+    # (DAH-2345), or the backend retries a doomed request and penalizes the miner.
+    assert isinstance(first, ContainerDeleted)
+    assert isinstance(second, ContainerDeleted)
+
+    # WHY: idempotency must come from tolerating the missing container, not from
+    # skipping the work — both deletes must actually attempt stop + remove, and
+    # remove_rented_machine must be safe to repeat.
+    assert harness.docker_client.stopped_containers == [payload.container_name] * 2
+    removed_names = [kwargs["container_name"] for kwargs in harness.docker_client.removed_containers]
+    assert removed_names == [payload.container_name] * 2
+    rented_machine_removals = [
+        name for name, _ in harness.redis.calls if name == "remove_rented_machine"
+    ]
+    assert rented_machine_removals == ["remove_rented_machine"] * 2
+
+
+# ---------------------------------------------------------------------------
+# E4 — redis-vs-docker side-effect ordering (crash-recovery contract)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_redis_vs_docker_ordering(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange: mark the (patched) running check in the shared journal so its
+    # position is comparable with the redis.* / docker.* entries.
+    svc = make_docker_service()
+    harness = patch_create_happy_path(svc, monkeypatch)
+
+    async def _running_check_marker(*args: Any, **kwargs: Any) -> bool:
+        harness.journal.append(("check.container_running", {}))
+        return True
+
+    harness.mocks["check_container_running"].side_effect = _running_check_marker
+    payload = make_create_request()
+    executor_info = make_executor_info(payload)
+
+    # Act
+    result = await _create(svc, payload, executor_info)
+
+    # Assert
+    assert isinstance(result, ContainerCreated)
+    names = [name for name, _ in harness.journal]
+    ordered_probes = [
+        "redis.add_pending_pod",
+        "docker.run_container",
+        "check.container_running",
+        "redis.add_rented_pod",
+    ]
+    # WHY: index() below must be unambiguous — each probe fires exactly once on
+    # this happy path.
+    for probe in ordered_probes:
+        assert names.count(probe) == 1, f"{probe} recorded {names.count(probe)} times"
+    # WHY: this order is invisible in the final state but decides crash-recovery:
+    # the pending-pod record must exist BEFORE any docker resource is created,
+    # and the rented-pod record only AFTER the container is confirmed running.
+    probe_positions = [names.index(probe) for probe in ordered_probes]
+    assert probe_positions == sorted(probe_positions), f"journal order broken: {names}"
+
+
+# ---------------------------------------------------------------------------
+# E5 — no orphan docker resources on create failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_failure_at_docker_run_cleans_up_container_and_volume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    svc = make_docker_service()
+    harness = patch_create_happy_path(svc, monkeypatch)
+    cleanup_calls = _spy_cleanup(svc, monkeypatch, harness.journal)
+    harness.docker_client.run_error = RentalDockerOperationError(
+        "Docker SDK run container failed: No such image: daturaai/pytorch:1.0.0"
+    )
+    payload = make_create_request()
+    executor_info = make_executor_info(payload)
+    container_name = f"pod_{payload.pod_id}"
+    volume_name = f"volume_{payload.pod_id}"
+
+    # Act
+    result = await _create(svc, payload, executor_info)
+
+    # Assert
+    # WHY: the funnel must report the failure at the docker_run step — and the
+    # just-created container/volume must not be stranded on the miner host
+    # (disk-exhaustion guard), so cleanup runs before the funnel returns.
+    assert isinstance(result, FailedContainerRequest)
+    assert result.failure_step == "docker_run"
+    assert len(cleanup_calls) == 1
+    assert cleanup_calls[0]["container_name"] == container_name
+    assert cleanup_calls[0]["volume_name"] == volume_name
+    assert cleanup_calls[0]["remove_volume"] is True
+
+    # WHY: cleanup's real sink is the host shell (docker rm -fv + docker volume
+    # rm over SSH), not the SDK client — assert at the seam that actually fires.
+    assert any(
+        f"/usr/bin/docker rm -fv {container_name}" in command
+        for command in harness.ssh_client.commands
+    )
+    assert any(
+        f"/usr/bin/docker volume rm {volume_name}" in command
+        for command in harness.ssh_client.commands
+    )
+
+    # WHY: cleanup must complete BEFORE the funnel's pending-pod removal — the
+    # funnel is the last step before the failure is reported to the backend.
+    names = [name for name, _ in harness.journal]
+    assert names.index("cleanup.failed_container_creation") < names.index(
+        "redis.remove_pending_pod"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_failure_at_health_check_cleans_up_container_and_volume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    svc = make_docker_service()
+    harness = patch_create_happy_path(svc, monkeypatch)
+    cleanup_calls = _spy_cleanup(svc, monkeypatch, harness.journal)
+    harness.mocks["check_container_running"].return_value = False
+    payload = make_create_request()
+    executor_info = make_executor_info(payload)
+    container_name = f"pod_{payload.pod_id}"
+    volume_name = f"volume_{payload.pod_id}"
+
+    # Act
+    result = await _create(svc, payload, executor_info)
+
+    # Assert
+    # WHY: a container that started but is not running is still an orphan-to-be —
+    # the sticky step reports container_health_check (not docker_run) and the
+    # same cleanup contract applies.
+    assert isinstance(result, FailedContainerRequest)
+    assert result.failure_step == "container_health_check"
+    assert len(cleanup_calls) == 1
+    assert cleanup_calls[0]["container_name"] == container_name
+    assert cleanup_calls[0]["volume_name"] == volume_name
+    assert cleanup_calls[0]["remove_volume"] is True
+    assert any(
+        f"/usr/bin/docker rm -fv {container_name}" in command
+        for command in harness.ssh_client.commands
+    )
+    assert any(
+        f"/usr/bin/docker volume rm {volume_name}" in command
+        for command in harness.ssh_client.commands
+    )
+
+
+# ---------------------------------------------------------------------------
+# E6 — secrets are injected per request, not module-global
+# ---------------------------------------------------------------------------
+
+
+def _token_of(jupyter_url: str) -> str:
+    return jupyter_url.split("token=")[1]
+
+
+@pytest.mark.asyncio
+async def test_jupyter_token_fresh_per_request_no_global_leak(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange / Act: two fully fresh service+harness pairs, token source NOT
+    # patched — the only nondeterminism left is secrets.token_hex itself.
+    svc_a = make_docker_service()
+    harness_a = patch_create_happy_path(svc_a, monkeypatch, jupyter_port_map=_JUPYTER_PORT_MAP)
+    payload_a = make_create_request(enable_jupyter=True)
+    result_a = await _create(svc_a, payload_a, make_executor_info(payload_a))
+
+    svc_b = make_docker_service()
+    patch_create_happy_path(svc_b, monkeypatch, jupyter_port_map=_JUPYTER_PORT_MAP)
+    payload_b = make_create_request(enable_jupyter=True)
+    result_b = await _create(svc_b, payload_b, make_executor_info(payload_b))
+
+    # Assert
+    # WHY: each request must draw a fresh token from secrets.token_hex(16) —
+    # equal tokens across requests would mean a module-global secret leaking
+    # between rentals.
+    token_a = _token_of(result_a.jupyter_url)
+    token_b = _token_of(result_b.jupyter_url)
+    assert token_a != token_b
+    for token in (token_a, token_b):
+        assert len(token) == 32
+        assert all(char in "0123456789abcdef" for char in token)
+
+    # WHY: the URL token and the token handed to run_jupyter must be the same
+    # secret — a mismatch would serve a Jupyter the renter cannot open.
+    assert harness_a.mocks["run_jupyter"].await_args.kwargs["jupyter_token"] == token_a
+
+
+@pytest.mark.asyncio
+async def test_jupyter_token_source_injectable_for_deterministic_goldens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: pin the sole token source (secrets.token_hex as referenced by
+    # services.docker_service) — goldens over the success payload rely on this seam.
+    svc = make_docker_service()
+    patch_create_happy_path(svc, monkeypatch, jupyter_port_map=_JUPYTER_PORT_MAP)
+    monkeypatch.setattr(
+        "services.docker_service.secrets.token_hex", lambda nbytes: "ab" * 16
+    )
+    payload = make_create_request(enable_jupyter=True)
+    executor_info = make_executor_info(payload)
+
+    # Act
+    result = await _create(svc, payload, executor_info)
+
+    # Assert
+    # WHY: with the nondeterminism seam pinned, the jupyter_url is byte-stable —
+    # host from executor address, port from jupyter_port_map[1], token injected.
+    assert isinstance(result, ContainerCreated)
+    assert result.jupyter_url == f"http://127.0.0.1:30888/lab?token={'ab' * 16}"

--- a/neurons/validators/tests/docker_oracle/test_create_success.py
+++ b/neurons/validators/tests/docker_oracle/test_create_success.py
@@ -1,0 +1,441 @@
+"""Oracle group B — create_container SUCCESS path (DAH-2382, PR-1a).
+
+Freezes the observable success boundary of DockerService.create_container on
+baseline 6be5649f: the full ContainerCreated wire form (B1), the three
+ProfilerStep wire shapes as produced by a real run (B2-B4), the ordered
+profiler step-name sequence (B5), the Loki "Deployment profile summary"
+profile_steps format (B6), the redis operation order incl. the executor lock
+(B7), the FILLER-only pending-pod cleanup (B8) and the streaming pub/sub
+payload shape (B9). B10/B11 are folded into test_deploy_optimizations.py and
+B12 is already covered there (DRAFT §0.5).
+
+Normalization per DRAFT §0: clock-derived durations are masked in goldens,
+absent key != null (exact key-set asserts on wire dicts), goldens use the
+repo's own --update-snapshot flag.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import services.docker_service as ds_module
+from docker_oracle.harness import (
+    make_create_request,
+    make_docker_service,
+    make_executor_info,
+    patch_create_happy_path,
+)
+from payload_models.payloads import (
+    ContainerCreated,
+    ContainerCreateRequest,
+    PayloadPortMapping,
+    ProfilerStepName,
+    WorkloadKind,
+)
+from services.docker_service import DockerService
+from services.redis_service import STREAMING_LOG_CHANNEL
+
+_FIXTURES_DIR = Path(__file__).parent.parent / "fixtures" / "docker_oracle"
+
+# Fixed ids so the B1 golden is byte-stable (pod_id must be a valid UUID —
+# create_container calls UUID(payload.pod_id) before the port planner).
+_B1_EXECUTOR_ID = "00000000-0000-0000-0000-0000000000e1"
+_B1_POD_ID = "00000000-0000-0000-0000-0000000000b1"
+
+
+def _assert_matches_golden(path: Path, serialized: str, update_snapshot: bool) -> None:
+    # repo-native golden mechanism (test_custom_dockerfile_build.py::test_A1 pattern):
+    # write-on-missing (then fail asking for a re-run), refresh via --update-snapshot,
+    # otherwise assert byte-equality.
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if update_snapshot or not path.exists():
+        path.write_text(serialized + "\n", encoding="utf-8")
+        if not update_snapshot:
+            pytest.fail(
+                f"Golden snapshot did not exist; wrote it. Re-run to assert. Path={path}"
+            )
+        return
+    expected = path.read_text(encoding="utf-8").rstrip("\n")
+    assert serialized == expected, (
+        "docker_service success golden drifted! Refresh with --update-snapshot only for an\n"
+        f"INTENDED behavior change. Path={path}\nexpected={expected!r}\nactual={serialized!r}"
+    )
+
+
+async def _create(svc: DockerService, payload: ContainerCreateRequest) -> object:
+    # drive the real create_container against the harness seams
+    return await svc.create_container(
+        payload=payload,
+        executor_info=make_executor_info(payload),
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+
+# ------------------------------------------------------------------
+# B1 — full ContainerCreated golden
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_container_created_full_golden(
+    monkeypatch: pytest.MonkeyPatch, update_snapshot: bool
+) -> None:
+    # Arrange
+    svc = make_docker_service()
+    patch_create_happy_path(svc, monkeypatch)  # ports [(22,20001,20001)], sizing 10/20
+    payload = make_create_request(
+        executor_id=_B1_EXECUTOR_ID,
+        pod_id=_B1_POD_ID,
+        backup_log_id="b1",
+        restore_path="/r",
+        enable_jupyter=False,
+    )
+
+    # Act
+    result = await _create(svc, payload)
+
+    # Assert
+    # WHY: pin the semantically loaded success fields explicitly (readable failures)
+    # before freezing the byte form — incl. the (docker, external) port projection,
+    # the fresh-sizing override of the payload limits and the "/root" default path.
+    assert isinstance(result, ContainerCreated)
+    assert result.workload_kind is WorkloadKind.CUSTOMER_RENTAL
+    assert result.container_name == f"pod_{_B1_POD_ID}"
+    assert result.volume_name == f"volume_{_B1_POD_ID}"
+    assert result.port_maps == [(22, 20001)]
+    assert result.backup_log_id == "b1"
+    assert result.restore_path == "/r"
+    assert result.jupyter_url is None
+    assert result.warnings == []
+    assert result.storage_limit_gb == 20
+    assert result.volume_limit_gb == 10
+    assert result.local_volume_path == "/root"
+    assert result.profilers, "profilers must be non-empty on success"
+
+    # WHY: the serialized response is what the backend parses — freeze it byte-for-byte
+    # with clock-derived durations masked (§0: assert type/relation, never literals).
+    data = json.loads(result.model_dump_json())
+    for step in data["profilers"]:
+        assert isinstance(step["duration"], int) and step["duration"] >= 0, step
+        step["duration"] = "<duration_ms>"
+    serialized = json.dumps(data, indent=2)
+    _assert_matches_golden(
+        _FIXTURES_DIR / "container_created_success_golden.json", serialized, update_snapshot
+    )
+
+
+# ------------------------------------------------------------------
+# B2/B3/B4 — the three ProfilerStep wire shapes, from a REAL run
+# (hand-built instances are shape-tested in test_deploy_optimizations.py:691)
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_profiler_shape_anchor_timestamp(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange: the backend-sent timestamp becomes the anchor step
+    svc = make_docker_service()
+    patch_create_happy_path(svc, monkeypatch)
+    payload = make_create_request(timestamp=1_700_000_000_000)
+
+    # Act
+    result = await _create(svc, payload)
+
+    # Assert
+    # WHY: the anchor wire shape is exactly {name, timestamp} — no duration/skipped
+    # key may appear (absent key != null for the backend parser), and the timestamp
+    # is the request value passed through untouched.
+    assert isinstance(result, ContainerCreated)
+    anchor = result.profilers[0]
+    assert anchor.model_dump() == {
+        "name": "Requested from backend",
+        "timestamp": 1_700_000_000_000,
+    }
+
+
+@pytest.mark.asyncio
+async def test_profiler_shape_duration_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange: no request timestamp -> the first step is a plain duration step
+    svc = make_docker_service()
+    patch_create_happy_path(svc, monkeypatch)
+    payload = make_create_request()
+
+    # Act
+    result = await _create(svc, payload)
+
+    # Assert
+    # WHY: a non-skipped step serializes to exactly {name, duration} —
+    # skipped=False is omitted from the wire, not sent as false.
+    assert isinstance(result, ContainerCreated)
+    dumped = result.profilers[0].model_dump()
+    assert set(dumped) == {"name", "duration"}
+    assert dumped["name"] == "Started in subnet"
+    assert isinstance(dumped["duration"], int) and dumped["duration"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_profiler_shape_duration_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange: image already present on the executor -> the pull short-circuits
+    svc = make_docker_service()
+    harness = patch_create_happy_path(svc, monkeypatch)
+    payload = make_create_request()
+    harness.docker_client.existing_images.add(payload.docker_image)
+
+    # Act
+    result = await _create(svc, payload)
+
+    # Assert
+    # WHY: a short-circuited step serializes to exactly {name, duration, skipped: true}
+    # — and the skip is real: no pull was issued to the docker client.
+    assert isinstance(result, ContainerCreated)
+    pull = next(p for p in result.profilers if p.name is ProfilerStepName.DOCKER_PULL)
+    dumped = pull.model_dump()
+    assert set(dumped) == {"name", "duration", "skipped"}
+    assert dumped["name"] == "Docker pull step finished"
+    assert dumped["skipped"] is True
+    assert isinstance(dumped["duration"], int) and dumped["duration"] >= 0
+    assert harness.docker_client.pulled_images == []
+
+
+# ------------------------------------------------------------------
+# B5 — ordered profiler name sequence (golden file, not an inline literal)
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_profiler_name_sequence_golden(
+    monkeypatch: pytest.MonkeyPatch, update_snapshot: bool
+) -> None:
+    # Arrange: happy path, jupyter off, inspector off (harness default), image
+    # absent (default), no request timestamp
+    svc = make_docker_service()
+    patch_create_happy_path(svc, monkeypatch)
+    payload = make_create_request()
+
+    # Act
+    result = await _create(svc, payload)
+
+    # Assert
+    assert isinstance(result, ContainerCreated)
+    names = [p.name.value for p in result.profilers]
+    # WHY: the anchor is gated on a truthy payload.timestamp — with none sent it
+    # must not appear at all (the sequence starts at "Started in subnet").
+    assert ProfilerStepName.REQUESTED_FROM_BACKEND.value not in names
+    assert names[0] == "Started in subnet"
+    # WHY: extraction must not drop, reorder or duplicate a deploy step; the ordered
+    # list is frozen as a golden file (a DAH-2440-style added step then shows up as a
+    # reviewable golden diff instead of a stale inline literal).
+    serialized = json.dumps(names, indent=2)
+    _assert_matches_golden(
+        _FIXTURES_DIR / "profiler_name_sequence_golden.json", serialized, update_snapshot
+    )
+
+
+# ------------------------------------------------------------------
+# B6 — Loki "Deployment profile summary" profile_steps format
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loki_profile_steps_format(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange: spy the module logger; request timestamp set so the anchor row
+    # exists; inspector off (harness default) so its row reports skipped
+    svc = make_docker_service()
+    patch_create_happy_path(svc, monkeypatch)
+    payload = make_create_request(timestamp=1_700_000_000_000)
+    spy_logger = Mock()
+    monkeypatch.setattr(ds_module, "logger", spy_logger)
+
+    # Act
+    result = await _create(svc, payload)
+
+    # Assert
+    assert isinstance(result, ContainerCreated)
+    summaries = [
+        c
+        for c in spy_logger.info.call_args_list
+        if c.args and getattr(c.args[0], "message", None) == "Deployment profile summary"
+    ]
+    # WHY: the Loki summary is the dashboard/classifier surface and is emitted
+    # exactly once on the success path.
+    assert len(summaries) == 1
+    extra = summaries[0].args[0].extra
+    profile_steps = extra["profile_steps"]
+    assert profile_steps
+    # WHY: unlike the ProfilerStep model serializer, the Loki dict-comp emits ALL
+    # THREE keys unconditionally — skipped always present, duration_ms nullable.
+    for entry in profile_steps:
+        assert set(entry) == {"name", "duration_ms", "skipped"}, entry
+    # WHY: the anchor row surfaces as duration_ms=null (never dropped) and is not skipped.
+    anchor = next(e for e in profile_steps if e["name"] == "Requested from backend")
+    assert anchor["duration_ms"] is None
+    assert anchor["skipped"] is False
+    # WHY: with ENABLE_INSPECTOR off the inspector row must still appear, marked skipped.
+    inspector = next(
+        e for e in profile_steps if e["name"] == "Inspector collector start step finished"
+    )
+    assert inspector["skipped"] is True
+    # WHY: the total excludes the anchor via `duration or 0` — it must equal the sum
+    # of the emitted rows exactly (relation, not literal, per §0 masking rules).
+    assert isinstance(extra["total_duration_ms"], int)
+    assert extra["total_duration_ms"] == sum(e["duration_ms"] or 0 for e in profile_steps)
+
+
+# ------------------------------------------------------------------
+# B7 — redis operation order for CUSTOMER_RENTAL (executor lock included)
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_redis_operation_order_customer_rental(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange: the executor lock lives INSIDE generate_portMappings, which the
+    # harness patches — restore the REAL planner over a small real port set so
+    # the lock acquisition lands in the journal (harness fact (b)).
+    svc = make_docker_service()
+    harness = patch_create_happy_path(svc, monkeypatch)
+    monkeypatch.setattr(
+        svc, "generate_portMappings", DockerService.generate_portMappings.__get__(svc)
+    )
+    payload = make_create_request(
+        available_ports=[
+            PayloadPortMapping(internal_port=port, external_port=port)
+            for port in (20000, 20001, 20002)
+        ],
+    )
+
+    # Act
+    result = await _create(svc, payload)
+
+    # Assert
+    assert isinstance(result, ContainerCreated)
+    tracked = {
+        "redis.acquire_executor_lock",
+        "redis.add_pending_pod",
+        "redis.add_rented_pod",
+        "redis.remove_pending_pod",
+    }
+    redis_ops = [name for name, _ in harness.journal if name in tracked]
+    # WHY: crash recovery depends on this exact sequence — lock during port planning,
+    # pending marker before any docker work, rented marker only after success; and a
+    # successful CUSTOMER_RENTAL never removes its pending pod.
+    assert redis_ops == [
+        "redis.acquire_executor_lock",
+        "redis.add_pending_pod",
+        "redis.add_rented_pod",
+    ]
+    # WHY: the lock is per-executor — it must be taken with this payload's executor_id.
+    lock_calls = [
+        kwargs for name, kwargs in harness.journal if name == "redis.acquire_executor_lock"
+    ]
+    assert lock_calls == [{"executor_id": payload.executor_id}]
+    # WHY: the pending marker must precede the docker-side run and the rented marker
+    # must follow it (the cross-layer ordering the boundary result cannot show).
+    op_names = [name for name, _ in harness.journal]
+    assert (
+        op_names.index("redis.add_pending_pod")
+        < op_names.index("docker.run_container")
+        < op_names.index("redis.add_rented_pod")
+    )
+    # WHY: the realtime log drainer task is started exactly once per create, keyed
+    # to this pod's identifiers.
+    assert harness.mocks["handle_stream_logs"].call_count == 1
+    assert harness.mocks["handle_stream_logs"].call_args.kwargs == {
+        "miner_hotkey": payload.miner_hotkey,
+        "executor_id": payload.executor_id,
+        "pod_id": payload.pod_id,
+    }
+
+
+# ------------------------------------------------------------------
+# B8 — FILLER-only pending-pod cleanup
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_redis_remove_pending_for_filler(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange
+    svc = make_docker_service()
+    harness = patch_create_happy_path(svc, monkeypatch)
+    payload = make_create_request(workload_kind=WorkloadKind.FILLER)
+
+    # Act
+    result = await _create(svc, payload)
+
+    # Assert
+    assert isinstance(result, ContainerCreated)
+    assert result.container_name == f"filler_{payload.pod_id}"
+    removes = [kwargs for name, kwargs in harness.journal if name == "redis.remove_pending_pod"]
+    # WHY: only the FILLER success path clears its pending marker — exactly once,
+    # with the pod's own identifiers (distinct from CUSTOMER_RENTAL, B7).
+    assert removes == [
+        {
+            "miner_hotkey": payload.miner_hotkey,
+            "executor_id": payload.executor_id,
+            "pod_id": payload.pod_id,
+        }
+    ]
+    # WHY: the cleanup is a post-success step — it must run only after the rented
+    # marker is in place.
+    op_names = [name for name, _ in harness.journal]
+    assert op_names.index("redis.add_rented_pod") < op_names.index("redis.remove_pending_pod")
+
+
+# ------------------------------------------------------------------
+# B9 — streaming pub/sub payload shape
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streaming_log_publish_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange: restore the REAL streaming trio (the harness mocks them) so the
+    # drainer publishes through the recording redis; interval 0 keeps the loop fast.
+    svc = make_docker_service()
+    harness = patch_create_happy_path(svc, monkeypatch)
+    for name in ("stream_log", "handle_stream_logs", "finish_stream_logs"):
+        monkeypatch.setattr(svc, name, getattr(DockerService, name).__get__(svc))
+    monkeypatch.setattr(ds_module, "LOG_STREAM_INTERVAL", 0)
+
+    async def _yielding_check(*args: object, **kwargs: object) -> bool:
+        # WHY: every other harness await completes without touching the event loop,
+        # so the drainer task would otherwise first run only INSIDE
+        # finish_stream_logs' `await log_task` — setting is_realtime_logging back to
+        # True after the stop flag was already cleared and spinning forever. One real
+        # yield lets the drainer start first (prod always yields on real I/O; the
+        # hang is a mock-only artifact, not a production behavior).
+        await asyncio.sleep(0)
+        return True
+
+    harness.mocks["check_container_running"].side_effect = _yielding_check
+    payload = make_create_request()
+
+    # Act (wait_for: a drainer regression must fail loudly, never hang the suite)
+    result = await asyncio.wait_for(_create(svc, payload), timeout=30)
+
+    # Assert
+    assert isinstance(result, ContainerCreated)
+    # WHY: the channel name is the contract with the sole subscriber
+    # (compute_client) — pin the constant's byte value, not just identity.
+    assert STREAMING_LOG_CHANNEL == "STREAMING_LOG_CHANNEL"
+    assert len(harness.redis.published) >= 1
+    # WHY: every published message must carry exactly {logs, miner_hotkey,
+    # executor_uuid, pod_id} — note the executor key is named executor_uuid on
+    # the wire while carrying payload.executor_id.
+    for channel, message in harness.redis.published:
+        assert channel == STREAMING_LOG_CHANNEL
+        assert set(message) == {"logs", "miner_hotkey", "executor_uuid", "pod_id"}
+        assert message["miner_hotkey"] == payload.miner_hotkey
+        assert message["executor_uuid"] == payload.executor_id
+        assert message["pod_id"] == payload.pod_id
+    # WHY: each streamed entry is the exact queue record stream_log enqueues —
+    # {log_text, log_status, log_tag} tagged container_creation.
+    entries = [entry for _, message in harness.redis.published for entry in message["logs"]]
+    assert entries
+    for entry in entries:
+        assert set(entry) == {"log_text", "log_status", "log_tag"}
+        assert entry["log_tag"] == "container_creation"
+    texts = {entry["log_text"] for entry in entries}
+    assert {"Creating docker container", "Created Docker Container"} <= texts

--- a/neurons/validators/tests/docker_oracle/test_delete_flow.py
+++ b/neurons/validators/tests/docker_oracle/test_delete_flow.py
@@ -1,0 +1,288 @@
+"""Characterization oracle — delete_container flow (DAH-2382 PR-1a, group D-DELETE).
+
+Pins the observable delete boundary on baseline 6be5649f: the exact
+ContainerDeleted / FailedContainerRequest wire shapes, the FILLER-only
+wedge-sweep call-site wiring (DAH-2427), and the best-effort post-teardown
+log contract. The sweep INTERNALS are covered by
+tests/test_gpu_wedge_teardown_sweep.py — here the module-level
+``_sweep_wedged_gpus_after_teardown`` seam is always patched so only the
+delete_container wiring is under test.
+
+The delete scaffold (make_delete_request / DeleteContainerHarness /
+patch_delete_happy_path and the redis delete-path surface) lives in the shared
+docker_oracle/harness.py.
+"""
+
+import logging
+from unittest.mock import Mock
+
+import pytest
+from docker_oracle.harness import (
+    make_delete_request,
+    make_docker_service,
+    make_executor_info,
+    patch_delete_happy_path,
+)
+from payload_models.payloads import (
+    ContainerDeleted,
+    ContainerResponseType,
+    FailedContainerErrorCodes,
+    FailedContainerErrorTypes,
+    FailedContainerRequest,
+    WorkloadKind,
+)
+from services.attestation_service import AttestationError
+
+_POST_TEARDOWN_FAILED_MSG = "delete_container post-teardown step failed (non-fatal)"
+_FUNNEL_MSG_PREFIX = "Unknown Error delete_container: "
+
+
+@pytest.mark.asyncio
+async def test_delete_success_returns_container_deleted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    svc = make_docker_service()
+    patch_delete_happy_path(svc, monkeypatch)
+    payload = make_delete_request()
+    executor_info = make_executor_info(payload)
+
+    # Act
+    result = await svc.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    # Assert
+    # WHY: the success ack is the exact backend wire object — pin the full
+    # field set so extraction can neither add, drop, nor rename a field
+    # (ContainerDeleted carries NO container_name / failure_step / msg at all).
+    assert isinstance(result, ContainerDeleted)
+    assert result.model_dump() == {
+        "message_type": ContainerResponseType.ContainerDeleted,
+        "miner_hotkey": "miner",
+        "executor_id": payload.executor_id,
+        "pod_id": payload.pod_id,
+        "workload_kind": WorkloadKind.CUSTOMER_RENTAL,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("step", "workload_kind", "enable_inspector"),
+    [
+        ("restore_filler_gpu_power", WorkloadKind.FILLER, False),
+        ("sweep_wedged_gpus", WorkloadKind.FILLER, False),
+        ("inspector_stop", WorkloadKind.CUSTOMER_RENTAL, True),
+    ],
+)
+async def test_delete_teardown_step_failure_nonfatal(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    step: str,
+    workload_kind: WorkloadKind,
+    enable_inspector: bool,
+) -> None:
+    # Arrange: fail exactly one post-teardown step after the forced removal succeeded
+    # (these three step failure sites are the ones no legacy delete test exercises
+    # with a log assert; prune/volumes/remove_rented_machine live in
+    # tests/test_docker_service.py:1286-1553)
+    svc = make_docker_service()
+    harness = patch_delete_happy_path(svc, monkeypatch, enable_inspector=enable_inspector)
+    boom = Exception(f"{step} boom")
+    if step == "restore_filler_gpu_power":
+        harness.mocks["restore_filler_pod_gpu_power_limits"].side_effect = boom
+    elif step == "sweep_wedged_gpus":
+        harness.mocks["_sweep_wedged_gpus_after_teardown"].side_effect = boom
+    else:
+        harness.redis.get_rented_machine_error = boom
+    payload = make_delete_request(workload_kind=workload_kind)
+    executor_info = make_executor_info(payload)
+
+    # Act
+    with caplog.at_level(logging.INFO, logger="services.docker_service"):
+        result = await svc.delete_container(
+            payload=payload,
+            executor_info=executor_info,
+            keypair=Mock(ss58_address="validator-hotkey"),
+            private_key="encrypted",
+        )
+
+    # Assert
+    # WHY: after the forced removal the container is gone — a failing teardown
+    # step must never fail the undeploy, or the backend retries a doomed
+    # request and penalizes the miner.
+    assert isinstance(result, ContainerDeleted)
+    # WHY: the non-fatal funnel is one ERROR line with a step= key — the only
+    # observable trace of which best-effort step broke (Loki triage surface).
+    records = [r for r in caplog.records if str(r.msg) == _POST_TEARDOWN_FAILED_MSG]
+    assert [r.levelno for r in records] == [logging.ERROR]
+    assert records[0].msg.extra["step"] == step
+    assert records[0].msg.extra["error"] == f"{step} boom"
+
+
+@pytest.mark.asyncio
+async def test_delete_filler_sweeps_wedged_gpus_on_success_nonfatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: FILLER success path; the patched sweep itself blows up
+    svc = make_docker_service()
+    harness = patch_delete_happy_path(svc, monkeypatch)
+    sweep = harness.mocks["_sweep_wedged_gpus_after_teardown"]
+    sweep.side_effect = Exception("sweep boom")
+    payload = make_delete_request(workload_kind=WorkloadKind.FILLER)
+    executor_info = make_executor_info(payload)
+
+    # Act
+    result = await svc.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    # Assert
+    # WHY: DAH-2427 — the success-path ghost-GPU sweep runs exactly once per
+    # FILLER teardown, over the delete's own SSH session, and is best-effort:
+    # a failing cure must not fail an undeploy whose container is already gone.
+    assert isinstance(result, ContainerDeleted)
+    assert sweep.await_count == 1
+    assert sweep.await_args.args[0] is harness.ssh_client
+
+
+@pytest.mark.asyncio
+async def test_delete_filler_sweeps_before_propagating_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: the fatal force-remove fails on a FILLER teardown
+    svc = make_docker_service()
+    harness = patch_delete_happy_path(svc, monkeypatch)
+    harness.docker_client.remove_error = Exception(
+        "Docker SDK remove container failed: 500 Server Error: daemon exploded"
+    )
+    payload = make_delete_request(workload_kind=WorkloadKind.FILLER)
+    executor_info = make_executor_info(payload)
+
+    # Act
+    result = await svc.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    # Assert
+    # WHY: DAH-2427 — a failed force-remove is the classic wedge path; the
+    # sweep must run exactly once, AFTER the failed remove and BEFORE the
+    # failure result, so a wedged card cannot outlive the failed delete.
+    assert harness.mocks["_sweep_wedged_gpus_after_teardown"].await_count == 1
+    journal_names = [name for name, _ in harness.journal]
+    assert journal_names.index("docker.remove_container") < journal_names.index(
+        "sweep.teardown_sweep"
+    )
+    # WHY: the remove failure stays fatal — the sweep is squeezed in but the
+    # undeploy still reports the frozen funnel shape and no later teardown
+    # step (prune / redis cleanup) runs.
+    assert isinstance(result, FailedContainerRequest)
+    assert result.error_type == FailedContainerErrorTypes.ContainerDeletionFailed
+    assert result.error_code == FailedContainerErrorCodes.UnknownError
+    assert result.msg.startswith(_FUNNEL_MSG_PREFIX)
+    assert result.workload_kind == WorkloadKind.FILLER
+    assert harness.docker_client.pruned_images == 0
+    assert "remove_rented_machine" not in [name for name, _ in harness.redis.calls]
+
+
+@pytest.mark.asyncio
+async def test_delete_customer_rental_does_not_sweep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: successful CUSTOMER_RENTAL teardown
+    svc = make_docker_service()
+    harness = patch_delete_happy_path(svc, monkeypatch)
+    payload = make_delete_request(workload_kind=WorkloadKind.CUSTOMER_RENTAL)
+    executor_info = make_executor_info(payload)
+
+    # Act
+    result = await svc.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    # Assert
+    # WHY: the DAH-2427 sweep and the DAH-2356 power restore share ONE
+    # workload gate — a customer teardown must never pay the FILLER-only steps.
+    assert isinstance(result, ContainerDeleted)
+    assert harness.mocks["_sweep_wedged_gpus_after_teardown"].await_count == 0
+    assert harness.mocks["restore_filler_pod_gpu_power_limits"].await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_unsafe_volume_name_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: a local_volume with shell metacharacters must die at the guard
+    svc = make_docker_service()
+    harness = patch_delete_happy_path(svc, monkeypatch)
+    payload = make_delete_request(local_volume="vol;rm -rf")
+    executor_info = make_executor_info(payload)
+
+    # Act
+    result = await svc.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    # Assert
+    # WHY: the volume-name guard is the delete path's injection boundary — its
+    # typed failure is byte-frozen and fires before any credential decrypt,
+    # SSH connect, or docker SDK call.
+    assert isinstance(result, FailedContainerRequest)
+    assert result.msg == "Invalid Docker volume name"
+    assert result.error_type == FailedContainerErrorTypes.ContainerDeletionFailed
+    assert result.error_code == FailedContainerErrorCodes.UnknownError
+    assert result.failure_step is None
+    assert harness.docker_client.calls == []
+    harness.mocks["asyncssh.connect"].assert_not_called()
+    svc.ssh_service.decrypt_payload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_attestation_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: the attestation service rejects the executor; the REAL
+    # _prepare_known_hosts_policy chokepoint re-raises AttestationError as-is
+    svc = make_docker_service()
+    harness = patch_delete_happy_path(svc, monkeypatch)
+    harness.mocks["prepare_host_policy"].side_effect = AttestationError(
+        "host key mismatch for executor"
+    )
+    payload = make_delete_request()
+    executor_info = make_executor_info(payload)
+
+    # Act
+    result = await svc.delete_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    # Assert
+    # WHY: attestation failure maps to the generic delete-failure shape — the
+    # frozen "Attestation failed" msg with error_code UnknownError (NOT the
+    # AttestationError enum member) and no failure_step — and no SSH session
+    # or docker SDK call is ever opened.
+    assert isinstance(result, FailedContainerRequest)
+    assert result.msg == "Attestation failed"
+    assert result.error_type == FailedContainerErrorTypes.ContainerDeletionFailed
+    assert result.error_code == FailedContainerErrorCodes.UnknownError
+    assert result.failure_step is None
+    assert harness.docker_client.calls == []
+    harness.mocks["asyncssh.connect"].assert_not_called()

--- a/neurons/validators/tests/docker_oracle/test_harness_smoke.py
+++ b/neurons/validators/tests/docker_oracle/test_harness_smoke.py
@@ -1,0 +1,37 @@
+"""Smoke test: the shared oracle harness drives DockerService.create_container
+end-to-end to a real ContainerCreated with no SSH and no docker daemon."""
+
+from unittest.mock import Mock
+
+import pytest
+from docker_oracle.harness import (
+    make_create_request,
+    make_docker_service,
+    make_executor_info,
+    patch_create_happy_path,
+)
+from payload_models.payloads import ContainerCreated
+
+
+@pytest.mark.asyncio
+async def test_harness_happy_path_reaches_container_created(monkeypatch):
+    # Arrange
+    svc = make_docker_service()
+    harness = patch_create_happy_path(svc, monkeypatch)
+    payload = make_create_request()
+    executor_info = make_executor_info(payload)
+
+    # Act
+    result = await svc.create_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    # Assert
+    # WHY: every oracle golden builds on this harness reaching the real success
+    # boundary with the live SDK retry wrapper actually driving the fake client.
+    assert isinstance(result, ContainerCreated), f"expected ContainerCreated, got: {result!r}"
+    run_calls = [name for name, _ in harness.docker_client.calls if name == "run_container"]
+    assert run_calls == ["run_container"]

--- a/neurons/validators/tests/docker_oracle/test_sdk_retry_loop.py
+++ b/neurons/validators/tests/docker_oracle/test_sdk_retry_loop.py
@@ -1,0 +1,542 @@
+"""Characterization oracle group C-RETRY (C10-C17, DAH-2382 PR-1a).
+
+Direct unit tests on the LIVE SDK create-retry loop
+``DockerService._run_rental_docker_create_with_port_retry``
+(src/services/docker_service.py:542, sole call site create_container:3499).
+
+This suite is the port of the DEAD SSH twin's suite
+(``_run_docker_create_with_port_retry``, tested at tests/test_docker_service.py:3335-4003
+but never called from src/) onto the live function. The twin and its tests are
+deleted in PR-3; these tests replace their intent on the production path.
+
+Pinned live semantics (baseline 6be5649f):
+- stale-mount match requires ALL THREE ``_VLOOPBACK_MOUNT_ERROR_PHRASES``
+  ("VolumeDriver.Mount", "cannot create mount point dir", "file exists");
+- vloopback repair runs at most once, only when ``local_volume`` is set, and
+  retries immediately (no sleep, no rm) after event VLOOPBACK_STALE_MOUNTPOINT_RETRY;
+- any single ``_PORT_ALLOCATED_PHRASES`` match retries on a 90s monotonic budget:
+  event PORT_ALREADY_ALLOCATED_RETRY, sleep 5s, then
+  ``remove_container(container_name=..., force=True, remove_volumes=True)``
+  (rm failure warns PORT_RETRY_STALE_RM_FAILED and continues);
+- unlike the dead twin, the final non-retryable error is logged as
+  "Docker SDK run container failed" and streamed via ``stream_log`` before re-raise.
+"""
+
+import logging
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from docker_oracle.harness import FakeRentalDockerClient, RecordedCall, make_docker_service
+from services.rental_docker_sdk import ContainerRunSpec
+
+# Same daemon texts the dead twin's suite used (tests/test_docker_service.py:3340/3392/3396),
+# plus single-phrase variants so each _PORT_ALLOCATED_PHRASES entry is pinned in isolation.
+_PORT_ALLOCATED_ERR = (
+    "docker: Error response from daemon: failed to set up container "
+    "networking: driver failed programming external connectivity on "
+    "endpoint pod_599e3ed0-...: Bind for 0.0.0.0:9101 failed: port is "
+    "already allocated"
+)
+_ADDRESS_IN_USE_ERR = (
+    "docker: Error response from daemon: driver failed programming external "
+    "connectivity on endpoint pod_test: Error starting userland proxy: "
+    "listen tcp4 0.0.0.0:9030: bind: address already in use"
+)
+_BIND_HOST_PORT_ERR = (
+    "docker: Error response from daemon: failed to bind host port 0.0.0.0:20001/tcp"
+)
+_VLOOPBACK_STALE_MOUNT_ERR = (
+    "docker: Error response from daemon: failed to populate volume: "
+    "error while mounting volume '/mnt/volume_test': "
+    "VolumeDriver.Mount: error while mounting volume: "
+    "cannot create mount point dir '/mnt/volume_test': "
+    "mkdir /mnt/volume_test: file exists"
+)
+# Only 2 of the 3 required phrases ("file exists" absent).
+_PARTIAL_VLOOPBACK_ERR = (
+    "docker: Error response from daemon: "
+    "VolumeDriver.Mount: error while mounting volume: "
+    "cannot create mount point dir '/mnt/volume_test': permission denied"
+)
+_NO_SUCH_IMAGE_ERR = "docker: Error response from daemon: No such image: bogus:latest"
+
+
+def _make_run_spec() -> ContainerRunSpec:
+    return ContainerRunSpec(image="daturaai/pytorch:1.0.0", name="pod_test")
+
+
+def _patch_sleep(
+    monkeypatch: pytest.MonkeyPatch, journal: list[RecordedCall] | None = None
+) -> list[float]:
+    # record retry backoffs without waiting; same patch target as the dead twin's tests
+    delays: list[float] = []
+
+    async def _fake_sleep(seconds: float) -> None:
+        delays.append(seconds)
+        if journal is not None:
+            journal.append(("sleep", {"seconds": seconds}))
+
+    monkeypatch.setattr("services.docker_service.asyncio.sleep", _fake_sleep)
+    return delays
+
+
+class _SleepAdvancedClock:
+    """Frozen fake monotonic clock that jumps forward only when the patched sleep fires.
+
+    Deterministic regardless of how many callers read the clock (the retry loop,
+    the observability wrapper, the event loop), unlike a finite scripted iterator.
+    """
+
+    def __init__(self, *, start: float, advance_per_sleep: float) -> None:
+        self.now = start
+        self.advance_per_sleep = advance_per_sleep
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def advance(self) -> None:
+        self.now += self.advance_per_sleep
+
+
+def _event_names(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [record.getMessage() for record in caplog.records]
+
+
+def _run_started_attempts(caplog: pytest.LogCaptureFixture) -> list[int]:
+    # attempt field of the per-try observability "started" line for run_container
+    return [
+        record.msg.extra["attempt"]
+        for record in caplog.records
+        if record.getMessage() == "Rental Docker SDK operation started"
+        and record.msg.extra.get("docker_operation") == "run_container"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sdk_repair_once_then_retry_success(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    caplog.set_level(logging.INFO)
+    svc = make_docker_service()
+    docker_client = FakeRentalDockerClient()
+    docker_client.run_errors = [Exception(_VLOOPBACK_STALE_MOUNT_ERR)]
+    repair = AsyncMock(return_value=True)
+    monkeypatch.setattr(svc, "repair_stale_vloopback_mountpoint", repair)
+    delays = _patch_sleep(monkeypatch)
+    ssh_client = Mock()
+    run_spec = _make_run_spec()
+
+    # Act
+    await svc._run_rental_docker_create_with_port_retry(
+        docker_client=docker_client,
+        ssh_client=ssh_client,
+        run_spec=run_spec,
+        container_name="pod_test",
+        default_extra={},
+        local_volume="volume_test",
+        log_tag="t",
+    )
+
+    # Assert
+    # WHY: a stale-mount failure (all 3 phrases) must repair exactly once and
+    # immediately re-run the SAME spec -- no backoff sleep and no stale-rm on
+    # the repair path, unlike the port-retry path.
+    assert docker_client.run_specs == [run_spec, run_spec]
+    assert docker_client.run_specs[0] is run_spec and docker_client.run_specs[1] is run_spec
+    repair.assert_awaited_once_with(ssh_client, "volume_test", {})
+    assert delays == []
+    assert docker_client.removed_containers == []
+    assert _event_names(caplog).count("VLOOPBACK_STALE_MOUNTPOINT_RETRY") == 1
+    # WHY: the port-attempt counter is NOT bumped by a repair retry -- both run
+    # tries are logged as attempt=1 (live-only observability field).
+    assert _run_started_attempts(caplog) == [1, 1]
+
+
+@pytest.mark.asyncio
+async def test_sdk_repair_not_attempted_twice(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    caplog.set_level(logging.INFO)
+    svc = make_docker_service()
+    docker_client = FakeRentalDockerClient()
+    docker_client.run_error = Exception(_VLOOPBACK_STALE_MOUNT_ERR)
+    repair = AsyncMock(return_value=True)
+    monkeypatch.setattr(svc, "repair_stale_vloopback_mountpoint", repair)
+    delays = _patch_sleep(monkeypatch)
+
+    # Act
+    with pytest.raises(Exception) as excinfo:
+        await svc._run_rental_docker_create_with_port_retry(
+            docker_client=docker_client,
+            ssh_client=Mock(),
+            run_spec=_make_run_spec(),
+            container_name="pod_test",
+            default_extra={},
+            local_volume="volume_test",
+            log_tag="t",
+        )
+
+    # Assert
+    # WHY: the repair-once flag caps the loop at one repair + one re-run; a second
+    # stale-mount failure propagates through the live error funnel (error log +
+    # streamed error), which the dead twin did not have.
+    assert _VLOOPBACK_STALE_MOUNT_ERR in str(excinfo.value)
+    repair.assert_awaited_once()
+    assert len(docker_client.run_specs) == 2
+    assert delays == []
+    assert _event_names(caplog).count("VLOOPBACK_STALE_MOUNTPOINT_RETRY") == 1
+    assert "Docker SDK run container failed" in _event_names(caplog)
+    assert svc.logs_queue == [
+        {"log_text": _VLOOPBACK_STALE_MOUNT_ERR, "log_status": "error", "log_tag": "t"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sdk_repair_skipped_without_local_volume(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    caplog.set_level(logging.INFO)
+    svc = make_docker_service()
+    docker_client = FakeRentalDockerClient()
+    docker_client.run_error = Exception(_VLOOPBACK_STALE_MOUNT_ERR)
+    repair = AsyncMock(return_value=True)
+    monkeypatch.setattr(svc, "repair_stale_vloopback_mountpoint", repair)
+    delays = _patch_sleep(monkeypatch)
+
+    # Act
+    with pytest.raises(Exception) as excinfo:
+        await svc._run_rental_docker_create_with_port_retry(
+            docker_client=docker_client,
+            ssh_client=Mock(),
+            run_spec=_make_run_spec(),
+            container_name="pod_test",
+            default_extra={},
+            log_tag="t",
+        )
+
+    # Assert
+    # WHY: the bool(local_volume) guard -- without a local volume a stale-mount
+    # error must raise on the first try and never touch the repair helper.
+    assert _VLOOPBACK_STALE_MOUNT_ERR in str(excinfo.value)
+    repair.assert_not_awaited()
+    assert len(docker_client.run_specs) == 1
+    assert delays == []
+    assert docker_client.removed_containers == []
+
+
+@pytest.mark.asyncio
+async def test_sdk_partial_mount_phrases_do_not_trigger_repair(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    caplog.set_level(logging.INFO)
+    svc = make_docker_service()
+    docker_client = FakeRentalDockerClient()
+    docker_client.run_error = Exception(_PARTIAL_VLOOPBACK_ERR)
+    repair = AsyncMock(return_value=True)
+    monkeypatch.setattr(svc, "repair_stale_vloopback_mountpoint", repair)
+    delays = _patch_sleep(monkeypatch)
+
+    # Act
+    with pytest.raises(Exception) as excinfo:
+        await svc._run_rental_docker_create_with_port_retry(
+            docker_client=docker_client,
+            ssh_client=Mock(),
+            run_spec=_make_run_spec(),
+            container_name="pod_test",
+            default_extra={},
+            local_volume="volume_test",
+            log_tag="t",
+        )
+
+    # Assert
+    # WHY: _is_stale_vloopback_mountpoint_error requires ALL THREE phrases
+    # (all(), not any()); 2 of 3 must not trigger repair even with a local volume.
+    assert _PARTIAL_VLOOPBACK_ERR in str(excinfo.value)
+    repair.assert_not_awaited()
+    assert len(docker_client.run_specs) == 1
+    assert delays == []
+
+
+@pytest.mark.asyncio
+async def test_sdk_port_retry_then_success(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    caplog.set_level(logging.INFO)
+    svc = make_docker_service()
+    docker_client = FakeRentalDockerClient()
+    docker_client.run_errors = [Exception(_PORT_ALLOCATED_ERR)]
+    delays = _patch_sleep(monkeypatch)
+    run_spec = _make_run_spec()
+
+    # Act
+    await svc._run_rental_docker_create_with_port_retry(
+        docker_client=docker_client,
+        ssh_client=Mock(),
+        run_spec=run_spec,
+        container_name="pod_test",
+        default_extra={},
+        log_tag="t",
+    )
+
+    # Assert
+    # WHY: DAH-1991/DAH-2018 -- one port-allocated failure means one 5s backoff,
+    # one stale-container rm (force + anonymous volumes), then the SAME spec
+    # re-run; the retry event carries attempt/sleep/phrase for the dashboards.
+    assert docker_client.run_specs == [run_spec, run_spec]
+    assert docker_client.run_specs[0] is run_spec and docker_client.run_specs[1] is run_spec
+    assert delays == [5]
+    assert docker_client.removed_containers == [
+        {"container_name": "pod_test", "force": True, "remove_volumes": True}
+    ]
+    retry_records = [
+        record for record in caplog.records
+        if record.getMessage() == "PORT_ALREADY_ALLOCATED_RETRY"
+    ]
+    assert len(retry_records) == 1
+    assert retry_records[0].msg.extra["attempt"] == 1
+    assert retry_records[0].msg.extra["sleep_seconds"] == 5
+    assert retry_records[0].msg.extra["port_allocation_phrase"] == "port is already allocated"
+    assert _run_started_attempts(caplog) == [1, 2]
+    # WHY: the success path streams nothing from inside the retry loop.
+    assert svc.logs_queue == []
+
+
+@pytest.mark.asyncio
+async def test_sdk_port_retry_sleeps_then_removes_then_reruns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    journal: list[RecordedCall] = []
+    svc = make_docker_service()
+    docker_client = FakeRentalDockerClient(journal)
+    docker_client.run_errors = [Exception(_PORT_ALLOCATED_ERR)]
+    _patch_sleep(monkeypatch, journal)
+
+    # Act
+    await svc._run_rental_docker_create_with_port_retry(
+        docker_client=docker_client,
+        ssh_client=Mock(),
+        run_spec=_make_run_spec(),
+        container_name="pod_test",
+        default_extra={},
+        log_tag="t",
+    )
+
+    # Assert
+    # WHY: DAH-2018 ordering -- backoff sleep FIRST, then rm, then re-run, so the
+    # rm->run window stays as tight as possible (port of the dead twin's
+    # events-order test onto the SDK journal).
+    assert [name for name, _ in journal] == [
+        "docker.run_container",
+        "sleep",
+        "docker.remove_container",
+        "docker.run_container",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sdk_port_retry_deadline_expired(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    caplog.set_level(logging.INFO)
+    svc = make_docker_service()
+    docker_client = FakeRentalDockerClient()
+    docker_client.run_error = Exception(_PORT_ALLOCATED_ERR)
+    clock = _SleepAdvancedClock(start=1000.0, advance_per_sleep=50.0)
+    monkeypatch.setattr("services.docker_service.time.monotonic", clock.monotonic)
+    delays: list[float] = []
+
+    async def _sleep_and_advance(seconds: float) -> None:
+        delays.append(seconds)
+        clock.advance()
+
+    monkeypatch.setattr("services.docker_service.asyncio.sleep", _sleep_and_advance)
+
+    # Act
+    with pytest.raises(Exception) as excinfo:
+        await svc._run_rental_docker_create_with_port_retry(
+            docker_client=docker_client,
+            ssh_client=Mock(),
+            run_spec=_make_run_spec(),
+            container_name="pod_test",
+            default_extra={},
+            log_tag="t",
+        )
+
+    # Assert
+    # WHY: the 90s monotonic budget -- deadline checks at t=+0s and t=+50s allow
+    # two retries, the check at t=+100s expires and the port error propagates
+    # (so the create boundary later reports failure_step="docker_run").
+    assert _PORT_ALLOCATED_ERR in str(excinfo.value)
+    assert len(docker_client.run_specs) == 3
+    assert delays == [5, 5]
+    assert len(docker_client.removed_containers) == 2
+    retry_attempts = [
+        record.msg.extra["attempt"]
+        for record in caplog.records
+        if record.getMessage() == "PORT_ALREADY_ALLOCATED_RETRY"
+    ]
+    assert retry_attempts == [1, 2]
+    assert "Docker SDK run container failed" in _event_names(caplog)
+    assert svc.logs_queue == [
+        {"log_text": _PORT_ALLOCATED_ERR, "log_status": "error", "log_tag": "t"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sdk_port_retry_second_phrase_address_in_use(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    caplog.set_level(logging.INFO)
+    svc = make_docker_service()
+    docker_client = FakeRentalDockerClient()
+    docker_client.run_errors = [Exception(_ADDRESS_IN_USE_ERR)]
+    delays = _patch_sleep(monkeypatch)
+
+    # Act
+    await svc._run_rental_docker_create_with_port_retry(
+        docker_client=docker_client,
+        ssh_client=Mock(),
+        run_spec=_make_run_spec(),
+        container_name="pod_test",
+        default_extra={},
+        log_tag="t",
+    )
+
+    # Assert
+    # WHY: DAH-2065 -- kernel-level bind(2) "address already in use" (2nd
+    # _PORT_ALLOCATED_PHRASES entry, matched in isolation) takes the same retry path.
+    assert len(docker_client.run_specs) == 2
+    assert delays == [5]
+    retry_records = [
+        record for record in caplog.records
+        if record.getMessage() == "PORT_ALREADY_ALLOCATED_RETRY"
+    ]
+    assert [r.msg.extra["port_allocation_phrase"] for r in retry_records] == [
+        "address already in use"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sdk_port_retry_third_phrase(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    caplog.set_level(logging.INFO)
+    svc = make_docker_service()
+    docker_client = FakeRentalDockerClient()
+    docker_client.run_errors = [Exception(_BIND_HOST_PORT_ERR)]
+    delays = _patch_sleep(monkeypatch)
+
+    # Act
+    await svc._run_rental_docker_create_with_port_retry(
+        docker_client=docker_client,
+        ssh_client=Mock(),
+        run_spec=_make_run_spec(),
+        container_name="pod_test",
+        default_extra={},
+        log_tag="t",
+    )
+
+    # Assert
+    # WHY: "failed to bind host port" (3rd _PORT_ALLOCATED_PHRASES entry, matched
+    # in isolation) retries then succeeds -- untested even on the dead twin.
+    assert len(docker_client.run_specs) == 2
+    assert delays == [5]
+    retry_records = [
+        record for record in caplog.records
+        if record.getMessage() == "PORT_ALREADY_ALLOCATED_RETRY"
+    ]
+    assert [r.msg.extra["port_allocation_phrase"] for r in retry_records] == [
+        "failed to bind host port"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sdk_port_rm_failure_continues(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    caplog.set_level(logging.INFO)
+    svc = make_docker_service()
+    docker_client = FakeRentalDockerClient()
+    docker_client.run_errors = [Exception(_PORT_ALLOCATED_ERR)]
+    docker_client.remove_error = Exception("rm exploded")
+    _patch_sleep(monkeypatch)
+
+    # Act
+    await svc._run_rental_docker_create_with_port_retry(
+        docker_client=docker_client,
+        ssh_client=Mock(),
+        run_spec=_make_run_spec(),
+        container_name="pod_test",
+        default_extra={},
+        log_tag="t",
+    )
+
+    # Assert
+    # WHY: the stale-container rm is best-effort -- its failure warns
+    # PORT_RETRY_STALE_RM_FAILED and the loop still re-runs to success.
+    assert len(docker_client.run_specs) == 2
+    assert len(docker_client.removed_containers) == 1
+    rm_failed_records = [
+        record for record in caplog.records
+        if record.getMessage() == "PORT_RETRY_STALE_RM_FAILED"
+    ]
+    assert len(rm_failed_records) == 1
+    assert rm_failed_records[0].levelno == logging.WARNING
+    assert rm_failed_records[0].msg.extra["container_name"] == "pod_test"
+    assert rm_failed_records[0].msg.extra["rm_error"] == "rm exploded"
+
+
+@pytest.mark.asyncio
+async def test_sdk_non_port_error_propagates(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    caplog.set_level(logging.INFO)
+    svc = make_docker_service()
+    docker_client = FakeRentalDockerClient()
+    docker_client.run_error = Exception(_NO_SUCH_IMAGE_ERR)
+    repair = AsyncMock(return_value=True)
+    monkeypatch.setattr(svc, "repair_stale_vloopback_mountpoint", repair)
+    delays = _patch_sleep(monkeypatch)
+
+    # Act (log_tag omitted on purpose: pins the signature default)
+    with pytest.raises(Exception, match="No such image"):
+        await svc._run_rental_docker_create_with_port_retry(
+            docker_client=docker_client,
+            ssh_client=Mock(),
+            run_spec=_make_run_spec(),
+            container_name="pod_test",
+            default_extra={},
+            local_volume="volume_test",
+        )
+
+    # Assert
+    # WHY: an unrelated docker error must propagate on the first try -- no sleep,
+    # no rm, no repair -- and (live-only, vs the bare-raise dead twin) be logged
+    # with traceback and streamed under the default "container_creation" tag.
+    assert len(docker_client.run_specs) == 1
+    assert delays == []
+    assert docker_client.removed_containers == []
+    repair.assert_not_awaited()
+    failed_records = [
+        record for record in caplog.records
+        if record.getMessage() == "Docker SDK run container failed"
+    ]
+    assert len(failed_records) == 1
+    assert failed_records[0].levelno == logging.ERROR
+    assert failed_records[0].exc_info is not None
+    assert failed_records[0].msg.extra["container_name"] == "pod_test"
+    assert failed_records[0].msg.extra["error"] == _NO_SUCH_IMAGE_ERR
+    assert svc.logs_queue == [
+        {"log_text": _NO_SUCH_IMAGE_ERR, "log_status": "error", "log_tag": "container_creation"}
+    ]

--- a/neurons/validators/tests/docker_oracle/test_ssh_keys_and_jupyter.py
+++ b/neurons/validators/tests/docker_oracle/test_ssh_keys_and_jupyter.py
@@ -1,0 +1,320 @@
+"""Characterization goldens for add_ssh_key / remove_ssh_keys / install_jupyter_server
+(DAH-2382 PR-1a, DRAFT sketches D14-D20 + the D11-style attestation variants).
+
+Every `msg` assert is byte-for-byte against the template literal in
+docker_service.py: `str(_m(...))` returns only the bare message (DRAFT §0
+discovery 1), so the serialized `msg` IS the template. Baseline 6be5649f.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+from docker_oracle.harness import (
+    FakeRentalDockerClient,
+    FakeRentalDockerFactory,
+    make_docker_service,
+    make_executor_info,
+    patch_rental_ssh_connect,
+)
+from payload_models.payloads import (
+    AddSshPublicKeyRequest,
+    FailedContainerErrorCodes,
+    FailedContainerErrorTypes,
+    FailedContainerRequest,
+    InstallJupyterServerRequest,
+    JupyterInstallationFailed,
+    JupyterServerInstalled,
+    RemoveSshPublicKeysRequest,
+    WorkloadKind,
+)
+from services.attestation_service import AttestationError
+from services.docker_service import DockerService
+
+_HEX_DIGITS = set("0123456789abcdef")
+
+
+def _make_service() -> DockerService:
+    # honest attestation stub so the REAL _prepare_known_hosts_policy chokepoint runs
+    svc = make_docker_service()
+    svc.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    svc.attestation_service.prepare_host_policy = AsyncMock(
+        return_value=SimpleNamespace(known_hosts=None)
+    )
+    svc.rental_docker_client_factory = FakeRentalDockerFactory(FakeRentalDockerClient())
+    return svc
+
+
+def _keypair() -> Mock:
+    return Mock(ss58_address="validator-hotkey")
+
+
+def _add_key_payload(**overrides: Any) -> AddSshPublicKeyRequest:
+    base: dict[str, Any] = dict(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id="pod-id",
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_test",
+        user_public_keys=["ssh-ed25519 test-key"],
+    )
+    base.update(overrides)
+    return AddSshPublicKeyRequest(**base)
+
+
+def _remove_keys_payload(**overrides: Any) -> RemoveSshPublicKeysRequest:
+    base: dict[str, Any] = dict(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id="pod-id",
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_test",
+        user_public_keys=["ssh-ed25519 test-key"],
+    )
+    base.update(overrides)
+    return RemoveSshPublicKeysRequest(**base)
+
+
+def _jupyter_payload(**overrides: Any) -> InstallJupyterServerRequest:
+    base: dict[str, Any] = dict(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id="pod-id",
+        workload_kind=WorkloadKind.CUSTOMER_RENTAL,
+        container_name="pod_test",
+        jupyter_port_map=(8888, 30888),
+    )
+    base.update(overrides)
+    return InstallJupyterServerRequest(**base)
+
+
+# --- D14 / D15: empty-keys early returns -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_ssh_key_no_keys() -> None:
+    # Arrange
+    svc = _make_service()
+    payload = _add_key_payload(user_public_keys=[])
+    executor_info = make_executor_info(payload)
+
+    # Act
+    result = await svc.add_ssh_key(payload, executor_info, _keypair(), "encrypted")
+
+    # Assert
+    # WHY (D14): the only NoSshKeys site on the add path — byte-frozen msg
+    # template, no failure_step, and the early return opens no docker connection.
+    assert isinstance(result, FailedContainerRequest)
+    assert result.error_type is FailedContainerErrorTypes.AddSSkeyFailed
+    assert result.error_code is FailedContainerErrorCodes.NoSshKeys
+    assert result.msg == "ssh key Add error: no public key"
+    assert result.failure_step is None
+    assert svc.rental_docker_client_factory.connect_calls == []
+
+
+@pytest.mark.asyncio
+async def test_remove_ssh_keys_no_keys() -> None:
+    # Arrange
+    svc = _make_service()
+    payload = _remove_keys_payload(user_public_keys=[])
+    executor_info = make_executor_info(payload)
+
+    # Act
+    result = await svc.remove_ssh_keys(payload, executor_info, _keypair(), "encrypted")
+
+    # Assert
+    # WHY (D15): the remove path REUSES the AddSSkeyFailed error type with its
+    # own byte-frozen "Remove" msg template; no docker connection is opened.
+    assert isinstance(result, FailedContainerRequest)
+    assert result.error_type is FailedContainerErrorTypes.AddSSkeyFailed
+    assert result.error_code is FailedContainerErrorCodes.NoSshKeys
+    assert result.msg == "ssh key Remove error: no public key"
+    assert result.failure_step is None
+    assert svc.rental_docker_client_factory.connect_calls == []
+
+
+# --- D16 / D17: generic-exception funnels ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_ssh_key_generic_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange
+    svc = _make_service()
+    monkeypatch.setattr(
+        svc,
+        "add_ssh_public_keys_with_rental_docker",
+        AsyncMock(side_effect=RuntimeError("exec exploded")),
+    )
+    payload = _add_key_payload()
+    executor_info = make_executor_info(payload)
+
+    # Act
+    result = await svc.add_ssh_key(payload, executor_info, _keypair(), "encrypted")
+
+    # Assert
+    # WHY (D16): any exception past the guards funnels to one byte-frozen shape
+    # ("Failed add_ssh_key" + UnknownError) with the no-failure_step asymmetry
+    # that distinguishes the ssh-key methods from create_container.
+    assert isinstance(result, FailedContainerRequest)
+    assert result.error_type is FailedContainerErrorTypes.AddSSkeyFailed
+    assert result.error_code is FailedContainerErrorCodes.UnknownError
+    assert result.msg == "Failed add_ssh_key"
+    assert result.failure_step is None
+
+
+@pytest.mark.asyncio
+async def test_remove_ssh_keys_generic_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange
+    svc = _make_service()
+    monkeypatch.setattr(
+        svc,
+        "remove_ssh_public_keys_with_rental_docker",
+        AsyncMock(side_effect=RuntimeError("exec exploded")),
+    )
+    payload = _remove_keys_payload()
+    executor_info = make_executor_info(payload)
+
+    # Act
+    result = await svc.remove_ssh_keys(payload, executor_info, _keypair(), "encrypted")
+
+    # Assert
+    # WHY (D17): the remove funnel uses a DIFFERENT template family than add
+    # ("Unknown Error remove_ssh_keys", delete_container-style) — freeze the
+    # asymmetry so extraction cannot silently unify the two.
+    assert isinstance(result, FailedContainerRequest)
+    assert result.error_type is FailedContainerErrorTypes.AddSSkeyFailed
+    assert result.error_code is FailedContainerErrorCodes.UnknownError
+    assert result.msg == "Unknown Error remove_ssh_keys"
+    assert result.failure_step is None
+
+
+# --- attestation variants (D11-style, per DRAFT §D.2 parenthetical) -----------
+
+
+@pytest.mark.parametrize(
+    ("method_name", "payload_factory"),
+    [
+        ("add_ssh_key", _add_key_payload),
+        ("remove_ssh_keys", _remove_keys_payload),
+    ],
+)
+@pytest.mark.asyncio
+async def test_ssh_key_methods_attestation_error_returns_addsskeyfailed(
+    method_name: str,
+    payload_factory: Callable[..., AddSshPublicKeyRequest | RemoveSshPublicKeysRequest],
+) -> None:
+    # Arrange
+    svc = _make_service()
+    svc.attestation_service.prepare_host_policy = AsyncMock(
+        side_effect=AttestationError("attestation rejected")
+    )
+    payload = payload_factory()
+    executor_info = make_executor_info(payload)
+
+    # Act
+    result = await getattr(svc, method_name)(payload, executor_info, _keypair(), "encrypted")
+
+    # Assert
+    # WHY: attestation gates BOTH ssh-key methods with one frozen failure shape —
+    # error_code is UnknownError (NOT the AttestationError enum member) and the
+    # byte-frozen "Attestation failed" msg — before any docker connection opens.
+    assert isinstance(result, FailedContainerRequest)
+    assert result.error_type is FailedContainerErrorTypes.AddSSkeyFailed
+    assert result.error_code is FailedContainerErrorCodes.UnknownError
+    assert result.msg == "Attestation failed"
+    assert result.failure_step is None
+    assert svc.rental_docker_client_factory.connect_calls == []
+
+
+# --- D18-D20: install_jupyter_server (zero tests before this file) ------------
+
+
+@pytest.mark.asyncio
+async def test_install_jupyter_success_url_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange
+    svc = _make_service()
+    patch_rental_ssh_connect(monkeypatch)
+    run_jupyter_mock = AsyncMock()
+    monkeypatch.setattr(svc, "run_jupyter", run_jupyter_mock)
+    payload = _jupyter_payload(jupyter_port_map=(8888, 30888))
+    executor_info = make_executor_info(payload)
+
+    # Act
+    result = await svc.install_jupyter_server(payload, executor_info, _keypair(), "encrypted")
+
+    # Assert
+    # WHY (D18): the URL is built from the executor ADDRESS + the EXTERNAL port
+    # (jupyter_port_map[1]) while run_jupyter receives the INTERNAL one
+    # (jupyter_port_map[0]); the token is one fresh secrets.token_hex(16) —
+    # 32 lowercase hex chars — shared between the install and the URL.
+    assert isinstance(result, JupyterServerInstalled)
+    url_prefix = "http://127.0.0.1:30888/lab?token="
+    assert result.jupyter_url.startswith(url_prefix)
+    token = result.jupyter_url.removeprefix(url_prefix)
+    assert len(token) == 32
+    assert set(token) <= _HEX_DIGITS
+    assert run_jupyter_mock.await_count == 1
+    assert run_jupyter_mock.await_args.kwargs["jupyter_token"] == token
+    assert run_jupyter_mock.await_args.kwargs["jupyter_port"] == 8888
+
+
+@pytest.mark.asyncio
+async def test_install_jupyter_attestation_returns_failed_container_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    svc = _make_service()
+    svc.attestation_service.prepare_host_policy = AsyncMock(
+        side_effect=AttestationError("attestation rejected")
+    )
+    _, connect_mock = patch_rental_ssh_connect(monkeypatch)
+    payload = _jupyter_payload()
+    executor_info = make_executor_info(payload)
+
+    # Act
+    result = await svc.install_jupyter_server(payload, executor_info, _keypair(), "encrypted")
+
+    # Assert
+    # WHY (D19): the SURPRISING contract — the jupyter attestation branch reports
+    # error_type=ContainerCreationFailed (not a jupyter-specific type), with
+    # UnknownError and the byte-frozen "Attestation failed" msg, and never
+    # opens the SSH connection.
+    assert isinstance(result, FailedContainerRequest)
+    assert result.error_type is FailedContainerErrorTypes.ContainerCreationFailed
+    assert result.error_code is FailedContainerErrorCodes.UnknownError
+    assert result.msg == "Attestation failed"
+    assert result.failure_step is None
+    assert connect_mock.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_install_jupyter_runtime_exception_returns_jupyter_installation_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    svc = _make_service()
+    patch_rental_ssh_connect(monkeypatch)
+    monkeypatch.setattr(
+        svc, "run_jupyter", AsyncMock(side_effect=RuntimeError("jupyter exploded"))
+    )
+    payload = _jupyter_payload()
+    executor_info = make_executor_info(payload)
+
+    # Act
+    result = await svc.install_jupyter_server(payload, executor_info, _keypair(), "encrypted")
+
+    # Assert
+    # WHY (D20): the two-shape failure asymmetry — runtime failures return
+    # JupyterInstallationFailed with ONLY a byte-frozen msg; the model carries
+    # no error_type/error_code/failure_step fields at all (unlike D19's
+    # FailedContainerRequest on the attestation branch).
+    assert isinstance(result, JupyterInstallationFailed)
+    assert result.msg == "Failed install jupyter server"
+    assert not hasattr(result, "error_type")
+    assert not hasattr(result, "error_code")
+    assert not hasattr(result, "failure_step")

--- a/neurons/validators/tests/docker_oracle/test_startup_argv.py
+++ b/neurons/validators/tests/docker_oracle/test_startup_argv.py
@@ -1,0 +1,138 @@
+"""Characterization goldens for the LIVE startup-commands argv sink and the
+rental known-hosts chokepoint (DAH-2382 PR-1a, DRAFT sketches D21-D24).
+
+The live builder is `build_container_command_argv` (rental_docker_sdk.py) —
+NOT the dead host-shell-quoting `build_startup_command_args` — and its live
+sink is `run_spec.command` via `_build_rental_container_run_spec`, so these
+tests pin the spec boundary. D24 characterizes the documented fail-open hole
+AS-IS per decision D-A (backlog, not fix-first). Baseline 6be5649f.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+from docker_oracle.harness import (
+    make_create_request,
+    make_docker_service,
+    make_executor_info,
+)
+from payload_models.payloads import CustomOptions
+from services.attestation_service import AttestationError
+from services.rental_docker_sdk import ContainerRunSpec, build_gpu_docker_config
+
+from core.config import settings
+
+
+def _build_run_spec(startup_commands: str) -> ContainerRunSpec:
+    # drive the LIVE argv builder through its real sink: run_spec.command
+    svc = make_docker_service()
+    return svc._build_rental_container_run_spec(
+        payload=make_create_request(),
+        container_name="pod_argv",
+        custom_options=CustomOptions(startup_commands=startup_commands),
+        port_maps=[(22, 20001, 20001)],
+        local_volume="volume_argv",
+        local_volume_path="/root",
+        external_volume_name=None,
+        gpu_devices=build_gpu_docker_config(["GPU-test"]),
+        effective_storage_limit_gb=1,
+        cpu_count=1,
+    )
+
+
+# --- D21-D23: build_container_command_argv -> run_spec.command ----------------
+
+
+def test_startup_commands_argv_neutralizes_injection() -> None:
+    # Arrange / Act
+    spec = _build_run_spec("echo hi; rm -rf /")
+
+    # Assert
+    # WHY (D21 case 2): the live builder shlex-splits into an SDK argv tuple
+    # executed with NO shell — ';' stays glued inside the "hi;" token instead
+    # of chaining a second command (case 1, "\n\nsh ...", is pinned
+    # full-boundary in test_docker_service_rental_security.py).
+    assert spec.command == ("echo", "hi;", "rm", "-rf", "/")
+
+
+def test_startup_commands_argv_preserves_quoted_metacharacters() -> None:
+    # Arrange / Act
+    spec = _build_run_spec('/bin/bash -c "a && b"')
+
+    # Assert
+    # WHY (D22): legitimate in-container shell usage survives — the quoted
+    # '&&' payload reaches the container as ONE argv element, so neutralizing
+    # injection does not break `bash -c` workloads.
+    assert spec.command == ("/bin/bash", "-c", "a && b")
+
+
+def test_startup_commands_unbalanced_quotes_fall_back() -> None:
+    # Arrange / Act
+    spec = _build_run_spec('bash -c "unterminated')
+
+    # Assert
+    # WHY (D23): shlex.split raises ValueError on the unbalanced quote and the
+    # builder falls back to an EMPTY argv (image default CMD) rather than
+    # propagating or guessing a tokenization.
+    assert spec.command == ()
+
+
+# --- D24: _prepare_known_hosts_policy fail-open / fail-closed -----------------
+
+
+@pytest.mark.asyncio
+async def test_prepare_known_hosts_policy_fail_open_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Arrange
+    svc = make_docker_service()
+    svc.attestation_service.prepare_host_policy = AsyncMock(
+        side_effect=RuntimeError("host key store unavailable")
+    )
+    monkeypatch.setattr(settings, "ENABLE_RENTAL_HOSTKEY_FAIL_CLOSED", False)
+    payload = make_create_request()
+    executor_info = make_executor_info(payload)
+
+    # Act
+    with caplog.at_level(logging.WARNING):
+        policy = await svc._prepare_known_hosts_policy(executor_info, "miner", {})
+
+    # Assert
+    # WHY (D24, decision D-A): the documented fail-open hole is characterized
+    # AS-IS and NOT fixed here — a non-attestation error with the flag off
+    # returns None (=> unpinned rental SSH downstream) and the warning line is
+    # the only trace the branch fired.
+    assert policy is None
+    assert "Unable to prepare known_hosts policy" in [
+        str(record.msg) for record in caplog.records
+    ]
+
+
+@pytest.mark.asyncio
+async def test_prepare_known_hosts_policy_fail_closed_raises_attestation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    svc = make_docker_service()
+    svc.attestation_service.prepare_host_policy = AsyncMock(
+        side_effect=RuntimeError("host key store unavailable")
+    )
+    monkeypatch.setattr(settings, "ENABLE_RENTAL_HOSTKEY_FAIL_CLOSED", True)
+    payload = make_create_request()
+    executor_info = make_executor_info(payload)
+
+    # Act / Assert
+    # WHY (D24 counterpart): with the flag on, the SAME non-attestation error
+    # refuses unpinned SSH via AttestationError; the byte-frozen message
+    # interpolates executor.address:port (the executor API port 8080, NOT
+    # ssh_port 2200).
+    with pytest.raises(AttestationError) as excinfo:
+        await svc._prepare_known_hosts_policy(executor_info, "miner", {})
+    assert str(excinfo.value) == (
+        "Unable to prepare host-key policy for executor 127.0.0.1:8080; "
+        "refusing unpinned rental SSH"
+    )

--- a/neurons/validators/tests/docker_oracle/test_volume_sizing_and_ports.py
+++ b/neurons/validators/tests/docker_oracle/test_volume_sizing_and_ports.py
@@ -1,0 +1,378 @@
+"""C-VOL oracle: volume-sizing branches (C1-C9) + port-planner lock failure (C20).
+
+DRAFT sketches C.1/C.3; per DRAFT section 6 these branches are invisible at the
+ContainerCreated boundary, so the asserts here target the finer unit boundary:
+the returned ``VolumeSizingResult`` dataclass, host SSH-command presence/order,
+and the warning log key.
+
+Baseline reality (6be5649f): tests/test_docker_service.py:4281-4458 already pins
+most of the C1-C8 table (shipped with DAH-2183; the DRAFT's [N] tags are stale).
+This file groups the C-VOL contracts under the oracle and adds the finer pins the
+sketches call for: the exact SSH command sequence per path, the byte-exact
+VolumeMinSizeError message, the tie-break winner for ``capped_by``, the full
+result-field set on fallback, and the parse formats the legacy test misses.
+
+Real arithmetic pinned here (all sketch numbers verified against the code):
+overhead 20 GB, headroom 10 GB, GB = 1024**3, pool = share * max(df + existing
+- 20G, 0), request_cap = volume_limit_gb * 1.5 G, df_guard = max((df - 10G) *
+1.5, 0), slice = min(candidates), volume = floor(slice * 2/3) and storage =
+floor(slice * 1/3) each floored to >= 1 GB.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock, patch
+from uuid import uuid4
+
+import pytest
+import redis.exceptions
+from docker_oracle.harness import make_create_request, make_docker_service
+from payload_models.payloads import PayloadPortMapping
+from services.docker_service import VolumeMinSizeError, _parse_volume_size_to_bytes
+
+_GB = 1024**3  # mirrors _FRESH_SIZING_GB_BYTES: sizing is 1024-based, not SI
+
+_DF_HEADER = "Filesystem           1-blocks       Used Available Capacity Mounted on\n"
+
+
+def _df_stdout(df_avail_bytes: int) -> str:
+    # POSIX `df -P -B1` table; the code reads the 4th column of the data line
+    return _DF_HEADER + f"/dev/vda1            1000 500 {df_avail_bytes}  80% /hostfs\n"
+
+
+class RoutingSSHClient:
+    """Local fake SSH client with per-command stdout routing.
+
+    The shared ``RecordingSSHClient`` returns one fixed stdout for every
+    command, but the fresh sizing path needs different text per command
+    (docker info vs df vs volume ls vs volume inspect). Routes are
+    ``(substring, stdout-or-exception)`` pairs, first match wins; every
+    command is recorded in ``.commands`` before routing so failure tests
+    still see how far the code got. An unrouted command fails the test.
+    """
+
+    def __init__(self, routes: list[tuple[str, str | Exception]]) -> None:
+        self.commands: list[str] = []
+        self._routes = routes
+
+    async def run(self, command: str, *args: Any, **kwargs: Any) -> SimpleNamespace:
+        self.commands.append(command)
+        for needle, outcome in self._routes:
+            if needle in command:
+                if isinstance(outcome, Exception):
+                    raise outcome
+                return SimpleNamespace(stdout=outcome, stderr="", exit_status=0)
+        raise AssertionError(f"unexpected ssh command: {command}")
+
+
+def make_sizing_ssh(
+    *,
+    df_avail_bytes: int = 0,
+    volume_ls_stdout: str = "",
+    volume_inspect_stdout: str = "",
+    df_error: Exception | None = None,
+) -> RoutingSSHClient:
+    # route table for the fresh-sizing measurement triplet behind get_docker_root_dir
+    df_outcome: str | Exception = (
+        df_error if df_error is not None else _df_stdout(df_avail_bytes)
+    )
+    return RoutingSSHClient(
+        [
+            ("docker info", "/var/lib/docker\n"),
+            ("df -P -B1 /hostfs", df_outcome),
+            ("volume ls", volume_ls_stdout),
+            ("volume inspect", volume_inspect_stdout),
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# C.1 volume sizing (resolve_volume_sizing)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sizing_pool_bound() -> None:
+    # Arrange: share=0.5, df=900G, one 300G vloopback volume, no request cap
+    # (volume_limit_gb=None drops the request_cap candidate entirely).
+    svc = make_docker_service()
+    payload = make_create_request(disk_share=0.5, volume_limit_gb=None, storage_limit_gb=1)
+    ssh_client = make_sizing_ssh(
+        df_avail_bytes=900 * _GB,
+        volume_ls_stdout="volume_abc vloopback:latest\nscratch local\n",
+        volume_inspect_stdout=f"{300 * _GB}|<no value>\n",
+    )
+
+    # Act
+    result = await svc.resolve_volume_sizing(
+        ssh_client=ssh_client, payload=payload, log_tag="tag", log_extra={}
+    )
+
+    # Assert
+    # WHY: pins the DAH-2183 pool math — pool = df + existing - 20G overhead =
+    # 1180G, slice = 0.5 * pool = 590G < df_guard (900-10)*1.5 = 1335G, then the
+    # 2:1 volume:storage split with floor(): vol = floor(590*2/3) = 393,
+    # storage = floor(590/3) = 196 (GB = 1024**3).
+    assert result.path == "fresh"
+    assert result.capped_by == "pool"
+    assert result.volume_limit_gb == 393
+    assert result.storage_limit_gb == 196
+    assert result.df_avail_bytes == 900 * _GB
+    assert result.existing_volumes_bytes == 300 * _GB
+    # WHY: the fresh path measures over exactly four host commands in this
+    # order: docker info (root dir), df inside the alpine helper container,
+    # volume ls, volume inspect of the vloopback-driver volumes only.
+    assert len(ssh_client.commands) == 4
+    assert "docker info --format" in ssh_client.commands[0]
+    assert "df -P -B1 /hostfs" in ssh_client.commands[1]
+    assert "docker.io/library/alpine:3.19" in ssh_client.commands[1]
+    assert "volume ls" in ssh_client.commands[2]
+    assert "volume inspect volume_abc" in ssh_client.commands[3]
+    assert "scratch" not in ssh_client.commands[3]
+
+
+@pytest.mark.asyncio
+async def test_sizing_df_guard_headroom_binds() -> None:
+    # Arrange: tight disk — share=0.9, df=50G, 1000G of existing volumes
+    # declared only via Options.size ("1000g"; Status size-max is "<no value>").
+    svc = make_docker_service()
+    payload = make_create_request(disk_share=0.9, volume_limit_gb=None, storage_limit_gb=1)
+    ssh_client = make_sizing_ssh(
+        df_avail_bytes=50 * _GB,
+        volume_ls_stdout="volume_abc vloopback\n",
+        volume_inspect_stdout="<no value>|1000g\n",
+    )
+
+    # Act
+    result = await svc.resolve_volume_sizing(
+        ssh_client=ssh_client, payload=payload, log_tag="tag", log_extra={}
+    )
+
+    # Assert
+    # WHY: pins the df headroom guard — df_guard = max((df - 10G) * 1.5, 0) =
+    # (50-10)*1.5 = 60G beats pool 0.9*(50+1000-20) = 927G; split 2:1 gives
+    # vol = floor(60*2/3) = 40, storage = floor(60/3) = 20. The sketch's
+    # (df-10G)*1.5 formula is CONFIRMED against the code.
+    assert result.path == "fresh"
+    assert result.capped_by == "df_guard"
+    assert result.volume_limit_gb == 40
+    assert result.storage_limit_gb == 20
+    assert result.existing_volumes_bytes == 1000 * _GB
+
+
+@pytest.mark.asyncio
+async def test_sizing_request_cap_binds() -> None:
+    # Arrange: share=0.5, df=900G, existing=300G, backend cap volume_limit_gb=100.
+    svc = make_docker_service()
+    payload = make_create_request(disk_share=0.5, volume_limit_gb=100, storage_limit_gb=50)
+    ssh_client = make_sizing_ssh(
+        df_avail_bytes=900 * _GB,
+        volume_ls_stdout="volume_abc vloopback\n",
+        volume_inspect_stdout=f"{300 * _GB}|<no value>\n",
+    )
+
+    # Act
+    result = await svc.resolve_volume_sizing(
+        ssh_client=ssh_client, payload=payload, log_tag="tag", log_extra={}
+    )
+
+    # Assert
+    # WHY: pins the request cap — request_cap = volume_limit_gb * 1.5 G = 150G
+    # beats pool 590G and df_guard 1335G (factor 1.5 CONFIRMED); the *1.5 then
+    # 2/3 split lands the volume EXACTLY back on the requested 100 and storage
+    # on 50, so a request-capped pod still gets its full requested volume.
+    assert result.path == "fresh"
+    assert result.capped_by == "request_cap"
+    assert result.volume_limit_gb == 100
+    assert result.storage_limit_gb == 50
+
+
+@pytest.mark.asyncio
+async def test_sizing_below_min_raises() -> None:
+    # Arrange: share=0.5, df=30G, no existing volumes, min_volume_gb=10.
+    svc = make_docker_service()
+    payload = make_create_request(
+        disk_share=0.5, volume_limit_gb=None, storage_limit_gb=1, min_volume_gb=10
+    )
+    ssh_client = make_sizing_ssh(df_avail_bytes=30 * _GB, volume_ls_stdout="")
+
+    # Act / Assert
+    # WHY: pins the reject threshold — pool = max(30-20, 0)*0.5 = 5G, vol =
+    # floor(5*2/3) = 3 < min_volume_gb=10 raises; the check compares the
+    # already-floored volume, and the message carries both numbers byte-exact.
+    with pytest.raises(
+        VolumeMinSizeError,
+        match="Fresh vloopback sizing produced 3GB volume, below required minimum 10GB",
+    ):
+        await svc.resolve_volume_sizing(
+            ssh_client=ssh_client, payload=payload, log_tag="tag", log_extra={}
+        )
+    # WHY: with zero vloopback volumes listed, the inspect command is skipped —
+    # measurement is docker info + df + volume ls only.
+    assert len(ssh_client.commands) == 3
+    assert not any("volume inspect" in command for command in ssh_client.commands)
+
+
+@pytest.mark.asyncio
+async def test_sizing_low_free_floor_to_1gb() -> None:
+    # Arrange: near-full disk — share=1.0, df=5G (below both the 20G overhead
+    # and the 10G headroom), no existing volumes, no caps.
+    svc = make_docker_service()
+    payload = make_create_request(disk_share=1.0, volume_limit_gb=None, storage_limit_gb=1)
+    ssh_client = make_sizing_ssh(df_avail_bytes=5 * _GB, volume_ls_stdout="")
+
+    # Act
+    result = await svc.resolve_volume_sizing(
+        ssh_client=ssh_client, payload=payload, log_tag="tag", log_extra={}
+    )
+
+    # Assert
+    # WHY: pins the negative clamp + 1 GB floor — pool max(5G-20G, 0) = 0 and
+    # df_guard max((5G-10G)*1.5, 0) = 0 both clamp to 0, slice = 0, and
+    # max(floor(0), 1) floors both limits to 1 GB instead of going negative;
+    # the 0.0 tie resolves to the FIRST candidate in list order, so
+    # capped_by == "pool" (candidate order: pool, request_cap, df_guard).
+    assert result.path == "fresh"
+    assert result.volume_limit_gb == 1
+    assert result.storage_limit_gb == 1
+    assert result.capped_by == "pool"
+
+
+@pytest.mark.asyncio
+async def test_sizing_measurement_failure_falls_back() -> None:
+    # Arrange: the df measurement raises after docker info succeeded.
+    svc = make_docker_service()
+    payload = make_create_request(disk_share=0.5, volume_limit_gb=40, storage_limit_gb=20)
+    ssh_client = make_sizing_ssh(df_error=Exception("df boom"))
+
+    # Act
+    with patch("services.docker_service.logger") as mock_logger:
+        result = await svc.resolve_volume_sizing(
+            ssh_client=ssh_client, payload=payload, log_tag="tag", log_extra={}
+        )
+
+    # Assert
+    # WHY: measurement failure never breaks the rent — the payload limits are
+    # echoed untouched under path="fresh_fallback" and every measurement field
+    # stays None (VolumeSizingResult has NO warnings field; the fallback signal
+    # lives only in the log).
+    assert result.path == "fresh_fallback"
+    assert result.volume_limit_gb == 40
+    assert result.storage_limit_gb == 20
+    assert result.capped_by is None
+    assert result.df_avail_bytes is None
+    assert result.existing_volumes_bytes is None
+    # WHY: the exact log key "vloopback_fresh_sizing_fallback" is emitted via
+    # logger.warning — the only observable trace of this branch (DRAFT C6).
+    warning_keys = [call.args[0].message for call in mock_logger.warning.call_args_list]
+    assert "vloopback_fresh_sizing_fallback" in warning_keys
+    # WHY: measurement stops at the failing df — volume ls/inspect never run.
+    assert len(ssh_client.commands) == 2
+    assert not any("volume ls" in command for command in ssh_client.commands)
+
+
+@pytest.mark.asyncio
+async def test_sizing_storage_opt_unsupported() -> None:
+    # Arrange: backend signals no --storage-opt support (storage_limit_gb=None)
+    # while disk_share IS set — the gate must win over the fresh path.
+    svc = make_docker_service()
+    payload = make_create_request(disk_share=0.5, volume_limit_gb=7, storage_limit_gb=None)
+    ssh_client = RoutingSSHClient([])
+
+    # Act
+    result = await svc.resolve_volume_sizing(
+        ssh_client=ssh_client, payload=payload, log_tag="tag", log_extra={}
+    )
+
+    # Assert
+    # WHY: storage_limit_gb is None is checked BEFORE disk_share, so even a
+    # disk_share payload skips fresh derivation entirely (else dockerd rejects
+    # --storage-opt on non-xfs/pquota hosts); limits pass through untouched,
+    # storage stays None, and no SSH command is issued.
+    assert result.path == "storage_opt_unsupported"
+    assert result.volume_limit_gb == 7
+    assert result.storage_limit_gb is None
+    assert result.capped_by is None
+    assert ssh_client.commands == []
+
+
+@pytest.mark.asyncio
+async def test_sizing_legacy_no_ssh() -> None:
+    # Arrange: no disk_share, both backend limits set (pre-DAH-2183 contract).
+    svc = make_docker_service()
+    payload = make_create_request(disk_share=None, volume_limit_gb=40, storage_limit_gb=20)
+    ssh_client = RoutingSSHClient([])
+
+    # Act
+    result = await svc.resolve_volume_sizing(
+        ssh_client=ssh_client, payload=payload, log_tag="tag", log_extra={}
+    )
+
+    # Assert
+    # WHY: legacy passthrough — backend limits are exact sizes echoed untouched,
+    # every fresh-only field stays None, and no host measurement runs.
+    assert result.path == "legacy"
+    assert result.volume_limit_gb == 40
+    assert result.storage_limit_gb == 20
+    assert result.capped_by is None
+    assert result.df_avail_bytes is None
+    assert result.existing_volumes_bytes is None
+    assert ssh_client.commands == []
+
+
+def test_parse_volume_size_formats() -> None:
+    # Arrange / Act / Assert
+    # WHY: the sketch's base formats ("20401094656"/"19g"/"1t"/"<no value>"/""/
+    # None, 1024-based multipliers) are already pinned at
+    # tests/test_docker_service.py:4434; this extends only the shapes the regex
+    # r"(\d+(?:\.\d+)?)\s*([kmgt]?)b?" accepts or rejects beyond that list.
+    assert _parse_volume_size_to_bytes("1.5g") == 1610612736  # decimal fraction, 1.5*1024**3
+    assert _parse_volume_size_to_bytes("19G") == 19 * 1024**3  # suffix is case-insensitive
+    assert _parse_volume_size_to_bytes("20gb") == 20 * 1024**3  # trailing 'b' accepted
+    assert _parse_volume_size_to_bytes("512m") == 512 * 1024**2
+    assert _parse_volume_size_to_bytes("10k") == 10 * 1024
+    assert _parse_volume_size_to_bytes("100b") == 100  # raw bytes with 'b'
+    assert _parse_volume_size_to_bytes("19 g") == 19 * 1024**3  # inner whitespace allowed
+    assert _parse_volume_size_to_bytes(" 19g ") == 19 * 1024**3  # outer whitespace stripped
+    assert _parse_volume_size_to_bytes("1.5") == 1  # sub-byte fraction truncates via int()
+    assert _parse_volume_size_to_bytes("12x") is None  # 'x' is not a size suffix
+    assert _parse_volume_size_to_bytes("-1g") is None  # no sign accepted
+
+
+# ---------------------------------------------------------------------------
+# C.3 port planner (generate_portMappings) — lock-failure branch only;
+# C18/C19 are covered at tests/test_docker_service.py:623/:673 (DRAFT 0.5).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "lock_exc_cls",
+    [redis.exceptions.LockError, redis.exceptions.LockNotOwnedError],
+)
+async def test_ports_lock_error_returns_empty(
+    lock_exc_cls: type[redis.exceptions.LockError],
+) -> None:
+    # Arrange
+    svc = make_docker_service()
+    svc.redis_service.acquire_executor_lock = Mock(side_effect=lock_exc_cls("lock failed"))
+    executor_id = str(uuid4())
+
+    # Act
+    result = await svc.generate_portMappings(
+        miner_hotkey="miner",
+        executor_id=executor_id,
+        pod_id=uuid4(),
+        available_ports_raw=[PayloadPortMapping(internal_port=20001, external_port=20001)],
+        pod_mapping_raw=[],
+    )
+
+    # Assert
+    # WHY: the planner catches exactly (redis.exceptions.LockError,
+    # redis.exceptions.LockNotOwnedError) and degrades to ([], None), which
+    # create_container later maps to NoPortMappings/failure_step="port_mapping"
+    # (that boundary is pinned at tests/test_docker_service.py:623).
+    assert result == ([], None)
+    svc.redis_service.acquire_executor_lock.assert_called_once_with(executor_id)

--- a/neurons/validators/tests/fixtures/docker_oracle/README.md
+++ b/neurons/validators/tests/fixtures/docker_oracle/README.md
@@ -1,0 +1,8 @@
+# Docker oracle golden files
+
+Golden snapshot files for the docker-service characterization oracle
+(`tests/docker_oracle/`, DAH-2382). A test writes its golden on first run (and
+fails, asking for a re-run), asserts byte-equality against it afterwards, and
+rewrites it only when pytest is invoked with `--update-snapshot` — the repo's
+own snapshot flag from `tests/conftest.py`. Review every diff under this
+directory as a behavior change of `docker_service.py`, never as noise.

--- a/neurons/validators/tests/fixtures/docker_oracle/container_created_success_golden.json
+++ b/neurons/validators/tests/fixtures/docker_oracle/container_created_success_golden.json
@@ -1,0 +1,86 @@
+{
+  "message_type": "ContainerCreated",
+  "miner_hotkey": "miner",
+  "executor_id": "00000000-0000-0000-0000-0000000000e1",
+  "pod_id": "00000000-0000-0000-0000-0000000000b1",
+  "workload_kind": "CUSTOMER_RENTAL",
+  "container_name": "pod_00000000-0000-0000-0000-0000000000b1",
+  "volume_name": "volume_00000000-0000-0000-0000-0000000000b1",
+  "port_maps": [
+    [
+      22,
+      20001
+    ]
+  ],
+  "profilers": [
+    {
+      "name": "Started in subnet",
+      "duration": "<duration_ms>"
+    },
+    {
+      "name": "Port mappings generated",
+      "duration": "<duration_ms>"
+    },
+    {
+      "name": "SSH connection established",
+      "duration": "<duration_ms>"
+    },
+    {
+      "name": "Docker login step finished",
+      "duration": "<duration_ms>",
+      "skipped": true
+    },
+    {
+      "name": "Docker pull step finished",
+      "duration": "<duration_ms>"
+    },
+    {
+      "name": "Container cleaning step finished",
+      "duration": "<duration_ms>"
+    },
+    {
+      "name": "Docker volume creation step finished",
+      "duration": "<duration_ms>"
+    },
+    {
+      "name": "GPU device probe step finished",
+      "duration": "<duration_ms>"
+    },
+    {
+      "name": "Port-check wait step finished",
+      "duration": "<duration_ms>"
+    },
+    {
+      "name": "Docker run step finished",
+      "duration": "<duration_ms>"
+    },
+    {
+      "name": "Container running check step finished",
+      "duration": "<duration_ms>"
+    },
+    {
+      "name": "SSH service installation step finished",
+      "duration": "<duration_ms>"
+    },
+    {
+      "name": "Adding public keys step finished",
+      "duration": "<duration_ms>"
+    },
+    {
+      "name": "Inspector collector start step finished",
+      "duration": "<duration_ms>",
+      "skipped": true
+    },
+    {
+      "name": "Finished in subnet.",
+      "duration": "<duration_ms>"
+    }
+  ],
+  "backup_log_id": "b1",
+  "restore_path": "/r",
+  "jupyter_url": null,
+  "warnings": [],
+  "storage_limit_gb": 20,
+  "volume_limit_gb": 10,
+  "local_volume_path": "/root"
+}

--- a/neurons/validators/tests/fixtures/docker_oracle/e7_differential_probe_surface.json
+++ b/neurons/validators/tests/fixtures/docker_oracle/e7_differential_probe_surface.json
@@ -1,0 +1,107 @@
+{
+  "daemon": {
+    "cmd": [
+      "sh",
+      "-c",
+      "trap : TERM INT; sleep infinity & wait"
+    ],
+    "entrypoint": null,
+    "env": {
+      "E7_SECRET_TOKEN": "<masked>",
+      "E7_SENTINEL": "sentinel-value",
+      "NVIDIA_DRIVER_CAPABILITIES": "all",
+      "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    },
+    "env_keys": [
+      "E7_SECRET_TOKEN",
+      "E7_SENTINEL",
+      "NVIDIA_DRIVER_CAPABILITIES",
+      "PATH"
+    ],
+    "host_config": {
+      "binds": [
+        "volume_00000000-0000-0000-0000-0000000000e7:/root:rw"
+      ],
+      "cap_add": [
+        "NET_ADMIN"
+      ],
+      "devices": [
+        {
+          "CgroupPermissions": "rwm",
+          "PathInContainer": "/dev/net/tun",
+          "PathOnHost": "/dev/net/tun"
+        }
+      ],
+      "memory": 1073741824,
+      "nano_cpus": 1000000000,
+      "port_bindings": {
+        "22/tcp": [
+          "20001"
+        ]
+      },
+      "restart_policy": {
+        "MaximumRetryCount": 0,
+        "Name": "unless-stopped"
+      },
+      "sysctls": {
+        "net.ipv4.conf.all.src_valid_mark": "1"
+      }
+    },
+    "labels": {}
+  },
+  "delete": {
+    "removed_after_force_remove": true,
+    "running_after_graceful_stop": false
+  },
+  "redis_call_order": [],
+  "run_spec": {
+    "cap_add": [
+      "NET_ADMIN"
+    ],
+    "command": [
+      "sh",
+      "-c",
+      "trap : TERM INT; sleep infinity & wait"
+    ],
+    "cpu_count": 1,
+    "device_requests": [],
+    "devices": [
+      {
+        "path_in_container": "/dev/net/tun",
+        "path_on_host": "/dev/net/tun",
+        "permissions": "rwm"
+      }
+    ],
+    "entrypoint": null,
+    "environment": {
+      "E7_SECRET_TOKEN": "<masked>",
+      "E7_SENTINEL": "sentinel-value",
+      "NVIDIA_DRIVER_CAPABILITIES": "all"
+    },
+    "image": "alpine:3.20",
+    "memory_gb": 1,
+    "name": "pod_00000000-0000-0000-0000-0000000000e7",
+    "ports": [
+      {
+        "container_port": 22,
+        "host_port": 20001,
+        "protocol": "tcp"
+      }
+    ],
+    "restart_policy": "unless-stopped",
+    "runtime": null,
+    "shm_size": null,
+    "storage_limit_gb": null,
+    "sysctls": {
+      "net.ipv4.conf.all.src_valid_mark": "1"
+    },
+    "volumes": [
+      {
+        "read_only": false,
+        "source": "volume_00000000-0000-0000-0000-0000000000e7",
+        "target": "/root"
+      }
+    ]
+  },
+  "schema": "e7-differential-probe/v1"
+}

--- a/neurons/validators/tests/fixtures/docker_oracle/profiler_name_sequence_golden.json
+++ b/neurons/validators/tests/fixtures/docker_oracle/profiler_name_sequence_golden.json
@@ -1,0 +1,17 @@
+[
+  "Started in subnet",
+  "Port mappings generated",
+  "SSH connection established",
+  "Docker login step finished",
+  "Docker pull step finished",
+  "Container cleaning step finished",
+  "Docker volume creation step finished",
+  "GPU device probe step finished",
+  "Port-check wait step finished",
+  "Docker run step finished",
+  "Container running check step finished",
+  "SSH service installation step finished",
+  "Adding public keys step finished",
+  "Inspector collector start step finished",
+  "Finished in subnet."
+]

--- a/neurons/validators/tests/integration/README_E7.md
+++ b/neurons/validators/tests/integration/README_E7.md
@@ -1,0 +1,61 @@
+# E7 — local differential gate for the docker-service refactor (DAH-2382)
+
+E7 is the differential harness from the characterization oracle (§E row E7).
+It drives the live docker-service layers through a **real local docker daemon**
+and pins the comparable surface (run spec, daemon-side container config, redis
+call-order, delete boundary) to a golden snapshot. It is the only check that
+catches mock-vs-reality drift and side-effect reordering that unit goldens
+cannot see.
+
+Decision **D-B** (2026-07-19): no docker-capable CI runner is budgeted, so E7
+runs as a **mandatory LOCAL gate before every extraction PR** (PR-2..PR-12),
+with the staging canary as the final backstop. Default CI collects this module
+and skips it (same env gate as `test_rental_docker_sdk_local.py`).
+
+## Prerequisites
+
+- A local docker daemon (Docker Desktop is fine) — the test pulls `alpine:3.20`
+  and creates/removes one container plus one named volume, all `e7`-named and
+  cleaned up afterwards.
+- docker-py reads `DOCKER_HOST`, not the docker CLI context. If the test skips
+  with "local Docker daemon unavailable" while `docker info` works (Docker
+  Desktop on macOS without the default-socket option), run with
+  `DOCKER_HOST=unix://$HOME/.docker/run/docker.sock make e7`.
+- The validator venv (`pdm install` in `neurons/validators/`).
+- No GPU needed: PR-1a scope drives the GPU-less run-spec layer (see the module
+  docstring of `test_docker_service_differential.py` for the exact scope).
+
+## The one command
+
+```bash
+cd neurons/validators
+make e7          # run the gate (byte-equal against the golden snapshot)
+make e7-record   # re-record the golden after an INTENDED behavior change
+```
+
+Equivalent raw invocation:
+
+```bash
+RUN_RENTAL_DOCKER_SDK_INTEGRATION=1 pdm run pytest \
+    tests/integration/test_docker_service_differential.py -q
+```
+
+## What extraction-PR authors must do (D-B, honour-system gate)
+
+1. Run `make e7` locally against the branch **before pushing**.
+2. Record the run in the PR description, e.g.:
+   `E7: ran locally, 1 passed @ <commit sha>`.
+3. If the snapshot drifted: either the extraction changed behavior (fix it), or
+   the change is intended — then re-record with `make e7-record` and call the
+   snapshot diff out in the PR as an explicit behavior change.
+
+## PR-2+ evolution: old-vs-new
+
+In PR-1a there is one implementation, so the harness asserts self-consistency
+against the pinned golden. From PR-2 on, the same probe runs against the
+pre-refactor facade (whose surface is the pinned golden) **and** the extracted
+package — any drift between the two fails the gate. PR-2 also extends the probe
+from the current narrow layer (run-spec build + live create retry loop + delete
+boundary) to the full `create_container`/`delete_container` facade over the
+`local_ssh_docker_endpoint` fixture, which populates the redis call-order
+channel already present in the snapshot schema.

--- a/neurons/validators/tests/integration/test_docker_service_differential.py
+++ b/neurons/validators/tests/integration/test_docker_service_differential.py
@@ -1,0 +1,328 @@
+"""E7 differential harness SKELETON (DAH-2382 PR-1a, oracle §E row E7, decision D-B).
+
+Purpose: the per-extraction-PR differential gate against a REAL docker daemon.
+In PR-1a there is only ONE implementation (the monolith), so the test asserts
+SELF-consistency: the probe drives the live docker-service layers, captures the
+comparable surface, and pins it byte-for-byte to a golden snapshot under
+``tests/fixtures/docker_oracle/``.
+
+In extraction PRs this becomes old-vs-new: the same probe runs against the
+pre-refactor facade (pinned golden) and the new package — any drift fails.
+
+Decision D-B (2026-07-19): no docker-capable CI runner is budgeted, so this
+module is env-gated exactly like ``test_rental_docker_sdk_local.py``
+(``RUN_RENTAL_DOCKER_SDK_INTEGRATION=1``) and runs as a mandatory LOCAL gate
+(``make e7`` in ``neurons/validators/``) before each extraction PR, with the
+staging canary as the final backstop. See ``tests/integration/README_E7.md``.
+
+Scope (PR-1a reality check): the FULL ``DockerService.create_container`` cannot
+run against the local fixtures under this gate —
+- the run spec always carries a GPU device request (``build_gpu_docker_config``
+  emits ``count=-1`` even for zero UUIDs), which a non-NVIDIA local daemon
+  rejects at ``docker run``;
+- port generation, volume sizing and sshd provisioning need a redis-backed port
+  state and the SSH executor endpoint, which sits behind the SEPARATE
+  ``RUN_RENTAL_DOCKER_SDK_SSH_INTEGRATION`` gate (``local_ssh_docker_endpoint``);
+- ``storage_limit_gb`` maps to ``--storage-opt size`` (xfs+pquota only).
+So the probe drives the deepest daemon-real layer instead: the real
+``CustomOptions.sanitize`` -> ``_build_rental_container_run_spec`` -> the LIVE
+``_run_rental_docker_create_with_port_retry`` (creates a REAL container) ->
+``docker inspect`` -> the real ``_stop_container_gracefully`` +
+``_force_remove_container`` delete boundary.
+TODO(PR-2): extend the probe to the full ``create_container``/``delete_container``
+facade over ``local_ssh_docker_endpoint`` (GPU-less spec seam + sshd-capable
+target image needed), populating the redis call-order surface below.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import re
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from docker_oracle.harness import RecordingRedisService, make_create_request, make_docker_service
+from payload_models.payloads import (
+    ContainerCreateRequest,
+    ContainerDeleteRequest,
+    CustomOptions,
+)
+from services.docker_service import DockerService, _BoundLog
+from services.rental_docker_sdk import GpuDockerConfig, RentalDockerSdkClient
+
+# WHY: fixture functions imported into this module's namespace are registered by
+# pytest for this module — the smallest reuse that leaves the source file untouched.
+from test_rental_docker_sdk_local import (
+    TARGET_IMAGE,
+    local_docker_api_client,  # noqa: F401
+    requires_local_docker,
+)
+
+# Same gate as test_rental_docker_sdk_local.py (decision D-B): default CI skips.
+pytestmark = requires_local_docker
+
+# Fixed identities keep every derived name (container, volume) and the golden
+# snapshot byte-stable across runs; the trailing e7 marks probe-owned resources.
+_PROBE_POD_ID = "00000000-0000-0000-0000-0000000000e7"
+_PROBE_EXECUTOR_ID = "00000000-0000-0000-0000-00000000e701"
+_PROBE_HOST_PORT = 20001
+
+_SNAPSHOT_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "fixtures"
+    / "docker_oracle"
+    / "e7_differential_probe_surface.json"
+)
+
+_SECRET_ENV_KEY_PATTERN = re.compile(r"(?i)secret|token|password|credential|_key")
+
+
+def _make_probe_payload() -> ContainerCreateRequest:
+    # trap TERM so the graceful-stop grace window (30s) resolves instantly,
+    # mirroring the lifecycle command of test_rental_docker_sdk_local.py.
+    return make_create_request(
+        executor_id=_PROBE_EXECUTOR_ID,
+        pod_id=_PROBE_POD_ID,
+        docker_image=TARGET_IMAGE,
+        available_ports=[],
+        custom_options=CustomOptions(
+            startup_commands="sh -c 'trap : TERM INT; sleep infinity & wait'",
+            environment={
+                "E7_SENTINEL": "sentinel-value",
+                "E7_SECRET_TOKEN": "must-not-reach-the-snapshot",
+            },
+        ),
+    )
+
+
+def _mask_env(environment: dict[str, str]) -> dict[str, str]:
+    # WHY: env values may carry secrets (registry passwords, jupyter tokens);
+    # the differential compares the key set plus non-secret values only.
+    return {
+        key: "<masked>" if _SECRET_ENV_KEY_PATTERN.search(key) else value
+        for key, value in environment.items()
+    }
+
+
+def _env_entries_to_dict(env_entries: list[str] | None) -> dict[str, str]:
+    return dict(entry.partition("=")[::2] for entry in env_entries or [])
+
+
+def _normalized_port_bindings(port_bindings: dict[str, Any] | None) -> dict[str, list[str]]:
+    # WHY: inspect wraps each binding as {"HostIp": "", "HostPort": ...} and the
+    # HostIp default shape drifts across daemon versions; the comparable fact is
+    # container-port -> host-port.
+    return {
+        port: [binding["HostPort"] for binding in bindings or []]
+        for port, bindings in (port_bindings or {}).items()
+    }
+
+
+@dataclasses.dataclass(frozen=True)
+class DifferentialProbeResult:
+    """Captured comparable surface plus the raw pieces the test asserts on."""
+
+    surface: dict[str, Any]
+    spec_argv: tuple[str, ...]
+    inspected_cmd: list[str] | None
+
+
+class DifferentialProbe:
+    """Drives the monolith's live docker layers through a real daemon and
+    captures the old-vs-new comparable surface (see module docstring for scope)."""
+
+    def __init__(self, api_client: Any, service: DockerService, redis: RecordingRedisService):
+        self._api_client = api_client
+        self._service = service
+        self._redis = redis
+
+    async def run(self, payload: ContainerCreateRequest) -> DifferentialProbeResult:
+        # run the create layer, inspect the real container, then run the delete
+        # boundary; always leaves the daemon clean
+        container_name = DockerService.get_container_name(payload)
+        local_volume = f"volume_{payload.pod_id}"
+
+        client = RentalDockerSdkClient(self._api_client)
+        self._cleanup(container_name, local_volume)
+        try:
+            run_spec = self._build_run_spec(payload, container_name, local_volume)
+
+            await client.pull(image=payload.docker_image)
+            # WHY Mock ssh_client: the retry loop touches SSH only on the
+            # vloopback stale-mount repair branch, unreachable on this happy path.
+            await self._service._run_rental_docker_create_with_port_retry(
+                docker_client=client,
+                ssh_client=Mock(),
+                run_spec=run_spec,
+                container_name=container_name,
+                default_extra={"probe": "e7"},
+                local_volume=local_volume,
+            )
+            inspect = self._api_client.inspect_container(container_name)
+
+            delete_observations = await self._run_delete_boundary(
+                client, payload, container_name, local_volume
+            )
+
+            return DifferentialProbeResult(
+                surface={
+                    "schema": "e7-differential-probe/v1",
+                    # Empty at PR-1a depth (the narrow layer never touches redis);
+                    # kept in the surface so the PR-2 full-facade drive fills it
+                    # without a snapshot schema change.
+                    "redis_call_order": [name for name, _ in self._redis.calls],
+                    "run_spec": self._serialize_run_spec(run_spec),
+                    "daemon": self._capture_daemon_view(inspect),
+                    "delete": delete_observations,
+                },
+                spec_argv=run_spec.command,
+                inspected_cmd=inspect["Config"].get("Cmd"),
+            )
+        finally:
+            self._cleanup(container_name, local_volume)
+            await client.aclose()
+
+    def _build_run_spec(
+        self,
+        payload: ContainerCreateRequest,
+        container_name: str,
+        local_volume: str,
+    ):
+        custom_options = CustomOptions.sanitize(payload.custom_options)
+        return self._service._build_rental_container_run_spec(
+            payload=payload,
+            container_name=container_name,
+            custom_options=custom_options,
+            port_maps=[(22, _PROBE_HOST_PORT, _PROBE_HOST_PORT)],
+            local_volume=local_volume,
+            local_volume_path="/root",
+            external_volume_name=None,
+            # WHY empty GPU config: build_gpu_docker_config emits a device
+            # request even for zero UUIDs, and a non-NVIDIA local daemon rejects
+            # it; the GPU seam joins the probe in the PR-2 full-facade drive.
+            gpu_devices=GpuDockerConfig(),
+            # WHY None: --storage-opt size requires overlay-on-xfs with pquota,
+            # unavailable on typical local daemons (Docker Desktop).
+            effective_storage_limit_gb=None,
+            cpu_count=payload.cpu_count,
+        )
+
+    async def _run_delete_boundary(
+        self,
+        client: RentalDockerSdkClient,
+        payload: ContainerCreateRequest,
+        container_name: str,
+        local_volume: str,
+    ) -> dict[str, Any]:
+        # the daemon-reachable slice of delete_container: graceful stop (never
+        # fatal) then the single fatal force-remove boundary
+        delete_payload = ContainerDeleteRequest(
+            miner_hotkey=payload.miner_hotkey,
+            executor_id=payload.executor_id,
+            pod_id=payload.pod_id,
+            container_name=container_name,
+            local_volume=local_volume,
+        )
+        log = _BoundLog({"probe": "e7", "pod_id": payload.pod_id})
+
+        await self._service._stop_container_gracefully(client, delete_payload, log)
+        running_after_stop = self._api_client.inspect_container(container_name)["State"]["Running"]
+        await self._service._force_remove_container(client, delete_payload, log)
+        return {
+            "running_after_graceful_stop": running_after_stop,
+            "removed_after_force_remove": not self._container_exists(container_name),
+        }
+
+    def _serialize_run_spec(self, run_spec: Any) -> dict[str, Any]:
+        spec = dataclasses.asdict(run_spec)
+        spec["environment"] = _mask_env(spec["environment"])
+        return spec
+
+    def _capture_daemon_view(self, inspect: dict[str, Any]) -> dict[str, Any]:
+        # WHY this projection: only fields that are deterministic across local
+        # daemons are captured — container id, timestamps and state are masked
+        # out by never being selected.
+        config = inspect["Config"]
+        host_config = inspect["HostConfig"]
+        environment = _env_entries_to_dict(config.get("Env"))
+        return {
+            "cmd": config.get("Cmd"),
+            "entrypoint": config.get("Entrypoint"),
+            "env_keys": sorted(environment),
+            "env": _mask_env(environment),
+            "labels": config.get("Labels") or {},
+            "host_config": {
+                "binds": host_config.get("Binds"),
+                "port_bindings": _normalized_port_bindings(host_config.get("PortBindings")),
+                "cap_add": host_config.get("CapAdd"),
+                "restart_policy": host_config.get("RestartPolicy"),
+                "sysctls": host_config.get("Sysctls"),
+                "devices": host_config.get("Devices"),
+                "nano_cpus": host_config.get("NanoCpus"),
+                "memory": host_config.get("Memory"),
+            },
+        }
+
+    def _container_exists(self, container_name: str) -> bool:
+        import docker
+
+        try:
+            self._api_client.inspect_container(container_name)
+            return True
+        except docker.errors.NotFound:
+            return False
+
+    def _cleanup(self, container_name: str, volume_name: str) -> None:
+        # idempotent pre/post cleanup so a crashed earlier run cannot poison
+        # the fixed-name container/volume of the next one
+        try:
+            self._api_client.remove_container(container_name, force=True, v=True)
+        except Exception:
+            pass
+        try:
+            self._api_client.remove_volume(volume_name, force=True)
+        except Exception:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_e7_differential_probe_self_consistency(
+    local_docker_api_client,  # noqa: F811
+    update_snapshot,
+):
+    # Arrange — monolith service with the recording redis fake wired in, so the
+    # captured surface already carries the redis call-order channel for PR-2.
+    service = make_docker_service()
+    redis = RecordingRedisService()
+    service.redis_service = redis
+    probe = DifferentialProbe(local_docker_api_client, service, redis)
+    payload = _make_probe_payload()
+
+    # Act
+    result = await probe.run(payload)
+
+    # Assert — the argv==Config.Cmd differential (same invariant as
+    # test_rental_docker_sdk_local.py's breakout test): the command the service
+    # built is exactly what the real daemon runs, with no host-shell hop.
+    assert result.inspected_cmd == list(result.spec_argv)
+
+    # Assert — byte-equal golden snapshot (repo's own --update-snapshot flow:
+    # write-on-missing then fail asking for a re-run; byte-equal afterwards).
+    serialized = json.dumps(result.surface, indent=2, sort_keys=True) + "\n"
+    _SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if update_snapshot or not _SNAPSHOT_PATH.exists():
+        _SNAPSHOT_PATH.write_text(serialized, encoding="utf-8")
+        if not update_snapshot:
+            pytest.fail(
+                f"E7 golden snapshot did not exist; wrote it. Re-run to assert. Path={_SNAPSHOT_PATH}"
+            )
+        return
+    expected = _SNAPSHOT_PATH.read_text(encoding="utf-8")
+    assert serialized == expected, (
+        "E7 differential surface drifted from the golden snapshot. If the change is an "
+        "intended behavior change, re-record with --update-snapshot (make e7-record) and "
+        f"review the diff as a docker_service behavior change. Path={_SNAPSHOT_PATH}"
+    )

--- a/neurons/validators/tests/test_deploy_optimizations.py
+++ b/neurons/validators/tests/test_deploy_optimizations.py
@@ -391,12 +391,18 @@ async def test_ships_sshd_true_forwards_jupyter_password_instead_of_run_jupyter(
         AsyncMock(return_value=([(22, 20001, 20001)], (8888, 30888))),
     )
 
-    result = await _run(svc, _payload(ships_sshd=True, enable_jupyter=True))
+    result = await _run(svc, _payload(ships_sshd=True, enable_jupyter=True, **_CREDS))
 
     assert isinstance(result, ContainerCreated)
     # Neither the validator sshd bootstrap nor run_jupyter should run.
     svc.install_open_ssh_server_and_start_ssh_service_with_rental_docker.assert_not_awaited()
     svc.run_jupyter.assert_not_awaited()
+
+    # WHY (oracle B10 fold, DAH-2382): the image-managed bundle also skips the docker
+    # login — ships_sshd is the default-image signal, so even with renter credentials
+    # attached the login must not run and its profiler step must say skipped.
+    assert _docker_client(svc).login_calls == []
+    assert _login_step(result).skipped is True
 
     # JUPYTER_PASSWORD is forwarded as create-time container env: it is the ONLY
     # Jupyter variable the image's start.sh reads (`if [[ $JUPYTER_PASSWORD ]]` →
@@ -442,12 +448,18 @@ async def test_ships_sshd_none_with_jupyter_uses_run_jupyter(svc, monkeypatch):
         AsyncMock(return_value=([(22, 20001, 20001)], (8888, 30888))),
     )
 
-    result = await _run(svc, _payload(enable_jupyter=True))
+    result = await _run(svc, _payload(enable_jupyter=True, **_CREDS))
 
     assert isinstance(result, ContainerCreated)
     svc.install_open_ssh_server_and_start_ssh_service_with_rental_docker.assert_awaited_once()
     svc.run_jupyter.assert_awaited_once()
     assert "JUPYTER_PASSWORD" not in _created_run_spec(svc).environment
+
+    # WHY (oracle B11 fold, DAH-2382): the validator-managed branch keeps the docker
+    # login — ships_sshd None with credentials is no default-image signal, so the
+    # login must run and the DOCKER_LOGIN profiler step must not claim skipped.
+    assert _docker_client(svc).login_calls == [{"username": "renter", "password": "renter-secret"}]
+    assert _login_step(result).skipped is False
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -23,6 +23,7 @@ from payload_models.payloads import (
     ContainerDeleted,
     ContainerStartRequest,
     ContainerStopRequest,
+    FailedContainerErrorCodes,
     FailedContainerErrorTypes,
     FailedContainerRequest,
     PayloadPortMapping,
@@ -1027,6 +1028,10 @@ async def test_delete_container_stops_gracefully_before_forced_removal(
         ("remove", payload.container_name),
     ]
     assert client.stop_grace_seconds_calls == [CONTAINER_STOP_GRACE_SECONDS]
+    # WHY (DAH-2382 D2): the customer grace window is a wire contract
+    # (docker stop -t 30) — pin the literal, not just the constant, so a silent
+    # constant change cannot pass characterization
+    assert client.stop_grace_seconds_calls == [30]
     assert client.removed_containers == [
         {
             "container_name": payload.container_name,
@@ -1095,6 +1100,7 @@ async def test_delete_container_logs_point_at_the_call_site(
 async def test_delete_container_stop_failure_still_removes(
     docker_service,
     monkeypatch,
+    caplog,
 ):
     # Arrange: the graceful stop fails (e.g. wedged runtime) — removal must proceed
     ssh_client = AsyncMock()
@@ -1132,12 +1138,13 @@ async def test_delete_container_stop_failure_still_removes(
     )
 
     # Act
-    result = await docker_service.delete_container(
-        payload=payload,
-        executor_info=executor_info,
-        keypair=Mock(ss58_address="validator-hotkey"),
-        private_key="encrypted",
-    )
+    with caplog.at_level(logging.WARNING, logger="services.docker_service"):
+        result = await docker_service.delete_container(
+            payload=payload,
+            executor_info=executor_info,
+            keypair=Mock(ss58_address="validator-hotkey"),
+            private_key="encrypted",
+        )
 
     # Assert: stop failure is swallowed, forced removal still runs and succeeds
     assert isinstance(result, ContainerDeleted)
@@ -1150,6 +1157,15 @@ async def test_delete_container_stop_failure_still_removes(
             "remove_volumes": True,
         }
     ]
+    # WHY (DAH-2382 D4): a failed graceful stop is demoted to a single WARNING —
+    # never an ERROR, never fatal — because the forced removal stays the single
+    # source of truth for deletion
+    stop_warnings = [
+        r
+        for r in caplog.records
+        if str(r.msg) == "Graceful container stop failed; proceeding to forced removal"
+    ]
+    assert [r.levelno for r in stop_warnings] == [logging.WARNING]
 
 
 @pytest.mark.asyncio
@@ -1277,6 +1293,9 @@ async def test_delete_filler_stops_with_reduced_grace(
     ]
     assert client.stop_grace_seconds_calls == [FILLER_CONTAINER_STOP_GRACE_SECONDS]
     assert FILLER_CONTAINER_STOP_GRACE_SECONDS < CONTAINER_STOP_GRACE_SECONDS
+    # WHY (DAH-2382 D3): the DAH-2364 filler grace must stay below the backend's
+    # 30s preemption budget — pin the literal 15, not just the constant
+    assert client.stop_grace_seconds_calls == [15]
     # DAH-2356 still restores the filler's GPU power caps after the graceful stop
     restore_filler_power.assert_awaited_once()
     assert restore_filler_power.await_args.args[2] == payload.pod_id
@@ -1595,6 +1614,16 @@ async def test_delete_container_remove_container_error_fails_undeploy(
     assert result.error_type == FailedContainerErrorTypes.ContainerDeletionFailed
     assert "500 Server Error: daemon exploded" in result.msg
     docker_service.redis_service.remove_rented_machine.assert_not_awaited()
+    # WHY (DAH-2382 D5): the fatal-remove funnel shape is a classifier surface —
+    # byte-frozen msg prefix + the raw str(exc) tail, error_code UnknownError,
+    # and (unlike the create funnel) NO failure_step
+    assert result.error_code == FailedContainerErrorCodes.UnknownError
+    assert result.msg.startswith("Unknown Error delete_container: ")
+    assert result.msg == (
+        "Unknown Error delete_container: "
+        "Docker SDK remove container failed: 500 Server Error: daemon exploded"
+    )
+    assert result.failure_step is None
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -19,6 +19,8 @@ from payload_models.payloads import (
     ExternalVolumeInfo,
     PayloadPortMapping,
     RemoveSshPublicKeysRequest,
+    SshPubKeyAdded,
+    SshPubKeyRemoved,
     WorkloadKind,
 )
 from services.docker_service import DockerService
@@ -622,7 +624,7 @@ async def test_add_ssh_key_writes_public_keys_as_stdin_data(
         user_public_keys=[HOSTILE_PUBLIC_KEY],
     )
 
-    await docker_service.add_ssh_key(
+    result = await docker_service.add_ssh_key(
         payload,
         executor_info,
         keypair,
@@ -639,6 +641,10 @@ async def test_add_ssh_key_writes_public_keys_as_stdin_data(
     assert spec.container_name == HOSTILE_CONTAINER_NAME
     assert HOSTILE_PUBLIC_KEY not in " ".join(spec.argv)
     assert spec.stdin == f"{HOSTILE_PUBLIC_KEY}\n"
+    # WHY (oracle D12): this test used to discard the return value — freeze the
+    # success ack the backend consumes: SshPubKeyAdded echoing the request keys.
+    assert isinstance(result, SshPubKeyAdded)
+    assert result.user_public_keys == [HOSTILE_PUBLIC_KEY]
 
 
 @pytest.mark.asyncio
@@ -659,7 +665,7 @@ async def test_remove_ssh_key_writes_public_keys_as_stdin_data(
         user_public_keys=[HOSTILE_PUBLIC_KEY],
     )
 
-    await docker_service.remove_ssh_keys(
+    result = await docker_service.remove_ssh_keys(
         payload,
         executor_info,
         keypair,
@@ -676,6 +682,11 @@ async def test_remove_ssh_key_writes_public_keys_as_stdin_data(
     assert spec.container_name == HOSTILE_CONTAINER_NAME
     assert HOSTILE_PUBLIC_KEY not in " ".join(spec.argv)
     assert spec.stdin == f"{HOSTILE_PUBLIC_KEY}\n"
+    # WHY (oracle D13): freeze the remove ack shape even though the backend
+    # silently drops it today (SshPubKeyRemoved is not in the backend RequestType,
+    # DRAFT §8) — extraction must not change the wire shape regardless.
+    assert isinstance(result, SshPubKeyRemoved)
+    assert result.user_public_keys == [HOSTILE_PUBLIC_KEY]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2382](https://www.notion.so/399b8bfdbde981baa129c772c5328b8a)

---

PR-1a of the docker-service-refactor sequence: the characterization oracle that freezes the observable boundary of `docker_service.py` (4,777 lines, baseline `6be5649f`) **before** any extraction PR moves code. Test-only — `src/` is untouched.

## Problem

`docker_service.py` is about to be split into a `services/docker/` package (sequential milestone plan). Its observable contracts — serialized `FailedContainerRequest`/`ContainerCreated`/`ContainerDeleted` payloads, byte-exact `msg` strings consumed by the lium-stats classifier, profiler wire shapes, Loki `profile_steps` format, Redis/pub-sub call order, and the shell-free argv boundary — are mostly unpinned. Worse, the audit found the tested retry helper and the tested security helper are both DEAD code, while their live SDK twins (`_run_rental_docker_create_with_port_retry`, `build_container_command_argv`) and `install_jupyter_server` had zero direct tests.

## Solution

A characterization test package `tests/docker_oracle/` (groups B/C/D/E of `openspec/changes/docker-service-refactor/characterization-oracle-DRAFT.md`; group A — the create failure matrix — lands in PR-1b) plus the E7 differential harness skeleton (decision D-B: mandatory local gate, no CI runner). Tests pin what baseline **actually does**, deviations from the plan sketches are recorded in the README ("Observed-vs-sketch corrections", 20 items). One shared harness (`harness.py`) replaces the pattern of per-file fake copies; goldens use the repo's own `--update-snapshot` mechanism.

## Changes

- `tests/docker_oracle/` — new package: shared harness + 7 suites, 67 tests (create success/profiler/Redis golden, live SDK retry loop, volume sizing arithmetic, delete flow incl. wedge-sweep call-sites, ssh keys, jupyter, live argv builder, known_hosts fail-open as-is per D-A, behavior invariants E1–E6)
- `tests/docker_oracle/README.md` — the oracle: baseline SHA, normalization rules, gap analysis (2.1), failure-site matrix (2.2), observed-vs-sketch corrections
- `tests/integration/test_docker_service_differential.py` + `Makefile` (`make e7` / `make e7-record`) + `tests/integration/README_E7.md` — E7 differential gate skeleton on the existing local-daemon fixtures
- `tests/fixtures/docker_oracle/` — 3 golden files (ContainerCreated shape, 15-step profiler sequence, E7 probe surface)
- Assert-folds in 3 existing suites (`test_deploy_optimizations.py` B10/B11, `test_docker_service.py` D2–D5, `test_docker_service_rental_security.py` D12/D13) — additive only
- 3 xfail(strict) by design: cancellation-cleanup SPEC test ×3 seams (D1 deviation #1, fix lands in the dedicated rollback-deviation milestone)

## Deployment Steps

Nothing to deploy — test-only change. Merges into the refactor sequence as its baseline gate.

## Review Request

- [x] Just code review

## Other PRs

None yet — this is the first PR of the DAH-2382 sequence; PR-1b (create failure matrix + msg goldens + security-sink table) follows; PR-1c completes the full-facade E7 gate before production extraction.

## Risks

- Test-only: no runtime behavior change. Main risk is over-pinning (a golden freezing incidental behavior) — mitigated by the normalization rules (timestamps masked, str(exc) tails normalized, absent-key≠null) and by recording every sketch-vs-reality difference in the README instead of "fixing" baseline behavior.
- The 3 `test_sshd_bootstrap_script.py` failures visible locally are **pre-existing and environment-dependent** (reproduced on a clean `main` checkout at the same SHA on macOS; the script's watchdog assert needs a Linux-like environment). Not introduced by this PR; delta vs clean main is +68 passed / 0 new failures.

## Test Cases

### Test Case 1 — full validator suite

**Actions**

`cd neurons/validators && pdm run pytest -q` on the branch.

**Expected Output**

1179 passed, 9 skipped, 3 xfailed (the by-design cancellation SPEC xfails) — identical failure set to clean `main` on the same machine (the 3 pre-existing env-dependent sshd-script failures).

### Test Case 2 — oracle package alone

**Actions**

`pdm run pytest tests/docker_oracle -q`

**Expected Output**

65 passed, 3 xfailed. Goldens byte-equal; regenerate intentionally via `pdm run pytest tests/docker_oracle --update-snapshot`.

### Test Case 3 — E7 differential gate (local docker daemon)

**Actions**

`cd neurons/validators && make e7` (needs a running local docker daemon; on macOS `DOCKER_HOST=unix://$HOME/.docker/run/docker.sock`).

**Expected Output**

1 passed. E7: ran locally, 1 passed @ `e69f6595`.

## Checklist

- [ ] Proper labels added (`ready-review`)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described

