### PR TITLE
Propagate pipeline_id / log context through port connectivity probes

### DIFF
--- a/neurons/validators/src/services/executor_connectivity/orchestrator.py
+++ b/neurons/validators/src/services/executor_connectivity/orchestrator.py
@@ -33,7 +33,13 @@ class ConnectivityOrchestrator:
         sysbox_runtime: bool,
         rented_ports: list[int] | None,
         ssh_client,
+        log_ctx: dict | None = None,
     ) -> PortVerificationResult:
+        log_ctx = {
+            **(log_ctx or {}),
+            "executor_uuid": executor_info.uuid,
+            "executor_ip": executor_info.address,
+        }
         rented = set(rented_ports) if rented_ports else set()
         ports = self.port_selector.select(executor_info, BATCH_PORT_VERIFICATION_SIZE, rented)
 
@@ -52,6 +58,7 @@ class ConnectivityOrchestrator:
             ports,
             ssh_client=ssh_client,
             host=executor_info.address,
+            log_ctx=log_ctx,
         )
 
         successful = list(probe_result.successful)
@@ -64,10 +71,7 @@ class ConnectivityOrchestrator:
             host=executor_info.address,
             container_name_prefix=f"container_{miner_hotkey}",
             sysbox_runtime=sysbox_runtime,
-            log_ctx={
-                "executor_uuid": executor_info.uuid,
-                "executor_ip": executor_info.address,
-            },
+            log_ctx=log_ctx,
         )
 
         if dind_result.success:

--- a/neurons/validators/src/services/executor_connectivity/port_probe.py
+++ b/neurons/validators/src/services/executor_connectivity/port_probe.py
@@ -1,5 +1,6 @@
 import logging
 
+from core.utils import _m, get_extra_info
 from services.executor_connectivity.models import PortPair, PortProbeResult
 from services.executor_connectivity.port_verifiers import BatchVerifier, FallbackVerifier
 
@@ -23,20 +24,26 @@ class PortProbe:
         *,
         ssh_client,
         host: str,
+        log_ctx: dict | None = None,
     ) -> PortProbeResult:
+        log_ctx = log_ctx or {}
         successful, failed = await self.batch_verifier.verify(
             ports,
             ssh_client=ssh_client,
             host=host,
+            log_ctx=log_ctx,
         )
 
         if not successful:
-            logger.warning("batch verification failed, trying fallback")
+            logger.warning(
+                _m("batch verification failed, trying fallback", extra=get_extra_info(log_ctx))
+            )
             successful, failed = await self.fallback_verifier.verify(
                 ports,
                 ssh_client=ssh_client,
                 host=host,
                 max_ports=10,
+                log_ctx=log_ctx,
             )
 
         return PortProbeResult(tuple(successful), tuple(failed))

--- a/neurons/validators/src/services/executor_connectivity/port_verifiers.py
+++ b/neurons/validators/src/services/executor_connectivity/port_verifiers.py
@@ -29,7 +29,7 @@ class BatchVerifier:
         log_ctx: dict | None = None,
     ) -> tuple[list[PortPair], list[PortPair]]:
         """Verify ports with retries."""
-        ctx = log_ctx or {}
+        log_ctx = log_ctx or {}
         max_attempts = 2
         timeout_sec = 60
 
@@ -40,31 +40,31 @@ class BatchVerifier:
             logger.info(
                 _m(
                     f"testing {len(ports)} ports (attempt {attempt}/{max_attempts}, timeout={timeout_sec}s)",
-                    extra=get_extra_info(ctx),
+                    extra=get_extra_info(log_ctx),
                 )
             )
 
             try:
                 successful, failed = await asyncio.wait_for(
-                    self._attempt(ports, token, container_name, ssh_client, host, ctx),
+                    self._attempt(ports, token, container_name, ssh_client, host, log_ctx),
                     timeout=timeout_sec
                 )
 
                 if successful:
                     logger.info(
-                        _m(f"complete: {len(successful)}/{len(ports)} verified", extra=get_extra_info(ctx))
+                        _m(f"complete: {len(successful)}/{len(ports)} verified", extra=get_extra_info(log_ctx))
                     )
                     return successful, failed
 
                 if attempt < max_attempts:
                     logger.warning(
-                        _m(f"attempt {attempt} failed, retrying in 2s", extra=get_extra_info(ctx))
+                        _m(f"attempt {attempt} failed, retrying in 2s", extra=get_extra_info(log_ctx))
                     )
                     await asyncio.sleep(2)
 
             except asyncio.TimeoutError:
                 logger.error(
-                    _m(f"attempt {attempt} timed out after {timeout_sec}s", extra=get_extra_info(ctx))
+                    _m(f"attempt {attempt} timed out after {timeout_sec}s", extra=get_extra_info(log_ctx))
                 )
                 await self.runner.cleanup(ssh_client, container_name)
                 if attempt < max_attempts:
@@ -72,14 +72,14 @@ class BatchVerifier:
 
             except Exception as e:
                 logger.error(
-                    _m(f"attempt {attempt} failed: {e}", extra=get_extra_info(ctx)),
+                    _m(f"attempt {attempt} failed: {e}", extra=get_extra_info(log_ctx)),
                     exc_info=True,
                 )
                 await self.runner.cleanup(ssh_client, container_name)
                 if attempt < max_attempts:
                     await asyncio.sleep(2)
 
-        logger.error(_m(f"all {max_attempts} attempts failed", extra=get_extra_info(ctx)))
+        logger.error(_m(f"all {max_attempts} attempts failed", extra=get_extra_info(log_ctx)))
         return [], ports
 
     async def _attempt(
@@ -92,14 +92,14 @@ class BatchVerifier:
         log_ctx: dict | None = None,
     ) -> tuple[list[PortPair], list[PortPair]]:
         """Single verification attempt."""
-        ctx = log_ctx or {}
+        log_ctx = log_ctx or {}
         script = NetcatScript.batch(ports, token, 0)
         start_result = await self.runner.run(ssh_client, name, script, "host", 60)
         if not start_result.ok:
             logger.warning(
                 _m(
                     f"batch start failed: status={start_result.status} logs={start_result.logs}",
-                    extra=get_extra_info(ctx),
+                    extra=get_extra_info(log_ctx),
                 )
             )
             return [], ports
@@ -108,7 +108,7 @@ class BatchVerifier:
             async with aiohttp.ClientSession() as session:
                 successful, failed = await self.port_tester.test_many(session, host, ports, token)
                 logger.info(
-                    _m(f"progress: {len(successful)}/{len(ports)} verified", extra=get_extra_info(ctx))
+                    _m(f"progress: {len(successful)}/{len(ports)} verified", extra=get_extra_info(log_ctx))
                 )
         finally:
             await self.runner.cleanup(ssh_client, name)
@@ -133,10 +133,10 @@ class FallbackVerifier:
         log_ctx: dict | None = None,
     ) -> tuple[list[PortPair], list[PortPair]]:
         """Test ports one by one."""
-        ctx = log_ctx or {}
+        log_ctx = log_ctx or {}
         ports_to_test = ports[:max_ports]
         logger.info(
-            _m(f"fallback: testing {len(ports_to_test)} ports sequentially", extra=get_extra_info(ctx))
+            _m(f"fallback: testing {len(ports_to_test)} ports sequentially", extra=get_extra_info(log_ctx))
         )
 
         successful, failed = [], []
@@ -156,7 +156,7 @@ class FallbackVerifier:
                             _m(
                                 f"fallback: port {port.internal} failed to start: "
                                 f"status={start_result.status} logs={start_result.logs}",
-                                extra=get_extra_info(ctx),
+                                extra=get_extra_info(log_ctx),
                             )
                         )
                         failed.append(port)
@@ -168,7 +168,7 @@ class FallbackVerifier:
                         logger.info(
                             _m(
                                 f"fallback: port {port.internal} ok ({idx}/{len(ports_to_test)})",
-                                extra=get_extra_info(ctx),
+                                extra=get_extra_info(log_ctx),
                             )
                         )
                         successful.append(port)
@@ -179,7 +179,7 @@ class FallbackVerifier:
                     logger.error(
                         _m(
                             f"fallback: error testing port {port.internal}: {str(e)[:100]}",
-                            extra=get_extra_info(ctx),
+                            extra=get_extra_info(log_ctx),
                         )
                     )
                     failed.append(port)
@@ -190,13 +190,13 @@ class FallbackVerifier:
                             await self.runner.cleanup(ssh_client, name)
                         except Exception as e:
                             logger.warning(
-                                _m(f"fallback: cleanup failed: {str(e)[:50]}", extra=get_extra_info(ctx))
+                                _m(f"fallback: cleanup failed: {str(e)[:50]}", extra=get_extra_info(log_ctx))
                             )
 
                     if idx < len(ports_to_test):
                         await asyncio.sleep(0.5)
 
         logger.info(
-            _m(f"fallback: {len(successful)}/{len(ports_to_test)} verified", extra=get_extra_info(ctx))
+            _m(f"fallback: {len(successful)}/{len(ports_to_test)} verified", extra=get_extra_info(log_ctx))
         )
         return successful, failed

--- a/neurons/validators/src/services/executor_connectivity/port_verifiers.py
+++ b/neurons/validators/src/services/executor_connectivity/port_verifiers.py
@@ -4,6 +4,7 @@ import uuid
 
 import aiohttp
 
+from core.utils import _m, get_extra_info
 from services.executor_connectivity.container_runner import ContainerRunner
 from services.executor_connectivity.models import PortPair
 from services.executor_connectivity.netcat_script import NetcatScript
@@ -25,8 +26,10 @@ class BatchVerifier:
         *,
         ssh_client,
         host: str,
+        log_ctx: dict | None = None,
     ) -> tuple[list[PortPair], list[PortPair]]:
         """Verify ports with retries."""
+        ctx = log_ctx or {}
         max_attempts = 2
         timeout_sec = 60
 
@@ -35,40 +38,48 @@ class BatchVerifier:
             container_name = f"port_test_{token[:8]}"
 
             logger.info(
-                "testing %s ports (attempt %s/%s, timeout=%ss)",
-                len(ports),
-                attempt,
-                max_attempts,
-                timeout_sec,
+                _m(
+                    f"testing {len(ports)} ports (attempt {attempt}/{max_attempts}, timeout={timeout_sec}s)",
+                    extra=get_extra_info(ctx),
+                )
             )
 
             try:
                 successful, failed = await asyncio.wait_for(
-                    self._attempt(ports, token, container_name, ssh_client, host),
+                    self._attempt(ports, token, container_name, ssh_client, host, ctx),
                     timeout=timeout_sec
                 )
 
                 if successful:
-                    logger.info("complete: %s/%s verified", len(successful), len(ports))
+                    logger.info(
+                        _m(f"complete: {len(successful)}/{len(ports)} verified", extra=get_extra_info(ctx))
+                    )
                     return successful, failed
 
                 if attempt < max_attempts:
-                    logger.warning("attempt %s failed, retrying in 2s", attempt)
+                    logger.warning(
+                        _m(f"attempt {attempt} failed, retrying in 2s", extra=get_extra_info(ctx))
+                    )
                     await asyncio.sleep(2)
 
             except asyncio.TimeoutError:
-                logger.error("attempt %s timed out after %ss", attempt, timeout_sec)
+                logger.error(
+                    _m(f"attempt {attempt} timed out after {timeout_sec}s", extra=get_extra_info(ctx))
+                )
                 await self.runner.cleanup(ssh_client, container_name)
                 if attempt < max_attempts:
                     await asyncio.sleep(2)
 
             except Exception as e:
-                logger.error("attempt %s failed: %s", attempt, e, exc_info=True)
+                logger.error(
+                    _m(f"attempt {attempt} failed: {e}", extra=get_extra_info(ctx)),
+                    exc_info=True,
+                )
                 await self.runner.cleanup(ssh_client, container_name)
                 if attempt < max_attempts:
                     await asyncio.sleep(2)
 
-        logger.error("all %s attempts failed", max_attempts)
+        logger.error(_m(f"all {max_attempts} attempts failed", extra=get_extra_info(ctx)))
         return [], ports
 
     async def _attempt(
@@ -78,22 +89,27 @@ class BatchVerifier:
         name: str,
         ssh_client,
         host: str,
+        log_ctx: dict | None = None,
     ) -> tuple[list[PortPair], list[PortPair]]:
         """Single verification attempt."""
+        ctx = log_ctx or {}
         script = NetcatScript.batch(ports, token, 0)
         start_result = await self.runner.run(ssh_client, name, script, "host", 60)
         if not start_result.ok:
             logger.warning(
-                "batch start failed: status=%s logs=%s",
-                start_result.status,
-                start_result.logs,
+                _m(
+                    f"batch start failed: status={start_result.status} logs={start_result.logs}",
+                    extra=get_extra_info(ctx),
+                )
             )
             return [], ports
 
         try:
             async with aiohttp.ClientSession() as session:
                 successful, failed = await self.port_tester.test_many(session, host, ports, token)
-                logger.info("progress: %s/%s verified", len(successful), len(ports))
+                logger.info(
+                    _m(f"progress: {len(successful)}/{len(ports)} verified", extra=get_extra_info(ctx))
+                )
         finally:
             await self.runner.cleanup(ssh_client, name)
 
@@ -114,10 +130,14 @@ class FallbackVerifier:
         ssh_client,
         host: str,
         max_ports: int = 10,
+        log_ctx: dict | None = None,
     ) -> tuple[list[PortPair], list[PortPair]]:
         """Test ports one by one."""
+        ctx = log_ctx or {}
         ports_to_test = ports[:max_ports]
-        logger.info("fallback: testing %s ports sequentially", len(ports_to_test))
+        logger.info(
+            _m(f"fallback: testing {len(ports_to_test)} ports sequentially", extra=get_extra_info(ctx))
+        )
 
         successful, failed = [], []
 
@@ -133,10 +153,11 @@ class FallbackVerifier:
                     start_result = await self.runner.run(ssh_client, name, script, network_flag, 10)
                     if not start_result.ok:
                         logger.warning(
-                            "fallback: port %s failed to start: status=%s logs=%s",
-                            port.internal,
-                            start_result.status,
-                            start_result.logs,
+                            _m(
+                                f"fallback: port {port.internal} failed to start: "
+                                f"status={start_result.status} logs={start_result.logs}",
+                                extra=get_extra_info(ctx),
+                            )
                         )
                         failed.append(port)
                         continue
@@ -145,10 +166,10 @@ class FallbackVerifier:
                     await asyncio.sleep(1.0)
                     if await self.port_tester.test_one(session, host, port, token):
                         logger.info(
-                            "fallback: port %s ok (%s/%s)",
-                            port.internal,
-                            idx,
-                            len(ports_to_test),
+                            _m(
+                                f"fallback: port {port.internal} ok ({idx}/{len(ports_to_test)})",
+                                extra=get_extra_info(ctx),
+                            )
                         )
                         successful.append(port)
                     else:
@@ -156,9 +177,10 @@ class FallbackVerifier:
 
                 except Exception as e:
                     logger.error(
-                        "fallback: error testing port %s: %s",
-                        port.internal,
-                        str(e)[:100],
+                        _m(
+                            f"fallback: error testing port {port.internal}: {str(e)[:100]}",
+                            extra=get_extra_info(ctx),
+                        )
                     )
                     failed.append(port)
 
@@ -167,10 +189,14 @@ class FallbackVerifier:
                         try:
                             await self.runner.cleanup(ssh_client, name)
                         except Exception as e:
-                            logger.warning("fallback: cleanup failed: %s", str(e)[:50])
+                            logger.warning(
+                                _m(f"fallback: cleanup failed: {str(e)[:50]}", extra=get_extra_info(ctx))
+                            )
 
                     if idx < len(ports_to_test):
                         await asyncio.sleep(0.5)
 
-        logger.info("fallback: %s/%s verified", len(successful), len(ports_to_test))
+        logger.info(
+            _m(f"fallback: {len(successful)}/{len(ports_to_test)} verified", extra=get_extra_info(ctx))
+        )
         return successful, failed

--- a/neurons/validators/src/services/executor_connectivity/service.py
+++ b/neurons/validators/src/services/executor_connectivity/service.py
@@ -81,8 +81,6 @@ class ExecutorConnectivityService:
                     "verification failed",
                     extra=get_extra_info({
                         **log_ctx,
-                        "executor_uuid": executor_info.uuid,
-                        "executor_ip": executor_info.address,
                         "error": str(e),
                     }),
                 ),

--- a/neurons/validators/src/services/executor_connectivity/service.py
+++ b/neurons/validators/src/services/executor_connectivity/service.py
@@ -31,8 +31,10 @@ class ExecutorConnectivityService:
         sysbox_runtime: bool = False,
         rented_ports: list[int] | None = None,
         rented_pod_names: list[str] | None = None,
+        log_ctx: dict | None = None,
     ) -> PortVerificationResult:
         """Verify executor port connectivity and DinD capability."""
+        log_ctx = log_ctx or {}
         t1 = time.monotonic()
         try:
             # Cleanup removed - test containers are ephemeral and short-lived anyway
@@ -42,6 +44,7 @@ class ExecutorConnectivityService:
                 miner_hotkey=miner_hotkey,
                 sysbox_runtime=sysbox_runtime,
                 rented_ports=rented_ports,
+                log_ctx=log_ctx,
             )
             sysbox_result = verification.sysbox_runtime
             if not sysbox_result and rented_ports and sysbox_runtime:
@@ -49,8 +52,7 @@ class ExecutorConnectivityService:
                     _m(
                         "Sysbox runtime fallback: using known value for rented executor",
                         extra=get_extra_info({
-                            "executor_uuid": executor_info.uuid,
-                            "executor_ip": executor_info.address,
+                            **log_ctx,
                             "miner_hotkey": miner_hotkey,
                             "rented_ports": rented_ports,
                             "verification_sysbox": verification.sysbox_runtime,
@@ -75,9 +77,15 @@ class ExecutorConnectivityService:
             return result
         except Exception as e:
             logger.error(
-                "verification failed: %s executor=%s",
-                str(e),
-                executor_info.address,
+                _m(
+                    "verification failed",
+                    extra=get_extra_info({
+                        **log_ctx,
+                        "executor_uuid": executor_info.uuid,
+                        "executor_ip": executor_info.address,
+                        "error": str(e),
+                    }),
+                ),
                 exc_info=True,
             )
             return PortVerificationResult(

--- a/neurons/validators/src/services/task/checks/port_connectivity.py
+++ b/neurons/validators/src/services/task/checks/port_connectivity.py
@@ -42,6 +42,13 @@ class PortConnectivityCheck:
             ctx.state.sysbox_runtime,
             rented_ports=rented_ports,
             rented_pod_names=rented_pod_names,
+            log_ctx={
+                "pipeline_id": ctx.pipeline_id,
+                "job_batch_id": ctx.config.job_batch_id,
+                "miner_hotkey": ctx.miner_hotkey,
+                "executor_uuid": ctx.executor.uuid,
+                "executor_ip": ctx.executor.address,
+            },
         )
         verified_port_count = len(result.successful_ports)
         extra_info = {

--- a/neurons/validators/tests/test_port_connectivity_check.py
+++ b/neurons/validators/tests/test_port_connectivity_check.py
@@ -60,6 +60,7 @@ class DummyConnectivityService:
         sysbox_runtime: bool,
         rented_ports: list[int] | None = None,
         rented_pod_names: list[str] | None = None,
+        log_ctx: dict | None = None,
     ) -> PortVerificationResult:
         """Mock method that mimics the real connectivity service."""
         # Track what parameters we were called with


### PR DESCRIPTION
## Summary

### Task Link

No Notion task yet (logging-only improvement; branch `fix/connectivity-log-ctx`).

---

## Problem

Logs emitted during executor port-connectivity verification carried no correlation identifiers. Lines like `testing 40 ports (attempt 1/2, timeout=60s)`, `batch verification failed, trying fallback`, or `fallback: port 8003 ok (2/10)` had no `pipeline_id`, `job_batch_id`, `executor_uuid`, `executor_ip`, or `miner_hotkey`, so there was no way to tell which validation pipeline / executor / miner a given line belonged to. Only `dind_probe` received a partial context (`executor_uuid`, `executor_ip`).

## Solution

Thread a `log_ctx` dict from `PortConnectivityCheck` down through the whole probing chain and attach it to every log line via the existing structured-logging helpers (`_m(...)` + `get_extra_info(...)`). The message text stays a compact one-liner; identifiers go into the JSON formatter's structured `extra` field, so log lines are not widened.

## Changes

- `checks/port_connectivity.py`: pass `log_ctx` (`pipeline_id`, `job_batch_id`, `miner_hotkey`, `executor_uuid`, `executor_ip`) into `verify_ports`.
- `executor_connectivity/service.py`: accept `log_ctx`, forward to the orchestrator, use it in the sysbox-fallback log and convert the error log to structured form.
- `executor_connectivity/orchestrator.py`: accept `log_ctx`, enrich once with executor identity, forward to both `port_probe` and `dind_probe` (removes the duplicated inline dict).
- `executor_connectivity/port_probe.py`: accept/forward `log_ctx`; structured fallback warning.
- `executor_connectivity/port_verifiers.py`: `BatchVerifier` / `FallbackVerifier` (and `_attempt`) accept `log_ctx`; all `%`-style logs converted to `_m(..., extra=get_extra_info(...))` with the message text preserved.
- `tests/test_port_connectivity_check.py`: `DummyConnectivityService.verify_ports` gains the `log_ctx` kwarg to match the new signature.

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review

## Other PRs

None.

## Risks

- Logging-only change; no behavior or control-flow change. All new `log_ctx` parameters are optional (default `None`), so existing callers and tests are unaffected.
- Log messages moved from `%`-style args to f-strings inside `_m(...)`; the visible text is unchanged, but records now carry a structured `extra` object.

## Test Cases

### Test Case 1 — module + check unit tests

**Actions:** `pdm run pytest tests/executor_connectivity/ tests/test_port_connectivity_check.py tests/test_pipeline_default_scenarios.py`

**Expected Output:** all green (27 passed).

### Test Case 2 — full validator suite

**Actions:** `pdm run pytest`

**Expected Output:** 1136 passed, 8 skipped. The 3 `test_sshd_bootstrap_script.py` failures are pre-existing on `main` and unrelated to this change (sshd bootstrap shell-script env test; not touched by this PR).

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
