### PR TITLE
DAH-2496: keep sysbox for S3FS volume pods via uid-aligned mount

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -150,6 +150,10 @@ DOCKER_VOLUME_PLUGINS = {
     "s3fs": "mochoa/s3fs-volume-plugin"
 }
 
+# DAH-2496: sysbox installers reserve one 65536-wide subuid slice per host and map
+# every container's root to its base. A wider range is handed out per container.
+SYSBOX_SUBUID_SLICE_SIZE = 65536
+
 # DAH-1991: tolerate concurrent health_check_* / container_* on the executor.
 # Probe TTL is short (~30s); same-command retry within a 90s budget covers the
 # documented race without regenerating port mappings.
@@ -2195,12 +2199,49 @@ class DockerService:
 
         return True
 
+    async def resolve_sysbox_uid_base(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        log_extra: dict,
+    ) -> int | None:
+        """Host uid that sysbox maps container root to, or None when unusable.
+
+        Only a single slice is usable: a wider range means sysbox hands out a
+        different base per container, and one static s3fs uid cannot match them.
+        """
+        result = await ssh_client.run("grep '^sysbox:' /etc/subuid")
+        entries: list[str] = (result.stdout or "").strip().splitlines()
+        if not entries:
+            return None
+
+        fields: list[str] = entries[0].strip().split(":")
+        if len(fields) != 3:
+            return None
+
+        try:
+            uid_base: int = int(fields[1])
+            slice_size: int = int(fields[2])
+        except ValueError:
+            return None
+
+        if slice_size != SYSBOX_SUBUID_SLICE_SIZE:
+            logger.warning(
+                _m(
+                    "sysbox subuid range is not a single slice; cannot align s3fs owner",
+                    extra=get_extra_info({**log_extra, "slice_size": slice_size}),
+                )
+            )
+            return None
+
+        return uid_base
+
     async def create_s3fs_volume(
         self,
         ssh_client: asyncssh.SSHClientConnection,
         log_extra: dict,
         volume_info: ExternalVolumeInfo,
         log_tag: str,
+        sysbox_uid_base: int | None = None,
     ):
         responses = []
         # install docker volume plugin
@@ -2215,8 +2256,14 @@ class DockerService:
         command = f"/usr/bin/docker plugin set s3fs AWSACCESSKEYID={volume_info.iam_user_access_key} AWSSECRETACCESSKEY={volume_info.iam_user_secret_key}"
         responses.append(await ssh_client.run(command))
 
-        # set allow_other option
-        command = '/usr/bin/docker plugin set s3fs DEFAULT_S3FSOPTS="allow_other"'
+        # DAH-2496: sysbox cannot ID-shift a FUSE mount, so under sysbox the pod's
+        # root sees the bucket as nobody and cannot write existing objects. s3fs
+        # keeps owner and mode in object metadata, so report the objects as owned
+        # by the uid sysbox maps container root to.
+        mount_options: str = "allow_other"
+        if sysbox_uid_base is not None:
+            mount_options = f"allow_other,uid={sysbox_uid_base},gid={sysbox_uid_base}"
+        command = f'/usr/bin/docker plugin set s3fs DEFAULT_S3FSOPTS="{mount_options}"'
         responses.append(await ssh_client.run(command))
 
         # enable volume plugin
@@ -3687,19 +3734,33 @@ class DockerService:
                 external_volume_name = None
                 if external_volume_info:
                     current_step = "external_volume_creation"
+                    sysbox_uid_base: int | None = (
+                        await self.resolve_sysbox_uid_base(
+                            ssh_client=ssh_client, log_extra=default_extra
+                        )
+                        if payload.is_sysbox
+                        else None
+                    )
+                    if payload.is_sysbox and sysbox_uid_base is None:
+                        # Without the base the pod would see /mnt owned by nobody;
+                        # runc keeps the volume writable, so trade isolation for it.
+                        payload.is_sysbox = False
+                        await self.stream_log(
+                            "Sysbox disabled: cannot align S3 volume owner with the executor's sysbox uid range",
+                            "warning",
+                            log_tag,
+                        )
                     success, msg = await self.create_s3fs_volume(
                         ssh_client=ssh_client,
                         log_extra=default_extra,
                         volume_info=external_volume_info,
                         log_tag=log_tag,
+                        sysbox_uid_base=sysbox_uid_base,
                     )
                     if success:
                         # Add profiler for docker volume creation
                         profilers.append(ProfilerStep.since(ProfilerStepName.DOCKER_VOLUME_CREATION, prev_timestamp))
                         prev_timestamp = now_ms()
-                        # Important: disable sysbox when using s3fs volume because s3fs volume is not supported by sysbox
-                        payload.is_sysbox = False
-
                         external_volume_name = external_volume_info.name
                     else:
                         warnings.append(ContainerWarningCode.ExternalVolumeFailed)

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -2199,37 +2199,29 @@ class DockerService:
 
         return True
 
-    async def resolve_sysbox_uid_base(
+    async def resolve_sysbox_subuid_base(
         self,
         ssh_client: asyncssh.SSHClientConnection,
         log_extra: dict,
     ) -> int | None:
-        """Host uid that sysbox maps container root to, or None when unusable.
+        """Read the host uid that sysbox maps container root to, None if unusable.
 
-        Only a single slice is usable: a wider range means sysbox hands out a
-        different base per container, and one static s3fs uid cannot match them.
-
-        The SSH session lands inside the executor container, whose /etc/subuid is
-        its own — the host file is reachable only through dockerd, which resolves
-        -v paths on the host.
+        The SSH session lands inside the executor container, whose own /etc/subuid
+        carries no sysbox entry; the executor shares the host PID namespace, so the
+        host copy is reachable through the host init's root.
         """
-        command: str = (
-            "/usr/bin/docker run --rm -v /etc/subuid:/etc/subuid:ro "
-            "--entrypoint cat daturaai/compute-subnet-executor:latest /etc/subuid"
-        )
-        result = await ssh_client.run(command)
-        lines: list[str] = (result.stdout or "").splitlines()
-        entries: list[str] = [line for line in lines if line.startswith("sysbox:")]
-        if not entries:
-            return None
-
-        fields: list[str] = entries[0].strip().split(":")
-        if len(fields) != 3:
+        result = await ssh_client.run("cat /proc/1/root/etc/subuid")
+        sysbox_entries: list[str] = [
+            line for line in (result.stdout or "").splitlines()
+            if line.startswith("sysbox:")
+        ]
+        if not sysbox_entries:
             return None
 
         try:
-            uid_base: int = int(fields[1])
-            slice_size: int = int(fields[2])
+            _, subuid_base_text, slice_size_text = sysbox_entries[0].strip().split(":")
+            subuid_base: int = int(subuid_base_text)
+            slice_size: int = int(slice_size_text)
         except ValueError:
             return None
 
@@ -2242,7 +2234,7 @@ class DockerService:
             )
             return None
 
-        return uid_base
+        return subuid_base
 
     async def create_s3fs_volume(
         self,
@@ -2250,7 +2242,7 @@ class DockerService:
         log_extra: dict,
         volume_info: ExternalVolumeInfo,
         log_tag: str,
-        sysbox_uid_base: int | None = None,
+        sysbox_subuid_base: int | None,
     ):
         responses = []
         # install docker volume plugin
@@ -2265,13 +2257,12 @@ class DockerService:
         command = f"/usr/bin/docker plugin set s3fs AWSACCESSKEYID={volume_info.iam_user_access_key} AWSSECRETACCESSKEY={volume_info.iam_user_secret_key}"
         responses.append(await ssh_client.run(command))
 
-        # DAH-2496: sysbox cannot ID-shift a FUSE mount, so under sysbox the pod's
-        # root sees the bucket as nobody and cannot write existing objects. s3fs
-        # keeps owner and mode in object metadata, so report the objects as owned
-        # by the uid sysbox maps container root to.
+        # DAH-2496: the kernel cannot ID-shift a FUSE mount, so under sysbox the
+        # pod's root would see the bucket as nobody. s3fs keeps owner in object
+        # metadata, so report the objects as owned by the pod's root instead.
         mount_options: str = "allow_other"
-        if sysbox_uid_base is not None:
-            mount_options = f"allow_other,uid={sysbox_uid_base},gid={sysbox_uid_base}"
+        if sysbox_subuid_base is not None:
+            mount_options = f"allow_other,uid={sysbox_subuid_base},gid={sysbox_subuid_base}"
         command = f'/usr/bin/docker plugin set s3fs DEFAULT_S3FSOPTS="{mount_options}"'
         responses.append(await ssh_client.run(command))
 
@@ -3743,34 +3734,32 @@ class DockerService:
                 external_volume_name = None
                 if external_volume_info:
                     current_step = "external_volume_creation"
-                    sysbox_uid_base: int | None = (
-                        await self.resolve_sysbox_uid_base(
+                    sysbox_subuid_base: int | None = None
+                    if payload.is_sysbox:
+                        sysbox_subuid_base = await self.resolve_sysbox_subuid_base(
                             ssh_client=ssh_client, log_extra=default_extra
-                        )
-                        if payload.is_sysbox
-                        else None
-                    )
-                    if payload.is_sysbox and sysbox_uid_base is None:
-                        # Without the base the pod would see /mnt owned by nobody;
-                        # runc keeps the volume writable, so trade isolation for it.
-                        payload.is_sysbox = False
-                        await self.stream_log(
-                            "Sysbox disabled: cannot align S3 volume owner with the executor's sysbox uid range",
-                            "warning",
-                            log_tag,
                         )
                     success, msg = await self.create_s3fs_volume(
                         ssh_client=ssh_client,
                         log_extra=default_extra,
                         volume_info=external_volume_info,
                         log_tag=log_tag,
-                        sysbox_uid_base=sysbox_uid_base,
+                        sysbox_subuid_base=sysbox_subuid_base,
                     )
                     if success:
                         # Add profiler for docker volume creation
                         profilers.append(ProfilerStep.since(ProfilerStepName.DOCKER_VOLUME_CREATION, prev_timestamp))
                         prev_timestamp = now_ms()
                         external_volume_name = external_volume_info.name
+                        if payload.is_sysbox and sysbox_subuid_base is None:
+                            # Decided only once the volume is really attached: runc
+                            # keeps /mnt writable, sysbox without the base does not.
+                            payload.is_sysbox = False
+                            await self.stream_log(
+                                "Sysbox disabled: cannot align S3 volume owner with the executor's sysbox uid range",
+                                "warning",
+                                log_tag,
+                            )
                     else:
                         warnings.append(ContainerWarningCode.ExternalVolumeFailed)
                         profilers.append(ProfilerStep.since(ProfilerStepName.DOCKER_VOLUME_CREATION_FAILED, prev_timestamp))

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -2208,9 +2208,18 @@ class DockerService:
 
         Only a single slice is usable: a wider range means sysbox hands out a
         different base per container, and one static s3fs uid cannot match them.
+
+        The SSH session lands inside the executor container, whose /etc/subuid is
+        its own — the host file is reachable only through dockerd, which resolves
+        -v paths on the host.
         """
-        result = await ssh_client.run("grep '^sysbox:' /etc/subuid")
-        entries: list[str] = (result.stdout or "").strip().splitlines()
+        command: str = (
+            "/usr/bin/docker run --rm -v /etc/subuid:/etc/subuid:ro "
+            "--entrypoint cat daturaai/compute-subnet-executor:latest /etc/subuid"
+        )
+        result = await ssh_client.run(command)
+        lines: list[str] = (result.stdout or "").splitlines()
+        entries: list[str] = [line for line in lines if line.startswith("sysbox:")]
         if not entries:
             return None
 

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -488,12 +488,21 @@ async def test_create_container_drops_sysbox_when_subuid_base_is_unusable(
 
 
 @pytest.mark.asyncio
-async def test_create_s3fs_volume_aligns_mount_owner_with_sysbox_uid_base(
+@pytest.mark.parametrize(
+    "sysbox_subuid_base,expected_options",
+    [
+        # Sysbox cannot ID-shift a FUSE mount, so s3fs must report the objects as
+        # owned by the host uid sysbox maps container root to.
+        (231072, "allow_other,uid=231072,gid=231072"),
+        (None, "allow_other"),
+    ],
+)
+async def test_create_s3fs_volume_mount_options(
     docker_service,
     monkeypatch,
+    sysbox_subuid_base,
+    expected_options,
 ):
-    # Sysbox cannot ID-shift a FUSE mount, so s3fs must report the objects as
-    # owned by the host uid sysbox maps container root to.
     ssh_client = RecordingSSHClient()
     monkeypatch.setattr(
         docker_service, "execute_and_stream_logs", AsyncMock(return_value=(True, ""))
@@ -510,41 +519,12 @@ async def test_create_s3fs_volume_aligns_mount_owner_with_sysbox_uid_base(
         log_extra={},
         volume_info=volume_info,
         log_tag="tag",
-        sysbox_uid_base=231072,
+        sysbox_subuid_base=sysbox_subuid_base,
     )
 
     assert any(
-        'DEFAULT_S3FSOPTS="allow_other,uid=231072,gid=231072"' in command
+        f'DEFAULT_S3FSOPTS="{expected_options}"' in command
         for command in ssh_client.commands
-    )
-
-
-@pytest.mark.asyncio
-async def test_create_s3fs_volume_keeps_plain_options_without_sysbox(
-    docker_service,
-    monkeypatch,
-):
-    ssh_client = RecordingSSHClient()
-    monkeypatch.setattr(
-        docker_service, "execute_and_stream_logs", AsyncMock(return_value=(True, ""))
-    )
-    volume_info = ExternalVolumeInfo(
-        name="celium-volume-safe",
-        plugin="s3fs",
-        iam_user_access_key="access-key",
-        iam_user_secret_key="secret-key",
-    )
-
-    await docker_service.create_s3fs_volume(
-        ssh_client=ssh_client,
-        log_extra={},
-        volume_info=volume_info,
-        log_tag="tag",
-        sysbox_uid_base=None,
-    )
-
-    assert any(
-        'DEFAULT_S3FSOPTS="allow_other"' in command for command in ssh_client.commands
     )
 
 
@@ -559,19 +539,17 @@ async def test_create_s3fs_volume_keeps_plain_options_without_sysbox(
         ("sysbox:not-a-number:65536", None),
     ],
 )
-async def test_resolve_sysbox_uid_base(docker_service, subuid_file, expected_base):
+async def test_resolve_sysbox_subuid_base(docker_service, subuid_file, expected_base):
     ssh_client = RecordingSSHClient(stdout=subuid_file)
 
-    base = await docker_service.resolve_sysbox_uid_base(
+    base = await docker_service.resolve_sysbox_subuid_base(
         ssh_client=ssh_client, log_extra={}
     )
 
     assert base == expected_base
-    # /etc/subuid must be the HOST's file: the ssh session lands inside the
-    # executor container, so the read goes through dockerd's -v host mount.
-    assert any(
-        "-v /etc/subuid:/etc/subuid:ro" in command for command in ssh_client.commands
-    )
+    # Must read the HOST's file: the ssh session lands inside the executor
+    # container, whose own /etc/subuid carries no sysbox entry.
+    assert ssh_client.commands == ["cat /proc/1/root/etc/subuid"]
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -417,13 +417,50 @@ async def test_create_container_keeps_hostile_fields_out_of_host_shell_commands(
 
 
 @pytest.mark.asyncio
-async def test_create_container_disables_sysbox_runtime_for_s3fs_external_volume(
+async def test_create_container_keeps_sysbox_runtime_for_s3fs_external_volume(
     docker_service,
     executor_info,
     keypair,
     monkeypatch,
 ):
-    ssh_client = RecordingSSHClient()
+    ssh_client = RecordingSSHClient(stdout="sysbox:231072:65536")
+    _patch_create_harness(monkeypatch, docker_service, ssh_client)
+    payload = _base_create_payload(
+        is_sysbox=True,
+        external_volume_info=ExternalVolumeInfo(
+            name="celium-volume-safe",
+            plugin="s3fs",
+            iam_user_access_key="access-key",
+            iam_user_secret_key="secret-key",
+        ),
+    )
+
+    await docker_service.create_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=keypair,
+        private_key="encrypted-private-key",
+    )
+
+    run_spec = docker_service.rental_docker_client_factory.client.run_specs[0]
+    assert run_spec.runtime == "sysbox-runc"
+    assert any(
+        volume.source == "celium-volume-safe" and volume.target == "/mnt"
+        for volume in run_spec.volumes
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_container_drops_sysbox_when_subuid_base_is_unusable(
+    docker_service,
+    executor_info,
+    keypair,
+    monkeypatch,
+):
+    # A range wider than one slice means sysbox picks a different base per
+    # container, so the mount owner cannot be aligned — the volume stays usable
+    # only under runc.
+    ssh_client = RecordingSSHClient(stdout="sysbox:231072:1048576")
     _patch_create_harness(monkeypatch, docker_service, ssh_client)
     payload = _base_create_payload(
         is_sysbox=True,
@@ -444,10 +481,91 @@ async def test_create_container_disables_sysbox_runtime_for_s3fs_external_volume
 
     run_spec = docker_service.rental_docker_client_factory.client.run_specs[0]
     assert run_spec.runtime is None
-    assert any(
-        volume.source == "celium-volume-safe" and volume.target == "/mnt"
-        for volume in run_spec.volumes
+    streamed_messages = [
+        call.args[0] for call in docker_service.stream_log.await_args_list
+    ]
+    assert any("Sysbox disabled" in message for message in streamed_messages)
+
+
+@pytest.mark.asyncio
+async def test_create_s3fs_volume_aligns_mount_owner_with_sysbox_uid_base(
+    docker_service,
+    monkeypatch,
+):
+    # Sysbox cannot ID-shift a FUSE mount, so s3fs must report the objects as
+    # owned by the host uid sysbox maps container root to.
+    ssh_client = RecordingSSHClient()
+    monkeypatch.setattr(
+        docker_service, "execute_and_stream_logs", AsyncMock(return_value=(True, ""))
     )
+    volume_info = ExternalVolumeInfo(
+        name="celium-volume-safe",
+        plugin="s3fs",
+        iam_user_access_key="access-key",
+        iam_user_secret_key="secret-key",
+    )
+
+    await docker_service.create_s3fs_volume(
+        ssh_client=ssh_client,
+        log_extra={},
+        volume_info=volume_info,
+        log_tag="tag",
+        sysbox_uid_base=231072,
+    )
+
+    assert any(
+        'DEFAULT_S3FSOPTS="allow_other,uid=231072,gid=231072"' in command
+        for command in ssh_client.commands
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_s3fs_volume_keeps_plain_options_without_sysbox(
+    docker_service,
+    monkeypatch,
+):
+    ssh_client = RecordingSSHClient()
+    monkeypatch.setattr(
+        docker_service, "execute_and_stream_logs", AsyncMock(return_value=(True, ""))
+    )
+    volume_info = ExternalVolumeInfo(
+        name="celium-volume-safe",
+        plugin="s3fs",
+        iam_user_access_key="access-key",
+        iam_user_secret_key="secret-key",
+    )
+
+    await docker_service.create_s3fs_volume(
+        ssh_client=ssh_client,
+        log_extra={},
+        volume_info=volume_info,
+        log_tag="tag",
+        sysbox_uid_base=None,
+    )
+
+    assert any(
+        'DEFAULT_S3FSOPTS="allow_other"' in command for command in ssh_client.commands
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "subuid_line,expected_base",
+    [
+        ("sysbox:231072:65536", 231072),
+        ("sysbox:231072:1048576", None),
+        ("", None),
+        ("sysbox:not-a-number:65536", None),
+    ],
+)
+async def test_resolve_sysbox_uid_base(docker_service, subuid_line, expected_base):
+    ssh_client = RecordingSSHClient(stdout=subuid_line)
+
+    base = await docker_service.resolve_sysbox_uid_base(
+        ssh_client=ssh_client, log_extra={}
+    )
+
+    assert base == expected_base
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -550,22 +550,28 @@ async def test_create_s3fs_volume_keeps_plain_options_without_sysbox(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "subuid_line,expected_base",
+    "subuid_file,expected_base",
     [
-        ("sysbox:231072:65536", 231072),
+        ("ubuntu:100000:65536\nsysbox:231072:65536", 231072),
         ("sysbox:231072:1048576", None),
+        ("liumuser:100000:65536", None),
         ("", None),
         ("sysbox:not-a-number:65536", None),
     ],
 )
-async def test_resolve_sysbox_uid_base(docker_service, subuid_line, expected_base):
-    ssh_client = RecordingSSHClient(stdout=subuid_line)
+async def test_resolve_sysbox_uid_base(docker_service, subuid_file, expected_base):
+    ssh_client = RecordingSSHClient(stdout=subuid_file)
 
     base = await docker_service.resolve_sysbox_uid_base(
         ssh_client=ssh_client, log_extra={}
     )
 
     assert base == expected_base
+    # /etc/subuid must be the HOST's file: the ssh session lands inside the
+    # executor container, so the read goes through dockerd's -v host mount.
+    assert any(
+        "-v /etc/subuid:/etc/subuid:ro" in command for command in ssh_client.commands
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Keep `sysbox-runc` on pods that mount an S3FS external volume, instead of silently downgrading them to plain `runc`.

The s3fs mount is now created with `uid`/`gid` set to the host's sysbox subuid base, so the pod's root owns the objects it sees.

## Why

Attaching a volume set `payload.is_sysbox = False` with no flag, log line or warning — the renter lost user-namespace isolation and Docker-in-Docker without knowing.

The downgrade is not necessary. sysbox cannot ID-shift a FUSE mount (`mount_setattr(MOUNT_ATTR_IDMAP)` returns EINVAL on s3fs, OK on ext4) and does not treat that as fatal, so the container starts either way — it just sees the bucket as `nobody` and cannot write objects it did not create.

Verified on staging against a real S3 bucket, on a node running host Docker 29.1.4 with sysbox subuid base 231072:

| operation under sysbox | `allow_other` (today) | `+ umask=0000` | `+ uid=<base>` |
| --- | --- | --- | --- |
| create file, mkdir, 20 MB write | OK | OK | OK |
| append to a file created outside the pod | EACCES | EACCES | OK |
| chown | EPERM | EPERM | OK |
| owner seen inside the pod | nobody | nobody | root |

`umask=0000` cannot work: it only masks bits away, and s3fs keeps owner and mode in object metadata. Owner alignment is what DAH-2201 recommended.

## Fallback

`resolve_sysbox_uid_base()` returns `None` when `/etc/subuid` has no sysbox entry or reserves more than one 65536-wide slice — a wider range means sysbox picks a different base per container, so no single uid matches. In that case the pod still drops to `runc`, but now it says so in the deploy log instead of doing it silently.

## Tests

`tests/test_docker_service_rental_security.py` — sysbox is kept with a volume attached, the fallback path, both mount-option shapes, and `/etc/subuid` parsing.

Follow-ups in separate PRs: the Create Pod form and the public docs still tell users the two cannot be combined.
