### PR TITLE
DAH-2451: read NVML allowlist from shared config + report unknown drivers

### DIFF
--- a/neurons/validators/pdm.lock
+++ b/neurons/validators/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:af83b9b4f8ade6ca68d0eaaadf1a6ebc678e704f24465a15774a7f71352ff13c"
+content_hash = "sha256:8ee9e62b9269e48f4d7b901bd7f92c568d55b76297e33c521776f1019c3e9c5f"
 
 [[metadata.targets]]
 requires_python = ">=3.11,<3.13"
@@ -1231,7 +1231,7 @@ files = [
 
 [[package]]
 name = "lium-core"
-version = "0.1.8rc1"
+version = "0.1.6"
 requires_python = ">=3.11"
 summary = "Shared core library for Lium platform"
 groups = ["default"]
@@ -1240,8 +1240,8 @@ dependencies = [
     "requests>=2.31.0",
 ]
 files = [
-    {file = "lium_core-0.1.8rc1-py3-none-any.whl", hash = "sha256:d4678f698559cdbc4372773d06a86f9407f169279144f78afbeab0f74626397b"},
-    {file = "lium_core-0.1.8rc1.tar.gz", hash = "sha256:aa567b89f8ddbbdca954a20918cf6ada5896c853455a7476eeb7a0248306e5e9"},
+    {file = "lium_core-0.1.6-py3-none-any.whl", hash = "sha256:80cb1e06d34c18c1152317259d0ca27487389b3c8cf08db3e3224721f63a96f7"},
+    {file = "lium_core-0.1.6.tar.gz", hash = "sha256:16efabf205e708c4d288cfda833faee5397fd4f8c8f2cb46041488789259f8d0"},
 ]
 
 [[package]]

--- a/neurons/validators/pdm.lock
+++ b/neurons/validators/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:8ee9e62b9269e48f4d7b901bd7f92c568d55b76297e33c521776f1019c3e9c5f"
+content_hash = "sha256:af83b9b4f8ade6ca68d0eaaadf1a6ebc678e704f24465a15774a7f71352ff13c"
 
 [[metadata.targets]]
 requires_python = ">=3.11,<3.13"
@@ -1231,7 +1231,7 @@ files = [
 
 [[package]]
 name = "lium-core"
-version = "0.1.6"
+version = "0.1.8rc1"
 requires_python = ">=3.11"
 summary = "Shared core library for Lium platform"
 groups = ["default"]
@@ -1240,8 +1240,8 @@ dependencies = [
     "requests>=2.31.0",
 ]
 files = [
-    {file = "lium_core-0.1.6-py3-none-any.whl", hash = "sha256:80cb1e06d34c18c1152317259d0ca27487389b3c8cf08db3e3224721f63a96f7"},
-    {file = "lium_core-0.1.6.tar.gz", hash = "sha256:16efabf205e708c4d288cfda833faee5397fd4f8c8f2cb46041488789259f8d0"},
+    {file = "lium_core-0.1.8rc1-py3-none-any.whl", hash = "sha256:d4678f698559cdbc4372773d06a86f9407f169279144f78afbeab0f74626397b"},
+    {file = "lium_core-0.1.8rc1.tar.gz", hash = "sha256:aa567b89f8ddbbdca954a20918cf6ada5896c853455a7476eeb7a0248306e5e9"},
 ]
 
 [[package]]

--- a/neurons/validators/pdm.lock
+++ b/neurons/validators/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:8ee9e62b9269e48f4d7b901bd7f92c568d55b76297e33c521776f1019c3e9c5f"
+content_hash = "sha256:d671cc6f83b100d85f6477a3cad172b142db8d65736ac6d3f250001021b13c71"
 
 [[metadata.targets]]
 requires_python = ">=3.11,<3.13"
@@ -1231,7 +1231,7 @@ files = [
 
 [[package]]
 name = "lium-core"
-version = "0.1.6"
+version = "0.1.8"
 requires_python = ">=3.11"
 summary = "Shared core library for Lium platform"
 groups = ["default"]
@@ -1240,8 +1240,8 @@ dependencies = [
     "requests>=2.31.0",
 ]
 files = [
-    {file = "lium_core-0.1.6-py3-none-any.whl", hash = "sha256:80cb1e06d34c18c1152317259d0ca27487389b3c8cf08db3e3224721f63a96f7"},
-    {file = "lium_core-0.1.6.tar.gz", hash = "sha256:16efabf205e708c4d288cfda833faee5397fd4f8c8f2cb46041488789259f8d0"},
+    {file = "lium_core-0.1.8-py3-none-any.whl", hash = "sha256:b37f1b670f1a4f4fc5b3c2f6e9c93e2876d36a6a872d4906c7da108396b2e812"},
+    {file = "lium_core-0.1.8.tar.gz", hash = "sha256:c03835b75718039a5cf4a9361caf9e9e82dc87b19e7ce4d8aeec64d57f2fa5c5"},
 ]
 
 [[package]]

--- a/neurons/validators/pyproject.toml
+++ b/neurons/validators/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "celium-collateral==1.2.0",
     "databases>=0.9.0",
     "datura @ file:///${PROJECT_ROOT}/../../datura",
-    "lium-core==0.1.8rc1",
+    "lium-core>=0.1.6",
     "fastapi>=0.110.3",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.10.1",

--- a/neurons/validators/pyproject.toml
+++ b/neurons/validators/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "celium-collateral==1.2.0",
     "databases>=0.9.0",
     "datura @ file:///${PROJECT_ROOT}/../../datura",
-    "lium-core>=0.1.6",
+    "lium-core==0.1.8rc1",
     "fastapi>=0.110.3",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.10.1",

--- a/neurons/validators/pyproject.toml
+++ b/neurons/validators/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "celium-collateral==1.2.0",
     "databases>=0.9.0",
     "datura @ file:///${PROJECT_ROOT}/../../datura",
-    "lium-core>=0.1.6",
+    "lium-core>=0.1.8",
     "fastapi>=0.110.3",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.10.1",

--- a/neurons/validators/src/clients/backend_client.py
+++ b/neurons/validators/src/clients/backend_client.py
@@ -27,6 +27,12 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=BaseModel)
 
 
+class NvmlReportAckResponse(BaseModel):
+    """Ack for a reported unknown driver — the verdict arrives later via shared config."""
+
+    status: str | None = None
+
+
 class BackendClient:
     """HTTP client with session pooling and validator signature headers."""
 
@@ -310,3 +316,21 @@ class BackendClient:
             add_signature=True,  # Use standard signature headers
             timeout=300,  # 5 minutes - backend needs time to SSH and verify container
         )
+
+    async def report_unknown_driver(self, driver_version: str) -> None:
+        """Ask the backend to verify an unknown NVIDIA driver (DAH-2451).
+
+        Fire-and-forget: the backend enqueues + resolves the driver against NVIDIA's
+        official installer, and the verdict reaches this validator later via shared
+        config. Never raises — a reporting failure must not disturb the pipeline.
+        """
+        try:
+            await self.post(
+                "/v1/nvml-driver/report-unknown",
+                NvmlReportAckResponse,
+                json_data={"driver_version": driver_version},
+                add_signature=True,
+                timeout=10,
+            )
+        except Exception as exc:
+            logger.warning(_m("Failed to report unknown driver", extra={"driver": driver_version, "error": str(exc)}))

--- a/neurons/validators/src/clients/backend_client.py
+++ b/neurons/validators/src/clients/backend_client.py
@@ -18,6 +18,7 @@ from protocol.vc_protocol.compute_requests import (
     DefaultDockerImagesResponse,
     ExecutorHealthCheckResponse,
     FillerRunActiveResponse,
+    NvmlReportAckResponse,
     PodRentalActiveResponse,
     RentedExecutorsResponse,
 )
@@ -25,12 +26,6 @@ from protocol.vc_protocol.compute_requests import (
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
-
-
-class NvmlReportAckResponse(BaseModel):
-    """Ack for a reported unknown driver — the verdict arrives later via shared config."""
-
-    status: str | None = None
 
 
 class BackendClient:

--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -200,3 +200,10 @@ class DefaultDockerImage(BaseModel, extra="allow"):
 class DefaultDockerImagesResponse(RootModel[list[DefaultDockerImage]]):
     """The backend returns a bare JSON list; wrap it so `BackendClient.get()`
     (which validates with a single model) can parse it."""
+
+
+class NvmlReportAckResponse(BaseModel):
+    """Ack for a reported unknown driver (DAH-2451) — the verdict arrives later via
+    shared config, so the body is intentionally empty."""
+
+    status: str | None = None

--- a/neurons/validators/src/services/task/checks/nvml_digest.py
+++ b/neurons/validators/src/services/task/checks/nvml_digest.py
@@ -29,6 +29,12 @@ class NvmlDigestCheck:
         if driver_version and expected_digest != lib_digest:
             # Check if driver version is unknown (not in our map)
             if expected_digest is None:
+                # Reactive verification (DAH-2451): ask the backend to resolve a driver we
+                # have never seen against NVIDIA's official installer. Skip versions already
+                # confirmed as spoofs so we don't re-report a known-invalid driver.
+                invalid_drivers = ctx.config.nvml_invalid_drivers or []
+                if driver_version not in invalid_drivers:
+                    await ctx.services.backend.report_unknown_driver(driver_version)
                 event = render_message(
                     Msg.DRIVER_UNKNOWN,
                     ctx=ctx,

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -53,6 +53,9 @@ class ContextConfig:
     max_gpu_count: Optional[int] = None
     gpu_model_rates: Optional[dict[str, Any]] = None
     nvml_digest_map: Optional[dict[str, str]] = None
+    # Driver versions already confirmed as spoofs (DAH-2451). The nvml_digest check
+    # rejects these without re-reporting them to the backend for verification.
+    nvml_invalid_drivers: Optional[list[str]] = None
     enable_no_collateral: bool = False
     verifyx_enabled: bool = False
     inspector_enabled: bool = False

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -210,6 +210,7 @@ class PipelineFactory:
                 # is a row insert, not a validator redeploy. Falls back to the packaged
                 # constant when the backend is unreachable (shared config empty).
                 nvml_digest_map=shared_client.config.nvml_ml_digests or LIB_NVIDIA_ML_DIGESTS,
+                nvml_invalid_drivers=shared_client.config.nvml_invalid_drivers,
                 enable_no_collateral=settings.ENABLE_NO_COLLATERAL,
                 verifyx_enabled=settings.ENABLE_VERIFYX,
                 inspector_enabled=settings.ENABLE_INSPECTOR,

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -23,7 +23,7 @@ from services.matrix_validation_service import ValidationService
 from services.redis_service import RENTAL_SUCCEED_MACHINE_SET, RedisService
 from services.verifyx_validation_service import VerifyXValidationService
 
-from core.config import settings
+from core.config import settings, shared_client
 from services.ssh_service import SSHService
 
 from .checks import (
@@ -206,7 +206,10 @@ class PipelineFactory:
                 validator_keypair=keypair,
                 max_gpu_count=MAX_GPU_COUNT,
                 gpu_model_rates=GPU_MODEL_RATES,
-                nvml_digest_map=LIB_NVIDIA_ML_DIGESTS,
+                # DB-backed allowlist served via shared config (DAH-2451): a new driver
+                # is a row insert, not a validator redeploy. Falls back to the packaged
+                # constant when the backend is unreachable (shared config empty).
+                nvml_digest_map=shared_client.config.nvml_ml_digests or LIB_NVIDIA_ML_DIGESTS,
                 enable_no_collateral=settings.ENABLE_NO_COLLATERAL,
                 verifyx_enabled=settings.ENABLE_VERIFYX,
                 inspector_enabled=settings.ENABLE_INSPECTOR,

--- a/neurons/validators/tests/helpers.py
+++ b/neurons/validators/tests/helpers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 from datura.requests.miner_requests import ExecutorSSHInfo
 
 from neurons.validators.src.services.task.pipeline import (
@@ -65,7 +67,7 @@ def build_services(**overrides) -> ContextServices:
         connectivity=None,
         shell=None,
         score_calculator=DummyScoreCalc(),
-        backend=None,
+        backend=AsyncMock(),
         container_cleanup=None,
     )
     base.update(overrides)

--- a/neurons/validators/tests/test_nvml_digest_check.py
+++ b/neurons/validators/tests/test_nvml_digest_check.py
@@ -114,6 +114,34 @@ async def test_nvml_digest_check_allows_driver_595_71_05(context_factory):
 
 
 @pytest.mark.asyncio
+async def test_unknown_driver_is_reported_to_backend(context_factory):
+    # An unknown driver (not in the map, not a known spoof) is reported for verification.
+    services = build_services()
+    config = build_context_config(nvml_digest_map={}, nvml_invalid_drivers=[])
+    state = build_state(specs={"gpu": {"driver": "999.99"}, "md5_checksums": {"libnvidia_ml": "abc"}})
+    ctx = context_factory(services=services, config=config, state=state)
+
+    result = await NvmlDigestCheck().run(ctx)
+
+    assert result.event.reason_code == Msg.DRIVER_UNKNOWN.reason
+    services.backend.report_unknown_driver.assert_awaited_once_with("999.99")
+
+
+@pytest.mark.asyncio
+async def test_known_spoof_driver_is_not_reported(context_factory):
+    # A driver already confirmed invalid is rejected but never re-reported to the backend.
+    services = build_services()
+    config = build_context_config(nvml_digest_map={}, nvml_invalid_drivers=["591.86"])
+    state = build_state(specs={"gpu": {"driver": "591.86"}, "md5_checksums": {"libnvidia_ml": "abc"}})
+    ctx = context_factory(services=services, config=config, state=state)
+
+    result = await NvmlDigestCheck().run(ctx)
+
+    assert result.event.reason_code == Msg.DRIVER_UNKNOWN.reason
+    services.backend.report_unknown_driver.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_nvml_digest_check_allows_driver_580_167_08(context_factory):
     specs = {
         "gpu": {"driver": "580.167.08"},


### PR DESCRIPTION
## What

Read the NVML allowlist from shared config and report unknown drivers for reactive verification (DAH-2451).

- `pipeline_factory` sources `nvml_digest_map` from `shared_client.config.nvml_ml_digests`, falling back to the packaged `LIB_NVIDIA_ML_DIGESTS` constant when the backend is unreachable (shared config empty). Also threads `nvml_invalid_drivers`.
- On a genuinely unknown driver (not in the map, not a known spoof), `NvmlDigestCheck` calls `BackendClient.report_unknown_driver` — fire-and-forget; the backend resolves it against NVIDIA's official installer and the verdict returns via shared config on a later cycle. Known spoofs are rejected but never re-reported.

Net effect: a new NVIDIA driver stops requiring a validator code change + redeploy — it's a backend DB row that reaches the validator through shared config.

## Depends on

`lium-core 0.1.8` (`nvml_ml_digests` / `nvml_invalid_drivers`): Datura-ai/lium-core#7 — **merge + release first**, then bump `lium-core>=0.1.8` here. Backend: Datura-ai/lium-io-backend#811.

Includes the already-merged `595.84` seed via rebase onto `main`.

## Tests

Updated `test_nvml_digest_check`: unknown driver is reported once; a known spoof is not. Existing digest cases unchanged. (Validator suite runs in CI — the local pdm/bittensor env is impractical to stand up here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
