### PR TITLE
chore: DAH-2470 — publish cache-prefetch state for the cached-template check

### DIFF
--- a/neurons/executor/src/services/cache_prefetch_state.py
+++ b/neurons/executor/src/services/cache_prefetch_state.py
@@ -24,6 +24,7 @@ import copy
 import functools
 import json
 import os
+from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -167,6 +168,36 @@ def _drop_images(doc: dict) -> None:
     doc["images"] = {}
 
 
+@dataclass(slots=True)
+class _ImageRecord:
+    """Everything known about one template, as a type rather than a bare dict.
+
+    ``slots=True`` is the whole point: a mistyped field name raises instead of
+    quietly adding an attribute nobody publishes. That matters here more than
+    usual, because every writer below runs under ``@_never_raises`` — with a dict,
+    the typo would be swallowed and the document would ship missing the field.
+    """
+
+    last_outcome: str | None = None
+    last_outcome_at: str | None = None
+    last_error: str | None = None
+    local_digests: list[str] = field(default_factory=list)
+    local_digest_first_seen_at: str | None = None
+    digest_changed_at: str | None = None
+    last_local_error: str | None = None
+    expected_digest: str | None = None
+    remote_digest: str | None = None
+    last_remote_read_ok_at: str | None = None
+    last_remote_error: str | None = None
+    last_pull_attempt_at: str | None = None
+    last_pull_ok_at: str | None = None
+    last_pull_error: str | None = None
+    last_cleanup_error: str | None = None
+    last_disk_required_bytes: int | None = None
+    last_disk_available_bytes: int | None = None
+    outcome_counts: dict[str, int] = field(default_factory=dict)
+
+
 class CachePrefetchState:
     """Accumulates what the prefetch loop knows, and publishes it as JSON.
 
@@ -211,7 +242,7 @@ class CachePrefetchState:
         self._last_error: str | None = None
         self._outcome_counts: dict[str, int] = {}
 
-        self._images: dict[str, dict] = {}
+        self._images: dict[str, _ImageRecord] = {}
 
     # -- loop-level facts -------------------------------------------------------
 
@@ -269,93 +300,71 @@ class CachePrefetchState:
 
     # -- per-image facts --------------------------------------------------------
 
-    def _record(self, image_ref: str) -> dict:
-        return self._images.setdefault(
-            image_ref,
-            {
-                "last_outcome": None,
-                "last_outcome_at": None,
-                "last_error": None,
-                "local_digests": [],
-                "local_digest_first_seen_at": None,
-                "digest_changed_at": None,
-                "last_local_error": None,
-                "expected_digest": None,
-                "remote_digest": None,
-                "last_remote_read_ok_at": None,
-                "last_remote_error": None,
-                "last_pull_attempt_at": None,
-                "last_pull_ok_at": None,
-                "last_pull_error": None,
-                "last_cleanup_error": None,
-                "last_disk_required_bytes": None,
-                "last_disk_available_bytes": None,
-                "outcome_counts": {},
-            },
-        )
+    def _record(self, image_ref: str) -> _ImageRecord:
+        return self._images.setdefault(image_ref, _ImageRecord())
 
     @_never_raises
     def note_local_digests(
         self, image_ref: str, digests: list[str], error: object | None = None
     ) -> None:
         record = self._record(image_ref)
-        previous = record["local_digests"]
-        record["local_digests"] = list(digests)
-        record["last_local_error"] = _clip(error)
+        previous = record.local_digests
+        record.local_digests = list(digests)
+        record.last_local_error = _clip(error)
         if not previous and digests:
-            record["local_digest_first_seen_at"] = _utcnow()
+            record.local_digest_first_seen_at = _utcnow()
         elif previous and digests and previous != list(digests):
             # The content under the tag moved. This is the single clearest signal
             # that a pull actually landed, as opposed to merely being attempted.
-            record["digest_changed_at"] = _utcnow()
+            record.digest_changed_at = _utcnow()
 
     @_never_raises
     def note_expected_digest(self, image_ref: str, digest: str | None) -> None:
-        self._record(image_ref)["expected_digest"] = digest
+        self._record(image_ref).expected_digest = digest
 
     @_never_raises
     def note_remote_digest(
         self, image_ref: str, digest: str | None, error: object | None = None
     ) -> None:
         record = self._record(image_ref)
-        record["remote_digest"] = digest
-        record["last_remote_error"] = _clip(error)
+        record.remote_digest = digest
+        record.last_remote_error = _clip(error)
         if digest:
-            record["last_remote_read_ok_at"] = _utcnow()
+            record.last_remote_read_ok_at = _utcnow()
 
     @_never_raises
     def note_disk(self, image_ref: str, required_bytes: int, available_bytes: int) -> None:
         record = self._record(image_ref)
-        record["last_disk_required_bytes"] = required_bytes
-        record["last_disk_available_bytes"] = available_bytes
+        record.last_disk_required_bytes = required_bytes
+        record.last_disk_available_bytes = available_bytes
 
     @_never_raises
     def note_pull_attempt(self, image_ref: str) -> None:
-        self._record(image_ref)["last_pull_attempt_at"] = _utcnow()
+        self._record(image_ref).last_pull_attempt_at = _utcnow()
 
     @_never_raises
     def note_pull_ok(self, image_ref: str) -> None:
         record = self._record(image_ref)
-        record["last_pull_ok_at"] = _utcnow()
-        record["last_pull_error"] = None
+        record.last_pull_ok_at = _utcnow()
+        record.last_pull_error = None
 
     @_never_raises
     def note_pull_error(self, image_ref: str, error: object) -> None:
-        self._record(image_ref)["last_pull_error"] = _clip(error)
+        self._record(image_ref).last_pull_error = _clip(error)
 
     @_never_raises
     def note_cleanup_error(self, image_ref: str, error: object | None) -> None:
-        self._record(image_ref)["last_cleanup_error"] = _clip(error)
+        self._record(image_ref).last_cleanup_error = _clip(error)
 
     @_never_raises
     def record_image_outcome(
         self, image_ref: str, outcome: str, error: object | None = None
     ) -> None:
         record = self._record(image_ref)
-        record["last_outcome"] = outcome
-        record["last_outcome_at"] = _utcnow()
-        record["last_error"] = _clip(error)
-        counts = record["outcome_counts"]
+        record.last_outcome = outcome
+        record.last_outcome_at = _utcnow()
+        record.last_error = _clip(error)
+        counts = record.outcome_counts
         counts[outcome] = counts.get(outcome, 0) + 1
 
     # -- publication ------------------------------------------------------------
@@ -386,7 +395,8 @@ class CachePrefetchState:
             "last_outcome_at": self._last_outcome_at,
             "last_error": self._last_error,
             "outcome_counts": dict(self._outcome_counts),
-            "images": copy.deepcopy(self._images),
+            # `asdict` copies as it flattens, so `_fit` can trim its result freely.
+            "images": {ref: asdict(record) for ref, record in self._images.items()},
         }
 
     def render(self) -> str:

--- a/neurons/executor/src/services/cache_prefetch_state.py
+++ b/neurons/executor/src/services/cache_prefetch_state.py
@@ -1,0 +1,404 @@
+"""DAH-2470 — structured state file for the cache-template prefetch loop.
+
+The prefetch loop already narrates every branch it takes, but ``core/logger.py``
+attaches only a ``StreamHandler``: that diagnosis is written on the provider's
+machine and never leaves it. This module mirrors the same information into a small
+JSON document inside the executor container, where the validator's cached-template
+check can read it over the SSH connection it already holds (``run.sh`` starts sshd
+in this very container) and attach it to the failure event.
+
+Two rules govern everything here:
+
+* **Never wedge the loop.** Every mutator swallows its own errors. A broken state
+  file must not change a single pull decision.
+* **Never grow without bound.** The document is capped, because the validator's log
+  line already carries a large monitoring payload and this rides along with it.
+
+The file is deliberately *not* durable. Watchtower recreates the executor container
+on every update, which resets the counters. ``started_at`` and ``sweep_count`` are
+therefore always published, so a reader can see the window the counters cover and
+never mistakes a fresh reset for a healthy node.
+"""
+
+import copy
+import functools
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+from core.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Bump when the document shape changes in a way a reader must notice.
+SCHEMA_VERSION = 1
+
+# Inside the executor container. The validator's shell lands in this same container,
+# so no bind-mount is involved.
+STATE_PATH = "/var/lib/lium/cache_prefetch_state.json"
+
+# Per-error and whole-document limits. 4 KB comfortably holds one image's full
+# history; the reduction ladder in `_fit` handles anything larger.
+MAX_ERROR_CHARS = 500
+MAX_PAYLOAD_BYTES = 4096
+
+
+class Outcome:
+    """Every way a sweep can end. Named so a reader can group and count them.
+
+    Loop-level outcomes describe the sweep as a whole; image-level outcomes describe
+    what happened to one template within it.
+    """
+
+    # Loop level. The top-level `last_outcome` always holds one of these, so a reader can
+    # tell "the loop finished a sweep" from "the loop keeps quitting early" without
+    # reading the images map.
+    PREFETCH_DISABLED_NO_BACKEND_URL = "prefetch_disabled_no_backend_url"
+    DOCKER_UNAVAILABLE = "docker_unavailable"
+    GPU_UNKNOWN = "gpu_unknown"
+    BACKEND_NO_TEMPLATES = "backend_no_templates"
+    MALFORMED_TEMPLATE = "malformed_template"
+    LOOP_ERROR = "loop_error"
+    # The sweep ran to the end. Individual templates may still have had a bad outcome —
+    # that is what the images map is for.
+    SWEEP_OK = "sweep_ok"
+
+    # Image level.
+    REMOTE_DIGEST_UNREADABLE = "remote_digest_unreadable"
+    UP_TO_DATE = "up_to_date"
+    INSUFFICIENT_DISK = "insufficient_disk"
+    LOCK_HELD = "lock_held"
+    PULL_OK = "pull_ok"
+    PULL_FAILED = "pull_failed"
+
+
+def _utcnow() -> str:
+    """Timestamp in the same shape the rest of the fleet's JSON uses."""
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _clip(value: object | None, limit: int = MAX_ERROR_CHARS) -> str | None:
+    """Stringify and bound one error message. ``None`` stays ``None``."""
+    if value is None:
+        return None
+    text = str(value)
+    return text if len(text) <= limit else text[:limit] + "…"
+
+
+def _executor_version() -> str:
+    """Executor release from ``version.txt``, the same file the validator reads."""
+    try:
+        version_file = Path(__file__).resolve().parents[2] / "version.txt"
+        return version_file.read_text().strip() or "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _never_raises(method):
+    """Diagnostics must never change prefetch behaviour, so absorb every failure."""
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        try:
+            return method(self, *args, **kwargs)
+        except Exception as e:
+            logger.warning(f"cache prefetch state: {method.__name__} failed: {e}")
+        return None
+
+    return wrapper
+
+
+def _size(payload: str) -> int:
+    return len(payload.encode("utf-8"))
+
+
+def _dump(doc: dict) -> str:
+    return json.dumps(doc, separators=(",", ":"), sort_keys=False, default=str)
+
+
+def _fit(doc: dict) -> str:
+    """Serialise ``doc``, shedding detail until it fits ``MAX_PAYLOAD_BYTES``.
+
+    Detail is dropped least-useful-first: extra images, then long error text, then
+    the counters, then the images map entirely. ``truncated`` marks that this ran, so
+    a reader never mistakes a trimmed document for the whole story.
+    """
+    payload = _dump(doc)
+    if _size(payload) <= MAX_PAYLOAD_BYTES:
+        return payload
+
+    doc = copy.deepcopy(doc)
+    doc["truncated"] = True
+    for shed in (_keep_newest_image, _shorten_errors, _drop_counts, _drop_images):
+        shed(doc)
+        payload = _dump(doc)
+        if _size(payload) <= MAX_PAYLOAD_BYTES:
+            break
+    return payload
+
+
+def _keep_newest_image(doc: dict) -> None:
+    images = doc.get("images") or {}
+    if len(images) <= 1:
+        return
+    newest = max(images.items(), key=lambda kv: kv[1].get("last_outcome_at") or "")
+    doc["images"] = {newest[0]: newest[1]}
+
+
+def _shorten_errors(doc: dict) -> None:
+    short = MAX_ERROR_CHARS // 5
+    for key, value in doc.items():
+        if key.endswith("_error") and isinstance(value, str):
+            doc[key] = _clip(value, short)
+    for record in (doc.get("images") or {}).values():
+        for key, value in record.items():
+            if (key.endswith("_error") or key == "last_error") and isinstance(value, str):
+                record[key] = _clip(value, short)
+
+
+def _drop_counts(doc: dict) -> None:
+    doc.pop("outcome_counts", None)
+    for record in (doc.get("images") or {}).values():
+        record.pop("outcome_counts", None)
+
+
+def _drop_images(doc: dict) -> None:
+    doc["images"] = {}
+
+
+class CachePrefetchState:
+    """Accumulates what the prefetch loop knows, and publishes it as JSON.
+
+    Pass ``path=None`` for a throwaway recorder that never writes — used when
+    ``_ensure_template`` is exercised on its own.
+    """
+
+    def __init__(
+        self,
+        *,
+        path: str | os.PathLike | None = STATE_PATH,
+        backend_url: str | None = None,
+        refresh_interval_seconds: int | None = None,
+    ) -> None:
+        self._path = Path(path) if path else None
+        self._started_at = _utcnow()
+        self._sweep_count = 0
+        self._executor_version = _executor_version()
+        self._backend_url = backend_url
+        self._refresh_interval_seconds = refresh_interval_seconds
+
+        self._gpu_model: str | None = None
+        self._driver_version: str | None = None
+        self._gpu_resolved_at: str | None = None
+        self._gpu_error: str | None = None
+
+        self._docker_available: bool | None = None
+        self._docker_error: str | None = None
+
+        self._last_backend_status: int | None = None
+        self._last_backend_template_count: int | None = None
+        self._last_backend_error: str | None = None
+
+        self._last_loop_error: str | None = None
+        self._last_loop_error_at: str | None = None
+
+        self._last_malformed_template: str | None = None
+        self._last_malformed_template_at: str | None = None
+
+        self._last_outcome: str | None = None
+        self._last_outcome_at: str | None = None
+        self._last_error: str | None = None
+        self._outcome_counts: dict[str, int] = {}
+
+        self._images: dict[str, dict] = {}
+
+    # -- loop-level facts -------------------------------------------------------
+
+    @_never_raises
+    def begin_sweep(self) -> None:
+        self._sweep_count += 1
+
+    @_never_raises
+    def note_docker(self, available: bool, error: object | None = None) -> None:
+        self._docker_available = available
+        self._docker_error = _clip(error)
+
+    @_never_raises
+    def note_gpu(self, gpu_model: str, driver_version: str, error: object | None = None) -> None:
+        self._gpu_model = gpu_model
+        self._driver_version = driver_version
+        self._gpu_error = _clip(error)
+        if gpu_model and gpu_model != "unknown":
+            self._gpu_resolved_at = _utcnow()
+
+    @_never_raises
+    def note_backend(
+        self,
+        status: int | None = None,
+        template_count: int | None = None,
+        error: object | None = None,
+    ) -> None:
+        self._last_backend_status = status
+        self._last_backend_template_count = template_count
+        self._last_backend_error = _clip(error)
+
+    @_never_raises
+    def note_malformed_template(self, entry: object) -> None:
+        """A backend entry we could not turn into an image reference.
+
+        Kept in its own field rather than the outcome slot: the sweep still finishes, so
+        `last_outcome` moves on to `sweep_ok` and would otherwise bury this.
+        """
+        self._last_malformed_template = _clip(entry)
+        self._last_malformed_template_at = _utcnow()
+        counts = self._outcome_counts
+        counts[Outcome.MALFORMED_TEMPLATE] = counts.get(Outcome.MALFORMED_TEMPLATE, 0) + 1
+
+    @_never_raises
+    def note_loop_error(self, error: object) -> None:
+        self._last_loop_error = _clip(error)
+        self._last_loop_error_at = _utcnow()
+
+    @_never_raises
+    def record_loop_outcome(self, outcome: str, error: object | None = None) -> None:
+        self._last_outcome = outcome
+        self._last_outcome_at = _utcnow()
+        self._last_error = _clip(error)
+        self._outcome_counts[outcome] = self._outcome_counts.get(outcome, 0) + 1
+
+    # -- per-image facts --------------------------------------------------------
+
+    def _record(self, image_ref: str) -> dict:
+        return self._images.setdefault(
+            image_ref,
+            {
+                "last_outcome": None,
+                "last_outcome_at": None,
+                "last_error": None,
+                "local_digests": [],
+                "local_digest_first_seen_at": None,
+                "digest_changed_at": None,
+                "last_local_error": None,
+                "expected_digest": None,
+                "remote_digest": None,
+                "last_remote_read_ok_at": None,
+                "last_remote_error": None,
+                "last_pull_attempt_at": None,
+                "last_pull_ok_at": None,
+                "last_pull_error": None,
+                "last_cleanup_error": None,
+                "last_disk_required_bytes": None,
+                "last_disk_available_bytes": None,
+                "outcome_counts": {},
+            },
+        )
+
+    @_never_raises
+    def note_local_digests(
+        self, image_ref: str, digests: list[str], error: object | None = None
+    ) -> None:
+        record = self._record(image_ref)
+        previous = record["local_digests"]
+        record["local_digests"] = list(digests)
+        record["last_local_error"] = _clip(error)
+        if not previous and digests:
+            record["local_digest_first_seen_at"] = _utcnow()
+        elif previous and digests and previous != list(digests):
+            # The content under the tag moved. This is the single clearest signal
+            # that a pull actually landed, as opposed to merely being attempted.
+            record["digest_changed_at"] = _utcnow()
+
+    @_never_raises
+    def note_expected_digest(self, image_ref: str, digest: str | None) -> None:
+        self._record(image_ref)["expected_digest"] = digest
+
+    @_never_raises
+    def note_remote_digest(
+        self, image_ref: str, digest: str | None, error: object | None = None
+    ) -> None:
+        record = self._record(image_ref)
+        record["remote_digest"] = digest
+        record["last_remote_error"] = _clip(error)
+        if digest:
+            record["last_remote_read_ok_at"] = _utcnow()
+
+    @_never_raises
+    def note_disk(self, image_ref: str, required_bytes: int, available_bytes: int) -> None:
+        record = self._record(image_ref)
+        record["last_disk_required_bytes"] = required_bytes
+        record["last_disk_available_bytes"] = available_bytes
+
+    @_never_raises
+    def note_pull_attempt(self, image_ref: str) -> None:
+        self._record(image_ref)["last_pull_attempt_at"] = _utcnow()
+
+    @_never_raises
+    def note_pull_ok(self, image_ref: str) -> None:
+        record = self._record(image_ref)
+        record["last_pull_ok_at"] = _utcnow()
+        record["last_pull_error"] = None
+
+    @_never_raises
+    def note_pull_error(self, image_ref: str, error: object) -> None:
+        self._record(image_ref)["last_pull_error"] = _clip(error)
+
+    @_never_raises
+    def note_cleanup_error(self, image_ref: str, error: object | None) -> None:
+        self._record(image_ref)["last_cleanup_error"] = _clip(error)
+
+    @_never_raises
+    def record_image_outcome(
+        self, image_ref: str, outcome: str, error: object | None = None
+    ) -> None:
+        record = self._record(image_ref)
+        record["last_outcome"] = outcome
+        record["last_outcome_at"] = _utcnow()
+        record["last_error"] = _clip(error)
+        counts = record["outcome_counts"]
+        counts[outcome] = counts.get(outcome, 0) + 1
+
+    # -- publication ------------------------------------------------------------
+
+    def as_dict(self) -> dict:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "executor_version": self._executor_version,
+            "started_at": self._started_at,
+            "updated_at": _utcnow(),
+            "sweep_count": self._sweep_count,
+            "refresh_interval_seconds": self._refresh_interval_seconds,
+            "gpu_model": self._gpu_model,
+            "driver_version": self._driver_version,
+            "gpu_resolved_at": self._gpu_resolved_at,
+            "gpu_error": self._gpu_error,
+            "backend_url": self._backend_url,
+            "docker_available": self._docker_available,
+            "docker_error": self._docker_error,
+            "last_backend_status": self._last_backend_status,
+            "last_backend_template_count": self._last_backend_template_count,
+            "last_backend_error": self._last_backend_error,
+            "last_loop_error": self._last_loop_error,
+            "last_loop_error_at": self._last_loop_error_at,
+            "last_malformed_template": self._last_malformed_template,
+            "last_malformed_template_at": self._last_malformed_template_at,
+            "last_outcome": self._last_outcome,
+            "last_outcome_at": self._last_outcome_at,
+            "last_error": self._last_error,
+            "outcome_counts": dict(self._outcome_counts),
+            "images": copy.deepcopy(self._images),
+        }
+
+    def render(self) -> str:
+        return _fit(self.as_dict())
+
+    @_never_raises
+    def flush(self) -> None:
+        """Publish the document. Atomic, so a reader never sees a half-written file."""
+        if self._path is None:
+            return
+        payload = self.render()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._path.with_name(self._path.name + ".tmp")
+        tmp.write_text(payload, encoding="utf-8")
+        os.replace(tmp, self._path)

--- a/neurons/executor/src/services/cache_template_service.py
+++ b/neurons/executor/src/services/cache_template_service.py
@@ -8,6 +8,13 @@ re-pulling whenever the template's remote digest changes.
 
 All blocking docker / NVML work is dispatched to a thread so the executor's
 event loop (and therefore its HTTP API) is never blocked by a multi-minute pull.
+
+DAH-2470: every branch below also records a named outcome into a
+``CachePrefetchState`` document, which the validator reads over SSH when it zeroes a
+node for a bad image digest. The helpers therefore return their error text instead of
+only logging it — the state file is the single source a reader will have, so nothing
+this module prints may be lost on the way there. Recording never changes a pull
+decision: state failures are swallowed inside ``cache_prefetch_state``.
 """
 
 import asyncio
@@ -19,6 +26,7 @@ import pynvml
 
 from core.config import settings
 from core.logger import get_logger
+from services.cache_prefetch_state import STATE_PATH, CachePrefetchState, Outcome
 from services.pull_lock import cache_pull_lock
 
 logger = get_logger(__name__)
@@ -31,10 +39,11 @@ ERROR_INTERVAL_SECONDS = 5 * 60
 DEFAULT_DOCKER_IMAGE_PATH = "/executors/default-docker-image"
 
 
-def _get_gpu_info() -> tuple[str, str]:
-    """Return (gpu_model, driver_version) via NVML, degrading to "unknown"."""
+def _get_gpu_info() -> tuple[str, str, str | None]:
+    """Return (gpu_model, driver_version, error) via NVML, degrading to "unknown"."""
     gpu_name = "unknown"
     driver_version = "unknown"
+    error: str | None = None
     try:
         pynvml.nvmlInit()
         handle = pynvml.nvmlDeviceGetHandleByIndex(0)
@@ -46,53 +55,64 @@ def _get_gpu_info() -> tuple[str, str]:
             driver_version = driver_version.decode("utf-8")
     except Exception as e:
         logger.error(f"Failed to get GPU info for cache pre-pull: {e}")
+        error = str(e)
     finally:
         try:
             pynvml.nvmlShutdown()
         except Exception:
             pass
-    return gpu_name, driver_version
+    return gpu_name, driver_version, error
 
 
-async def _fetch_templates(session: aiohttp.ClientSession, url: str, params: dict) -> list[dict]:
+async def _fetch_templates(
+    session: aiohttp.ClientSession, url: str, params: dict
+) -> tuple[list[dict], int | None, str | None]:
+    """Return (templates, http_status, error) for the backend recommendation call."""
     async with session.get(url, params=params) as response:
         if response.status != 200:
             logger.error(f"Failed to get cache templates. Status: {response.status}")
-            return []
+            return [], response.status, f"HTTP {response.status}"
         data = await response.json()
         logger.info(f"Received {len(data) if data else 0} cache template(s)")
-        return data or []
+        return data or [], response.status, None
 
 
-async def _remote_digest(client: "docker.DockerClient", image_ref: str) -> str | None:
-    """Manifest digest the registry currently serves for image_ref, or None."""
+async def _remote_digest(
+    client: "docker.DockerClient", image_ref: str
+) -> tuple[str | None, str | None]:
+    """Return (manifest digest the registry serves for image_ref, error)."""
     try:
         registry_data = await asyncio.to_thread(client.images.get_registry_data, image_ref)
-        return registry_data.id
+        return registry_data.id, None
     except Exception as e:
         logger.warning(f"Could not read remote digest for {image_ref}: {e}")
-        return None
+        return None, str(e)
 
 
-async def _local_digests(client: "docker.DockerClient", image_ref: str) -> list[str]:
-    """RepoDigests of the locally cached image, or [] if not present."""
+async def _local_digests(
+    client: "docker.DockerClient", image_ref: str
+) -> tuple[list[str], str | None]:
+    """Return (RepoDigests of the locally cached image, error). Absent image is not an error."""
     try:
         image = await asyncio.to_thread(client.images.get, image_ref)
     except docker.errors.ImageNotFound:
-        return []
+        return [], None
     except Exception as e:
         logger.warning(f"Could not read local image {image_ref}: {e}")
-        return []
-    return image.attrs.get("RepoDigests", []) or []
+        return [], str(e)
+    return image.attrs.get("RepoDigests", []) or [], None
 
 
-async def _cleanup_old_tags(client: "docker.DockerClient", repository: str, keep_tag: str) -> None:
-    """Remove other locally cached tags of the same repository."""
+async def _cleanup_old_tags(
+    client: "docker.DockerClient", repository: str, keep_tag: str
+) -> str | None:
+    """Remove other locally cached tags of the same repository; return the last error."""
     try:
         images = await asyncio.to_thread(client.images.list, repository)
     except Exception as e:
         logger.warning(f"Failed to list images for {repository}: {e}")
-        return
+        return str(e)
+    error: str | None = None
     for image in images:
         for tag in list(image.tags):
             repo, _, tg = tag.rpartition(":")
@@ -102,9 +122,16 @@ async def _cleanup_old_tags(client: "docker.DockerClient", repository: str, keep
                     logger.info(f"Removed unused image: {tag}")
                 except Exception as e:
                     logger.warning(f"Failed to remove image {tag}: {e}")
+                    error = str(e)
+    return error
 
 
-async def _ensure_template(client: "docker.DockerClient", data: dict) -> None:
+async def _ensure_template(
+    client: "docker.DockerClient", data: dict, state: CachePrefetchState | None = None
+) -> None:
+    # A throwaway recorder keeps the body free of `if state:` guards when this is
+    # called on its own (tests); the loop always passes the real one.
+    state = state or CachePrefetchState(path=None)
     docker_image = data.get("docker_image")
     docker_image_tag = data.get("docker_image_tag")
     docker_image_size = data.get("docker_image_size") or 0
@@ -116,42 +143,60 @@ async def _ensure_template(client: "docker.DockerClient", data: dict) -> None:
 
     if not docker_image or not docker_image_tag:
         logger.warning(f"Skipping malformed cache template entry: {data}")
+        state.note_malformed_template(data)
         return
 
     image_ref = f"{docker_image}:{docker_image_tag}"
 
-    local = await _local_digests(client, image_ref)
+    local, local_error = await _local_digests(client, image_ref)
+    state.note_local_digests(image_ref, local, error=local_error)
+    state.note_expected_digest(image_ref, expected_digest)
     remote: str | None = None
     if expected_digest:
         if any(expected_digest in digest for digest in local):
             logger.info(
                 f"Cache template {image_ref} already at backend digest ({expected_digest}); skipping pull"
             )
+            state.record_image_outcome(image_ref, Outcome.UP_TO_DATE)
             return
     elif local:
         # Legacy fallback (backend sent no digest): only query the daemon for the
         # remote digest when the image is already cached; on a first pull there is
         # nothing to compare against, so skip the call and avoid a needless registry
         # manifest request (counts against pull limits).
-        remote = await _remote_digest(client, image_ref)
+        remote, remote_error = await _remote_digest(client, image_ref)
+        state.note_remote_digest(image_ref, remote, error=remote_error)
         # Re-pull only if we can confirm the remote digest changed. If the remote
         # digest is unreadable (rate limit / auth), keep the cached copy rather
         # than re-pulling every cycle.
         if remote is None:
             logger.info(f"{image_ref} cached; remote digest unreadable, keeping local copy")
+            # DAH-2470 leading hypothesis: this branch never retries, so a node that
+            # lands here keeps a stale image indefinitely. The counter makes that
+            # visible — one occurrence is noise, hundreds is the answer.
+            state.record_image_outcome(
+                image_ref, Outcome.REMOTE_DIGEST_UNREADABLE, error=remote_error
+            )
             return
         if any(remote in digest for digest in local):
             logger.info(f"Cache template {image_ref} already up to date ({remote}); skipping pull")
+            state.record_image_outcome(image_ref, Outcome.UP_TO_DATE)
             return
 
     # Ensure enough disk headroom before pulling.
     if docker_image_size:
         required_space = int(docker_image_size * MIN_DISK_SPACE_MULTIPLIER)
         available_space = psutil.disk_usage("/").free
+        state.note_disk(image_ref, required_space, available_space)
         if available_space < required_space:
             logger.warning(
                 f"Skipping pull of {image_ref} - insufficient disk space. "
                 f"Required: {required_space}, Available: {available_space}"
+            )
+            state.record_image_outcome(
+                image_ref,
+                Outcome.INSUFFICIENT_DISK,
+                error=f"required {required_space}, available {available_space}",
             )
             return
 
@@ -160,40 +205,66 @@ async def _ensure_template(client: "docker.DockerClient", data: dict) -> None:
     with cache_pull_lock() as acquired:
         if not acquired:
             logger.info(f"Another puller holds the lock; skipping {image_ref} this cycle")
+            state.record_image_outcome(image_ref, Outcome.LOCK_HELD)
             return
-        if expected_digest:
-            pinned_ref = f"{docker_image}@{expected_digest}"
-            logger.info(f"Pulling cache template {pinned_ref} (local={local})")
-            image = await asyncio.to_thread(client.images.pull, pinned_ref)
-            # Re-point the tag at the pinned build: a digest pull alone leaves the
-            # tag (possibly poisoned by a stale mirror) untouched.
-            await asyncio.to_thread(image.tag, docker_image, docker_image_tag)
-            logger.info(f"Successfully pulled {image_ref} at {expected_digest}")
-        else:
-            logger.info(f"Pulling cache template {image_ref} (remote={remote}, local={local})")
-            await asyncio.to_thread(client.images.pull, docker_image, docker_image_tag)
-            logger.info(f"Successfully pulled {image_ref}")
+        state.note_pull_attempt(image_ref)
+        try:
+            if expected_digest:
+                pinned_ref = f"{docker_image}@{expected_digest}"
+                logger.info(f"Pulling cache template {pinned_ref} (local={local})")
+                image = await asyncio.to_thread(client.images.pull, pinned_ref)
+                # Re-point the tag at the pinned build: a digest pull alone leaves the
+                # tag (possibly poisoned by a stale mirror) untouched.
+                await asyncio.to_thread(image.tag, docker_image, docker_image_tag)
+                logger.info(f"Successfully pulled {image_ref} at {expected_digest}")
+            else:
+                logger.info(f"Pulling cache template {image_ref} (remote={remote}, local={local})")
+                await asyncio.to_thread(client.images.pull, docker_image, docker_image_tag)
+                logger.info(f"Successfully pulled {image_ref}")
+        except Exception as e:
+            # Record, then re-raise: a failed pull already aborts the sweep and backs
+            # off, and DAH-2470 must not change that.
+            state.note_pull_error(image_ref, e)
+            state.record_image_outcome(image_ref, Outcome.PULL_FAILED, error=e)
+            raise
+        state.note_pull_ok(image_ref)
+        state.record_image_outcome(image_ref, Outcome.PULL_OK)
 
-    await _cleanup_old_tags(client, docker_image, docker_image_tag)
+    cleanup_error = await _cleanup_old_tags(client, docker_image, docker_image_tag)
+    state.note_cleanup_error(image_ref, cleanup_error)
 
 
-async def run_cache_template_prefetch() -> None:
+async def run_cache_template_prefetch(state_path: str | None = STATE_PATH) -> None:
     """Background loop: pull the GPU's cache template on boot and keep it fresh."""
     base_url = settings.COMPUTE_REST_API_URL
+    refresh_interval = settings.CACHE_TEMPLATE_REFRESH_SECONDS
+    # Published from the first line onward, so the two ways this loop can quit before
+    # it ever starts are visible to the validator instead of silent.
+    state = CachePrefetchState(
+        path=state_path,
+        backend_url=f"{base_url.rstrip('/')}{DEFAULT_DOCKER_IMAGE_PATH}" if base_url else None,
+        refresh_interval_seconds=refresh_interval,
+    )
+
     if not base_url:
         logger.warning(
             "COMPUTE_REST_API_URL not set; cache template pre-pull disabled"
         )
+        state.record_loop_outcome(Outcome.PREFETCH_DISABLED_NO_BACKEND_URL)
+        state.flush()
         return
 
-    refresh_interval = settings.CACHE_TEMPLATE_REFRESH_SECONDS
     error_interval = min(ERROR_INTERVAL_SECONDS, refresh_interval)
     url = f"{base_url.rstrip('/')}{DEFAULT_DOCKER_IMAGE_PATH}"
 
     try:
         client = docker.from_env()
+        state.note_docker(available=True)
     except Exception as e:
         logger.error(f"Cannot connect to docker; cache pre-pull disabled: {e}")
+        state.note_docker(available=False, error=e)
+        state.record_loop_outcome(Outcome.DOCKER_UNAVAILABLE, error=e)
+        state.flush()
         return
 
     logger.info(f"Cache template pre-pull starting (refresh every {refresh_interval}s)")
@@ -206,13 +277,17 @@ async def run_cache_template_prefetch() -> None:
     async with aiohttp.ClientSession(timeout=session_timeout) as session:
         while True:
             try:
+                state.begin_sweep()
                 # Resolve GPU info off-thread, and keep retrying while it is still
                 # unknown: at early boot the NVIDIA driver may not be ready yet,
                 # and caching "unknown" once would wedge the loop forever.
                 if gpu_model == "unknown":
-                    gpu_model, driver_version = await asyncio.to_thread(_get_gpu_info)
+                    gpu_model, driver_version, gpu_error = await asyncio.to_thread(_get_gpu_info)
+                    state.note_gpu(gpu_model, driver_version, error=gpu_error)
                     if gpu_model == "unknown":
                         logger.warning("GPU not detected yet; retrying cache pre-pull shortly")
+                        state.record_loop_outcome(Outcome.GPU_UNKNOWN, error=gpu_error)
+                        state.flush()
                         await asyncio.sleep(error_interval)
                         continue
                     logger.info(
@@ -221,14 +296,23 @@ async def run_cache_template_prefetch() -> None:
                     )
 
                 params = {"gpu_model": gpu_model, "driver_version": driver_version}
-                templates = await _fetch_templates(session, url, params)
+                templates, status, backend_error = await _fetch_templates(session, url, params)
+                state.note_backend(
+                    status=status, template_count=len(templates), error=backend_error
+                )
                 if not templates:
+                    state.record_loop_outcome(Outcome.BACKEND_NO_TEMPLATES, error=backend_error)
+                    state.flush()
                     await asyncio.sleep(error_interval)
                     continue
 
                 for data in templates:
-                    await _ensure_template(client, data)
+                    await _ensure_template(client, data, state)
 
+                state.record_loop_outcome(Outcome.SWEEP_OK)
+                # Publish before sleeping, so the document is never a full refresh
+                # interval behind what the loop actually knows.
+                state.flush()
                 # Sleep once per full sweep, after all templates are processed.
                 await asyncio.sleep(refresh_interval)
             except asyncio.CancelledError:
@@ -236,7 +320,13 @@ async def run_cache_template_prefetch() -> None:
                 raise
             except aiohttp.ClientError as e:
                 logger.error(f"Network error during cache pre-pull: {e}")
+                state.note_loop_error(e)
+                state.record_loop_outcome(Outcome.LOOP_ERROR, error=e)
+                state.flush()
                 await asyncio.sleep(error_interval)
             except Exception as e:
                 logger.error(f"Unexpected error during cache pre-pull: {e}")
+                state.note_loop_error(e)
+                state.record_loop_outcome(Outcome.LOOP_ERROR, error=e)
+                state.flush()
                 await asyncio.sleep(error_interval)

--- a/neurons/executor/tests/test_cache_prefetch_state.py
+++ b/neurons/executor/tests/test_cache_prefetch_state.py
@@ -1,0 +1,379 @@
+"""DAH-2470 — the cache-prefetch loop's structured state file.
+
+The validator reads this document when it zeroes a node for a bad image digest, and it
+is the only thing a reader will have: the loop's log lines never leave the provider's
+machine. So every exit path must be named, every error text must survive, and neither
+the document nor a broken write may ever disturb the loop.
+"""
+
+import asyncio
+import json
+from unittest.mock import MagicMock
+
+import docker
+import pytest
+
+# conftest replaces the docker module with a MagicMock; except-clauses in the
+# service need a real exception class to catch.
+docker.errors.ImageNotFound = type("ImageNotFound", (Exception,), {})
+
+from services.cache_prefetch_state import (  # noqa: E402
+    MAX_ERROR_CHARS,
+    MAX_PAYLOAD_BYTES,
+    SCHEMA_VERSION,
+    CachePrefetchState,
+    Outcome,
+)
+
+from services import cache_template_service  # noqa: E402
+
+REPO = "daturaai/pytorch"
+TAG = "2.12.0-py3.12-cuda13.0.2-devel-ubuntu24.04-dind"
+IMAGE_REF = f"{REPO}:{TAG}"
+FRESH_DIGEST = "sha256:70bd5fa697877594b753a146e207ca4de66d9b875d606ae09e6ee7bac8f4f423"
+STALE_DIGEST = "sha256:2d19c94ce8a37c6fa364f8a6211d8b6dc1a44ece574c4c22ab5579925ce7a4c8"
+
+
+def _make_client(local_digests: list[str] | None = None, image_absent: bool = False) -> MagicMock:
+    client = MagicMock()
+    if image_absent:
+        client.images.get.side_effect = docker.errors.ImageNotFound("absent")
+    else:
+        image = MagicMock()
+        image.attrs = {"RepoDigests": [f"{REPO}@{digest}" for digest in (local_digests or [])]}
+        client.images.get.return_value = image
+    client.images.list.return_value = []
+    return client
+
+
+def _template(digest: str | None = None, size: int = 0) -> dict:
+    data = {"docker_image": REPO, "docker_image_tag": TAG, "docker_image_size": size}
+    if digest is not None:
+        data["docker_image_digest"] = digest
+    return data
+
+
+def _run(client, template, state):
+    asyncio.run(cache_template_service._ensure_template(client, template, state))
+
+
+def _image(state: CachePrefetchState) -> dict:
+    return state.as_dict()["images"][IMAGE_REF]
+
+
+# --- image-level outcomes ----------------------------------------------------------------
+
+
+def test_up_to_date_at_backend_digest():
+    state = CachePrefetchState(path=None)
+
+    _run(_make_client(local_digests=[FRESH_DIGEST]), _template(FRESH_DIGEST), state)
+
+    record = _image(state)
+    assert record["last_outcome"] == Outcome.UP_TO_DATE
+    assert record["expected_digest"] == FRESH_DIGEST
+    assert record["local_digests"] == [f"{REPO}@{FRESH_DIGEST}"]
+
+
+def test_up_to_date_at_registry_digest():
+    # Legacy path: no backend digest, so the daemon's remote digest is the comparison.
+    state = CachePrefetchState(path=None)
+    client = _make_client(local_digests=[STALE_DIGEST])
+    client.images.get_registry_data.return_value = MagicMock(id=STALE_DIGEST)
+
+    _run(client, _template(), state)
+
+    record = _image(state)
+    assert record["last_outcome"] == Outcome.UP_TO_DATE
+    assert record["remote_digest"] == STALE_DIGEST
+    assert record["last_remote_read_ok_at"] is not None
+
+
+def test_remote_digest_unreadable_keeps_the_registry_error():
+    # DAH-2470's leading hypothesis. The error text is the whole point: it says whether
+    # the registry rate-limited us, rejected auth, or was simply unreachable.
+    state = CachePrefetchState(path=None)
+    client = _make_client(local_digests=[STALE_DIGEST])
+    client.images.get_registry_data.side_effect = RuntimeError("429 Too Many Requests")
+
+    _run(client, _template(), state)
+
+    record = _image(state)
+    assert record["last_outcome"] == Outcome.REMOTE_DIGEST_UNREADABLE
+    assert "429 Too Many Requests" in record["last_error"]
+    assert "429 Too Many Requests" in record["last_remote_error"]
+    assert record["remote_digest"] is None
+    client.images.pull.assert_not_called()
+
+
+def test_repeated_unreadable_remote_accumulates_a_count():
+    # One occurrence is noise; a count in the hundreds against an unchanged local digest
+    # is the answer. That distinction only exists if the counter accumulates.
+    state = CachePrefetchState(path=None)
+    client = _make_client(local_digests=[STALE_DIGEST])
+    client.images.get_registry_data.side_effect = RuntimeError("registry unreachable")
+
+    for _ in range(3):
+        _run(client, _template(), state)
+
+    assert _image(state)["outcome_counts"][Outcome.REMOTE_DIGEST_UNREADABLE] == 3
+
+
+def test_insufficient_disk_records_both_numbers(monkeypatch):
+    state = CachePrefetchState(path=None)
+    monkeypatch.setattr(
+        cache_template_service.psutil, "disk_usage", lambda _: MagicMock(free=1_000)
+    )
+    client = _make_client(image_absent=True)
+
+    _run(client, _template(size=10_000), state)
+
+    record = _image(state)
+    assert record["last_outcome"] == Outcome.INSUFFICIENT_DISK
+    assert record["last_disk_required_bytes"] == 30_000
+    assert record["last_disk_available_bytes"] == 1_000
+    client.images.pull.assert_not_called()
+
+
+def test_lock_held(monkeypatch):
+    state = CachePrefetchState(path=None)
+
+    class _Denied:
+        def __enter__(self):
+            return False
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(cache_template_service, "cache_pull_lock", lambda: _Denied())
+    client = _make_client(image_absent=True)
+
+    _run(client, _template(FRESH_DIGEST), state)
+
+    assert _image(state)["last_outcome"] == Outcome.LOCK_HELD
+    client.images.pull.assert_not_called()
+
+
+def test_pull_ok():
+    state = CachePrefetchState(path=None)
+    client = _make_client(image_absent=True)
+
+    _run(client, _template(FRESH_DIGEST), state)
+
+    record = _image(state)
+    assert record["last_outcome"] == Outcome.PULL_OK
+    assert record["last_pull_attempt_at"] is not None
+    assert record["last_pull_ok_at"] is not None
+    assert record["last_pull_error"] is None
+
+
+def test_pull_failed_is_recorded_and_re_raised():
+    # Today a failed pull aborts the sweep and backs off. Recording must not change that.
+    state = CachePrefetchState(path=None)
+    client = _make_client(image_absent=True)
+    client.images.pull.side_effect = RuntimeError("manifest unknown")
+
+    with pytest.raises(RuntimeError):
+        _run(client, _template(FRESH_DIGEST), state)
+
+    record = _image(state)
+    assert record["last_outcome"] == Outcome.PULL_FAILED
+    assert "manifest unknown" in record["last_pull_error"]
+
+
+def test_local_read_error_is_kept():
+    state = CachePrefetchState(path=None)
+    client = _make_client()
+    client.images.get.side_effect = RuntimeError("daemon busy")
+
+    _run(client, _template(FRESH_DIGEST), state)
+
+    assert "daemon busy" in _image(state)["last_local_error"]
+
+
+def test_cleanup_error_is_kept():
+    state = CachePrefetchState(path=None)
+    client = _make_client(image_absent=True)
+    client.images.list.side_effect = RuntimeError("cannot list")
+
+    _run(client, _template(FRESH_DIGEST), state)
+
+    assert "cannot list" in _image(state)["last_cleanup_error"]
+
+
+def test_digest_change_is_timestamped():
+    state = CachePrefetchState(path=None)
+
+    state.note_local_digests(IMAGE_REF, [f"{REPO}@{STALE_DIGEST}"])
+    assert _image(state)["local_digest_first_seen_at"] is not None
+    assert _image(state)["digest_changed_at"] is None
+
+    state.note_local_digests(IMAGE_REF, [f"{REPO}@{FRESH_DIGEST}"])
+    assert _image(state)["digest_changed_at"] is not None
+
+
+def test_malformed_template_gets_its_own_field():
+    # No usable image_ref exists, so it would only pollute the images map. It also cannot
+    # live in the outcome slot: the sweep still finishes, and sweep_ok would bury it.
+    state = CachePrefetchState(path=None)
+
+    _run(_make_client(), {"docker_image": REPO}, state)
+
+    doc = state.as_dict()
+    assert REPO in doc["last_malformed_template"]
+    assert doc["last_malformed_template_at"] is not None
+    assert doc["outcome_counts"][Outcome.MALFORMED_TEMPLATE] == 1
+    assert doc["images"] == {}
+
+
+# --- loop-level outcomes -----------------------------------------------------------------
+
+
+def _prefetch(state_path=None):
+    asyncio.run(cache_template_service.run_cache_template_prefetch(state_path))
+
+
+def test_prefetch_disabled_without_backend_url(monkeypatch, tmp_path):
+    monkeypatch.setattr(cache_template_service.settings, "COMPUTE_REST_API_URL", "")
+    path = tmp_path / "state.json"
+
+    _prefetch(str(path))
+
+    doc = json.loads(path.read_text())
+    assert doc["last_outcome"] == Outcome.PREFETCH_DISABLED_NO_BACKEND_URL
+    assert doc["backend_url"] is None
+
+
+def test_docker_unavailable(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        cache_template_service.settings, "COMPUTE_REST_API_URL", "https://lium.io/api"
+    )
+    monkeypatch.setattr(
+        cache_template_service.docker,
+        "from_env",
+        MagicMock(side_effect=RuntimeError("no docker socket")),
+    )
+    path = tmp_path / "state.json"
+
+    _prefetch(str(path))
+
+    doc = json.loads(path.read_text())
+    assert doc["last_outcome"] == Outcome.DOCKER_UNAVAILABLE
+    assert doc["docker_available"] is False
+    assert "no docker socket" in doc["docker_error"]
+    assert doc["backend_url"].endswith("/executors/default-docker-image")
+
+
+def test_gpu_unknown():
+    state = CachePrefetchState(path=None)
+
+    state.note_gpu("unknown", "unknown", error="NVML shared library not found")
+    state.record_loop_outcome(Outcome.GPU_UNKNOWN, error="NVML shared library not found")
+
+    doc = state.as_dict()
+    assert doc["last_outcome"] == Outcome.GPU_UNKNOWN
+    assert doc["gpu_resolved_at"] is None
+    assert "NVML" in doc["gpu_error"]
+
+
+def test_backend_no_templates():
+    state = CachePrefetchState(path=None)
+
+    state.note_backend(status=503, template_count=0, error="HTTP 503")
+    state.record_loop_outcome(Outcome.BACKEND_NO_TEMPLATES, error="HTTP 503")
+
+    doc = state.as_dict()
+    assert doc["last_outcome"] == Outcome.BACKEND_NO_TEMPLATES
+    assert doc["last_backend_status"] == 503
+    assert doc["last_backend_template_count"] == 0
+
+
+def test_loop_error():
+    state = CachePrefetchState(path=None)
+
+    state.note_loop_error(RuntimeError("connection reset"))
+    state.record_loop_outcome(Outcome.LOOP_ERROR, error=RuntimeError("connection reset"))
+
+    doc = state.as_dict()
+    assert doc["last_outcome"] == Outcome.LOOP_ERROR
+    assert "connection reset" in doc["last_loop_error"]
+    assert doc["last_loop_error_at"] is not None
+
+
+def test_sweep_ok_clears_a_stale_loop_error():
+    # Without this, a loop that erred once and then recovered would keep reporting
+    # loop_error forever, and a reader would chase a problem that had already passed.
+    state = CachePrefetchState(path=None)
+
+    state.record_loop_outcome(Outcome.LOOP_ERROR, error="connection reset")
+    state.record_loop_outcome(Outcome.SWEEP_OK)
+
+    doc = state.as_dict()
+    assert doc["last_outcome"] == Outcome.SWEEP_OK
+    assert doc["last_error"] is None
+    # The error is still on record, just no longer the headline.
+    assert doc["outcome_counts"][Outcome.LOOP_ERROR] == 1
+
+
+# --- the document itself -----------------------------------------------------------------
+
+
+def test_header_is_always_published():
+    # started_at + sweep_count are what stop a post-recreate reset reading as a healthy node.
+    state = CachePrefetchState(
+        path=None, backend_url="https://lium.io/api", refresh_interval_seconds=900
+    )
+    state.begin_sweep()
+    state.begin_sweep()
+
+    doc = state.as_dict()
+    assert doc["schema_version"] == SCHEMA_VERSION
+    assert doc["executor_version"]
+    assert doc["started_at"]
+    assert doc["updated_at"]
+    assert doc["sweep_count"] == 2
+    assert doc["refresh_interval_seconds"] == 900
+
+
+def test_error_text_is_clipped():
+    state = CachePrefetchState(path=None)
+
+    state.record_image_outcome(IMAGE_REF, Outcome.PULL_FAILED, error="x" * 5_000)
+
+    assert len(_image(state)["last_error"]) <= MAX_ERROR_CHARS + 1
+
+
+def test_document_is_capped_and_marked_truncated():
+    state = CachePrefetchState(path=None)
+    for index in range(40):
+        ref = f"{REPO}-{index}:{TAG}"
+        state.record_image_outcome(ref, Outcome.PULL_FAILED, error="y" * MAX_ERROR_CHARS)
+        state.note_local_digests(ref, [f"{REPO}@{STALE_DIGEST}"])
+
+    payload = state.render()
+
+    assert len(payload.encode("utf-8")) <= MAX_PAYLOAD_BYTES
+    assert json.loads(payload)["truncated"] is True
+
+
+def test_flush_writes_atomically_and_leaves_no_temp_file(tmp_path):
+    path = tmp_path / "nested" / "state.json"
+    state = CachePrefetchState(path=str(path))
+    state.begin_sweep()
+    state.record_image_outcome(IMAGE_REF, Outcome.UP_TO_DATE)
+
+    state.flush()
+
+    assert json.loads(path.read_text())["images"][IMAGE_REF]["last_outcome"] == Outcome.UP_TO_DATE
+    assert list(path.parent.iterdir()) == [path]
+
+
+def test_flush_failure_is_swallowed(tmp_path):
+    # A read-only filesystem must cost the loop nothing.
+    path = tmp_path / "state.json"
+    path.mkdir()  # a directory where the file should go: os.replace will refuse
+    state = CachePrefetchState(path=str(path))
+
+    state.flush()  # must not raise
+
+    assert path.is_dir()

--- a/neurons/executor/tests/test_cache_prefetch_state.py
+++ b/neurons/executor/tests/test_cache_prefetch_state.py
@@ -23,6 +23,7 @@ from services.cache_prefetch_state import (  # noqa: E402
     SCHEMA_VERSION,
     CachePrefetchState,
     Outcome,
+    _ImageRecord,
 )
 
 from services import cache_template_service  # noqa: E402
@@ -210,6 +211,25 @@ def test_digest_change_is_timestamped():
 
     state.note_local_digests(IMAGE_REF, [f"{REPO}@{FRESH_DIGEST}"])
     assert _image(state)["digest_changed_at"] is not None
+
+
+def test_misspelled_field_raises_instead_of_being_published():
+    # Every writer runs under @_never_raises, so a bare dict would have absorbed the typo
+    # and shipped a document quietly missing the field. `slots=True` is what stops that;
+    # this test fails the moment someone drops it.
+    record = _ImageRecord()
+
+    with pytest.raises(AttributeError):
+        record.last_pul_ok_at = "typo"
+
+
+def test_published_images_are_a_copy_not_the_live_record():
+    state = CachePrefetchState(path=None)
+    state.note_local_digests(IMAGE_REF, [f"{REPO}@{FRESH_DIGEST}"])
+
+    _image(state)["local_digests"].append("mutated by a reader")
+
+    assert _image(state)["local_digests"] == [f"{REPO}@{FRESH_DIGEST}"]
 
 
 def test_malformed_template_gets_its_own_field():

--- a/neurons/validators/src/services/task/checks/cached_template_verification.py
+++ b/neurons/validators/src/services/task/checks/cached_template_verification.py
@@ -11,6 +11,17 @@ from ..messages import CachedTemplateMessages as Msg
 from ..messages import render_message
 from ..pipeline import CheckResult, Context
 
+# DAH-2470 — the executor's cache-prefetch loop publishes its own state here, inside the
+# executor container. The validator's shell lands in that same container (run.sh starts
+# sshd there and compose maps ${SSH_PORT}:22 to it), so this is a plain read.
+PREFETCH_STATE_PATH = "/var/lib/lium/cache_prefetch_state.json"
+# The writer caps the document at 4 KB. Read a little more so a document from a newer
+# executor is still parseable, and refuse anything past that rather than bloat the log.
+_PREFETCH_READ_BYTES = 8192
+_PREFETCH_MAX_BYTES = 6144
+# Enough of a bad file to recognise it, not enough to matter in the log.
+_PREFETCH_ERROR_CHARS = 200
+
 
 def _repo_digest(stdout: str | None, repo: str) -> str | None:
     """Bare sha256 of the RepoDigests entry matching ``repo`` ("repo@sha256:…"), or None.
@@ -54,6 +65,10 @@ class CachedTemplateVerificationCheck:
 
     Fails open on every uncertainty (unknown GPU/driver, backend unreachable, empty
     recommendation, SSH error) by recording a skip and leaving score untouched.
+
+    DAH-2470: on the failure path only, the event also carries ``prefetch_state`` — the
+    executor's own record of what its cache-prefetch loop was doing — so the reason a node
+    holds a stale image is readable in Grafana without SSHing anywhere.
     """
 
     check_id = "executor.validate.cached_template"
@@ -61,6 +76,41 @@ class CachedTemplateVerificationCheck:
     # (NOT_CACHED / DIGEST_MISMATCH on/after CACHED_TEMPLATE_CUTOFF) halts the pipeline and the
     # executor scores 0. Every uncertainty still fails open inside run() (passed=True).
     fatal = True
+
+    async def _read_prefetch_state(self, ctx: Context) -> dict:
+        """Read the executor's prefetch-state document (DAH-2470).
+
+        Only ever called on the failure path. Returns a dict either way: every way the
+        read can fall short is reported as a distinguishable ``unavailable`` value,
+        because absence is itself a finding — an executor too old to write the file,
+        a loop that never started, or ``COMPUTE_REST_API_URL`` left unset.
+
+        Never raises, so it can never change ``passed``.
+        """
+        try:
+            result = await ctx.ssh.run(
+                f"head -c {_PREFETCH_READ_BYTES} {shlex.quote(PREFETCH_STATE_PATH)}",
+                check=False,
+            )
+        except Exception as exc:
+            return {"unavailable": "ssh_read_failed", "error": str(exc)[:_PREFETCH_ERROR_CHARS]}
+
+        if getattr(result, "exit_status", 1) != 0:
+            return {"unavailable": "missing"}
+
+        raw = (getattr(result, "stdout", None) or "").strip()
+        if not raw:
+            return {"unavailable": "empty"}
+        if len(raw.encode("utf-8", "replace")) > _PREFETCH_MAX_BYTES:
+            return {"unavailable": "oversized", "bytes": len(raw.encode("utf-8", "replace"))}
+
+        try:
+            state = json.loads(raw)
+        except Exception:
+            return {"unavailable": "unparseable", "raw_prefix": raw[:_PREFETCH_ERROR_CHARS]}
+        if not isinstance(state, dict):
+            return {"unavailable": "unparseable", "raw_prefix": raw[:_PREFETCH_ERROR_CHARS]}
+        return state
 
     async def run(self, ctx: Context) -> CheckResult:
         gpu_model = ctx.state.gpu_model
@@ -159,6 +209,24 @@ class CachedTemplateVerificationCheck:
         after_cutoff = datetime.utcnow() >= settings.CACHED_TEMPLATE_CUTOFF
         should_fail = after_cutoff and template in (Msg.NOT_CACHED, Msg.DIGEST_MISMATCH)
 
+        what = {
+            "recommended_image": image_ref,
+            "cached": cached,
+            "digest_match": digest_match,
+            "backend_digest": backend_digest,
+            "local_digest": local_digest,
+            "gpu_model": gpu_model,
+            "driver_version": driver_version,
+            "after_cutoff": after_cutoff,
+        }
+        # DAH-2470: when we are about to zero this node, also carry what the executor's
+        # own prefetch loop was doing at the time, so a reader can tell a provider-side
+        # cause (registry rate-limits, disk, network) from ours (loop gave up, never
+        # retried). Only on the failure path — a handful of nodes per cycle — so healthy
+        # nodes add neither an SSH round trip nor log volume.
+        if should_fail:
+            what["prefetch_state"] = await self._read_prefetch_state(ctx)
+
         event = render_message(
             template,
             ctx=ctx,
@@ -169,16 +237,7 @@ class CachedTemplateVerificationCheck:
                 if should_fail
                 else None
             ),
-            what={
-                "recommended_image": image_ref,
-                "cached": cached,
-                "digest_match": digest_match,
-                "backend_digest": backend_digest,
-                "local_digest": local_digest,
-                "gpu_model": gpu_model,
-                "driver_version": driver_version,
-                "after_cutoff": after_cutoff,
-            },
+            what=what,
         )
         return CheckResult(
             passed=not should_fail,

--- a/neurons/validators/tests/test_cached_template_verification.py
+++ b/neurons/validators/tests/test_cached_template_verification.py
@@ -10,6 +10,7 @@ An autouse fixture pins the cutoff to the future by default so the advisory-mode
 are wall-clock-independent; cutoff-enforcement tests opt in with ``_set_cutoff(active=True)``.
 """
 
+import json
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, Mock
 
@@ -53,6 +54,21 @@ def _ssh(exit_status=0, stdout="", raises=False):
         ssh.run = AsyncMock(side_effect=RuntimeError("ssh down"))
     else:
         ssh.run = AsyncMock(return_value=Mock(exit_status=exit_status, stdout=stdout))
+    return ssh
+
+
+def _result(exit_status=0, stdout=""):
+    return Mock(exit_status=exit_status, stdout=stdout)
+
+
+def _ssh_seq(*results):
+    """SSH whose successive ``run`` calls return the given results in order.
+
+    DAH-2470 makes a second call on the failure path (the prefetch-state read), so these
+    tests need to answer the two calls differently. An Exception instance is raised.
+    """
+    ssh = AsyncMock()
+    ssh.run = AsyncMock(side_effect=list(results))
     return ssh
 
 
@@ -432,6 +448,102 @@ async def test_digest_skipped_passes_after_cutoff(context_factory, monkeypatch):
 
     assert result.passed is True
     assert result.event.reason_code == Msg.DIGEST_SKIPPED.reason
+
+
+# --- DAH-2470 prefetch-state passthrough --------------------------------------------------
+#
+# When this check zeroes a node it also carries the executor's own record of what its
+# cache-prefetch loop was doing, so a reader can tell a provider-side cause from ours. The
+# read happens on the failure path only, and can never change the verdict.
+
+_PREFETCH_STATE = json.dumps(
+    {
+        "schema_version": 1,
+        "executor_version": "4.0.3",
+        "sweep_count": 208,
+        "images": {
+            _IMAGE_REF: {
+                "last_outcome": "remote_digest_unreadable",
+                "last_error": "429 Client Error: Too Many Requests",
+                "outcome_counts": {"remote_digest_unreadable": 208},
+            }
+        },
+    }
+)
+
+
+def _failing_ctx(context_factory, monkeypatch, ssh):
+    """Context that lands on DIGEST_MISMATCH after the cutoff — i.e. the node is zeroed."""
+    _set_cutoff(monkeypatch, active=True)
+    return context_factory(
+        services=_services([_IMAGE]),
+        config=_config_with_digests({_IMAGE_REF: _IMAGE_DIGEST}),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=ssh,
+    )
+
+
+@pytest.mark.asyncio
+async def test_prefetch_state_attached_on_failure(context_factory, monkeypatch):
+    ssh = _ssh_seq(_result(stdout=_LOCAL_MISMATCH), _result(stdout=_PREFETCH_STATE))
+    ctx = _failing_ctx(context_factory, monkeypatch, ssh)
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is False
+    state = result.event.what_we_saw["prefetch_state"]
+    assert state["sweep_count"] == 208
+    assert state["images"][_IMAGE_REF]["last_outcome"] == "remote_digest_unreadable"
+    # Read from the executor container, over the connection the check already holds.
+    assert "/var/lib/lium/cache_prefetch_state.json" in ssh.run.await_args.args[0]
+    assert ssh.run.await_args.kwargs["check"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("state_result", "expected"),
+    [
+        (_result(exit_status=1), "missing"),
+        (_result(stdout="   "), "empty"),
+        (_result(stdout="{not json"), "unparseable"),
+        (_result(stdout='"a string, not an object"'), "unparseable"),
+        (_result(stdout="x" * 9000), "oversized"),
+        (RuntimeError("connection closed"), "ssh_read_failed"),
+    ],
+)
+async def test_prefetch_state_absence_is_itself_a_finding(
+    context_factory, monkeypatch, state_result, expected
+):
+    # Each way the read can fall short must be distinguishable: an executor too old to
+    # write the file reads differently from one whose loop crashed.
+    ssh = _ssh_seq(_result(stdout=_LOCAL_MISMATCH), state_result)
+    ctx = _failing_ctx(context_factory, monkeypatch, ssh)
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    # The verdict is decided before the read and is never touched by it.
+    assert result.passed is False
+    assert result.event.reason_code == Msg.DIGEST_MISMATCH.reason
+    assert result.event.what_we_saw["prefetch_state"]["unavailable"] == expected
+
+
+@pytest.mark.asyncio
+async def test_healthy_node_issues_no_extra_ssh_call(context_factory, monkeypatch):
+    # Roughly three quarters of checked nodes pass. None of them may pay for this.
+    _set_cutoff(monkeypatch, active=True)
+    ssh = _ssh_seq(_result(stdout=_LOCAL_MATCH))
+    ctx = context_factory(
+        services=_services([_IMAGE]),
+        config=_config_with_digests({_IMAGE_REF: _IMAGE_DIGEST}),
+        state=build_state(gpu_model=_GPU, specs=_SPECS),
+        ssh=ssh,
+    )
+
+    result = await CachedTemplateVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert ssh.run.await_count == 1
+    assert "prefetch_state" not in result.event.what_we_saw
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Describe your changes

When `executor.validate.cached_template` zeroes a node for a stale or missing default image, the log line does not say **why**. The executor's cache-prefetch loop already narrates every branch it takes — with digests and exception text — but `neurons/executor/src/core/logger.py` attaches only a `StreamHandler`, so that diagnosis is written on the provider's machine and never leaves it. This PR is transport for it, not new logging.

**Executor** — `run_cache_template_prefetch()` records a named outcome for every exit path and publishes `/var/lib/lium/cache_prefetch_state.json` after each sweep. Atomic write, capped at 4 KB, every failure swallowed. No pull decision, interval or retry changes; a failed pull is recorded and then **re-raised**, so the sweep still aborts and backs off exactly as before.

**Validator** — `CachedTemplateVerificationCheck` reads that file and attaches it to the event as `prefetch_state`, so it reaches Loki through the existing `LoggerSink`. Only when `should_fail` is true (roughly 2–6 nodes per cycle against 86–88 checked), so healthy nodes pay neither an SSH round trip nor log volume. The read is wrapped and can never change `passed`.

Worth knowing: **the validator's shell lands inside the executor container**, not on the host — `run.sh` starts sshd there and `docker-compose.app.yml` maps `${SSH_PORT}:22` to it. So this is a plain `cat`. No bind-mount, no compose change, no runner-image change.

### Reading the output

```
last_outcome            = sweep_ok                    <- the loop itself is healthy
images[…].last_outcome  = remote_digest_unreadable    <- this image is stuck
images[…].last_error    = 429 Client Error: Too Many Requests …
images[…].outcome_counts.remote_digest_unreadable = 208
```

That is a provider-side answer. `pull_ok` climbing while `local_digests` never moves would be ours.

A missing or unreadable file reports a distinguishable value — `missing`, `empty`, `unparseable`, `oversized`, `ssh_read_failed` — because absence is itself a finding (executor image too old, loop never started, `COMPUTE_REST_API_URL` unset).

### Notes

- The file is deliberately **not** durable. Watchtower recreates the container and resets the counters, so `started_at` and `sweep_count` are always published and a fresh reset can never be mistaken for a healthy node.
- One outcome beyond the twelve exit paths: `sweep_ok`. Without it a single transient error would pin `last_outcome` to `loop_error` forever, and a reader would chase a problem that had already passed.
- DAH-2461 means the suspected branch (registry digest unreadable → keep the stale copy, never retry) is now reached only when the backend sends no `docker_image_digest`. Still instrumented, and the counters can refute it as well as confirm it.

## Issue ticket number and link

[DAH-2470 — Get every SN51 node to a healthy result on the validator cached-template check](https://app.notion.com/p/Get-every-SN51-node-to-a-healthy-result-on-the-validator-cached-template-check-3a4b8bfdbde9818eae41f7bcb544acfb)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [x] Need to take care of performance?

Executor 50 passed, validator 1138 passed / 4 skipped. `ruff check` and `ruff format` add no new findings (four remain on untouched lines, each verified byte-identical at `main`). Four executor test modules fail to *collect* in my environment on a stale installed `datura` — reproduced on `main`, unrelated to this branch.

Performance: one extra SSH read on the failure path only, and up to ~6 KB added to those events. Healthy nodes are unchanged — asserted by a test.

Also proven end to end locally: the real prefetch loop with the registry lookup forced to 429 wrote the document, and the real check read it back through real shell commands (`docker image inspect` against a local image at a genuinely different digest, then `head -c 8192`), producing `passed=False` with the executor's state in the event.
