### PR TITLE
fix(validator): give Docker SDK its own thread pool so a create wave cannot starve DNS

### DIFF
--- a/neurons/validators/src/connector.py
+++ b/neurons/validators/src/connector.py
@@ -4,7 +4,7 @@ import time
 from clients.compute_client import ComputeClient
 
 from core.config import settings
-from core.utils import get_logger, wait_for_services_sync
+from core.utils import get_logger, wait_for_services_sync, widen_default_thread_pool
 from services.ioc import initiate_services, ioc
 
 logger = get_logger(__name__)
@@ -27,6 +27,7 @@ def start_process():
         try:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
+            widen_default_thread_pool(loop)
             loop.run_until_complete(run_forever())
         except Exception as e:
             logger.error(f"Compute app connector crashed: {e}", exc_info=True)

--- a/neurons/validators/src/core/utils.py
+++ b/neurons/validators/src/core/utils.py
@@ -2,6 +2,7 @@ import asyncio
 import contextvars
 import json
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from logging.config import dictConfig  # noqa
 from tenacity import retry, stop_after_attempt, wait_fixed
 import asyncssh
@@ -65,6 +66,16 @@ class JSONFormatter(logging.Formatter):
 
 
 logger = logging.getLogger(__name__)
+
+
+def widen_default_thread_pool(loop: asyncio.AbstractEventLoop) -> None:
+    # asyncio sizes its default executor from os.cpu_count(), which in a container reports the node's
+    # cores and ignores the cgroup limit — 8 threads here. DNS resolution and the blocking bittensor
+    # SDK calls share that pool, so it needs headroom. Docker SDK calls have their own pool, see
+    # services/rental_docker_sdk.py.
+    loop.set_default_executor(
+        ThreadPoolExecutor(max_workers=32, thread_name_prefix="asyncio-default")
+    )
 
 
 def wait_for_services_sync(timeout=30):

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -6,8 +6,10 @@ import socket as socket_module
 import tempfile
 import threading
 from collections.abc import AsyncIterator, Callable
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field
+from functools import partial
 from pathlib import Path
 
 from core.utils import _m, get_extra_info
@@ -19,7 +21,22 @@ _DOCKER_EXEC_READY_TIMEOUT_SECONDS = 15
 _DOCKER_EXEC_READY_POLL_INTERVAL_SECONDS = 0.5
 _DOCKER_EXEC_TRANSIENT_RETRY_DELAYS_SECONDS = (1, 2, 4, 8)
 _DOCKER_SDK_SSH_ADAPTER_LOCK = threading.Lock()
+# DAH-2475: the Docker SDK is synchronous, so every call below has to run in a thread. It must not be
+# the event loop's default executor: asyncio resolves DNS there too (loop.getaddrinfo runs in it), and
+# a wave of filler creates fills that pool with minutes-long pulls. Name resolution then queues behind
+# them and every new Redis/WebSocket connection times out before it ever reaches the socket. A thread
+# pool is FIFO, so a bigger default pool does not help — the queue has to be a separate one.
+_DOCKER_EXECUTOR_MAX_WORKERS = 32
+_DOCKER_EXECUTOR = ThreadPoolExecutor(
+    max_workers=_DOCKER_EXECUTOR_MAX_WORKERS, thread_name_prefix="docker-sdk"
+)
 logger = logging.getLogger(__name__)
+
+
+async def _in_docker_thread(func: Callable, /, *args, **kwargs):
+    # runs a blocking Docker SDK call in the dedicated pool instead of the loop's default executor
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_DOCKER_EXECUTOR, partial(func, *args, **kwargs))
 
 
 class RentalDockerConnectionError(RuntimeError):
@@ -141,7 +158,7 @@ class RentalDockerSdkClient:
     async def pull(self, *, image: str) -> None:
         timeout_seconds = self._normalized_pull_timeout_seconds()
         try:
-            pull_call = asyncio.to_thread(self._pull_sync, image)
+            pull_call = _in_docker_thread(self._pull_sync, image)
             if timeout_seconds is not None:
                 await asyncio.wait_for(
                     pull_call,
@@ -162,7 +179,7 @@ class RentalDockerSdkClient:
 
     async def image_exists(self, *, image: str) -> bool:
         try:
-            await asyncio.to_thread(self._api_client.inspect_image, image)
+            await _in_docker_thread(self._api_client.inspect_image, image)
         except Exception as exc:
             if _is_docker_not_found_error(exc):
                 return False
@@ -173,7 +190,7 @@ class RentalDockerSdkClient:
 
     async def run_container(self, spec: ContainerRunSpec) -> None:
         try:
-            await asyncio.to_thread(self._run_container_sync, spec)
+            await _in_docker_thread(self._run_container_sync, spec)
         except Exception as exc:
             raise RentalDockerOperationError(
                 _wrap_error_message("Docker SDK run container failed", exc)
@@ -189,7 +206,7 @@ class RentalDockerSdkClient:
             # for the remaining inspect-vs-exec race.
             await self._wait_for_container_exec_ready(spec.container_name)
             try:
-                result = await asyncio.to_thread(self._exec_in_container_sync, spec)
+                result = await _in_docker_thread(self._exec_in_container_sync, spec)
             except Exception as exc:
                 if not _is_docker_container_restarting_error(exc):
                     raise RentalDockerOperationError(
@@ -271,7 +288,7 @@ class RentalDockerSdkClient:
         timeout: int | None = None,
     ) -> None:
         try:
-            await asyncio.to_thread(
+            await _in_docker_thread(
                 self._create_volume_sync,
                 volume_name=volume_name,
                 driver=driver,
@@ -300,11 +317,11 @@ class RentalDockerSdkClient:
     async def aclose(self) -> None:
         close = getattr(self._api_client, "close", None)
         if close is not None:
-            await asyncio.to_thread(close)
+            await _in_docker_thread(close)
 
     async def _call_api(self, *args, operation_label: str, api_method, **kwargs) -> None:
         try:
-            await asyncio.to_thread(api_method, *args, **kwargs)
+            await _in_docker_thread(api_method, *args, **kwargs)
         except Exception as exc:
             raise RentalDockerOperationError(
                 _wrap_error_message(f"Docker SDK {operation_label} failed", exc)
@@ -322,7 +339,7 @@ class RentalDockerSdkClient:
         loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout_seconds
         while True:
-            readiness = await asyncio.to_thread(
+            readiness = await _in_docker_thread(
                 self._inspect_container_exec_readiness,
                 container_name,
             )
@@ -514,7 +531,7 @@ class RentalDockerSdkClientFactory:
             _validate_paramiko_known_hosts(known_hosts_path)
 
             try:
-                api_client = await asyncio.to_thread(
+                api_client = await _in_docker_thread(
                     self._create_api_client,
                     _build_docker_ssh_base_url(executor_info),
                     key_path,

--- a/neurons/validators/src/validator.py
+++ b/neurons/validators/src/validator.py
@@ -5,7 +5,11 @@ import uvicorn
 from fastapi import FastAPI
 
 from core.config import settings
-from core.utils import configure_logs_of_other_modules, wait_for_services_sync
+from core.utils import (
+    configure_logs_of_other_modules,
+    wait_for_services_sync,
+    widen_default_thread_pool,
+)
 from core.validator import Validator
 
 configure_logs_of_other_modules()
@@ -13,6 +17,7 @@ wait_for_services_sync()
 
 
 async def app_lifespan(app: FastAPI):
+    widen_default_thread_pool(asyncio.get_running_loop())
     validator = Validator()
     # Run the miner in the background
     task = asyncio.create_task(validator.start())

--- a/neurons/validators/tests/test_docker_thread_pool.py
+++ b/neurons/validators/tests/test_docker_thread_pool.py
@@ -1,0 +1,88 @@
+"""Tests for the dedicated Docker SDK thread pool (DAH-2475 follow-up).
+
+Blocking Docker SDK calls used to run in the event loop's default executor. asyncio resolves DNS
+in that same pool (`loop.getaddrinfo` -> `run_in_executor`), so a wave of filler creates filled it
+with minutes-long pulls and name resolution queued behind them: every new Redis connection and the
+backend WebSocket handshake timed out before reaching a socket. A thread pool is FIFO, so a wider
+default pool does not fix this — the Docker calls need a queue of their own.
+"""
+
+import asyncio
+import threading
+from pathlib import Path
+
+import pytest
+from neurons.validators.src.core.utils import widen_default_thread_pool
+from neurons.validators.src.services import rental_docker_sdk
+from neurons.validators.src.services.rental_docker_sdk import (
+    _DOCKER_EXECUTOR_MAX_WORKERS,
+    _in_docker_thread,
+)
+
+
+def _current_thread_name() -> str:
+    return threading.current_thread().name
+
+
+@pytest.mark.asyncio
+async def test_docker_calls_run_in_the_dedicated_pool() -> None:
+    thread_name = await _in_docker_thread(_current_thread_name)
+
+    assert thread_name.startswith("docker-sdk")
+
+
+@pytest.mark.asyncio
+async def test_docker_calls_forward_keyword_arguments() -> None:
+    # create_volume() and friends pass their arguments by keyword.
+    result = await _in_docker_thread(dict, name="volume", driver="local")
+
+    assert result == {"name": "volume", "driver": "local"}
+
+
+@pytest.mark.asyncio
+async def test_default_pool_still_runs_while_every_docker_thread_is_busy() -> None:
+    # The regression itself: with a shared pool, the call below queues behind the busy Docker
+    # threads — that is how a create wave starved getaddrinfo and timed out every new connection.
+    loop = asyncio.get_running_loop()
+    entered = threading.Semaphore(0)
+    release = threading.Event()
+
+    def _occupy_thread() -> None:
+        entered.release()
+        release.wait()
+
+    busy = [asyncio.create_task(_in_docker_thread(_occupy_thread)) for _ in range(64)]
+    try:
+        deadline = loop.time() + 5
+        saturated = 0
+        while saturated < _DOCKER_EXECUTOR_MAX_WORKERS and loop.time() < deadline:
+            if entered.acquire(blocking=False):
+                saturated += 1
+            else:
+                await asyncio.sleep(0.01)
+        assert saturated == _DOCKER_EXECUTOR_MAX_WORKERS, "Docker pool never filled up, test proves nothing"
+
+        thread_name = await asyncio.wait_for(
+            loop.run_in_executor(None, _current_thread_name), timeout=5
+        )
+        assert not thread_name.startswith("docker-sdk")
+    finally:
+        release.set()
+        await asyncio.gather(*busy)
+
+
+def test_docker_sdk_module_does_not_use_the_default_executor() -> None:
+    # asyncio.to_thread() always targets the default executor, so it must not come back here.
+    source = Path(rental_docker_sdk.__file__).read_text()
+
+    assert "asyncio.to_thread" not in source
+
+
+@pytest.mark.asyncio
+async def test_widen_default_thread_pool_replaces_the_default_executor() -> None:
+    loop = asyncio.get_running_loop()
+
+    widen_default_thread_pool(loop)
+
+    thread_name = await loop.run_in_executor(None, _current_thread_name)
+    assert thread_name.startswith("asyncio-default")


### PR DESCRIPTION
## Why

On 2026-07-23 12:00–12:06 UTC a filler wave (165 `create_container` in one minute against a
5–48 background) knocked out three things at once on prod:

- 42 Redis errors on the validator, all `workload_kind=FILLER`, all on `finalize`
- the backend WebSocket could not be opened: `timed out during opening handshake`, reconnects
  backing off 2.4s → 55.6s
- 23 × `No validator consumer available` on the backend, each rental answered with a 400

Redis was not the problem. It sat at 23m CPU, ~5 ops/sec, `rejected_connections=0`, 3.7 MB of data,
with its replica connected for 43 days straight. CoreDNS was clean too — no errors for two hours,
no restarts in 76 days.

The stack trace points somewhere else entirely:

```
File "asyncio/base_events.py", line 868, in getaddrinfo
    return await self.run_in_executor(   ← DNS runs in the default executor
asyncio.exceptions.CancelledError
```

`getaddrinfo` is blocking, so asyncio dispatches it to the event loop's **default**
`ThreadPoolExecutor`. Every Docker SDK call in `rental_docker_sdk.py` went to that same pool via
`asyncio.to_thread` — including `pull`, whose timeout is 3 hours. The pool holds
`min(32, os.cpu_count() + 4)` threads, and `os.cpu_count()` inside the pod reports the node's 4
cores rather than the 1-CPU cgroup limit, so it is **8 threads**.

Under the wave those 8 threads were all inside blocking Docker calls, name resolution queued behind
them, and `socket_connect_timeout` expired before the resolver ever ran. Redis connections and the
backend WebSocket both need `getaddrinfo`, which is why one saturated pool produced all three
symptoms — they were never related to each other.

## What changed

**Dedicated pool for the Docker SDK.** A thread pool is FIFO, so widening the default one does not
help: `getaddrinfo` still queues behind minutes-long pulls. The Docker calls need a separate queue.
All 10 `asyncio.to_thread` call sites now go through `_in_docker_thread`, which dispatches to
`_DOCKER_EXECUTOR`. Semantics are unchanged — like `to_thread`, `run_in_executor` is not cancelled
by a timeout either.

**Headroom in the default pool.** `widen_default_thread_pool()` raises it to 32 in both entrypoints
(`validator.py` lifespan and `connector.py`). The connector runs the same image and was hit just as
hard — six of the seven dead Redis connections found after the incident were its. Even with the
Docker calls moved out, blocking bittensor SDK calls (`price_provider.py:147`, `miner_jobs/score.py:50`,
`interactive_shell_service.py:40`) still share the default pool, and 8 threads is thin for them.

## Tests

`tests/test_docker_thread_pool.py` — the regression test saturates every Docker thread and asserts
the default pool still runs, which is exactly what failed in production. Verified it fails when the
helper is pointed back at the default executor (both that test and the thread-name one go red).
Plus a grep guard, since the likely regression is someone adding an 11th `asyncio.to_thread` by
copying a neighbouring line.

Full validator suite: 1156 passed. The 3 failures in `test_sshd_bootstrap_script.py` are
pre-existing on `main` (confirmed by stashing this branch's changes).

## Scope

This does not replace DAH-2475 — it is the piece that set is missing. The in-flight create cap in
lium-io-backend#802 is **per node** ("cap how many bundles this node may have CREATING at once"),
so it lowers the wave without moving the threshold; the validator serves the whole fleet. And
lium-io#1161 bounds the Redis pool, which cuts the number of resolutions, but `socket_connect_timeout=5`
is still shorter than the queue in a saturated pool. Both are good changes; neither touches the
mechanism.

Deliberately left out: a global create semaphore (belongs in #802) and the Redis timeouts (all in
#1161 — duplicating them here would only conflict at merge).

Not worth doing: making `REDIS_HOST` an absolute name to dodge the `ndots:5` search-domain lookups.
Measured on prod CoreDNS — 99.77% of requests finish under 4ms, so the extra NXDOMAIN costs ~3ms per
new connection, against the minutes a `docker pull` holds a thread. Cluster-wide, 57.8% of all DNS
traffic is NXDOMAIN (73.8M of 127.6M), which is worth cleaning up on its own — but as a cluster-level
change (`dnsConfig` ndots, or CoreDNS `autopath`), not here, and not urgently.

## Verification after deploy

During the next filler wave the validator log should carry no `timed out during opening handshake`,
and the backend no `No validator consumer available`. Yesterday's wave produced both.
