### PR TITLE
DAH-2461: digest-pinned default template pulls in executor

### DIFF
--- a/neurons/executor/src/gpus_utility.py
+++ b/neurons/executor/src/gpus_utility.py
@@ -144,6 +144,56 @@ async def scrape_gpu_metrics(
             pynvml.nvmlShutdown()
 
 
+def _local_tag_matches_digest(template: str, expected_digest: str) -> bool:
+    # True when the locally cached template already carries the expected RepoDigest
+    inspect_result = subprocess.run(
+        ['docker', 'image', 'inspect', '--format', '{{json .RepoDigests}}', template],
+        capture_output=True,
+        text=True
+    )
+    if inspect_result.returncode != 0:
+        return False
+    return expected_digest in inspect_result.stdout
+
+
+def _pull_template_image(docker_image: str, docker_image_tag: str, expected_digest: str | None) -> bool:
+    # pull the template; with a backend digest, pin the pull (repo@sha256:…) and re-point
+    # the tag — tag pulls resolve through provider registry mirrors, which can serve a
+    # stale manifest, while digest pulls are content-addressed and bypass them (DAH-2461)
+    template = f"{docker_image}:{docker_image_tag}"
+    if expected_digest:
+        pinned_ref = f"{docker_image}@{expected_digest}"
+        pull_result = subprocess.run(
+            ['docker', 'pull', pinned_ref],
+            capture_output=True,
+            text=True
+        )
+        if pull_result.returncode != 0:
+            logger.error(f"Failed to pull {pinned_ref}: {pull_result.stderr}")
+            return False
+        tag_result = subprocess.run(
+            ['docker', 'tag', pinned_ref, template],
+            capture_output=True,
+            text=True
+        )
+        if tag_result.returncode != 0:
+            logger.error(f"Failed to tag {pinned_ref} as {template}: {tag_result.stderr}")
+            return False
+        logger.info(f"Successfully pulled {template} at {expected_digest}")
+        return True
+
+    pull_result = subprocess.run(
+        ['docker', 'pull', template],
+        capture_output=True,
+        text=True
+    )
+    if pull_result.returncode != 0:
+        logger.error(f"Failed to pull {template}: {pull_result.stderr}")
+        return False
+    logger.info(f"Successfully pulled {template}")
+    return True
+
+
 async def manage_docker_images(
     compute_rest_app_url: str,
     min_disk_space_multiplier: float = 3.0,  # Minimum disk space required (3x image size)
@@ -207,6 +257,9 @@ async def manage_docker_images(
                         docker_image = data['docker_image']
                         docker_image_tag = data['docker_image_tag']
                         docker_image_size = data['docker_image_size']
+                        # DAH-2461: optional bare "sha256:…" digest resolved by the backend
+                        # from Docker Hub; absent on older backends.
+                        expected_digest = data.get('docker_image_digest')
                         
                         # Check if no templates were found for the GPU
                         if not docker_image or not docker_image_tag:
@@ -245,6 +298,15 @@ async def manage_docker_images(
                         else:
                             logger.warning(f"Failed to list Docker images: {docker_list_result.stderr}")
 
+                        # DAH-2461: with a backend digest, skip pulling when the local tag
+                        # already matches — otherwise this loop's unconditional tag pull
+                        # would re-poison the tag on hosts behind a stale registry mirror.
+                        if expected_digest and _local_tag_matches_digest(template, expected_digest):
+                            logger.info(
+                                f"Template {template} already at backend digest ({expected_digest}); skipping pull"
+                            )
+                            continue
+
                         # Process template and pull image
                         required_space = int(docker_image_size * min_disk_space_multiplier)
                         
@@ -264,16 +326,9 @@ async def manage_docker_images(
                                     f"Another puller holds the lock; skipping {template} this cycle"
                                 )
                                 continue
-                            pull_result = subprocess.run(
-                                ['docker', 'pull', template],
-                                capture_output=True,
-                                text=True
-                            )
+                            pulled = _pull_template_image(docker_image, docker_image_tag, expected_digest)
 
-                        if pull_result.returncode == 0:
-                            logger.info(f"Successfully pulled {template}")
-                        else:
-                            logger.error(f"Failed to pull {template}: {pull_result.stderr}")
+                        if not pulled:
                             had_error = True
 
                     # Sleep once per full sweep: retry sooner if anything failed.

--- a/neurons/executor/src/services/cache_template_service.py
+++ b/neurons/executor/src/services/cache_template_service.py
@@ -108,6 +108,11 @@ async def _ensure_template(client: "docker.DockerClient", data: dict) -> None:
     docker_image = data.get("docker_image")
     docker_image_tag = data.get("docker_image_tag")
     docker_image_size = data.get("docker_image_size") or 0
+    # DAH-2461: bare "sha256:…" digest the backend resolved live from Docker Hub.
+    # When present it is the source of truth for freshness: digest-pinned pulls are
+    # content-addressed, so they bypass provider registry mirrors that keep serving
+    # a stale manifest for the tag (and 403 on digests they don't have cached).
+    expected_digest = data.get("docker_image_digest")
 
     if not docker_image or not docker_image_tag:
         logger.warning(f"Skipping malformed cache template entry: {data}")
@@ -115,12 +120,19 @@ async def _ensure_template(client: "docker.DockerClient", data: dict) -> None:
 
     image_ref = f"{docker_image}:{docker_image_tag}"
 
-    # Only query the registry for the digest when the image is already cached;
-    # on a first pull there is nothing to compare against, so skip the call and
-    # avoid a needless registry manifest request (counts against pull limits).
     local = await _local_digests(client, image_ref)
     remote: str | None = None
-    if local:
+    if expected_digest:
+        if any(expected_digest in digest for digest in local):
+            logger.info(
+                f"Cache template {image_ref} already at backend digest ({expected_digest}); skipping pull"
+            )
+            return
+    elif local:
+        # Legacy fallback (backend sent no digest): only query the daemon for the
+        # remote digest when the image is already cached; on a first pull there is
+        # nothing to compare against, so skip the call and avoid a needless registry
+        # manifest request (counts against pull limits).
         remote = await _remote_digest(client, image_ref)
         # Re-pull only if we can confirm the remote digest changed. If the remote
         # digest is unreadable (rate limit / auth), keep the cached copy rather
@@ -149,9 +161,18 @@ async def _ensure_template(client: "docker.DockerClient", data: dict) -> None:
         if not acquired:
             logger.info(f"Another puller holds the lock; skipping {image_ref} this cycle")
             return
-        logger.info(f"Pulling cache template {image_ref} (remote={remote}, local={local})")
-        await asyncio.to_thread(client.images.pull, docker_image, docker_image_tag)
-        logger.info(f"Successfully pulled {image_ref}")
+        if expected_digest:
+            pinned_ref = f"{docker_image}@{expected_digest}"
+            logger.info(f"Pulling cache template {pinned_ref} (local={local})")
+            image = await asyncio.to_thread(client.images.pull, pinned_ref)
+            # Re-point the tag at the pinned build: a digest pull alone leaves the
+            # tag (possibly poisoned by a stale mirror) untouched.
+            await asyncio.to_thread(image.tag, docker_image, docker_image_tag)
+            logger.info(f"Successfully pulled {image_ref} at {expected_digest}")
+        else:
+            logger.info(f"Pulling cache template {image_ref} (remote={remote}, local={local})")
+            await asyncio.to_thread(client.images.pull, docker_image, docker_image_tag)
+            logger.info(f"Successfully pulled {image_ref}")
 
     await _cleanup_old_tags(client, docker_image, docker_image_tag)
 

--- a/neurons/executor/tests/test_cache_template_digest.py
+++ b/neurons/executor/tests/test_cache_template_digest.py
@@ -1,0 +1,128 @@
+"""Digest-pinned cache template refresh (DAH-2461).
+
+The backend serves the expected Docker Hub digest for the default cache template;
+``_ensure_template`` must treat it as the source of truth (pull by digest + retag on
+mismatch) and only fall back to the daemon's remote-digest compare when the backend
+sends no digest — the daemon path resolves through provider registry mirrors, which
+can serve stale manifests for a tag.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import docker
+
+# conftest replaces the docker module with a MagicMock; except-clauses in the
+# service need a real exception class to catch.
+docker.errors.ImageNotFound = type("ImageNotFound", (Exception,), {})
+
+from services import cache_template_service  # noqa: E402
+
+EXPECTED_DIGEST = "sha256:70bd5fa697877594b753a146e207ca4de66d9b875d606ae09e6ee7bac8f4f423"
+STALE_DIGEST = "sha256:2d19c94ce8a37c6fa364f8a6211d8b6dc1a44ece574c4c22ab5579925ce7a4c8"
+REPO = "daturaai/pytorch"
+TAG = "2.12.0-py3.12-cuda13.0.2-devel-ubuntu24.04-dind"
+
+
+def _make_client(local_digests: list[str] | None = None, image_absent: bool = False) -> MagicMock:
+    client = MagicMock()
+    if image_absent:
+        client.images.get.side_effect = docker.errors.ImageNotFound("absent")
+    else:
+        image = MagicMock()
+        image.attrs = {"RepoDigests": [f"{REPO}@{digest}" for digest in (local_digests or [])]}
+        client.images.get.return_value = image
+    client.images.list.return_value = []
+    return client
+
+
+def _template(digest: str | None = None) -> dict:
+    data = {
+        "docker_image": REPO,
+        "docker_image_tag": TAG,
+        "docker_image_size": 0,
+    }
+    if digest is not None:
+        data["docker_image_digest"] = digest
+    return data
+
+
+def test_backend_digest_match_skips_pull():
+    # Arrange
+    client = _make_client(local_digests=[EXPECTED_DIGEST])
+
+    # Act
+    asyncio.run(cache_template_service._ensure_template(client, _template(EXPECTED_DIGEST)))
+
+    # Assert
+    client.images.pull.assert_not_called()
+    client.images.get_registry_data.assert_not_called()
+
+
+def test_backend_digest_mismatch_pulls_pinned_and_retags():
+    # Arrange: local tag poisoned by a stale mirror, backend knows the fresh digest
+    client = _make_client(local_digests=[STALE_DIGEST])
+    pulled_image = MagicMock()
+    client.images.pull.return_value = pulled_image
+
+    # Act
+    asyncio.run(cache_template_service._ensure_template(client, _template(EXPECTED_DIGEST)))
+
+    # Assert: content-addressed pull, then the tag is re-pointed at the pinned build
+    client.images.pull.assert_called_once_with(f"{REPO}@{EXPECTED_DIGEST}")
+    pulled_image.tag.assert_called_once_with(REPO, TAG)
+    client.images.get_registry_data.assert_not_called()
+
+
+def test_backend_digest_image_absent_pulls_pinned():
+    # Arrange: nothing cached locally yet
+    client = _make_client(image_absent=True)
+    pulled_image = MagicMock()
+    client.images.pull.return_value = pulled_image
+
+    # Act
+    asyncio.run(cache_template_service._ensure_template(client, _template(EXPECTED_DIGEST)))
+
+    # Assert: first pull is digest-pinned too (bypasses the mirror from the start)
+    client.images.pull.assert_called_once_with(f"{REPO}@{EXPECTED_DIGEST}")
+    pulled_image.tag.assert_called_once_with(REPO, TAG)
+
+
+def test_no_backend_digest_matching_remote_skips_pull():
+    # Arrange: legacy path — daemon reports the same digest as cached
+    client = _make_client(local_digests=[STALE_DIGEST])
+    registry_data = MagicMock()
+    registry_data.id = STALE_DIGEST
+    client.images.get_registry_data.return_value = registry_data
+
+    # Act
+    asyncio.run(cache_template_service._ensure_template(client, _template()))
+
+    # Assert
+    client.images.pull.assert_not_called()
+
+
+def test_no_backend_digest_changed_remote_pulls_by_tag():
+    # Arrange: legacy path — daemon reports a new digest
+    client = _make_client(local_digests=[STALE_DIGEST])
+    registry_data = MagicMock()
+    registry_data.id = EXPECTED_DIGEST
+    client.images.get_registry_data.return_value = registry_data
+
+    # Act
+    asyncio.run(cache_template_service._ensure_template(client, _template()))
+
+    # Assert: legacy pull by repo + tag, no digest pinning involved
+    client.images.pull.assert_called_once_with(REPO, TAG)
+
+
+def test_no_backend_digest_unreadable_remote_keeps_local():
+    # Arrange: legacy path — daemon cannot resolve the remote digest
+    client = _make_client(local_digests=[STALE_DIGEST])
+    client.images.get_registry_data.side_effect = RuntimeError("registry unreachable")
+
+    # Act
+    asyncio.run(cache_template_service._ensure_template(client, _template()))
+
+    # Assert
+    client.images.pull.assert_not_called()

--- a/neurons/executor/tests/test_gpus_utility_digest.py
+++ b/neurons/executor/tests/test_gpus_utility_digest.py
@@ -1,0 +1,114 @@
+"""Digest-aware template pulls in the legacy image-management loop (DAH-2461).
+
+``manage_docker_images`` pulls the default template by tag unconditionally every
+sweep; on hosts behind a stale provider registry mirror that silently re-poisons
+the tag. With a backend digest the loop must skip when the local tag already
+matches, and otherwise pull digest-pinned and re-point the tag.
+"""
+
+import subprocess
+from unittest.mock import call, patch
+
+import gpus_utility
+
+DIGEST = "sha256:70bd5fa697877594b753a146e207ca4de66d9b875d606ae09e6ee7bac8f4f423"
+REPO = "daturaai/pytorch"
+TAG = "2.12.0-py3.12-cuda13.0.2-devel-ubuntu24.04-dind"
+TEMPLATE = f"{REPO}:{TAG}"
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_local_tag_matches_digest_true():
+    # Arrange
+    inspect_output = f'["{REPO}@{DIGEST}"]'
+    with patch.object(
+        gpus_utility.subprocess, "run", return_value=_completed(stdout=inspect_output)
+    ) as run:
+        # Act
+        matches = gpus_utility._local_tag_matches_digest(TEMPLATE, DIGEST)
+
+    # Assert
+    assert matches is True
+    run.assert_called_once_with(
+        ['docker', 'image', 'inspect', '--format', '{{json .RepoDigests}}', TEMPLATE],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_local_tag_matches_digest_false_on_other_digest():
+    # Arrange
+    inspect_output = '["daturaai/pytorch@sha256:2d19c94ce8a37c6fa364f8a6211d8b6dc1a44ece574c4c22ab5579925ce7a4c8"]'
+    with patch.object(gpus_utility.subprocess, "run", return_value=_completed(stdout=inspect_output)):
+        # Act
+        matches = gpus_utility._local_tag_matches_digest(TEMPLATE, DIGEST)
+
+    # Assert
+    assert matches is False
+
+
+def test_local_tag_matches_digest_false_when_inspect_fails():
+    # Arrange: image not present locally
+    with patch.object(gpus_utility.subprocess, "run", return_value=_completed(returncode=1)):
+        # Act
+        matches = gpus_utility._local_tag_matches_digest(TEMPLATE, DIGEST)
+
+    # Assert
+    assert matches is False
+
+
+def test_pull_template_image_with_digest_pulls_pinned_and_retags():
+    # Arrange
+    with patch.object(
+        gpus_utility.subprocess, "run", side_effect=[_completed(), _completed()]
+    ) as run:
+        # Act
+        pulled = gpus_utility._pull_template_image(REPO, TAG, DIGEST)
+
+    # Assert: content-addressed pull, then the tag is re-pointed at the pinned build
+    assert pulled is True
+    assert run.call_args_list == [
+        call(['docker', 'pull', f'{REPO}@{DIGEST}'], capture_output=True, text=True),
+        call(['docker', 'tag', f'{REPO}@{DIGEST}', TEMPLATE], capture_output=True, text=True),
+    ]
+
+
+def test_pull_template_image_with_digest_pull_failure_skips_retag():
+    # Arrange
+    with patch.object(
+        gpus_utility.subprocess, "run", return_value=_completed(returncode=1, stderr="403")
+    ) as run:
+        # Act
+        pulled = gpus_utility._pull_template_image(REPO, TAG, DIGEST)
+
+    # Assert
+    assert pulled is False
+    assert run.call_count == 1
+
+
+def test_pull_template_image_with_digest_tag_failure_reports_error():
+    # Arrange
+    with patch.object(
+        gpus_utility.subprocess,
+        "run",
+        side_effect=[_completed(), _completed(returncode=1, stderr="no such image")],
+    ):
+        # Act
+        pulled = gpus_utility._pull_template_image(REPO, TAG, DIGEST)
+
+    # Assert
+    assert pulled is False
+
+
+def test_pull_template_image_without_digest_pulls_by_tag():
+    # Arrange: legacy path for backends that send no digest
+    with patch.object(gpus_utility.subprocess, "run", return_value=_completed()) as run:
+        # Act
+        pulled = gpus_utility._pull_template_image(REPO, TAG, None)
+
+    # Assert
+    assert pulled is True
+    run.assert_called_once_with(['docker', 'pull', TEMPLATE], capture_output=True, text=True)

--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -158,9 +158,9 @@ class DefaultDockerImage(BaseModel, extra="allow"):
     docker_image: str
     docker_image_tag: str
     docker_image_size: int | None = None
-    # DAH-2380: bare manifest-list digest ("sha256:…") the validator fetches from Docker Hub.
-    # Kept on the model for backward compatibility with older responses; no longer populated
-    # by the backend.
+    # Bare manifest-list digest ("sha256:…"). Populated by the backend again as of
+    # DAH-2461 (resolved live from Docker Hub) so executors can pull digest-pinned;
+    # the validator still verifies against its OWN Hub snapshot (DAH-2380), not this field.
     docker_image_digest: str | None = None
 
     @property


### PR DESCRIPTION
## What

Both executor default-template refresh loops become digest-aware. When the backend response carries `docker_image_digest` (paired backend PR: https://github.com/Datura-ai/lium-io-backend/pull/791):

- `cache_template_service._ensure_template` (15-min on-boot loop): if local `RepoDigests` already contain the backend digest → skip; otherwise pull `repo@sha256:…` (content-addressed, bypasses poisoned tag caches) and re-point the tag at the pinned build — both inside the existing `cache_pull_lock`. The daemon `get_registry_data` compare stays as the fallback when the backend sends no digest.
- `gpus_utility.manage_docker_images` (validator-launched ~2 h loop): new subprocess helpers `_local_tag_matches_digest` / `_pull_template_image`. A matching digest now skips the previously unconditional tag pull (which would silently re-poison the tag on mirrored hosts); a mismatch pulls pinned + retags; no digest → legacy pull by tag. The script stays import-light (no docker SDK / settings imports), per the `services/pull_lock.py` contract for the standalone invocation.
- Validators: comment-only fix in `vc_protocol/compute_requests.py` — `docker_image_digest` is populated by the backend again as of DAH-2461. The validator keeps verifying against its OWN Docker Hub snapshot (DAH-2380); no validator behavior change.

## Why

The Massed Compute registry mirror (`mcache-dsm.massedcompute.com`, preconfigured in `/etc/docker/daemon.json` on their hosts) has been frozen since Jun 26: it serves stale tag manifests with HTTP 200 and 403s anything uncached. 11 executors (216.81.200.x / 216.81.248.x) ran the Jun 26 build of the default template a week after the Jul 14 re-push — renters got pods with dead SSH (incident pod `00eaf722-82bb-4aee-97e4-2b7e891faace`, executor `b009a4d6-b4f2-40f6-9e4c-014f1b1c0e04`). Both loops trusted the mirror: the cache loop asks the daemon for the remote digest (resolved via the mirror → "already up to date" forever), and the 2 h loop pulls by tag unconditionally (would revert any manual fix). Digest pulls self-heal: the mirror 403s unknown digests and dockerd falls back to `registry-1.docker.io` directly (verified live from 216.81.248.181).

## Verification

- 13 new tests (`test_cache_template_digest.py`, `test_gpus_utility_digest.py`): digest match / mismatch / absent-image paths including the pinned-pull + retag ordering, legacy fallback preserved (matching / changed / unreadable remote digest), subprocess helper argv sequences and failure paths.
- Live parity probe between the backend fetcher and the validator fetcher passed (see the backend PR) — scoring-critical, since `CachedTemplateVerificationCheck` is fatal.
- Pre-deploy (staging executor): tag an older build as the expected tag and have the backend return a different build's digest → the refresh cycle logs the mismatch, pulls by digest, retags; `docker image inspect` shows the tag pointing at the expected digest. Fail-open: backend returns no digest → current daemon-compare behavior, no pull.
- Post-deploy: +1 d — the 11 mirrored nodes converge to the current Hub digest; Loki `{namespace="subnet", container="validator"} |= "RECOMMENDED_IMAGE_DIGEST_MISMATCH"` drops to 0. +7 d — stays ~0 fleet-wide, including after the next re-push of the template tag.

Rollout notes: ships via the `executor-v*` tag → watchtower; safe in any order relative to the backend PR (executors without a digest use the legacy path). The 11 frozen nodes need a one-shot manual delivery — their watchtower is blocked by the same mirror.

Ticket: DAH-2461 — Make executor default-image updates digest-pinned (backend serves expected digest).
