### PR TITLE
DAH-2499: carry the real cause into the set_environment failure

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -2693,13 +2693,14 @@ class DockerService:
         environment: dict[str, str] | None,
         log_tag: str,
         log_extra: dict,
-    ) -> bool:
+    ) -> str | None:
+        # returns the failure cause, or None when the environment was applied
         exec_spec = build_environment_exec_spec(
             container_name=container_name,
             environment=environment,
         )
         if exec_spec is None:
-            return True
+            return None
 
         try:
             result = await exec_logged_rental_docker_sdk_operation(
@@ -2721,7 +2722,7 @@ class DockerService:
                 ),
                 exc_info=True,
             )
-            return False
+            return str(exc)
 
         if result.exit_status != 0:
             await self.stream_log(
@@ -2741,9 +2742,9 @@ class DockerService:
                     }),
                 )
             )
-            return False
+            return f"exit_status={result.exit_status}; stderr={result.stderr}; stdout={result.stdout}"
 
-        return True
+        return None
 
     async def resolve_sysbox_subuid_base(
         self,
@@ -4739,15 +4740,15 @@ class DockerService:
 
                     # add environment variables
                     current_step = "set_environment"
-                    environment_ok = await self.add_environment_variables_with_rental_docker(
+                    environment_error = await self.add_environment_variables_with_rental_docker(
                         docker_client=docker_client,
                         container_name=container_name,
                         environment=custom_options.environment if custom_options else None,
                         log_tag=log_tag,
                         log_extra=default_extra,
                     )
-                    if not environment_ok:
-                        raise RuntimeError("Failed to set environment variables")
+                    if environment_error:
+                        raise RuntimeError(f"Failed to set environment variables: {environment_error}")
 
                     # Historical name — key injection moved before the bootstrap
                     # (DAH-2341), so this step now times the environment setup.

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -3423,6 +3423,7 @@ async def test_create_container_reports_docker_pull_failure_step(
 async def test_create_container_reports_set_environment_failure_step(
     docker_service,
     monkeypatch,
+    caplog,
 ):
     ssh_client = AsyncMock()
     ssh_client.run = AsyncMock(return_value=_make_ssh_command_result())
@@ -3469,7 +3470,7 @@ async def test_create_container_reports_set_environment_failure_step(
     monkeypatch.setattr(
         docker_service,
         "add_environment_variables_with_rental_docker",
-        AsyncMock(return_value=False),
+        AsyncMock(return_value="exit_status=1; stderr=cannot write /etc/environment; stdout="),
     )
     monkeypatch.setattr(docker_service, "stream_log", AsyncMock())
     monkeypatch.setattr(docker_service, "finish_stream_logs", AsyncMock())
@@ -3503,15 +3504,21 @@ async def test_create_container_reports_set_environment_failure_step(
         ssh_host_key=FAKE_SSH_HOST_KEY,
     )
 
-    result = await docker_service.create_container(
-        payload=payload,
-        executor_info=executor_info,
-        keypair=Mock(ss58_address="validator-hotkey"),
-        private_key="encrypted",
-    )
+    with caplog.at_level(logging.ERROR, logger="services.docker_service"):
+        result = await docker_service.create_container(
+            payload=payload,
+            executor_info=executor_info,
+            keypair=Mock(ss58_address="validator-hotkey"),
+            private_key="encrypted",
+        )
 
     assert isinstance(result, FailedContainerRequest)
     assert result.failure_step == "set_environment"
+    # the logged cause is what lium-stats classifies, so the bare wrapper must not swallow it
+    failure_extra = next(
+        record.msg.extra for record in caplog.records if str(record.msg) == "Failed create_container"
+    )
+    assert "cannot write /etc/environment" in failure_extra["error"]
     docker_service.redis_service.add_rented_pod.assert_not_awaited()
     docker_service.redis_service.remove_pending_pod.assert_awaited_once_with(
         payload.miner_hotkey,

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -824,7 +824,7 @@ async def test_sdk_exec_logs_exit_status_stdout_and_stderr_lengths(
     caplog,
 ):
     with caplog.at_level(logging.WARNING, logger="services.rental_docker_observability"):
-        ok = await docker_service.add_environment_variables_with_rental_docker(
+        error = await docker_service.add_environment_variables_with_rental_docker(
             docker_client=NonZeroExecRentalDockerClient(),
             container_name="pod_logs",
             environment={"APP_MODE": "prod"},
@@ -832,7 +832,7 @@ async def test_sdk_exec_logs_exit_status_stdout_and_stderr_lengths(
             log_extra={"pod_id": "pod-id", "miner_hotkey": "miner-hotkey"},
         )
 
-    assert ok is False
+    assert error == "exit_status=7; stderr=stderr details; stdout=stdout details"
     failed_extra = _sdk_log_extra(
         caplog,
         operation="exec_append_environment",


### PR DESCRIPTION
## Problem

`create_container` re-raises a bare `RuntimeError("Failed to set environment variables")`. The actual cause is logged separately by `rental_docker_observability`, so the ERROR record lium-stats classifies carries no diagnostic content at all.

Over the last 7 days (12–19 Aug) that is 10 of 579 `create_container` failures — 1.7%. Every one of them takes the exception branch, and the causes are already known and specific:

- `Docker container is not ready for exec: status='exited' running=False … exit_code=143`
- `Docker SDK exec failed: 409 … container … is not running`
- `Docker SDK inspect container failed: 404 … No such container: filler_…`

The `exit_status != 0` branch produced nothing in that window.

> Opened on 27 Jul, when this signature was 41 of 256 — 16% and the largest unclassifiable one. The mix has shifted since; see Follow-up.

## Change

`add_environment_variables_with_rental_docker` returns the failure cause (`str | None`) instead of a bool, and the caller puts it in the `RuntimeError` message. The cause therefore reaches `extra.error` on the `Failed create_container` record, which is what Datura-ai/lium-stats#83 reads, and `filler_run.failure_reason` on the backend.

Same shape as the neighbouring `Failed to add SSH public keys: exit_status=...; stderr=...; stdout=...`, which classifies fine today.

## What this buys

The three texts above are matched by rules that already exist in lium-stats#83 and sit above the generic `failed to set environment variables` rule, so the records reclassify with no classifier change:

| now | after |
|---|---|
| `environment.set_failed` (ambiguous) | `container.exited_before_exec` |
| `environment.set_failed` (ambiguous) | `container.disappeared` |

Which also settles the question: there is no distinct "environment" failure class — the container is already dead by the time we exec (`exit_code=143`, i.e. SIGTERM, and `exit_code=0`). `set_environment` is just where we first notice.

Nothing changes for the renter: `msg` is built from `str(log_text)` and `_StructuredMessage.__str__` returns the headline only. Environment values cannot leak either — they travel over stdin (`sh -c "cat >> /etc/environment"`), and only the command's own `exit_status`/`stderr`/`stdout` reach the message.

## Follow-up (not in this PR)

`gpu_power_cap` is now the largest unclassifiable signature: **125 of 579** failures in the last 7 days, all carrying the same bare text `GPU power cap could not be applied; refusing to start PEARL filler uncapped`. `apply_filler_gpu_power_limits` has five distinct `return False` paths collapsing into that one string — same disease, same fix, separate PR.

Full breakdown over the same window:

| failure_step | count | share |
|---|---|---|
| docker_run | 258 | 45% |
| gpu_power_cap | 125 | 22% |
| add_public_keys | 90 | 16% |
| docker_pull | 80 | 14% |
| set_environment | 10 | 1.7% |
| other | 16 | 3% |

For contrast, `docker_run` — the largest step — already carries full detail (`Docker SDK run container failed: 400 Client Error … /containers/create?name=pod_…`) and needs nothing.

## Verification

Rebased onto current `main` (no conflicts). `pdm run pytest tests/test_docker_service.py tests/test_docker_service_rental_security.py -q` in `neurons/validators`: 208 passed, 1 skipped.

The test on `create_container` asserts the cause reaches the logged `extra.error`, not just that the step is reported.
