### PR TITLE
DAH-2469: central miner serves executors from bulk portal snapshot

### DIFF
--- a/neurons/miners/src/clients/miner_portal_api.py
+++ b/neurons/miners/src/clients/miner_portal_api.py
@@ -29,7 +29,7 @@ class MinerPortalAPI:
 
     _snapshot: dict[str, list[dict[str, Any]]] = {}
     _snapshot_fetched_at: float | None = None
-    _last_refresh_attempt_at: float = 0.0
+    _last_refresh_attempt_at: float | None = None
     _refresh_lock: asyncio.Lock = asyncio.Lock()
 
     @classmethod
@@ -61,8 +61,13 @@ class MinerPortalAPI:
         async with cls._refresh_lock:
             if cls._is_fresh():
                 return cls._snapshot
-            # after a failed refresh, don't hammer the portal on every call
-            if time.monotonic() - cls._last_refresh_attempt_at < FAILED_REFRESH_RETRY_SECONDS:
+            # after a failed refresh, don't hammer the portal on every call; None means
+            # never attempted - monotonic counts from host boot, so a 0.0 sentinel would
+            # silently swallow the very first refresh on a freshly booted host
+            if (
+                cls._last_refresh_attempt_at is not None
+                and time.monotonic() - cls._last_refresh_attempt_at < FAILED_REFRESH_RETRY_SECONDS
+            ):
                 return cls._snapshot
             cls._last_refresh_attempt_at = time.monotonic()
 

--- a/neurons/miners/src/clients/miner_portal_api.py
+++ b/neurons/miners/src/clients/miner_portal_api.py
@@ -28,7 +28,7 @@ class MinerPortalAPI:
     """
 
     _snapshot: dict[str, list[dict[str, Any]]] = {}
-    _snapshot_fetched_at: float = 0.0
+    _snapshot_fetched_at: float | None = None
     _last_refresh_attempt_at: float = 0.0
     _refresh_lock: asyncio.Lock = asyncio.Lock()
 
@@ -40,13 +40,15 @@ class MinerPortalAPI:
         snapshot = await cls._get_snapshot()
         executors = snapshot.get(miner_hotkey, [])
         if executor_id:
-            executors = [e for e in executors if str(e.get("id")) == str(executor_id)]
+            # case-insensitive: the replaced DB-side filter compared UUIDs, not strings
+            wanted_id = str(executor_id).lower()
+            executors = [e for e in executors if str(e.get("id")).lower() == wanted_id]
         return executors
 
     @classmethod
     def _is_fresh(cls) -> bool:
         return (
-            bool(cls._snapshot)
+            cls._snapshot_fetched_at is not None
             and time.monotonic() - cls._snapshot_fetched_at < SNAPSHOT_TTL_SECONDS
         )
 
@@ -65,24 +67,60 @@ class MinerPortalAPI:
             cls._last_refresh_attempt_at = time.monotonic()
 
             try:
-                snapshot = await cls._fetch_bulk()
+                snapshot = await cls._fetch_bulk_snapshot()
+            except asyncio.CancelledError:
+                # bypasses `except Exception`; without this log a cancelled refresh
+                # (validator dropped the connection mid-fetch) would leave no trace
+                logger.warning(
+                    _m("Executor snapshot refresh cancelled mid-fetch", extra=get_extra_info({}))
+                )
+                raise
             except Exception as e:
+                had_snapshot = cls._snapshot_fetched_at is not None
                 logger.error(
                     _m(
-                        "Failed to refresh executor snapshot from portal - serving stale snapshot",
+                        "Failed to refresh executor snapshot from portal - serving stale snapshot"
+                        if had_snapshot
+                        else "No executor snapshot available and portal refresh failed"
+                        " - serving EMPTY executor list for ALL miners",
                         extra=get_extra_info(
                             {
+                                "url": cls._bulk_snapshot_url(),
                                 "error": str(e),
+                                "error_type": type(e).__name__,
                                 "stale_hotkeys": len(cls._snapshot),
                                 "stale_age_seconds": int(
                                     time.monotonic() - cls._snapshot_fetched_at
                                 )
-                                if cls._snapshot
+                                if cls._snapshot_fetched_at is not None
+                                else None,
+                            }
+                        ),
+                    ),
+                    exc_info=True,
+                )
+                return cls._snapshot
+
+            if not snapshot and cls._snapshot:
+                # a sudden "no opted-in miners at all" is far more likely a portal bug than
+                # a real mass opt-out; replacing the snapshot would zero every fleet
+                logger.warning(
+                    _m(
+                        "Portal returned an empty bulk snapshot while a populated one exists"
+                        " - keeping the previous snapshot",
+                        extra=get_extra_info(
+                            {
+                                "previous_hotkeys": len(cls._snapshot),
+                                "stale_age_seconds": int(
+                                    time.monotonic() - cls._snapshot_fetched_at
+                                )
+                                if cls._snapshot_fetched_at is not None
                                 else None,
                             }
                         ),
                     )
                 )
+                cls._snapshot_fetched_at = time.monotonic()
                 return cls._snapshot
 
             cls._snapshot = snapshot
@@ -101,9 +139,13 @@ class MinerPortalAPI:
             return cls._snapshot
 
     @classmethod
-    async def _fetch_bulk(cls) -> dict[str, list[dict[str, Any]]]:
+    def _bulk_snapshot_url(cls) -> str:
+        return f"{settings.MINER_PORTAL_API_URL}/miners/executors"
+
+    @classmethod
+    async def _fetch_bulk_snapshot(cls) -> dict[str, list[dict[str, Any]]]:
         # one portal request for every opted-in miner's executors, grouped by hotkey
-        api_url = f"{settings.MINER_PORTAL_API_URL}/miners/executors"
+        api_url = cls._bulk_snapshot_url()
 
         keypair = settings.get_bittensor_wallet().get_hotkey()
         auth = AuthenticateRequest.from_keypair(keypair)
@@ -122,7 +164,11 @@ class MinerPortalAPI:
                         f"portal bulk executors returned {resp.status}: {text[:200]}"
                     )
                 data = await resp.json()
-                if not isinstance(data, dict):
+                # reject anything but {hotkey: [executor, ...]}: caching e.g. an
+                # ApiResponse envelope would silently zero every fleet for a full TTL
+                if not isinstance(data, dict) or not all(
+                    isinstance(executors, list) for executors in data.values()
+                ):
                     raise RuntimeError(
                         f"unexpected portal bulk response shape: {type(data).__name__}"
                     )

--- a/neurons/miners/src/clients/miner_portal_api.py
+++ b/neurons/miners/src/clients/miner_portal_api.py
@@ -1,7 +1,9 @@
-import aiohttp
 import asyncio
 import logging
+import time
 from typing import Any
+
+import aiohttp
 
 from core.config import settings
 from core.utils import _m, get_extra_info
@@ -9,78 +11,119 @@ from protocol.miner_request import AuthenticateRequest
 
 logger = logging.getLogger(__name__)
 
+SNAPSHOT_TTL_SECONDS = 300
+FAILED_REFRESH_RETRY_SECONDS = 30
+BULK_FETCH_TIMEOUT_SECONDS = 15
+
 
 class MinerPortalAPI:
-    @staticmethod
-    async def fetch_executors(miner_hotkey: str, executor_id: str | None) -> list[dict[str, Any]]:
-        api_url = f"{settings.MINER_PORTAL_API_URL}/miners/{miner_hotkey}/executors"
+    """Executor lookup backed by a portal-wide snapshot instead of per-hotkey requests.
+
+    The validator wave asks for every opted-in miner within the same minute; fetching
+    per hotkey turned that into ~40 concurrent portal requests and exhausted the portal
+    DB pool (DAH-2469). Instead, one bulk request per TTL fills an in-memory snapshot
+    {miner_hotkey: [executors]} that all callers read. A failed refresh keeps serving
+    the previous snapshot, so a portal outage no longer looks like "miner has zero
+    executors" (which zeroed the miner's whole fleet for the cycle).
+    """
+
+    _snapshot: dict[str, list[dict[str, Any]]] = {}
+    _snapshot_fetched_at: float = 0.0
+    _last_refresh_attempt_at: float = 0.0
+    _refresh_lock: asyncio.Lock = asyncio.Lock()
+
+    @classmethod
+    async def fetch_executors(
+        cls, miner_hotkey: str, executor_id: str | None
+    ) -> list[dict[str, Any]]:
+        # serve one miner's executors from the shared snapshot, refreshing it when stale
+        snapshot = await cls._get_snapshot()
+        executors = snapshot.get(miner_hotkey, [])
         if executor_id:
-            api_url += f"?executor_id={executor_id}"
+            executors = [e for e in executors if str(e.get("id")) == str(executor_id)]
+        return executors
+
+    @classmethod
+    def _is_fresh(cls) -> bool:
+        return (
+            bool(cls._snapshot)
+            and time.monotonic() - cls._snapshot_fetched_at < SNAPSHOT_TTL_SECONDS
+        )
+
+    @classmethod
+    async def _get_snapshot(cls) -> dict[str, list[dict[str, Any]]]:
+        # single-flight refresh: the first caller past TTL fetches, the rest await it
+        if cls._is_fresh():
+            return cls._snapshot
+
+        async with cls._refresh_lock:
+            if cls._is_fresh():
+                return cls._snapshot
+            # after a failed refresh, don't hammer the portal on every call
+            if time.monotonic() - cls._last_refresh_attempt_at < FAILED_REFRESH_RETRY_SECONDS:
+                return cls._snapshot
+            cls._last_refresh_attempt_at = time.monotonic()
+
+            try:
+                snapshot = await cls._fetch_bulk()
+            except Exception as e:
+                logger.error(
+                    _m(
+                        "Failed to refresh executor snapshot from portal - serving stale snapshot",
+                        extra=get_extra_info(
+                            {
+                                "error": str(e),
+                                "stale_hotkeys": len(cls._snapshot),
+                                "stale_age_seconds": int(
+                                    time.monotonic() - cls._snapshot_fetched_at
+                                )
+                                if cls._snapshot
+                                else None,
+                            }
+                        ),
+                    )
+                )
+                return cls._snapshot
+
+            cls._snapshot = snapshot
+            cls._snapshot_fetched_at = time.monotonic()
+            logger.info(
+                _m(
+                    "Refreshed executor snapshot from portal",
+                    extra=get_extra_info(
+                        {
+                            "hotkeys": len(snapshot),
+                            "executors": sum(len(v) for v in snapshot.values()),
+                        }
+                    ),
+                )
+            )
+            return cls._snapshot
+
+    @classmethod
+    async def _fetch_bulk(cls) -> dict[str, list[dict[str, Any]]]:
+        # one portal request for every opted-in miner's executors, grouped by hotkey
+        api_url = f"{settings.MINER_PORTAL_API_URL}/miners/executors"
 
         keypair = settings.get_bittensor_wallet().get_hotkey()
         auth = AuthenticateRequest.from_keypair(keypair)
-
         headers = {
             "hotkey": auth.payload.miner_hotkey,
             "timestamp": str(auth.payload.timestamp),
             "signature": auth.signature,
         }
-        
-        base_log_extra = {
-            "miner_hotkey": miner_hotkey,
-            "executor_id": executor_id,
-            "url": api_url,
-        }
-        
-        logger.info(
-            _m(
-                "Fetching executors from portal",
-                extra=get_extra_info(base_log_extra),
-            ),
-        )
 
-        timeout = aiohttp.ClientTimeout(total=10)
+        timeout = aiohttp.ClientTimeout(total=BULK_FETCH_TIMEOUT_SECONDS)
         async with aiohttp.ClientSession(timeout=timeout) as session:
-            try:
-                async with session.get(api_url, headers=headers) as resp:
-                    if resp.status != 200:
-                        text = await resp.text()
-                        logger.error(
-                            _m(
-                                "Failed to fetch executors from portal - HTTP error",
-                                extra=get_extra_info(
-                                    {
-                                        **base_log_extra,
-                                        "status": resp.status,
-                                        "body": text,
-                                    }
-                                ),
-                            )
-                        )
-                        return []
-                    data = await resp.json()
-                    # Expecting list of executors in JSON
-                    if not isinstance(data, list):
-                        logger.error(
-                            _m(
-                                "Unexpected portal response shape",
-                                extra=get_extra_info({**base_log_extra, "type": type(data).__name__}),
-                            )
-                        )
-                        return []
-                    return data
-            except asyncio.TimeoutError:
-                logger.error(
-                    _m("Timeout fetching executors from portal", extra=get_extra_info(base_log_extra))
-                )
-                return []
-            except Exception as e:
-                logger.error(
-                    _m(
-                        "Failed to fetch executors from portal - request exception",
-                        extra=get_extra_info({**base_log_extra, "error": str(e)}),
+            async with session.get(api_url, headers=headers) as resp:
+                if resp.status != 200:
+                    text = await resp.text()
+                    raise RuntimeError(
+                        f"portal bulk executors returned {resp.status}: {text[:200]}"
                     )
-                )
-                return []
-
-
+                data = await resp.json()
+                if not isinstance(data, dict):
+                    raise RuntimeError(
+                        f"unexpected portal bulk response shape: {type(data).__name__}"
+                    )
+                return data

--- a/neurons/miners/tests/test_miner_portal_api.py
+++ b/neurons/miners/tests/test_miner_portal_api.py
@@ -7,8 +7,10 @@ and filter by executor_id locally.
 """
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
+import aiohttp
+import bittensor
 import pytest
 
 from clients.miner_portal_api import (
@@ -16,6 +18,7 @@ from clients.miner_portal_api import (
     SNAPSHOT_TTL_SECONDS,
     MinerPortalAPI,
 )
+from core.config import settings
 
 SNAPSHOT = {
     "hotkey-a": [
@@ -30,7 +33,7 @@ SNAPSHOT = {
 def reset_cache():
     # fresh lock per test: asyncio primitives bind to the first loop that uses them
     MinerPortalAPI._snapshot = {}
-    MinerPortalAPI._snapshot_fetched_at = 0.0
+    MinerPortalAPI._snapshot_fetched_at = None
     MinerPortalAPI._last_refresh_attempt_at = 0.0
     MinerPortalAPI._refresh_lock = asyncio.Lock()
     yield
@@ -43,7 +46,7 @@ def _expire_snapshot():
 
 async def test_one_bulk_call_serves_all_hotkeys(monkeypatch):
     bulk = AsyncMock(return_value=SNAPSHOT)
-    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk", bulk)
+    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk_snapshot", bulk)
 
     executors_a = await MinerPortalAPI.fetch_executors("hotkey-a", None)
     executors_b = await MinerPortalAPI.fetch_executors("hotkey-b", None)
@@ -61,7 +64,7 @@ async def test_concurrent_calls_share_one_refresh(monkeypatch):
         return SNAPSHOT
 
     bulk = AsyncMock(side_effect=slow_bulk)
-    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk", bulk)
+    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk_snapshot", bulk)
 
     results = await asyncio.gather(
         *[MinerPortalAPI.fetch_executors("hotkey-a", None) for _ in range(10)]
@@ -73,7 +76,7 @@ async def test_concurrent_calls_share_one_refresh(monkeypatch):
 
 async def test_expired_snapshot_is_fully_replaced(monkeypatch):
     bulk = AsyncMock(return_value=SNAPSHOT)
-    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk", bulk)
+    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk_snapshot", bulk)
     await MinerPortalAPI.fetch_executors("hotkey-a", None)
 
     _expire_snapshot()
@@ -89,7 +92,7 @@ async def test_expired_snapshot_is_fully_replaced(monkeypatch):
 
 async def test_stale_snapshot_served_when_refresh_fails(monkeypatch):
     bulk = AsyncMock(return_value=SNAPSHOT)
-    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk", bulk)
+    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk_snapshot", bulk)
     await MinerPortalAPI.fetch_executors("hotkey-a", None)
 
     _expire_snapshot()
@@ -103,7 +106,7 @@ async def test_stale_snapshot_served_when_refresh_fails(monkeypatch):
 
 async def test_failed_refresh_backs_off_then_recovers(monkeypatch):
     bulk = AsyncMock(side_effect=RuntimeError("portal is down"))
-    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk", bulk)
+    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk_snapshot", bulk)
 
     # cold start with portal down: the only case that still yields []
     assert await MinerPortalAPI.fetch_executors("hotkey-a", None) == []
@@ -120,9 +123,36 @@ async def test_failed_refresh_backs_off_then_recovers(monkeypatch):
     assert bulk.await_count == 2
 
 
+async def test_empty_refresh_keeps_populated_snapshot(monkeypatch):
+    bulk = AsyncMock(return_value=SNAPSHOT)
+    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk_snapshot", bulk)
+    await MinerPortalAPI.fetch_executors("hotkey-a", None)
+
+    _expire_snapshot()
+    bulk.return_value = {}
+
+    executors_a = await MinerPortalAPI.fetch_executors("hotkey-a", None)
+
+    assert executors_a == SNAPSHOT["hotkey-a"]  # sudden 200+{} treated as suspect
+    assert bulk.await_count == 2
+    # the empty response still stamps freshness: no re-fetch within TTL
+    await MinerPortalAPI.fetch_executors("hotkey-a", None)
+    assert bulk.await_count == 2
+
+
+async def test_cold_start_empty_refresh_respects_ttl(monkeypatch):
+    bulk = AsyncMock(return_value={})
+    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk_snapshot", bulk)
+
+    assert await MinerPortalAPI.fetch_executors("hotkey-a", None) == []
+    assert await MinerPortalAPI.fetch_executors("hotkey-a", None) == []
+
+    assert bulk.await_count == 1  # empty-but-successful fetch is fresh, not a 30s poll
+
+
 async def test_executor_id_filters_locally(monkeypatch):
     bulk = AsyncMock(return_value=SNAPSHOT)
-    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk", bulk)
+    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk_snapshot", bulk)
 
     matched = await MinerPortalAPI.fetch_executors("hotkey-a", "aaaa-2")
     missing = await MinerPortalAPI.fetch_executors("hotkey-a", "no-such-id")
@@ -130,3 +160,88 @@ async def test_executor_id_filters_locally(monkeypatch):
     assert matched == [{"id": "aaaa-2", "validator_hotkey": "v1"}]
     assert missing == []
     assert bulk.await_count == 1
+
+
+class _FakeResponse:
+    def __init__(self, status: int, json_body=None, text_body: str = ""):
+        self.status = status
+        self._json_body = json_body
+        self._text_body = text_body
+
+    async def json(self):
+        return self._json_body
+
+    async def text(self):
+        return self._text_body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class _FakeSession:
+    last_url: str | None = None
+    last_headers: dict | None = None
+
+    def __init__(self, response: _FakeResponse):
+        self._response = response
+
+    def get(self, url, headers=None):
+        _FakeSession.last_url = url
+        _FakeSession.last_headers = headers
+        return self._response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+@pytest.fixture
+def portal_http(monkeypatch):
+    # replaces the wallet and aiohttp session so _fetch_bulk_snapshot runs for real
+    keypair = bittensor.Keypair.create_from_uri("//LiumTestMiner")
+    fake_wallet = Mock()
+    fake_wallet.get_hotkey.return_value = keypair
+    monkeypatch.setattr(type(settings), "get_bittensor_wallet", lambda self: fake_wallet)
+
+    def install_response(response: _FakeResponse):
+        monkeypatch.setattr(aiohttp, "ClientSession", lambda timeout: _FakeSession(response))
+
+    return install_response
+
+
+async def test_bulk_fetch_raises_on_http_error(portal_http):
+    portal_http(_FakeResponse(status=500, text_body="Database error occurred"))
+
+    with pytest.raises(RuntimeError, match="500"):
+        await MinerPortalAPI._fetch_bulk_snapshot()
+
+
+async def test_bulk_fetch_raises_on_non_dict_body(portal_http):
+    portal_http(_FakeResponse(status=200, json_body=[{"id": "aaaa-1"}]))
+
+    with pytest.raises(RuntimeError, match="shape"):
+        await MinerPortalAPI._fetch_bulk_snapshot()
+
+
+async def test_bulk_fetch_raises_on_wrapped_response_envelope(portal_http):
+    portal_http(
+        _FakeResponse(status=200, json_body={"success": True, "data": {"hotkey-a": []}})
+    )
+
+    with pytest.raises(RuntimeError, match="shape"):
+        await MinerPortalAPI._fetch_bulk_snapshot()
+
+
+async def test_bulk_fetch_sends_signature_headers_and_returns_snapshot(portal_http):
+    portal_http(_FakeResponse(status=200, json_body=SNAPSHOT))
+
+    snapshot = await MinerPortalAPI._fetch_bulk_snapshot()
+
+    assert snapshot == SNAPSHOT
+    assert _FakeSession.last_url.endswith("/miners/executors")
+    assert set(_FakeSession.last_headers) == {"hotkey", "timestamp", "signature"}

--- a/neurons/miners/tests/test_miner_portal_api.py
+++ b/neurons/miners/tests/test_miner_portal_api.py
@@ -34,14 +34,14 @@ def reset_cache():
     # fresh lock per test: asyncio primitives bind to the first loop that uses them
     MinerPortalAPI._snapshot = {}
     MinerPortalAPI._snapshot_fetched_at = None
-    MinerPortalAPI._last_refresh_attempt_at = 0.0
+    MinerPortalAPI._last_refresh_attempt_at = None
     MinerPortalAPI._refresh_lock = asyncio.Lock()
     yield
 
 
 def _expire_snapshot():
     MinerPortalAPI._snapshot_fetched_at -= SNAPSHOT_TTL_SECONDS + 1
-    MinerPortalAPI._last_refresh_attempt_at = 0.0
+    MinerPortalAPI._last_refresh_attempt_at = None
 
 
 async def test_one_bulk_call_serves_all_hotkeys(monkeypatch):
@@ -121,6 +121,19 @@ async def test_failed_refresh_backs_off_then_recovers(monkeypatch):
 
     assert await MinerPortalAPI.fetch_executors("hotkey-a", None) == SNAPSHOT["hotkey-a"]
     assert bulk.await_count == 2
+
+
+async def test_cold_start_on_young_host_still_refreshes(monkeypatch):
+    # regression: monotonic counts from host boot, so with a 0.0 backoff sentinel a
+    # process started <30s after boot silently skipped its very first refresh
+    monkeypatch.setattr("clients.miner_portal_api.time", Mock(monotonic=lambda: 5.0))
+    bulk = AsyncMock(return_value=SNAPSHOT)
+    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk_snapshot", bulk)
+
+    executors = await MinerPortalAPI.fetch_executors("hotkey-a", None)
+
+    assert executors == SNAPSHOT["hotkey-a"]
+    assert bulk.await_count == 1
 
 
 async def test_empty_refresh_keeps_populated_snapshot(monkeypatch):

--- a/neurons/miners/tests/test_miner_portal_api.py
+++ b/neurons/miners/tests/test_miner_portal_api.py
@@ -1,0 +1,132 @@
+"""
+Tests for the MinerPortalAPI snapshot cache (DAH-2469).
+
+The cache must collapse the validator wave into one bulk portal request,
+serve stale data when a refresh fails, back off after a failed refresh,
+and filter by executor_id locally.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from clients.miner_portal_api import (
+    FAILED_REFRESH_RETRY_SECONDS,
+    SNAPSHOT_TTL_SECONDS,
+    MinerPortalAPI,
+)
+
+SNAPSHOT = {
+    "hotkey-a": [
+        {"id": "aaaa-1", "validator_hotkey": "v1"},
+        {"id": "aaaa-2", "validator_hotkey": "v1"},
+    ],
+    "hotkey-b": [{"id": "bbbb-1", "validator_hotkey": "v1"}],
+}
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    # fresh lock per test: asyncio primitives bind to the first loop that uses them
+    MinerPortalAPI._snapshot = {}
+    MinerPortalAPI._snapshot_fetched_at = 0.0
+    MinerPortalAPI._last_refresh_attempt_at = 0.0
+    MinerPortalAPI._refresh_lock = asyncio.Lock()
+    yield
+
+
+def _expire_snapshot():
+    MinerPortalAPI._snapshot_fetched_at -= SNAPSHOT_TTL_SECONDS + 1
+    MinerPortalAPI._last_refresh_attempt_at = 0.0
+
+
+async def test_one_bulk_call_serves_all_hotkeys(monkeypatch):
+    bulk = AsyncMock(return_value=SNAPSHOT)
+    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk", bulk)
+
+    executors_a = await MinerPortalAPI.fetch_executors("hotkey-a", None)
+    executors_b = await MinerPortalAPI.fetch_executors("hotkey-b", None)
+    executors_unknown = await MinerPortalAPI.fetch_executors("hotkey-x", None)
+
+    assert executors_a == SNAPSHOT["hotkey-a"]
+    assert executors_b == SNAPSHOT["hotkey-b"]
+    assert executors_unknown == []
+    assert bulk.await_count == 1
+
+
+async def test_concurrent_calls_share_one_refresh(monkeypatch):
+    async def slow_bulk():
+        await asyncio.sleep(0.05)
+        return SNAPSHOT
+
+    bulk = AsyncMock(side_effect=slow_bulk)
+    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk", bulk)
+
+    results = await asyncio.gather(
+        *[MinerPortalAPI.fetch_executors("hotkey-a", None) for _ in range(10)]
+    )
+
+    assert bulk.await_count == 1
+    assert all(result == SNAPSHOT["hotkey-a"] for result in results)
+
+
+async def test_expired_snapshot_is_fully_replaced(monkeypatch):
+    bulk = AsyncMock(return_value=SNAPSHOT)
+    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk", bulk)
+    await MinerPortalAPI.fetch_executors("hotkey-a", None)
+
+    _expire_snapshot()
+    bulk.return_value = {"hotkey-a": [{"id": "aaaa-3", "validator_hotkey": "v1"}]}
+
+    executors_a = await MinerPortalAPI.fetch_executors("hotkey-a", None)
+    executors_b = await MinerPortalAPI.fetch_executors("hotkey-b", None)
+
+    assert executors_a == [{"id": "aaaa-3", "validator_hotkey": "v1"}]
+    assert executors_b == []  # old snapshot fully replaced, not merged
+    assert bulk.await_count == 2
+
+
+async def test_stale_snapshot_served_when_refresh_fails(monkeypatch):
+    bulk = AsyncMock(return_value=SNAPSHOT)
+    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk", bulk)
+    await MinerPortalAPI.fetch_executors("hotkey-a", None)
+
+    _expire_snapshot()
+    bulk.side_effect = RuntimeError("portal is down")
+
+    executors_a = await MinerPortalAPI.fetch_executors("hotkey-a", None)
+
+    assert executors_a == SNAPSHOT["hotkey-a"]  # stale data, not []
+    assert bulk.await_count == 2
+
+
+async def test_failed_refresh_backs_off_then_recovers(monkeypatch):
+    bulk = AsyncMock(side_effect=RuntimeError("portal is down"))
+    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk", bulk)
+
+    # cold start with portal down: the only case that still yields []
+    assert await MinerPortalAPI.fetch_executors("hotkey-a", None) == []
+    # within the backoff window no second attempt is made
+    assert await MinerPortalAPI.fetch_executors("hotkey-a", None) == []
+    assert bulk.await_count == 1
+
+    # past the backoff window the next call refreshes successfully
+    MinerPortalAPI._last_refresh_attempt_at -= FAILED_REFRESH_RETRY_SECONDS + 1
+    bulk.side_effect = None
+    bulk.return_value = SNAPSHOT
+
+    assert await MinerPortalAPI.fetch_executors("hotkey-a", None) == SNAPSHOT["hotkey-a"]
+    assert bulk.await_count == 2
+
+
+async def test_executor_id_filters_locally(monkeypatch):
+    bulk = AsyncMock(return_value=SNAPSHOT)
+    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk", bulk)
+
+    matched = await MinerPortalAPI.fetch_executors("hotkey-a", "aaaa-2")
+    missing = await MinerPortalAPI.fetch_executors("hotkey-a", "no-such-id")
+
+    assert matched == [{"id": "aaaa-2", "validator_hotkey": "v1"}]
+    assert missing == []
+    assert bulk.await_count == 1


### PR DESCRIPTION
## Summary
Reworks `MinerPortalAPI.fetch_executors` (central mode) to serve from an in-memory snapshot `{miner_hotkey: [executors]}` refreshed via the portal's new bulk endpoint, instead of one portal request per hotkey.

Root cause being fixed (DAH-2469): the validator wave fans out ~40 concurrent per-hotkey portal GETs; portal pool exhausts 3-4x/day; `fetch_executors` returned `[]` on ANY error, indistinguishable from a miner with no machines, so the validator zeroed the miner's whole fleet for the cycle (placeholder `11111111-1111-1111-1111-111111111111`).

## Behavior
- One bulk request per 5 min (`SNAPSHOT_TTL_SECONDS=300`) instead of ~40 per-hotkey GETs per cycle; snapshot dict is fully replaced on each successful refresh.
- Single-flight: concurrent callers past TTL await one in-flight refresh (`asyncio.Lock`).
- Stale-on-error: a failed refresh keeps serving the previous snapshot with a loud error log — a portal outage no longer looks like "miner has zero executors". 30s backoff between failed refresh attempts.
- `executor_id` filtering now local; call site (`ExecutorService.get_executors_for_validator`) unchanged.
- Residual `[]`-on-error case: cold start (miner restart) while the portal is down — same as today's behavior, logged.

## Deploy ordering
Deploy AFTER lium-miner-portal PR https://github.com/Datura-ai/lium-miner-portal/pull/155 — the bulk endpoint must exist first, otherwise every refresh 404s and (with no snapshot yet) all opted-in miners get empty lists.

## Testing
`neurons/miners/tests/test_miner_portal_api.py` (6 tests): one bulk call serves all hotkeys; single-flight under 10 concurrent calls; TTL expiry fully replaces the snapshot; stale served on refresh failure; failed-refresh backoff then recovery; local executor_id filter. Full miners suite: 19 passed. Ruff clean.

Notion: DAH-2469