### PR TITLE
DAH-2448, executor disk reserve so validator writes survive a full disk

### DIFF
--- a/neurons/executor/Dockerfile
+++ b/neurons/executor/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
      build-essential \
      ca-certificates \
      curl \
+     e2fsprogs \
      git \
      gnupg \
      libffi-dev \

--- a/neurons/executor/docker-compose.app.dev.yml
+++ b/neurons/executor/docker-compose.app.dev.yml
@@ -25,6 +25,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /etc/docker/daemon.json:/etc/docker/daemon.json
       - /etc/nvidia-container-runtime/config.toml:/etc/nvidia-container-runtime/config.toml
+      - reserve_data:/var/lium-reserve
     pid: host
     privileged: true
     environment:
@@ -71,3 +72,4 @@ services:
 
 volumes:
   db_data:
+  reserve_data:

--- a/neurons/executor/docker-compose.app.local.yml
+++ b/neurons/executor/docker-compose.app.local.yml
@@ -29,6 +29,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /etc/docker/daemon.json:/etc/docker/daemon.json
       - /etc/nvidia-container-runtime/config.toml:/etc/nvidia-container-runtime/config.toml
+      - reserve_data:/var/lium-reserve
     pid: host
     privileged: true
     environment:
@@ -75,3 +76,4 @@ services:
 
 volumes:
   db_data:
+  reserve_data:

--- a/neurons/executor/docker-compose.app.yml
+++ b/neurons/executor/docker-compose.app.yml
@@ -26,6 +26,7 @@ services:
       - /etc/docker/daemon.json:/etc/docker/daemon.json
       - /var/run/dstack.sock:/var/run/dstack.sock
       - /etc/nvidia-container-runtime/config.toml:/etc/nvidia-container-runtime/config.toml
+      - reserve_data:/var/lium-reserve
     pid: host
     privileged: true
     environment:
@@ -74,3 +75,4 @@ services:
 
 volumes:
   db_data:
+  reserve_data:

--- a/neurons/executor/run.sh
+++ b/neurons/executor/run.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -eux -o pipefail
 
+# disk reserve: validator-cycle writes must survive a 100%-full host disk
+bash setup_disk_reserve.sh || echo "[disk-reserve] setup failed; continuing without reserve"
+bash setup_disk_reserve.sh janitor &
+# re-enter cwd through the overlay mount (the old dentry would bypass it)
+cd /root/app
+
 # ensure docker group matches host socket
 SOCK=/var/run/docker.sock
 if [ -S "$SOCK" ]; then

--- a/neurons/executor/setup_disk_reserve.sh
+++ b/neurons/executor/setup_disk_reserve.sh
@@ -54,9 +54,14 @@ setup_backing_fs() {
     fi
 
     # nodiscard is mandatory: default mkfs.ext4 discards blocks and silently
-    # destroys the fallocate reservation
+    # destroys the fallocate reservation. lazy init must be off too: the
+    # kernel's post-mount ext4lazyinit zeroes inode tables via WRITE_ZEROES,
+    # which loop turns into hole-punching in the backing file (~80M of the
+    # reservation lost; a write into a hole on a full disk aborts the journal
+    # and flips the reserve read-only)
+    local mkfs_opts="nodiscard,lazy_itable_init=0,lazy_journal_init=0"
     if [ "$(blkid -o value -s TYPE "$loop" 2>/dev/null)" != "ext4" ]; then
-        mkfs.ext4 -q -F -E nodiscard -m 0 -L lium-reserve "$loop" || { log "mkfs.ext4 $loop failed"; return 1; }
+        mkfs.ext4 -q -F -E "$mkfs_opts" -m 0 -L lium-reserve "$loop" || { log "mkfs.ext4 $loop failed"; return 1; }
     fi
 
     mkdir -p "$MNT" || return 1
@@ -64,9 +69,18 @@ setup_backing_fs() {
         # reserve content is disposable — rebuild a corrupted fs instead of
         # staying unprotected forever
         log "mount failed — re-creating reserve fs on $loop"
-        mkfs.ext4 -q -F -E nodiscard -m 0 -L lium-reserve "$loop" || { log "mkfs.ext4 $loop failed"; return 1; }
+        mkfs.ext4 -q -F -E "$mkfs_opts" -m 0 -L lium-reserve "$loop" || { log "mkfs.ext4 $loop failed"; return 1; }
         mount "$loop" "$MNT" || { log "mount $loop failed"; return 1; }
     fi
+    # an fs with a previously aborted journal can still mount, but read-only —
+    # same rebuild rule as a failed mount
+    if ! touch "$MNT/.rw_probe" 2>/dev/null; then
+        log "reserve mounted read-only — re-creating fs on $loop"
+        umount "$MNT" || return 1
+        mkfs.ext4 -q -F -E "$mkfs_opts" -m 0 -L lium-reserve "$loop" || { log "mkfs.ext4 $loop failed"; return 1; }
+        mount "$loop" "$MNT" || { log "mount $loop failed"; return 1; }
+    fi
+    rm -f "$MNT/.rw_probe"
     touch "$MARKER" || true
 }
 
@@ -122,6 +136,9 @@ janitor_loop() {
     # pipeline never deletes its upload dirs, and a scrape session killed
     # mid-run leaks its /tmp files
     while :; do
+        # re-extend the backing file: any holes punched at runtime are
+        # re-filled while the host disk still has room
+        fallocate -l "${SIZE_MB}M" "$IMG" 2>/dev/null
         find /root/app -maxdepth 1 -type d -regextype posix-extended \
             -regex '.*/[0-9a-f]{32}' -mmin +90 -exec rm -rf {} + 2>/dev/null
         find /tmp -mindepth 1 -maxdepth 1 -mmin +90 -exec rm -rf {} + 2>/dev/null

--- a/neurons/executor/setup_disk_reserve.sh
+++ b/neurons/executor/setup_disk_reserve.sh
@@ -48,7 +48,14 @@ setup_backing_fs() {
         ensure_loop_node "$loop" || return 1
     else
         [ -f "$MARKER" ] && log "WARNING: reserve initialized earlier but no loop attached — previous device may have leaked"
-        loop=$(losetup -f 2>&1) || { log "losetup -f failed: $loop"; return 1; }
+        # stderr dropped so a stray warning cannot corrupt the path; the shape
+        # check below is the validation ([ -b ] would be wrong here: the node
+        # may legally not exist yet — ensure_loop_node creates it)
+        loop=$(losetup -f 2>/dev/null)
+        case "$loop" in
+            /dev/loop[0-9]*) ;;
+            *) log "losetup -f failed (no free loop device?)"; return 1 ;;
+        esac
         ensure_loop_node "$loop" || return 1
         losetup "$loop" "$IMG" || { log "losetup $loop $IMG failed"; return 1; }
     fi

--- a/neurons/executor/setup_disk_reserve.sh
+++ b/neurons/executor/setup_disk_reserve.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Disk reserve for validator writes (DAH-2448).
+#
+# On machines without XFS/vloopback a renter can fill the host disk to 100%;
+# the validator's upload then fails (UPLOAD_FAILED) and the miner collects a
+# false penalty. This script pre-allocates a 5G loop-backed ext4 inside the
+# reserve_data volume and mounts it over every path the validation cycle
+# writes to, so those writes keep working on a full disk:
+#   /root/app   — overlay (upper in reserve): validator sftp uploads
+#   /tmp        — bind: machine_scrape onefile extraction + tempfiles
+#   /root/.ssh  — bind: authorized_keys appends before each cycle
+#
+# /run is deliberately NOT covered: /var/run symlinks to /run, so any mount
+# there shadows the bind-mounted docker.sock/dstack.sock. Consequence: an
+# executor RESTART while the disk is already full may fail on /run/sshd —
+# same as today; the reserve protects the running executor.
+#
+# Everything is fail-open: any failure logs a warning and the executor runs
+# with partial or no protection (today's behavior).
+#
+# Usage: setup_disk_reserve.sh [setup|janitor]
+
+RESERVE_DIR=/var/lium-reserve
+IMG="$RESERVE_DIR/reserve.img"
+MARKER="$RESERVE_DIR/.initialized"
+MNT=/mnt/lium-reserve
+SIZE_MB=5120
+
+log() { echo "[disk-reserve] $*"; }
+
+ensure_loop_node() {
+    # loop devices are global, but their /dev nodes are not created in a fresh
+    # container (no udev) — recreate the node if missing
+    [ -b "$1" ] || mknod "$1" b 7 "${1#/dev/loop}"
+}
+
+setup_backing_fs() {
+    # create/attach the loop-backed ext4 whose blocks are pre-allocated on the
+    # host fs — the reservation must exist before the disk ever fills
+    [ -d "$RESERVE_DIR" ] || { log "$RESERVE_DIR not mounted (compose volume missing)"; return 1; }
+
+    # idempotent: extends/repairs the allocation, no-op when already full-size
+    fallocate -l "${SIZE_MB}M" "$IMG" || { log "fallocate ${SIZE_MB}M failed (host disk too full?)"; return 1; }
+
+    local loop
+    loop=$(losetup -j "$IMG" 2>/dev/null | head -1 | cut -d: -f1)
+    if [ -n "$loop" ]; then
+        ensure_loop_node "$loop" || return 1
+    else
+        [ -f "$MARKER" ] && log "WARNING: reserve initialized earlier but no loop attached — previous device may have leaked"
+        loop=$(losetup -f 2>&1) || { log "losetup -f failed: $loop"; return 1; }
+        ensure_loop_node "$loop" || return 1
+        losetup "$loop" "$IMG" || { log "losetup $loop $IMG failed"; return 1; }
+    fi
+
+    # nodiscard is mandatory: default mkfs.ext4 discards blocks and silently
+    # destroys the fallocate reservation
+    if [ "$(blkid -o value -s TYPE "$loop" 2>/dev/null)" != "ext4" ]; then
+        mkfs.ext4 -q -F -E nodiscard -m 0 -L lium-reserve "$loop" || { log "mkfs.ext4 $loop failed"; return 1; }
+    fi
+
+    mkdir -p "$MNT" || return 1
+    if ! mountpoint -q "$MNT" && ! mount "$loop" "$MNT"; then
+        # reserve content is disposable — rebuild a corrupted fs instead of
+        # staying unprotected forever
+        log "mount failed — re-creating reserve fs on $loop"
+        mkfs.ext4 -q -F -E nodiscard -m 0 -L lium-reserve "$loop" || { log "mkfs.ext4 $loop failed"; return 1; }
+        mount "$loop" "$MNT" || { log "mount $loop failed"; return 1; }
+    fi
+    touch "$MARKER" || true
+}
+
+mount_app_overlay() {
+    # upper/work wiped every boot: uploads are ephemeral and a stale upper
+    # must not shadow files after an image upgrade
+    rm -rf "$MNT/app-upper" "$MNT/app-work" &&
+        mkdir -p "$MNT/app-upper" "$MNT/app-work" &&
+        mount -t overlay overlay \
+            -o "lowerdir=/root/app,upperdir=$MNT/app-upper,workdir=$MNT/app-work" /root/app
+}
+
+mount_tmp() {
+    rm -rf "$MNT/tmp" &&
+        mkdir -p "$MNT/tmp" &&
+        chmod 1777 "$MNT/tmp" &&
+        mount --bind "$MNT/tmp" /tmp
+}
+
+mount_ssh() {
+    # not wiped: keys now survive container recreation (previously lost)
+    mkdir -p "$MNT/ssh" &&
+        chmod 700 "$MNT/ssh" &&
+        if [ -f /root/.ssh/authorized_keys ] && [ ! -f "$MNT/ssh/authorized_keys" ]; then
+            cp -p /root/.ssh/authorized_keys "$MNT/ssh/authorized_keys"
+        fi &&
+        mount --bind "$MNT/ssh" /root/.ssh
+}
+
+evict_upload_dirs_under_pressure() {
+    # delete oldest upload dirs until reserve usage drops below 80%; only
+    # meaningful when the reserve is mounted — otherwise df would measure the
+    # host disk and evict live upload dirs on any ≥80%-full machine
+    mountpoint -q "$MNT" || return 0
+    local usage oldest prev=""
+    while :; do
+        usage=$(df --output=pcent "$MNT" 2>/dev/null | tail -1 | tr -dc '0-9')
+        { [ -n "$usage" ] && [ "$usage" -ge 80 ]; } || break
+        oldest=$(find /root/app -maxdepth 1 -type d -regextype posix-extended \
+            -regex '.*/[0-9a-f]{32}' -printf '%T@ %p\n' 2>/dev/null | sort -n | head -1 | cut -d' ' -f2-)
+        if [ -z "$oldest" ] || [ "$oldest" = "$prev" ]; then
+            find /tmp -mindepth 1 -maxdepth 1 -mmin +10 -exec rm -rf {} + 2>/dev/null
+            break
+        fi
+        log "reserve ${usage}% full — evicting $oldest"
+        rm -rf "$oldest"
+        prev="$oldest"
+    done
+}
+
+janitor_loop() {
+    # steady-state cleanup, not just a crash backstop: the current validator
+    # pipeline never deletes its upload dirs, and a scrape session killed
+    # mid-run leaks its /tmp files
+    while :; do
+        find /root/app -maxdepth 1 -type d -regextype posix-extended \
+            -regex '.*/[0-9a-f]{32}' -mmin +90 -exec rm -rf {} + 2>/dev/null
+        find /tmp -mindepth 1 -maxdepth 1 -mmin +90 -exec rm -rf {} + 2>/dev/null
+        evict_upload_dirs_under_pressure
+        sleep 900
+    done
+}
+
+setup() {
+    setup_backing_fs || { log "reserve unavailable; executor continues without disk protection"; return 1; }
+    # each mount is an independent benefit — one failure must not skip the rest
+    mount_app_overlay || log "WARNING: overlay on /root/app failed — validator uploads not protected"
+    mount_tmp || log "WARNING: /tmp bind failed — scrape tempfiles not protected"
+    mount_ssh || log "WARNING: /root/.ssh bind failed — ssh key appends not protected"
+    log "reserve active: $(df -h --output=size,used,avail "$MNT" | tail -1 | tr -s ' ')"
+}
+
+case "${1:-setup}" in
+    setup) setup ;;
+    janitor) janitor_loop ;;
+    *) log "unknown command: $1"; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2448](https://app.notion.com/p/Executor-disk-reserve-validator-writes-survive-100-full-disk-no-XFS-false-penalties-3a3b8bfdbde98157a28debbca81b75f6)

---

## Problem

On executor machines without XFS/vloopback, a renter can fill the host disk to 100%. The validator's `UploadFilesCheck` (fatal) then fails with `UPLOAD_FAILED`, the executor is marked inactive, and the miner collects a false `EXECUTOR_INACTIVE_MID_RENTAL` penalty — even though the GPUs are healthy and rented. This has been recurring in waves (~30 penalties over 3 weeks), tied to disk-heavy customers.

For a rented executor the validation pipeline short-circuits at `TenantEnforcementCheck` (`halt=True`), so only two disk-dependent fatal steps actually run: `UploadFilesCheck` and `MachineSpecScrapeCheck`. Both just need a few writable paths to survive a full disk.

## Solution

The executor container (privileged) bootstraps a small pre-allocated disk reserve at start and mounts it over exactly the paths the validation cycle writes to, so those writes keep succeeding at 100% host disk. Executor-only change — no protocol change, no miner action, rolls out with the normal executor release train.

The reserve is a 5 GB loop-backed ext4 image inside a named Docker volume:
- `fallocate` + `mkfs.ext4 -E nodiscard` — `nodiscard` is mandatory, otherwise mkfs discards the blocks and silently destroys the pre-allocation.
- backing file lives in the `reserve_data` named volume (host fs, survives `--force-recreate`), so the reservation exists before the disk ever fills.

Mounted into the executor:
- `overlay` over `/root/app` (upper/work in the reserve) — validator sftp uploads land in `{root_dir}/{uuid}`;
- `bind` `/tmp` — `machine_scrape` onefile self-extraction and tempfiles;
- `bind` `/root/.ssh` — per-cycle `authorized_keys` appends.

Everything is fail-open: any failure logs a warning and the executor continues unprotected (today's behavior). A janitor loop (every 15 min) removes upload dirs / `/tmp` entries older than 90 min and evicts oldest under ≥80% reserve pressure — required because the current validator pipeline never deletes its own upload dirs.

`/run` is deliberately NOT covered: Debian's `/var/run` → `/run` symlink means a tmpfs there would shadow the bind-mounted `docker.sock`/`dstack.sock`. Consequence: an executor restart while the disk is already full may still fail (same as today, where alembic/postgres also fail); the reserve protects the running executor, which is the penalty scenario.

## Changes

- `neurons/executor/setup_disk_reserve.sh` (new) — reserve bootstrap + mounts + janitor, fully fail-open.
- `neurons/executor/run.sh` — invoke bootstrap (fail-open), start janitor, re-`cd /root/app` through the overlay.
- `neurons/executor/Dockerfile` — add `e2fsprogs` (`python:3.11-slim` has no `mkfs.ext4`).
- `neurons/executor/docker-compose.app.yml` / `.app.dev.yml` / `.app.local.yml` — `reserve_data` named volume, mounted only on the `executor` service.

## Deployment Steps

Use GitHub Action.

Not urgent for this PR, but before fleet rollout: canary on a kernel-5.15 box (overlay nesting was verified on 6.8) and a CVM smoke check (dstack.sock path not exercised on the plain staging box). Then the normal `executor-v*` release with image backup.

## Review Request

- [x] Just code review

## Other PRs

Complementary backend-side work (renter-facing disk caps) tracked separately in the `reserve-system-disk-space` proposal; not required for this PR.

## Risks

- **overlay over `/root/app`**: verified to mount on the container's own overlay2 rootfs on kernel 6.8; kernel 5.15 not yet canaried (arithmetic is version-independent, but worth a canary).
- **CVM machines**: same compose/Dockerfile/run.sh change; TDX/GPU attestation calls in `upload_ssh_key` already fail soft, but the dstack.sock path was not exercised on staging.
- **`/root/.ssh` semantics**: keys now survive container recreation (previously lost on recreate). Strictly an improvement; validator re-uploads keys per cycle anyway.
- **Fail-open**: on any bootstrap failure the executor runs exactly as today (unprotected) — no new hard-fail path.

## Test Cases

Verified on a staging box (ext4, no XFS, kernel 6.8, RTX A4000) with a locally-built `compute-subnet-executor:local` image (nothing pushed to Docker Hub, no `executor-v*` tag). Full battery: 24/26 passing (2 "failures" were defects in the probes themselves, re-verified by hand).

### Test Case 1 — validator writes at 100% host disk

**Actions**: fill the host disk to 100%, then from the validator side push an sftp upload into `/root/app/<uuid>`, write a 200 MB `NamedTemporaryFile` in `/tmp`, and append to `/root/.ssh/authorized_keys`.

**Expected Output**: all three succeed and physically land in the reserve; the executor API and `nvidia-smi` stay alive. Paired proof at 100% disk: a host-side `dd` writes 0 bytes (ENOSPC) while the container writes 50 MB to `/tmp` in the same window.

### Test Case 2 — restart reuse and spec integrity

**Actions**: restart the executor container after freeing the disk; check mounts and reported disk specs.

**Expected Output**: the reserve is re-attached without re-`mkfs`, overlay/binds restored, ssh keys persisted; `df /` inside the container still equals the host disk (reported `hard_disk` specs unchanged — only `free` drops by 5 GB, `total` unchanged).

### Test Case 3 — fail-open

**Actions**: start with the volume missing, and start with a reserve dir too small for `fallocate`.

**Expected Output**: each logs a warning and the executor continues unprotected; no hard fail.

## Checklist

- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
