### PR TITLE
DAH-2512: one s3fs plugin instance per volume

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -150,6 +150,17 @@ DOCKER_VOLUME_PLUGINS = {
     "s3fs": "mochoa/s3fs-volume-plugin"
 }
 
+S3FS_PLUGIN_IMAGE = DOCKER_VOLUME_PLUGINS["s3fs"]
+
+
+def s3fs_plugin_alias(volume_name: str) -> str:
+    """DAH-2512: one plugin instance per volume.
+
+    A shared instance holds a single credential pair and dies on `plugin disable`,
+    so attaching or detaching one pod's volume breaks every other pod on the host.
+    """
+    return f"s3fs-{volume_name}"
+
 # DAH-2496: sysbox installers reserve one 65536-wide subuid slice per host and map
 # every container's root to its base. A wider range is handed out per container.
 SYSBOX_SUBUID_SLICE_SIZE = 65536
@@ -2245,16 +2256,21 @@ class DockerService:
         sysbox_subuid_base: int | None,
     ):
         responses = []
+        plugin_alias: str = s3fs_plugin_alias(volume_info.name)
+
         # install docker volume plugin
-        command = "/usr/bin/docker plugin install mochoa/s3fs-volume-plugin --alias s3fs --grant-all-permissions --disable"
+        command = (
+            f"/usr/bin/docker plugin install {S3FS_PLUGIN_IMAGE} "
+            f"--alias {plugin_alias} --grant-all-permissions --disable"
+        )
         responses.append(await ssh_client.run(command))
 
         # disable volume plugin
-        command = "/usr/bin/docker plugin disable s3fs -f"
+        command = f"/usr/bin/docker plugin disable {plugin_alias} -f"
         responses.append(await ssh_client.run(command))
 
         # set credentials
-        command = f"/usr/bin/docker plugin set s3fs AWSACCESSKEYID={volume_info.iam_user_access_key} AWSSECRETACCESSKEY={volume_info.iam_user_secret_key}"
+        command = f"/usr/bin/docker plugin set {plugin_alias} AWSACCESSKEYID={volume_info.iam_user_access_key} AWSSECRETACCESSKEY={volume_info.iam_user_secret_key}"
         responses.append(await ssh_client.run(command))
 
         # DAH-2496: the kernel cannot ID-shift a FUSE mount, so under sysbox the
@@ -2263,15 +2279,15 @@ class DockerService:
         mount_options: str = "allow_other"
         if sysbox_subuid_base is not None:
             mount_options = f"allow_other,uid={sysbox_subuid_base},gid={sysbox_subuid_base}"
-        command = f'/usr/bin/docker plugin set s3fs DEFAULT_S3FSOPTS="{mount_options}"'
+        command = f'/usr/bin/docker plugin set {plugin_alias} DEFAULT_S3FSOPTS="{mount_options}"'
         responses.append(await ssh_client.run(command))
 
         # enable volume plugin
-        command = "/usr/bin/docker plugin enable s3fs"
+        command = f"/usr/bin/docker plugin enable {plugin_alias}"
         responses.append(await ssh_client.run(command))
 
         # create volume
-        command = f"/usr/bin/docker volume create -d s3fs {volume_info.name}"
+        command = f"/usr/bin/docker volume create -d {plugin_alias} {volume_info.name}"
         result = await self.execute_and_stream_logs(
             ssh_client=ssh_client,
             command=command,
@@ -2291,13 +2307,18 @@ class DockerService:
 
         return result
 
-    async def disable_s3fs_volume_plugin(
+    async def remove_s3fs_volume_plugin(
         self,
         ssh_client: asyncssh.SSHClientConnection,
-    ):
-        # disable volume plugin
-        command = "/usr/bin/docker plugin disable s3fs -f"
-        await ssh_client.run(command)
+        volume_name: str,
+    ) -> None:
+        """Drop the plugin instance that served this volume, leaving the rest alone."""
+        if not _is_safe_docker_volume_name(volume_name):
+            return
+
+        plugin_alias: str = s3fs_plugin_alias(volume_name)
+        await ssh_client.run(f"/usr/bin/docker plugin disable {plugin_alias} -f")
+        await ssh_client.run(f"/usr/bin/docker plugin rm {plugin_alias}")
 
     async def run_jupyter(
         self,
@@ -4658,7 +4679,9 @@ class DockerService:
                             volume_name=payload.external_volume,
                             volume_role="external",
                         )
-                        await self.disable_s3fs_volume_plugin(ssh_client)
+                        await self.remove_s3fs_volume_plugin(
+                            ssh_client=ssh_client, volume_name=payload.external_volume
+                        )
 
                 log.info(
                     "Remove rented machine from redis",

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -153,6 +153,9 @@ DOCKER_VOLUME_PLUGINS = {
 S3FS_PLUGIN_IMAGE = DOCKER_VOLUME_PLUGINS["s3fs"]
 
 
+LEGACY_S3FS_PLUGIN_ALIAS = "s3fs"
+
+
 def s3fs_plugin_alias(volume_name: str) -> str:
     """DAH-2512: one plugin instance per volume.
 
@@ -2286,12 +2289,15 @@ class DockerService:
         command = f"/usr/bin/docker plugin enable {plugin_alias}"
         responses.append(await ssh_client.run(command))
 
-        # A volume of this name may still be registered against another driver —
-        # the shared `s3fs` instance used before DAH-2512, or a stale alias. Docker
-        # then refuses the create as a duplicate name. Dropping the handle is safe:
-        # the data lives in the bucket, not in the volume.
-        command = f"/usr/bin/docker volume rm {volume_info.name}"
-        responses.append(await ssh_client.run(command))
+        # Hosts provisioned before DAH-2512 still hold a volume of this name under
+        # the shared `s3fs` instance, and docker refuses both create and rm of the
+        # name while that instance is disabled — it cannot query it. Enable it, drop
+        # the handle (the data lives in the bucket, not in the volume) and leave it
+        # enabled: pods still mounting through it keep working, new ones do not use it.
+        responses.append(
+            await ssh_client.run(f"/usr/bin/docker plugin enable {LEGACY_S3FS_PLUGIN_ALIAS}")
+        )
+        responses.append(await ssh_client.run(f"/usr/bin/docker volume rm {volume_info.name}"))
 
         # create volume
         command = f"/usr/bin/docker volume create -d {plugin_alias} {volume_info.name}"

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -2286,6 +2286,13 @@ class DockerService:
         command = f"/usr/bin/docker plugin enable {plugin_alias}"
         responses.append(await ssh_client.run(command))
 
+        # A volume of this name may still be registered against another driver —
+        # the shared `s3fs` instance used before DAH-2512, or a stale alias. Docker
+        # then refuses the create as a duplicate name. Dropping the handle is safe:
+        # the data lives in the bucket, not in the volume.
+        command = f"/usr/bin/docker volume rm {volume_info.name}"
+        responses.append(await ssh_client.run(command))
+
         # create volume
         command = f"/usr/bin/docker volume create -d {plugin_alias} {volume_info.name}"
         result = await self.execute_and_stream_logs(

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -150,13 +150,13 @@ DOCKER_VOLUME_PLUGINS = {
     "s3fs": "mochoa/s3fs-volume-plugin"
 }
 
-S3FS_PLUGIN_IMAGE = DOCKER_VOLUME_PLUGINS["s3fs"]
+S3FS_PLUGIN_IMAGE = "mochoa/s3fs-volume-plugin"
 
 
 LEGACY_S3FS_PLUGIN_ALIAS = "s3fs"
 
 
-def s3fs_plugin_alias(volume_name: str) -> str:
+def _s3fs_plugin_alias(volume_name: str) -> str:
     """DAH-2512: one plugin instance per volume.
 
     A shared instance holds a single credential pair and dies on `plugin disable`,
@@ -2258,23 +2258,14 @@ class DockerService:
         log_tag: str,
         sysbox_subuid_base: int | None,
     ):
-        responses = []
-        plugin_alias: str = s3fs_plugin_alias(volume_info.name)
+        # The name arrives from the backend and lands in a plugin alias, a volume
+        # name and two shell commands — refuse it before any of that.
+        if not _is_safe_docker_volume_name(volume_info.name):
+            message = f"Unsafe external volume name: {volume_info.name!r}"
+            logger.warning(_m(f"s3fs_volume failed. {message}", extra=get_extra_info({**log_extra})))
+            return False, message
 
-        # install docker volume plugin
-        command = (
-            f"/usr/bin/docker plugin install {S3FS_PLUGIN_IMAGE} "
-            f"--alias {plugin_alias} --grant-all-permissions --disable"
-        )
-        responses.append(await ssh_client.run(command))
-
-        # disable volume plugin
-        command = f"/usr/bin/docker plugin disable {plugin_alias} -f"
-        responses.append(await ssh_client.run(command))
-
-        # set credentials
-        command = f"/usr/bin/docker plugin set {plugin_alias} AWSACCESSKEYID={volume_info.iam_user_access_key} AWSSECRETACCESSKEY={volume_info.iam_user_secret_key}"
-        responses.append(await ssh_client.run(command))
+        plugin_alias: str = _s3fs_plugin_alias(volume_info.name)
 
         # DAH-2496: the kernel cannot ID-shift a FUSE mount, so under sysbox the
         # pod's root would see the bucket as nobody. s3fs keeps owner in object
@@ -2282,43 +2273,89 @@ class DockerService:
         mount_options: str = "allow_other"
         if sysbox_subuid_base is not None:
             mount_options = f"allow_other,uid={sysbox_subuid_base},gid={sysbox_subuid_base}"
-        command = f'/usr/bin/docker plugin set {plugin_alias} DEFAULT_S3FSOPTS="{mount_options}"'
-        responses.append(await ssh_client.run(command))
 
-        # enable volume plugin
-        command = f"/usr/bin/docker plugin enable {plugin_alias}"
-        responses.append(await ssh_client.run(command))
-
-        # Hosts provisioned before DAH-2512 still hold a volume of this name under
-        # the shared `s3fs` instance, and docker refuses both create and rm of the
-        # name while that instance is disabled — it cannot query it. Enable it, drop
-        # the handle (the data lives in the bucket, not in the volume) and leave it
-        # enabled: pods still mounting through it keep working, new ones do not use it.
-        responses.append(
-            await ssh_client.run(f"/usr/bin/docker plugin enable {LEGACY_S3FS_PLUGIN_ALIAS}")
+        setup_results: list[asyncssh.SSHCompletedProcess] = (
+            await self._install_s3fs_plugin_instance(
+                ssh_client=ssh_client,
+                plugin_alias=plugin_alias,
+                volume_info=volume_info,
+                mount_options=mount_options,
+            )
         )
-        responses.append(await ssh_client.run(f"/usr/bin/docker volume rm {volume_info.name}"))
 
-        # create volume
-        command = f"/usr/bin/docker volume create -d {plugin_alias} {volume_info.name}"
+        create_command: str = (
+            f"/usr/bin/docker volume create -d {plugin_alias} {volume_info.name}"
+        )
         result = await self.execute_and_stream_logs(
             ssh_client=ssh_client,
-            command=command,
+            command=create_command,
             log_tag=log_tag,
             log_text="Creating docker volume",
             log_extra=log_extra,
             raise_exception=False,
         )
+        if not result[0]:
+            setup_results.extend(
+                await self._drop_legacy_shared_s3fs_volume(ssh_client, volume_info.name)
+            )
+            result = await self.execute_and_stream_logs(
+                ssh_client=ssh_client,
+                command=create_command,
+                log_tag=log_tag,
+                log_text="Creating docker volume",
+                log_extra=log_extra,
+                raise_exception=False,
+            )
+
         is_success, message = result
         if not is_success:
             responses_text = message
-            for i, r in enumerate(responses):
+            for i, r in enumerate(setup_results):
                 responses_text += f"|Step {i}: exit={r.exit_status}, stdout={r.stdout}, stderr={r.stderr}"
             logger.warning(_m(f"s3fs_volume failed. {responses_text}",extra=get_extra_info({**log_extra})))
         else:
             logger.info(_m("s3fs_volume success", extra=get_extra_info({**log_extra})))
 
         return result
+
+    async def _install_s3fs_plugin_instance(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        plugin_alias: str,
+        volume_info: ExternalVolumeInfo,
+        mount_options: str,
+    ) -> list[asyncssh.SSHCompletedProcess]:
+        """Install and configure the plugin instance that serves this one volume."""
+        commands: list[str] = [
+            f"/usr/bin/docker plugin install {S3FS_PLUGIN_IMAGE} "
+            f"--alias {plugin_alias} --grant-all-permissions --disable",
+            f"/usr/bin/docker plugin disable {plugin_alias} -f",
+            f"/usr/bin/docker plugin set {plugin_alias} "
+            f"AWSACCESSKEYID={volume_info.iam_user_access_key} "
+            f"AWSSECRETACCESSKEY={volume_info.iam_user_secret_key}",
+            f'/usr/bin/docker plugin set {plugin_alias} DEFAULT_S3FSOPTS="{mount_options}"',
+            f"/usr/bin/docker plugin enable {plugin_alias}",
+        ]
+        return [await ssh_client.run(command) for command in commands]
+
+    async def _drop_legacy_shared_s3fs_volume(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        volume_name: str,
+    ) -> list[asyncssh.SSHCompletedProcess]:
+        """Free a volume name still held by the pre-DAH-2512 shared plugin instance.
+
+        Docker refuses both create and rm of the name while that instance is
+        disabled — it cannot query it — so enable it first and leave it enabled:
+        pods still mounting through it keep working. Dropping the handle is safe,
+        the data lives in the bucket.
+        """
+        return [
+            await ssh_client.run(
+                f"/usr/bin/docker plugin enable {LEGACY_S3FS_PLUGIN_ALIAS}"
+            ),
+            await ssh_client.run(f"/usr/bin/docker volume rm {volume_name}"),
+        ]
 
     async def remove_s3fs_volume_plugin(
         self,
@@ -2329,7 +2366,7 @@ class DockerService:
         if not _is_safe_docker_volume_name(volume_name):
             return
 
-        plugin_alias: str = s3fs_plugin_alias(volume_name)
+        plugin_alias: str = _s3fs_plugin_alias(volume_name)
         await ssh_client.run(f"/usr/bin/docker plugin disable {plugin_alias} -f")
         await ssh_client.run(f"/usr/bin/docker plugin rm {plugin_alias}")
 

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -488,6 +488,71 @@ async def test_create_container_drops_sysbox_when_subuid_base_is_unusable(
 
 
 @pytest.mark.asyncio
+async def test_create_s3fs_volume_uses_a_plugin_instance_of_its_own(
+    docker_service,
+    monkeypatch,
+):
+    # DAH-2512: one shared plugin instance holds one credential pair and dies on
+    # `plugin disable`, taking every other pod's mount on the host with it.
+    ssh_client = RecordingSSHClient()
+    stream_logs = AsyncMock(return_value=(True, ""))
+    monkeypatch.setattr(docker_service, "execute_and_stream_logs", stream_logs)
+    volume_info = ExternalVolumeInfo(
+        name="celium-volume-safe",
+        plugin="s3fs",
+        iam_user_access_key="access-key",
+        iam_user_secret_key="secret-key",
+    )
+
+    await docker_service.create_s3fs_volume(
+        ssh_client=ssh_client,
+        log_extra={},
+        volume_info=volume_info,
+        log_tag="tag",
+        sysbox_subuid_base=None,
+    )
+
+    alias = "s3fs-celium-volume-safe"
+    assert any(f"--alias {alias} " in command for command in ssh_client.commands)
+    assert any(f"plugin set {alias} AWSACCESSKEYID=" in command for command in ssh_client.commands)
+    assert any(f"plugin enable {alias}" in command for command in ssh_client.commands)
+    assert f"volume create -d {alias} " in stream_logs.await_args.kwargs["command"]
+    # nothing may touch the shared instance any more
+    assert not any(
+        " s3fs " in command or command.endswith(" s3fs") for command in ssh_client.commands
+    )
+
+
+@pytest.mark.asyncio
+async def test_remove_s3fs_volume_plugin_removes_only_its_own_instance(
+    docker_service,
+):
+    ssh_client = RecordingSSHClient()
+
+    await docker_service.remove_s3fs_volume_plugin(
+        ssh_client=ssh_client, volume_name="celium-volume-safe"
+    )
+
+    assert ssh_client.commands == [
+        "/usr/bin/docker plugin disable s3fs-celium-volume-safe -f",
+        "/usr/bin/docker plugin rm s3fs-celium-volume-safe",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_remove_s3fs_volume_plugin_ignores_unsafe_volume_name(
+    docker_service,
+):
+    ssh_client = RecordingSSHClient()
+
+    await docker_service.remove_s3fs_volume_plugin(
+        ssh_client=ssh_client, volume_name=HOSTILE_VOLUME_NAME
+    )
+
+    assert ssh_client.commands == []
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "sysbox_subuid_base,expected_options",
     [

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -517,10 +517,9 @@ async def test_create_s3fs_volume_uses_a_plugin_instance_of_its_own(
     assert any(f"plugin set {alias} AWSACCESSKEYID=" in command for command in ssh_client.commands)
     assert any(f"plugin enable {alias}" in command for command in ssh_client.commands)
     assert f"volume create -d {alias} " in stream_logs.await_args.kwargs["command"]
-    # a handle left by the shared instance blocks the create as a duplicate name,
-    # and docker cannot drop it while that instance is disabled
-    assert ssh_client.commands.index("/usr/bin/docker plugin enable s3fs") < ssh_client.commands.index(
-        f"/usr/bin/docker volume rm {volume_info.name}"
+    # the legacy instance is left alone entirely while the create succeeds
+    assert not any(
+        LEGACY_S3FS_PLUGIN_ALIAS == command.split()[-1] for command in ssh_client.commands
     )
     # the shared instance is only ever enabled, never reconfigured or disabled —
     # that is what used to break every other pod on the host
@@ -530,6 +529,66 @@ async def test_create_s3fs_volume_uses_a_plugin_instance_of_its_own(
         f"/usr/bin/docker volume create -d {LEGACY_S3FS_PLUGIN_ALIAS} ",
     )
     assert not any(command.startswith(forbidden) for command in ssh_client.commands)
+
+
+@pytest.mark.asyncio
+async def test_create_s3fs_volume_frees_a_name_held_by_the_legacy_instance(
+    docker_service,
+    monkeypatch,
+):
+    # Hosts provisioned before DAH-2512 still hold the volume name under the shared
+    # instance, and docker cannot even drop that handle while it is disabled.
+    ssh_client = RecordingSSHClient()
+    stream_logs = AsyncMock(side_effect=[(False, "volume name must be unique"), (True, "")])
+    monkeypatch.setattr(docker_service, "execute_and_stream_logs", stream_logs)
+    volume_info = ExternalVolumeInfo(
+        name="celium-volume-safe",
+        plugin="s3fs",
+        iam_user_access_key="access-key",
+        iam_user_secret_key="secret-key",
+    )
+
+    is_success, _ = await docker_service.create_s3fs_volume(
+        ssh_client=ssh_client,
+        log_extra={},
+        volume_info=volume_info,
+        log_tag="tag",
+        sysbox_subuid_base=None,
+    )
+
+    assert is_success is True
+    assert stream_logs.await_count == 2
+    assert ssh_client.commands.index(
+        f"/usr/bin/docker plugin enable {LEGACY_S3FS_PLUGIN_ALIAS}"
+    ) < ssh_client.commands.index(f"/usr/bin/docker volume rm {volume_info.name}")
+
+
+@pytest.mark.asyncio
+async def test_create_s3fs_volume_refuses_an_unsafe_volume_name(
+    docker_service,
+    monkeypatch,
+):
+    ssh_client = RecordingSSHClient()
+    monkeypatch.setattr(
+        docker_service, "execute_and_stream_logs", AsyncMock(return_value=(True, ""))
+    )
+    volume_info = ExternalVolumeInfo(
+        name=HOSTILE_VOLUME_NAME,
+        plugin="s3fs",
+        iam_user_access_key="access-key",
+        iam_user_secret_key="secret-key",
+    )
+
+    is_success, _ = await docker_service.create_s3fs_volume(
+        ssh_client=ssh_client,
+        log_extra={},
+        volume_info=volume_info,
+        log_tag="tag",
+        sysbox_subuid_base=None,
+    )
+
+    assert is_success is False
+    assert ssh_client.commands == []
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -21,7 +21,7 @@ from payload_models.payloads import (
     RemoveSshPublicKeysRequest,
     WorkloadKind,
 )
-from services.docker_service import DockerService
+from services.docker_service import LEGACY_S3FS_PLUGIN_ALIAS, DockerService
 from services.rental_docker_sdk import (
     ContainerExecResult,
     RentalDockerOperationError,
@@ -517,15 +517,19 @@ async def test_create_s3fs_volume_uses_a_plugin_instance_of_its_own(
     assert any(f"plugin set {alias} AWSACCESSKEYID=" in command for command in ssh_client.commands)
     assert any(f"plugin enable {alias}" in command for command in ssh_client.commands)
     assert f"volume create -d {alias} " in stream_logs.await_args.kwargs["command"]
-    # a handle left by the shared instance blocks the create as a duplicate name
-    assert any(
-        command == f"/usr/bin/docker volume rm {volume_info.name}"
-        for command in ssh_client.commands
+    # a handle left by the shared instance blocks the create as a duplicate name,
+    # and docker cannot drop it while that instance is disabled
+    assert ssh_client.commands.index("/usr/bin/docker plugin enable s3fs") < ssh_client.commands.index(
+        f"/usr/bin/docker volume rm {volume_info.name}"
     )
-    # nothing may touch the shared instance any more
-    assert not any(
-        " s3fs " in command or command.endswith(" s3fs") for command in ssh_client.commands
+    # the shared instance is only ever enabled, never reconfigured or disabled —
+    # that is what used to break every other pod on the host
+    forbidden = (
+        f"/usr/bin/docker plugin disable {LEGACY_S3FS_PLUGIN_ALIAS} -f",
+        f"/usr/bin/docker plugin set {LEGACY_S3FS_PLUGIN_ALIAS} ",
+        f"/usr/bin/docker volume create -d {LEGACY_S3FS_PLUGIN_ALIAS} ",
     )
+    assert not any(command.startswith(forbidden) for command in ssh_client.commands)
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -517,6 +517,11 @@ async def test_create_s3fs_volume_uses_a_plugin_instance_of_its_own(
     assert any(f"plugin set {alias} AWSACCESSKEYID=" in command for command in ssh_client.commands)
     assert any(f"plugin enable {alias}" in command for command in ssh_client.commands)
     assert f"volume create -d {alias} " in stream_logs.await_args.kwargs["command"]
+    # a handle left by the shared instance blocks the create as a duplicate name
+    assert any(
+        command == f"/usr/bin/docker volume rm {volume_info.name}"
+        for command in ssh_client.commands
+    )
     # nothing may touch the shared instance any more
     assert not any(
         " s3fs " in command or command.endswith(" s3fs") for command in ssh_client.commands


### PR DESCRIPTION
## What

Give every S3FS volume its own plugin instance (`s3fs-<volume name>`) instead of reconfiguring one shared `s3fs` instance per host. Pod deletion now removes that instance only.

## Why

The shared instance holds a single credential pair and dies on `plugin disable`, so attaching or detaching one pod's volume breaks every other pod mounting a volume on the same host. Reproduced on a node with a running container:

```
ls /mnt                          -> 6 files
docker plugin disable s3fs -f    # what create_s3fs_volume does for the next volume
ls /mnt                          -> ls: /mnt: Socket not connected
docker plugin enable s3fs
ls /mnt                          -> ls: /mnt: Socket not connected   (does not recover)
```

The first pod's mount stays dead until its container is recreated, with no error surfaced to the renter. The delete path has the same problem: it disabled the shared instance for everyone.

Skipping the reconfiguration when nothing changed would not fix it — each volume has its own IAM user and the plugin stores one credential pair per instance, so a second volume overwrites the first one's credentials regardless. The plugin's own documentation says credentials are global per instance and recommends a separate alias per key set.

## Scope

Pre-existing, not a regression from DAH-2496 — but while volumes silently disabled sysbox and Docker-in-Docker there was little reason to use them, and DAH-2496 makes them usable. Only nodes rented in parts (GPU splitting) can host two volume pods at once.

## Leftovers on already-provisioned hosts

Hosts that served a volume before this change keep the old shared `s3fs` instance installed and unused; volumes created with it keep working until their pod goes away. `remove_s3fs_volume_plugin` is a no-op for them, which is harmless.

## Tests

`tests/test_docker_service_rental_security.py` — the per-volume alias is used for install / credentials / enable / volume create and the shared instance is never touched; removal drops only its own instance; an unsafe volume name issues no commands.

Based on #1169 — same functions. Merge that first.
