### PR TITLE
DAH-2488, reword GPU_OUTSIDE_TENANT provider message

### DIFF
--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -656,7 +656,7 @@ class TenantEnforcementMessages:
         ),
     )
     GPU_OUTSIDE_TENANT = MessageTemplate(
-        event="Tenant container does not own GPU",
+        event="Provider is using the GPU",
         reason="GPU_USAGE_OUTSIDE_TENANT",
         severity="warning",
         category="runtime",


### PR DESCRIPTION
## What

Rewords the validator message shown to providers when a rented node fails the tenant-enforcement GPU check.

- `event`: `"Tenant container does not own GPU"` → `"Provider is using the GPU"`
- `reason` code (`GPU_USAGE_OUTSIDE_TENANT`), severity, category and remediation are unchanged.

## Why

The old wording was unclear from the provider's side — a provider asked in Discord what "tenant container does not own GPU" meant. The check actually means: a process outside the renter's container is using the rented GPU (usually a leftover host-level process), so the cycle scores 0. Fish proposed clearer, provider-facing wording.

## Scope / safety

- One line changed. Pure display string; no logic touched.
- The machine-readable `reason` code is kept, so log filters and dashboards are unaffected.
- No test asserts the event text (tests reference `GPU_OUTSIDE_TENANT.reason` only).

Ticket: DAH-2488
