### PR TITLE
fix(validator): SemiBatchVerifier tier so firewalled nodes verify up to 50 ports

### DIFF
--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -20,7 +20,7 @@ from services.executor_connectivity.orchestrator import ConnectivityOrchestrator
 from services.executor_connectivity.port_probe import PortProbe
 from services.executor_connectivity.port_selector import PortSelector
 from services.executor_connectivity.port_tester import PortTester
-from services.executor_connectivity.port_verifiers import BatchVerifier, FallbackVerifier
+from services.executor_connectivity.port_verifiers import BatchVerifier, FallbackVerifier, SemiBatchVerifier
 from services.executor_connectivity_service import ExecutorConnectivityService
 from services.file_encrypt_service import FileEncryptService
 from services.matrix_validation_service import ValidationService
@@ -81,6 +81,7 @@ class Validator:
                 PortSelector(),
                 PortProbe(
                     BatchVerifier(port_tester, runner),
+                    SemiBatchVerifier(port_tester, runner),
                     FallbackVerifier(port_tester, runner),
                 ),
                 DindProbe(DindVerifier(ssh_service)),

--- a/neurons/validators/src/services/executor_connectivity/port_probe.py
+++ b/neurons/validators/src/services/executor_connectivity/port_probe.py
@@ -2,7 +2,7 @@ import logging
 
 from core.utils import _m, get_extra_info
 from services.executor_connectivity.models import PortPair, PortProbeResult
-from services.executor_connectivity.port_verifiers import BatchVerifier, FallbackVerifier
+from services.executor_connectivity.port_verifiers import BatchVerifier, FallbackVerifier, SemiBatchVerifier
 
 logger = logging.getLogger(__name__)
 
@@ -13,9 +13,11 @@ class PortProbe:
     def __init__(
         self,
         batch_verifier: BatchVerifier,
+        semi_batch_verifier: SemiBatchVerifier,
         fallback_verifier: FallbackVerifier,
     ):
         self.batch_verifier = batch_verifier
+        self.semi_batch_verifier = semi_batch_verifier
         self.fallback_verifier = fallback_verifier
 
     async def probe(
@@ -36,7 +38,19 @@ class PortProbe:
 
         if not successful:
             logger.warning(
-                _m("batch verification failed, trying fallback", extra=get_extra_info(log_ctx))
+                _m("batch verification failed, trying semi-batch", extra=get_extra_info(log_ctx))
+            )
+            successful, failed = await self.semi_batch_verifier.verify(
+                ports,
+                ssh_client=ssh_client,
+                host=host,
+                max_ports=50,
+                log_ctx=log_ctx,
+            )
+
+        if not successful:
+            logger.warning(
+                _m("semi-batch verification failed, trying fallback", extra=get_extra_info(log_ctx))
             )
             successful, failed = await self.fallback_verifier.verify(
                 ports,

--- a/neurons/validators/src/services/executor_connectivity/port_verifiers.py
+++ b/neurons/validators/src/services/executor_connectivity/port_verifiers.py
@@ -3,6 +3,7 @@ import logging
 import uuid
 
 import aiohttp
+from asyncssh import SSHClientConnection
 
 from core.utils import _m, get_extra_info
 from services.executor_connectivity.container_runner import ContainerRunner
@@ -219,7 +220,7 @@ class SemiBatchVerifier:
         self,
         ports: list[PortPair],
         *,
-        ssh_client,
+        ssh_client: SSHClientConnection,
         host: str,
         max_ports: int = 50,
         log_ctx: dict | None = None,
@@ -240,23 +241,41 @@ class SemiBatchVerifier:
             )
         )
 
-        # short self-kill window: a missed cleanup would otherwise hold every published
-        # port (and its docker-proxy) against the next cycle's verification
-        start_result = await self.runner.run(ssh_client, container_name, script, publish_flags, 20)
-        if not start_result.ok:
-            logger.warning(
-                _m(
-                    f"semi-batch start failed: status={start_result.status} logs={start_result.logs}",
-                    extra=get_extra_info(log_ctx),
+        # any error below must not escape: an exception here would zero the whole
+        # verification (fatal PortCountCheck) instead of falling through to the
+        # sequential fallback tier
+        started = False
+        try:
+            # short self-kill window: a missed cleanup would otherwise hold every published
+            # port (and its docker-proxy) against the next cycle's verification
+            start_result = await self.runner.run(ssh_client, container_name, script, publish_flags, 20)
+            if not start_result.ok:
+                logger.warning(
+                    _m(
+                        f"semi-batch start failed: status={start_result.status} logs={start_result.logs}",
+                        extra=get_extra_info(log_ctx),
+                    )
                 )
+                return [], ports_to_test
+
+            started = True
+            async with aiohttp.ClientSession() as session:
+                successful, failed = await self.port_tester.test_many(session, host, ports_to_test, token)
+
+        except Exception as e:
+            logger.error(
+                _m(f"semi-batch: error: {str(e)[:100]}", extra=get_extra_info(log_ctx))
             )
             return [], ports_to_test
 
-        try:
-            async with aiohttp.ClientSession() as session:
-                successful, failed = await self.port_tester.test_many(session, host, ports_to_test, token)
         finally:
-            await self.runner.cleanup(ssh_client, container_name)
+            if started:
+                try:
+                    await self.runner.cleanup(ssh_client, container_name)
+                except Exception as e:
+                    logger.warning(
+                        _m(f"semi-batch: cleanup failed: {str(e)[:50]}", extra=get_extra_info(log_ctx))
+                    )
 
         logger.info(
             _m(f"semi-batch: {len(successful)}/{len(ports_to_test)} verified", extra=get_extra_info(log_ctx))

--- a/neurons/validators/src/services/executor_connectivity/port_verifiers.py
+++ b/neurons/validators/src/services/executor_connectivity/port_verifiers.py
@@ -200,3 +200,65 @@ class FallbackVerifier:
             _m(f"fallback: {len(successful)}/{len(ports_to_test)} verified", extra=get_extra_info(log_ctx))
         )
         return successful, failed
+
+
+class SemiBatchVerifier:
+    """Verifies ports by publishing a whole batch in ONE container via -p.
+
+    Middle tier of the cascade: published ports are reached through the nat/DOCKER
+    DNAT chain, so they survive a ufw default-deny INPUT policy — the same policy
+    that silently drops BatchVerifier's --network=host listeners. Returns nothing
+    verified if the container cannot start, letting the caller fall through.
+    """
+
+    def __init__(self, port_tester: PortTester, runner: ContainerRunner):
+        self.port_tester = port_tester
+        self.runner = runner
+
+    async def verify(
+        self,
+        ports: list[PortPair],
+        *,
+        ssh_client,
+        host: str,
+        max_ports: int = 50,
+        log_ctx: dict | None = None,
+    ) -> tuple[list[PortPair], list[PortPair]]:
+        """Publish up to max_ports in one container, then probe them concurrently."""
+        log_ctx = log_ctx or {}
+        ports_to_test = ports[:max_ports]
+        token = uuid.uuid4().hex
+        container_name = f"port_test_pub_{token[:8]}"
+        script = NetcatScript.batch(ports_to_test, token, 0)
+        # external differs from internal when the miner advertises port_mappings
+        publish_flags = " ".join(f"-p {port.external}:{port.internal}" for port in ports_to_test)
+
+        logger.info(
+            _m(
+                f"semi-batch: publishing {len(ports_to_test)} ports in one container",
+                extra=get_extra_info(log_ctx),
+            )
+        )
+
+        # short self-kill window: a missed cleanup would otherwise hold every published
+        # port (and its docker-proxy) against the next cycle's verification
+        start_result = await self.runner.run(ssh_client, container_name, script, publish_flags, 20)
+        if not start_result.ok:
+            logger.warning(
+                _m(
+                    f"semi-batch start failed: status={start_result.status} logs={start_result.logs}",
+                    extra=get_extra_info(log_ctx),
+                )
+            )
+            return [], ports_to_test
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                successful, failed = await self.port_tester.test_many(session, host, ports_to_test, token)
+        finally:
+            await self.runner.cleanup(ssh_client, container_name)
+
+        logger.info(
+            _m(f"semi-batch: {len(successful)}/{len(ports_to_test)} verified", extra=get_extra_info(log_ctx))
+        )
+        return successful, failed

--- a/neurons/validators/src/services/ioc.py
+++ b/neurons/validators/src/services/ioc.py
@@ -9,7 +9,7 @@ from services.executor_connectivity.dind_probe import DindProbe, DindVerifier
 from services.executor_connectivity.port_probe import PortProbe
 from services.executor_connectivity.port_selector import PortSelector
 from services.executor_connectivity.port_tester import PortTester
-from services.executor_connectivity.port_verifiers import BatchVerifier, FallbackVerifier
+from services.executor_connectivity.port_verifiers import BatchVerifier, FallbackVerifier, SemiBatchVerifier
 from services.executor_connectivity.orchestrator import ConnectivityOrchestrator
 from services.executor_connectivity_service import ExecutorConnectivityService
 from services.file_encrypt_service import FileEncryptService
@@ -48,6 +48,7 @@ async def initiate_services():
             PortSelector(),
             PortProbe(
                 BatchVerifier(port_tester, runner),
+                SemiBatchVerifier(port_tester, runner),
                 FallbackVerifier(port_tester, runner),
             ),
             DindProbe(DindVerifier(ioc["SSHService"])),

--- a/neurons/validators/tests/executor_connectivity/test_port_probe.py
+++ b/neurons/validators/tests/executor_connectivity/test_port_probe.py
@@ -10,35 +10,61 @@ async def test_port_probe_uses_batch_when_successful(mocker):
 
     batch = mocker.Mock()
     batch.verify = mocker.AsyncMock(return_value=(ports, []))
-
+    semi = mocker.Mock()
+    semi.verify = mocker.AsyncMock()
     fallback = mocker.Mock()
     fallback.verify = mocker.AsyncMock()
 
-    probe = PortProbe(batch, fallback)
+    probe = PortProbe(batch, semi, fallback)
 
     result = await probe.probe(ports, ssh_client=mocker.Mock(), host="127.0.0.1")
 
     assert list(result.successful) == ports
     assert list(result.failed) == []
     batch.verify.assert_called_once()
+    semi.verify.assert_not_called()
     fallback.verify.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_port_probe_uses_fallback_on_empty_success(mocker):
+async def test_port_probe_uses_semi_batch_when_batch_empty(mocker):
     ports = [PortPair(9000, 9000), PortPair(9001, 9001)]
 
     batch = mocker.Mock()
     batch.verify = mocker.AsyncMock(return_value=([], ports))
+    semi = mocker.Mock()
+    semi.verify = mocker.AsyncMock(return_value=(ports, []))
+    fallback = mocker.Mock()
+    fallback.verify = mocker.AsyncMock()
 
+    probe = PortProbe(batch, semi, fallback)
+
+    result = await probe.probe(ports, ssh_client=mocker.Mock(), host="127.0.0.1")
+
+    assert list(result.successful) == ports
+    assert list(result.failed) == []
+    batch.verify.assert_called_once()
+    semi.verify.assert_called_once()
+    fallback.verify.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_port_probe_falls_through_to_fallback_when_batch_and_semi_empty(mocker):
+    ports = [PortPair(9000, 9000), PortPair(9001, 9001)]
+
+    batch = mocker.Mock()
+    batch.verify = mocker.AsyncMock(return_value=([], ports))
+    semi = mocker.Mock()
+    semi.verify = mocker.AsyncMock(return_value=([], ports))
     fallback = mocker.Mock()
     fallback.verify = mocker.AsyncMock(return_value=(ports[:1], ports[1:]))
 
-    probe = PortProbe(batch, fallback)
+    probe = PortProbe(batch, semi, fallback)
 
     result = await probe.probe(ports, ssh_client=mocker.Mock(), host="127.0.0.1")
 
     assert list(result.successful) == ports[:1]
     assert list(result.failed) == ports[1:]
     batch.verify.assert_called_once()
+    semi.verify.assert_called_once()
     fallback.verify.assert_called_once()

--- a/neurons/validators/tests/executor_connectivity/test_port_verifiers.py
+++ b/neurons/validators/tests/executor_connectivity/test_port_verifiers.py
@@ -1,0 +1,94 @@
+import pytest
+
+from services.executor_connectivity.models import ContainerStartResult, PortPair
+from services.executor_connectivity.port_verifiers import SemiBatchVerifier
+
+
+CONTAINER_STARTED = ContainerStartResult(ok=True, container_id="c", status="Up")
+CONTAINER_START_FAILED = ContainerStartResult(
+    ok=False, container_id=None, status="port is already allocated"
+)
+
+
+@pytest.mark.asyncio
+async def test_semi_batch_publishes_all_ports_in_one_container(mocker):
+    ports = [PortPair(9000, 9000), PortPair(9001, 9001), PortPair(9002, 9002)]
+
+    runner = mocker.Mock()
+    runner.run = mocker.AsyncMock(return_value=CONTAINER_STARTED)
+    runner.cleanup = mocker.AsyncMock()
+
+    port_tester = mocker.Mock()
+    port_tester.test_many = mocker.AsyncMock(return_value=(ports, []))
+
+    verifier = SemiBatchVerifier(port_tester, runner)
+
+    successful, failed = await verifier.verify(ports, ssh_client=mocker.Mock(), host="1.2.3.4")
+
+    assert successful == ports
+    assert failed == []
+    runner.run.assert_called_once()
+    runner.cleanup.assert_called_once()
+    publish_flags = runner.run.call_args.args[3]
+    assert publish_flags == "-p 9000:9000 -p 9001:9001 -p 9002:9002"
+    port_tester.test_many.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_semi_batch_maps_external_to_internal(mocker):
+    ports = [PortPair(22, 40009), PortPair(8000, 40010)]
+
+    runner = mocker.Mock()
+    runner.run = mocker.AsyncMock(return_value=CONTAINER_STARTED)
+    runner.cleanup = mocker.AsyncMock()
+
+    port_tester = mocker.Mock()
+    port_tester.test_many = mocker.AsyncMock(return_value=(ports, []))
+
+    verifier = SemiBatchVerifier(port_tester, runner)
+
+    await verifier.verify(ports, ssh_client=mocker.Mock(), host="1.2.3.4")
+
+    publish_flags = runner.run.call_args.args[3]
+    assert publish_flags == "-p 40009:22 -p 40010:8000"
+
+
+@pytest.mark.asyncio
+async def test_semi_batch_caps_at_max_ports(mocker):
+    ports = [PortPair(9000 + i, 9000 + i) for i in range(80)]
+
+    runner = mocker.Mock()
+    runner.run = mocker.AsyncMock(return_value=CONTAINER_STARTED)
+    runner.cleanup = mocker.AsyncMock()
+
+    port_tester = mocker.Mock()
+    port_tester.test_many = mocker.AsyncMock(side_effect=lambda session, host, tested, token: (tested, []))
+
+    verifier = SemiBatchVerifier(port_tester, runner)
+
+    successful, _ = await verifier.verify(ports, ssh_client=mocker.Mock(), host="1.2.3.4", max_ports=50)
+
+    assert len(successful) == 50
+    tested_ports = port_tester.test_many.call_args.args[2]
+    assert len(tested_ports) == 50
+
+
+@pytest.mark.asyncio
+async def test_semi_batch_returns_empty_when_container_cannot_start(mocker):
+    ports = [PortPair(9000, 9000), PortPair(9001, 9001)]
+
+    runner = mocker.Mock()
+    runner.run = mocker.AsyncMock(return_value=CONTAINER_START_FAILED)
+    runner.cleanup = mocker.AsyncMock()
+
+    port_tester = mocker.Mock()
+    port_tester.test_many = mocker.AsyncMock()
+
+    verifier = SemiBatchVerifier(port_tester, runner)
+
+    successful, failed = await verifier.verify(ports, ssh_client=mocker.Mock(), host="1.2.3.4")
+
+    assert successful == []
+    assert failed == ports
+    port_tester.test_many.assert_not_called()
+    runner.cleanup.assert_not_called()

--- a/neurons/validators/tests/executor_connectivity/test_port_verifiers.py
+++ b/neurons/validators/tests/executor_connectivity/test_port_verifiers.py
@@ -92,3 +92,63 @@ async def test_semi_batch_returns_empty_when_container_cannot_start(mocker):
     assert failed == ports
     port_tester.test_many.assert_not_called()
     runner.cleanup.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_semi_batch_returns_empty_when_run_raises(mocker):
+    ports = [PortPair(9000, 9000), PortPair(9001, 9001)]
+
+    runner = mocker.Mock()
+    runner.run = mocker.AsyncMock(side_effect=ConnectionError("ssh channel closed"))
+    runner.cleanup = mocker.AsyncMock()
+
+    port_tester = mocker.Mock()
+    port_tester.test_many = mocker.AsyncMock()
+
+    verifier = SemiBatchVerifier(port_tester, runner)
+
+    successful, failed = await verifier.verify(ports, ssh_client=mocker.Mock(), host="1.2.3.4")
+
+    assert successful == []
+    assert failed == ports
+    port_tester.test_many.assert_not_called()
+    runner.cleanup.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_semi_batch_returns_empty_when_test_many_raises(mocker):
+    ports = [PortPair(9000, 9000), PortPair(9001, 9001)]
+
+    runner = mocker.Mock()
+    runner.run = mocker.AsyncMock(return_value=CONTAINER_STARTED)
+    runner.cleanup = mocker.AsyncMock()
+
+    port_tester = mocker.Mock()
+    port_tester.test_many = mocker.AsyncMock(side_effect=RuntimeError("probe blew up"))
+
+    verifier = SemiBatchVerifier(port_tester, runner)
+
+    successful, failed = await verifier.verify(ports, ssh_client=mocker.Mock(), host="1.2.3.4")
+
+    assert successful == []
+    assert failed == ports
+    runner.cleanup.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_semi_batch_survives_cleanup_failure(mocker):
+    ports = [PortPair(9000, 9000), PortPair(9001, 9001)]
+
+    runner = mocker.Mock()
+    runner.run = mocker.AsyncMock(return_value=CONTAINER_STARTED)
+    runner.cleanup = mocker.AsyncMock(side_effect=ConnectionError("ssh dropped"))
+
+    port_tester = mocker.Mock()
+    port_tester.test_many = mocker.AsyncMock(return_value=(ports, []))
+
+    verifier = SemiBatchVerifier(port_tester, runner)
+
+    successful, failed = await verifier.verify(ports, ssh_client=mocker.Mock(), host="1.2.3.4")
+
+    assert successful == ports
+    assert failed == []


### PR DESCRIPTION
## Problem

The validator's port-connectivity check under-counts verified ports on any executor host running `ufw` with a default-deny inbound policy (only SSH allowed) — standard host hardening. `verified_ports` directly caps how many renter/filler containers the platform places on the node, so these hosts get throttled far below their hardware (and DPHN filler splitting suffers).

Mechanism (reproduced live on a prod executor, subnet `13567ffb-c410-4edc-b09f-0e47c0363bac`):
- The **batch** verifier uses `--network=host`; its netcat listeners bind directly on host ports and inbound traffic to them traverses the INPUT chain → **ufw drops it** → `0/N` verified.
- After 2 attempts it fell back to a **sequential verifier that publishes with `-p` (bypasses ufw via nat/DOCKER DNAT, so it works) but tested only the first 10 ports**.
- Net: firewalled nodes cap at ≤10 verified ports regardless of how many they actually opened.

Repro on such a host: an external TCP connect to a `--network=host`-bound port times out (dropped by ufw INPUT), while a `-p`-published port connects fine. Default docker runtime is plain `runc` (not sysbox) — ufw is the blocker.

## Fix

Add a new **`SemiBatchVerifier`** tier between `BatchVerifier` (`--network=host`) and the existing `FallbackVerifier` (sequential, one container per port). `PortProbe` now cascades **batch → semi-batch(50) → fallback(10)**, each tier falling through to the next when it verifies nothing.

`SemiBatchVerifier` publishes up to 50 ports in ONE container via `-p external:internal` and reuses the existing batch netcat script + concurrent `test_many`. Published ports reach their listeners through the nat/DOCKER DNAT chain — the same path renter pods use — so they bypass ufw's default-deny INPUT. One container + concurrent probes keeps it fast. If the publish container cannot start (e.g. a candidate port is already held by a live container — rare, since `PortSelector` already excludes rented ports), it verifies nothing and the cascade falls through to the existing sequential fallback.

Existing `BatchVerifier` and `FallbackVerifier` are left untouched; the change is additive.

- `port_verifiers.py`: new `SemiBatchVerifier` class
- `port_probe.py`: middle cascade tier + constructor param
- `ioc.py`, `core/validator.py`: wire the new tier into both DI paths
- `test_port_verifiers.py` (SemiBatchVerifier: single-container publish, external→internal mapping, cap at 50, empty-on-start-failure), `test_port_probe.py` (3-tier cascade)

## Testing

`pytest tests/executor_connectivity/ tests/test_port_connectivity_check.py` → 30 passed. Full validator suite otherwise green except pre-existing/unrelated failures (`test_sshd_bootstrap_script` timing, `test_port_mapping_dao` DB-fixture errors) that do not touch these modules.

**Verified end-to-end on staging** (full detail in the comment below). Stand: staging executor `02fdbaf8-2598-40c5-9597-23843ec7bab7` with 200 declared ports and `ufw` default-deny — a copy of the prod node above. Deployed this branch to the staging validator and compared against the previous build:

| metric | before | after |
| --- | --- | --- |
| `verified_ports` | **10** | **50** |
| verification wall clock | 55.2s | 24.4s |
| control nodes (no ufw) | 299 / 9 | 299 / 9 — unchanged |

Healthy nodes never reach the new tier. The firewalled node also gets *faster*: 50 ports probed concurrently in 4.7s vs ~20s for 10 sequential.

## Notes

- #1158 (log-context threading over the same files) is merged; this branch was rebased onto `main` and retargeted.
- Not addressed here (kept the existing class untouched): `FallbackVerifier` still publishes `-p internal:internal`, which is wrong for `port_mappings` miners where external != internal. It is now only the last-resort 3rd tier; `SemiBatchVerifier` uses the correct `-p external:internal`. Worth a separate follow-up.

