### PR TITLE
DAH-2518, serve the last good opted-in miner list when the portal is unavailable

### DIFF
--- a/neurons/validators/src/clients/subtensor_client.py
+++ b/neurons/validators/src/clients/subtensor_client.py
@@ -284,11 +284,10 @@ class SubtensorClient:
             miners = metagraph.neurons
 
             # Get miners that have opted in from portal BE
-            miners_with_opt_in_status = await ValidatorPortalAPI.get_opted_in_miners()
-            if miners_with_opt_in_status is None:
-                # Without the central-miner axons the opt-in miners fall out of the
-                # is_serving filter below, so a stale miner list beats a truncated one.
-                # With no previous list at all, truncated still beats empty.
+            opted_in_miners = await ValidatorPortalAPI.get_opted_in_miners()
+            if opted_in_miners is None:
+                # without the central-miner axons the opt-in miners fall out of the
+                # is_serving filter below, so a stale miner list beats a truncated one
                 if self.miners:
                     logger.error(
                         _m(
@@ -306,25 +305,23 @@ class SubtensorClient:
                         extra=get_extra_info(self.default_extra),
                     ),
                 )
-                miners_with_opt_in_status = []
+                opted_in_miners = []
 
             logger.info(
                 _m(
-                    # not "from portal": the list may be the cached one served through an outage
-                    f"[fetch_miners] Applying opt-in routing for {len(miners_with_opt_in_status)} miners",
+                    f"[fetch_miners] Applying opt-in routing for {len(opted_in_miners)} miners",
                     extra=get_extra_info(self.default_extra),
                 ),
             )
-            # Update miners in `miners` list based on miners_with_opt_in_status.
-            hotkey_to_opt_in = {
-                opt_in["miner_hotkey"]: opt_in for opt_in in miners_with_opt_in_status if opt_in.get("miner_hotkey", None)
+            opt_in_by_hotkey = {
+                opt_in.miner_hotkey: opt_in for opt_in in opted_in_miners if opt_in.miner_hotkey
             }
             for miner in miners:
-                opt_in = hotkey_to_opt_in.get(miner.hotkey)
+                opt_in = opt_in_by_hotkey.get(miner.hotkey)
                 if opt_in is not None:
-                    miner.axon_info.ip = opt_in.get("central_miner_ip")
-                    miner.axon_info.port = opt_in.get("central_miner_port")
-                    
+                    miner.axon_info.ip = opt_in.central_miner_ip
+                    miner.axon_info.port = opt_in.central_miner_port
+
             miners = [
                 neuron
                 for neuron in metagraph.neurons

--- a/neurons/validators/src/clients/subtensor_client.py
+++ b/neurons/validators/src/clients/subtensor_client.py
@@ -285,10 +285,33 @@ class SubtensorClient:
 
             # Get miners that have opted in from portal BE
             miners_with_opt_in_status = await ValidatorPortalAPI.get_opted_in_miners()
+            if miners_with_opt_in_status is None:
+                # Without the central-miner axons the opt-in miners fall out of the
+                # is_serving filter below, so a stale miner list beats a truncated one.
+                # With no previous list at all, truncated still beats empty.
+                if self.miners:
+                    logger.error(
+                        _m(
+                            "[fetch_miners] Portal unavailable with no cached opt-in list"
+                            " - keeping the previous miner list",
+                            extra=get_extra_info({**self.default_extra, "miners": len(self.miners)}),
+                        ),
+                    )
+                    return
+
+                logger.error(
+                    _m(
+                        "[fetch_miners] Portal unavailable with no cached opt-in list and no"
+                        " previous miner list - opt-in miners will be MISSING this cycle",
+                        extra=get_extra_info(self.default_extra),
+                    ),
+                )
+                miners_with_opt_in_status = []
 
             logger.info(
                 _m(
-                    f"[fetch_miners] Found {len(miners_with_opt_in_status)} opted-in miners from portal",
+                    # not "from portal": the list may be the cached one served through an outage
+                    f"[fetch_miners] Applying opt-in routing for {len(miners_with_opt_in_status)} miners",
                     extra=get_extra_info(self.default_extra),
                 ),
             )

--- a/neurons/validators/src/clients/subtensor_client.py
+++ b/neurons/validators/src/clients/subtensor_client.py
@@ -286,22 +286,13 @@ class SubtensorClient:
             # Get miners that have opted in from portal BE
             opted_in_miners = await ValidatorPortalAPI.get_opted_in_miners()
             if opted_in_miners is None:
-                # without the central-miner axons the opt-in miners fall out of the
-                # is_serving filter below, so a stale miner list beats a truncated one
-                if self.miners:
-                    logger.error(
-                        _m(
-                            "[fetch_miners] Portal unavailable with no cached opt-in list"
-                            " - keeping the previous miner list",
-                            extra=get_extra_info({**self.default_extra, "miners": len(self.miners)}),
-                        ),
-                    )
-                    return
-
+                # the portal never answered once since startup, so there is no list to fall
+                # back on. bittensor's AxonInfo.is_serving is just `ip != "0.0.0.0"`, so the
+                # opt-in miners keep their on-chain 0.0.0.0 and drop out of the filter below.
                 logger.error(
                     _m(
-                        "[fetch_miners] Portal unavailable with no cached opt-in list and no"
-                        " previous miner list - opt-in miners will be MISSING this cycle",
+                        "[fetch_miners] Portal unavailable with no cached opt-in list"
+                        " - opt-in miners will be MISSING this cycle",
                         extra=get_extra_info(self.default_extra),
                     ),
                 )
@@ -313,9 +304,7 @@ class SubtensorClient:
                     extra=get_extra_info(self.default_extra),
                 ),
             )
-            opt_in_by_hotkey = {
-                opt_in.miner_hotkey: opt_in for opt_in in opted_in_miners if opt_in.miner_hotkey
-            }
+            opt_in_by_hotkey = {opt_in.miner_hotkey: opt_in for opt_in in opted_in_miners}
             for miner in miners:
                 opt_in = opt_in_by_hotkey.get(miner.hotkey)
                 if opt_in is not None:

--- a/neurons/validators/src/clients/validator_portal_api.py
+++ b/neurons/validators/src/clients/validator_portal_api.py
@@ -12,14 +12,15 @@ logger = logging.getLogger(__name__)
 
 
 class OptedInMiner(BaseModel):
-    """One row of the portal's `/validators/opted-in` answer.
+    """The fields the validator needs from one row of the portal's `/validators/opted-in`.
 
-    Mirrors `OptInStatusResponse` in lium-miner-portal - all four fields are
-    required there, so a record missing one means the portal is misbehaving.
+    All three are required in `OptInStatusResponse` (lium-miner-portal `src/dtos/miner.py`),
+    so a record missing one means the portal is misbehaving. Nothing enforces that contract
+    across the two repos, and a failed row fails the whole fetch - hence only the fields
+    that are actually read, and `miner_coldkey` is left to the ignored extras.
     """
 
     miner_hotkey: str
-    miner_coldkey: str
     central_miner_ip: str
     central_miner_port: int
 
@@ -29,9 +30,12 @@ class ValidatorPortalAPI:
 
     Every failure used to return an empty list, indistinguishable from "nobody opted
     in": `SubtensorClient.fetch_miners` then skipped the central-miner axon override
-    and the opt-in miners dropped out of the validated fleet (372 -> 268 executors
-    during the 2026-07-28 portal outage). Mirrors the miner-side cache in
-    `MinerPortalAPI`.
+    and the opt-in miners dropped out of the validated fleet (DAH-2518).
+
+    Not a cache in the `MinerPortalAPI` sense - every call still hits the portal, and
+    the stored answer only serves failures. It has no expiry, so a long outage keeps
+    serving an arbitrarily old list; `cached_age_seconds` on the failure log is the
+    only signal of how old.
     """
 
     _last_good_opted_in_miners: list[OptedInMiner] | None = None
@@ -41,23 +45,36 @@ class ValidatorPortalAPI:
     async def get_opted_in_miners(cls) -> list[OptedInMiner] | None:
         """Fetch the opted-in miners, falling back to the last successful answer.
 
-        Returns None when the fetch failed and nothing was ever cached - callers
-        must not read that as "zero opted-in miners".
+        Returns None when the fetch failed and no populated answer was ever cached -
+        callers must not read that as "zero opted-in miners". An unconfigured portal
+        URL still returns an empty list: there is nothing to route to.
         """
         api_base = (settings.MINER_PORTAL_REST_API_URL or "").rstrip("/")
         if not api_base:
-            # a blank portal URL is a deliberate opt-out of portal routing, not an outage
+            # the setting defaults to the real portal, so an empty one is a broken deploy,
+            # and without this line it is the only way to lose the fleet without a trace
+            logger.warning(
+                _m(
+                    "MINER_PORTAL_REST_API_URL is empty - opt-in routing is off this cycle",
+                    extra=get_extra_info({}),
+                )
+            )
             return []
 
         url = f"{api_base}/validators/opted-in"
 
         try:
             miners = await cls._fetch_opted_in_miners(url)
-        except Exception as e:
-            cls._log_fetch_failure(url, e)
+        except Exception as error:
+            cls._log_fetch_failure(url, error)
             return cls._last_good_opted_in_miners
 
-        if not miners and cls._last_good_opted_in_miners:
+        if miners:
+            cls._last_good_opted_in_miners = miners
+            cls._last_good_fetched_at = time.monotonic()
+            return miners
+
+        if cls._last_good_opted_in_miners:
             # a sudden "nobody is opted in" is far more likely a portal bug than a real
             # mass opt-out, and accepting it would drop every opt-in miner at once
             logger.warning(
@@ -73,20 +90,20 @@ class ValidatorPortalAPI:
             )
             return cls._last_good_opted_in_miners
 
-        cls._last_good_opted_in_miners = miners
-        cls._last_good_fetched_at = time.monotonic()
-        return miners
+        # an empty answer is deliberately not stored: it would make every later failure
+        # return that empty list instead of None, which is exactly the "an outage looks
+        # like nobody opted in" confusion this class exists to remove
+        return []
 
     @classmethod
     def _log_fetch_failure(cls, url: str, error: Exception) -> None:
+        # the caller reports the consequence, so this stays neutral - both layers claiming
+        # "opt-in miners will be MISSING" double-counts one outage in the ERROR alerts
         has_cached_miners = cls._last_good_opted_in_miners is not None
         if has_cached_miners:
             message = "Failed to fetch opted-in miners from portal - serving the last good list"
         else:
-            message = (
-                "Failed to fetch opted-in miners from portal and nothing is cached"
-                " - opt-in miners will be MISSING this cycle"
-            )
+            message = "Failed to fetch opted-in miners from portal and nothing is cached"
         logger.error(
             _m(
                 message,

--- a/neurons/validators/src/clients/validator_portal_api.py
+++ b/neurons/validators/src/clients/validator_portal_api.py
@@ -3,6 +3,7 @@ import time
 
 import aiohttp
 import bittensor
+from pydantic import BaseModel
 
 from core.config import settings
 from core.utils import _m, get_extra_info
@@ -10,39 +11,40 @@ from core.utils import _m, get_extra_info
 logger = logging.getLogger(__name__)
 
 
+class OptedInMiner(BaseModel):
+    """One row of the portal's `/validators/opted-in` answer.
+
+    Mirrors `OptInStatusResponse` in lium-miner-portal - all four fields are
+    required there, so a record missing one means the portal is misbehaving.
+    """
+
+    miner_hotkey: str
+    miner_coldkey: str
+    central_miner_ip: str
+    central_miner_port: int
+
+
 class ValidatorPortalAPI:
     """Opted-in miner list, with the last successful portal answer as a fallback.
 
-    Every failure used to return an empty list, which is indistinguishable from
-    "nobody opted in": `SubtensorClient.fetch_miners` then skipped the central-miner
-    axon override and the opt-in miners silently dropped out of the validated fleet
-    (165 -> 137 miners, 372 -> 268 executors during the 2026-07-28 portal outage).
-    Keeping the last good answer in memory turns a portal outage into stale-but-correct
-    routing instead. Mirrors the miner-side snapshot cache in `MinerPortalAPI`.
+    Every failure used to return an empty list, indistinguishable from "nobody opted
+    in": `SubtensorClient.fetch_miners` then skipped the central-miner axon override
+    and the opt-in miners dropped out of the validated fleet (372 -> 268 executors
+    during the 2026-07-28 portal outage). Mirrors the miner-side cache in
+    `MinerPortalAPI`.
     """
 
-    _last_good: list[dict] | None = None
+    _last_good_opted_in_miners: list[OptedInMiner] | None = None
     _last_good_fetched_at: float | None = None
 
     @classmethod
-    async def get_opted_in_miners(cls) -> list[dict] | None:
-        """Fetch list of miners that have opted in.
+    async def get_opted_in_miners(cls) -> list[OptedInMiner] | None:
+        """Fetch the opted-in miners, falling back to the last successful answer.
 
-        Returns list of dicts with shape:
-            [
-                {
-                    "miner_hotkey": str,
-                    "miner_coldkey": str,
-                    "central_miner_ip": str,
-                    "central_miner_port": int,
-                },
-                ...
-            ]
-        On a failed fetch returns the last successful list instead. Returns None when the
-        fetch failed and nothing was ever cached - callers must not read that as "zero
-        opted-in miners".
+        Returns None when the fetch failed and nothing was ever cached - callers
+        must not read that as "zero opted-in miners".
         """
-        api_base = settings.MINER_PORTAL_REST_API_URL.rstrip("/") if settings.MINER_PORTAL_REST_API_URL else ""
+        api_base = (settings.MINER_PORTAL_REST_API_URL or "").rstrip("/")
         if not api_base:
             # a blank portal URL is a deliberate opt-out of portal routing, not an outage
             return []
@@ -50,61 +52,63 @@ class ValidatorPortalAPI:
         url = f"{api_base}/validators/opted-in"
 
         try:
-            miners = await cls._fetch(url)
+            miners = await cls._fetch_opted_in_miners(url)
         except Exception as e:
             cls._log_fetch_failure(url, e)
-            return cls._last_good
+            return cls._last_good_opted_in_miners
 
-        if not miners and cls._last_good:
-            # a sudden "nobody is opted in" is far more likely a portal bug than a real mass
-            # opt-out; accepting it would drop every opt-in miner from the fleet at once.
-            # The age deliberately keeps counting from the last real answer.
+        if not miners and cls._last_good_opted_in_miners:
+            # a sudden "nobody is opted in" is far more likely a portal bug than a real
+            # mass opt-out, and accepting it would drop every opt-in miner at once
             logger.warning(
                 _m(
                     "Portal returned an empty opted-in list while a populated one is cached"
                     " - keeping the cached list",
                     extra=get_extra_info({
                         "url": url,
-                        "cached_miners": len(cls._last_good),
-                        "cached_age_seconds": cls._last_good_age_seconds(),
+                        "cached_miners": len(cls._last_good_opted_in_miners),
+                        "cached_age_seconds": cls._seconds_since_last_good_fetch(),
                     }),
                 )
             )
-            return cls._last_good
+            return cls._last_good_opted_in_miners
 
-        cls._last_good = miners
+        cls._last_good_opted_in_miners = miners
         cls._last_good_fetched_at = time.monotonic()
         return miners
 
     @classmethod
     def _log_fetch_failure(cls, url: str, error: Exception) -> None:
-        # only a failure with nothing cached can still shrink the validated fleet
-        has_cache = cls._last_good is not None
+        has_cached_miners = cls._last_good_opted_in_miners is not None
+        if has_cached_miners:
+            message = "Failed to fetch opted-in miners from portal - serving the last good list"
+        else:
+            message = (
+                "Failed to fetch opted-in miners from portal and nothing is cached"
+                " - opt-in miners will be MISSING this cycle"
+            )
         logger.error(
             _m(
-                "Failed to fetch opted-in miners from portal - serving the last good list"
-                if has_cache
-                else "Failed to fetch opted-in miners from portal and nothing is cached"
-                " - opt-in miners will be MISSING this cycle",
+                message,
                 extra=get_extra_info({
                     "url": url,
                     "error": str(error),
                     "error_type": type(error).__name__,
-                    "cached_miners": len(cls._last_good) if has_cache else None,
-                    "cached_age_seconds": cls._last_good_age_seconds(),
+                    "cached_miners": len(cls._last_good_opted_in_miners) if has_cached_miners else None,
+                    "cached_age_seconds": cls._seconds_since_last_good_fetch(),
                 }),
             ),
             exc_info=True,
         )
 
     @classmethod
-    def _last_good_age_seconds(cls) -> int | None:
+    def _seconds_since_last_good_fetch(cls) -> int | None:
         if cls._last_good_fetched_at is None:
             return None
         return int(time.monotonic() - cls._last_good_fetched_at)
 
     @staticmethod
-    async def _fetch(url: str) -> list[dict]:
+    async def _fetch_opted_in_miners(url: str) -> list[OptedInMiner]:
         # raises on any portal problem, so the caller decides between fresh and cached
         keypair: bittensor.Keypair = settings.get_bittensor_wallet().get_hotkey()
 
@@ -122,10 +126,10 @@ class ValidatorPortalAPI:
         async with aiohttp.ClientSession(timeout=timeout) as session:
             async with session.get(url, headers=headers) as resp:
                 if resp.status != 200:
-                    body = await resp.text()
-                    raise RuntimeError(f"portal returned status {resp.status}: {body[:500]}")
+                    error_body = await resp.text()
+                    raise RuntimeError(f"portal returned status {resp.status}: {error_body[:500]}")
 
-                data = await resp.json()
-                if not isinstance(data, list):
-                    raise RuntimeError(f"portal returned {type(data).__name__}, expected a list")
-                return data
+                records = await resp.json()
+                if not isinstance(records, list):
+                    raise RuntimeError(f"portal returned {type(records).__name__}, expected a list")
+                return [OptedInMiner.model_validate(record) for record in records]

--- a/neurons/validators/src/clients/validator_portal_api.py
+++ b/neurons/validators/src/clients/validator_portal_api.py
@@ -1,21 +1,31 @@
-import aiohttp
-import asyncio
-import json
 import logging
 import time
 
+import aiohttp
 import bittensor
 
 from core.config import settings
 from core.utils import _m, get_extra_info
 
-
 logger = logging.getLogger(__name__)
 
 
 class ValidatorPortalAPI:
-    @staticmethod
-    async def get_opted_in_miners() -> list[dict]:
+    """Opted-in miner list, with the last successful portal answer as a fallback.
+
+    Every failure used to return an empty list, which is indistinguishable from
+    "nobody opted in": `SubtensorClient.fetch_miners` then skipped the central-miner
+    axon override and the opt-in miners silently dropped out of the validated fleet
+    (165 -> 137 miners, 372 -> 268 executors during the 2026-07-28 portal outage).
+    Keeping the last good answer in memory turns a portal outage into stale-but-correct
+    routing instead. Mirrors the miner-side snapshot cache in `MinerPortalAPI`.
+    """
+
+    _last_good: list[dict] | None = None
+    _last_good_fetched_at: float | None = None
+
+    @classmethod
+    async def get_opted_in_miners(cls) -> list[dict] | None:
         """Fetch list of miners that have opted in.
 
         Returns list of dicts with shape:
@@ -28,56 +38,94 @@ class ValidatorPortalAPI:
                 },
                 ...
             ]
-        Returns empty list on error.
+        On a failed fetch returns the last successful list instead. Returns None when the
+        fetch failed and nothing was ever cached - callers must not read that as "zero
+        opted-in miners".
         """
-        try:
-            keypair: bittensor.Keypair = settings.get_bittensor_wallet().get_hotkey()
-            validator_hotkey = keypair.ss58_address
-
-            api_base = settings.MINER_PORTAL_REST_API_URL.rstrip("/") if settings.MINER_PORTAL_REST_API_URL else ""
-            if not api_base:
-                return []
-
-            url = f"{api_base}/validators/opted-in"
-
-            timestamp = int(time.time())
-            signature = f"0x{keypair.sign(str(timestamp)).hex()}"
-
-            headers = {
-                "hotkey": validator_hotkey,
-                "timestamp": str(timestamp),
-                "signature": signature,
-            }
-
-            # Generous total timeout so we survive short event-loop stalls from concurrent
-            # sync bittensor/subtensor calls in this process. aiohttp's timer is driven by
-            # the event loop, so a 10s cap fires spuriously whenever the loop stays blocked.
-            timeout = aiohttp.ClientTimeout(total=60)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                try:
-                    async with session.get(url, headers=headers) as resp:
-                        if resp.status != 200:
-                            text = await resp.text()
-                            logger.error(
-                                _m(
-                                    "Failed to fetch opted-in miners from portal",
-                                    extra=get_extra_info({
-                                        "status": resp.status,
-                                        "body": text,
-                                        "url": url,
-                                    }),
-                                )
-                            )
-                            return []
-
-                        data = await resp.json()
-                        return data if isinstance(data, list) else []
-                except asyncio.TimeoutError:
-                    logger.error(_m("Timeout fetching opted-in miners from portal", extra=get_extra_info({"url": url})))
-                    return []
-                except Exception as e:
-                    logger.error(_m("Error fetching opted-in miners from portal", extra=get_extra_info({"url": url, "error": str(e)})))
-                    return []
-        except Exception as e:
-            logger.error(_m("Unexpected error during opted-in miners fetch", extra=get_extra_info({"error": str(e)})))
+        api_base = settings.MINER_PORTAL_REST_API_URL.rstrip("/") if settings.MINER_PORTAL_REST_API_URL else ""
+        if not api_base:
+            # a blank portal URL is a deliberate opt-out of portal routing, not an outage
             return []
+
+        url = f"{api_base}/validators/opted-in"
+
+        try:
+            miners = await cls._fetch(url)
+        except Exception as e:
+            cls._log_fetch_failure(url, e)
+            return cls._last_good
+
+        if not miners and cls._last_good:
+            # a sudden "nobody is opted in" is far more likely a portal bug than a real mass
+            # opt-out; accepting it would drop every opt-in miner from the fleet at once.
+            # The age deliberately keeps counting from the last real answer.
+            logger.warning(
+                _m(
+                    "Portal returned an empty opted-in list while a populated one is cached"
+                    " - keeping the cached list",
+                    extra=get_extra_info({
+                        "url": url,
+                        "cached_miners": len(cls._last_good),
+                        "cached_age_seconds": cls._last_good_age_seconds(),
+                    }),
+                )
+            )
+            return cls._last_good
+
+        cls._last_good = miners
+        cls._last_good_fetched_at = time.monotonic()
+        return miners
+
+    @classmethod
+    def _log_fetch_failure(cls, url: str, error: Exception) -> None:
+        # only a failure with nothing cached can still shrink the validated fleet
+        has_cache = cls._last_good is not None
+        logger.error(
+            _m(
+                "Failed to fetch opted-in miners from portal - serving the last good list"
+                if has_cache
+                else "Failed to fetch opted-in miners from portal and nothing is cached"
+                " - opt-in miners will be MISSING this cycle",
+                extra=get_extra_info({
+                    "url": url,
+                    "error": str(error),
+                    "error_type": type(error).__name__,
+                    "cached_miners": len(cls._last_good) if has_cache else None,
+                    "cached_age_seconds": cls._last_good_age_seconds(),
+                }),
+            ),
+            exc_info=True,
+        )
+
+    @classmethod
+    def _last_good_age_seconds(cls) -> int | None:
+        if cls._last_good_fetched_at is None:
+            return None
+        return int(time.monotonic() - cls._last_good_fetched_at)
+
+    @staticmethod
+    async def _fetch(url: str) -> list[dict]:
+        # raises on any portal problem, so the caller decides between fresh and cached
+        keypair: bittensor.Keypair = settings.get_bittensor_wallet().get_hotkey()
+
+        timestamp = int(time.time())
+        headers = {
+            "hotkey": keypair.ss58_address,
+            "timestamp": str(timestamp),
+            "signature": f"0x{keypair.sign(str(timestamp)).hex()}",
+        }
+
+        # Generous total timeout so we survive short event-loop stalls from concurrent
+        # sync bittensor/subtensor calls in this process. aiohttp's timer is driven by
+        # the event loop, so a 10s cap fires spuriously whenever the loop stays blocked.
+        timeout = aiohttp.ClientTimeout(total=60)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(url, headers=headers) as resp:
+                if resp.status != 200:
+                    body = await resp.text()
+                    raise RuntimeError(f"portal returned status {resp.status}: {body[:500]}")
+
+                data = await resp.json()
+                if not isinstance(data, list):
+                    raise RuntimeError(f"portal returned {type(data).__name__}, expected a list")
+                return data

--- a/neurons/validators/tests/test_validator_portal_api.py
+++ b/neurons/validators/tests/test_validator_portal_api.py
@@ -12,12 +12,13 @@ from unittest.mock import AsyncMock, Mock
 import aiohttp
 import bittensor
 import pytest
+from pydantic import ValidationError
 
 from clients.subtensor_client import SubtensorClient
-from clients.validator_portal_api import ValidatorPortalAPI
+from clients.validator_portal_api import OptedInMiner, ValidatorPortalAPI
 from core.config import settings
 
-OPTED_IN = [
+OPTED_IN_RECORDS = [
     {
         "miner_hotkey": "hotkey-a",
         "miner_coldkey": "cold-a",
@@ -31,46 +32,47 @@ OPTED_IN = [
         "central_miner_port": 8000,
     },
 ]
+OPTED_IN_MINERS = [OptedInMiner.model_validate(record) for record in OPTED_IN_RECORDS]
 
 
 @pytest.fixture(autouse=True)
-def reset_cache(monkeypatch):
-    ValidatorPortalAPI._last_good = None
+def reset_portal_cache(monkeypatch):
+    ValidatorPortalAPI._last_good_opted_in_miners = None
     ValidatorPortalAPI._last_good_fetched_at = None
     monkeypatch.setattr(settings, "MINER_PORTAL_REST_API_URL", "https://portal.test/")
     yield
 
 
-def _install_fetch(monkeypatch, *results):
+def _install_fake_fetch(monkeypatch, *results):
     # each call returns the next result; an Exception instance is raised instead
     fetch = AsyncMock(side_effect=list(results))
-    monkeypatch.setattr(ValidatorPortalAPI, "_fetch", fetch)
+    monkeypatch.setattr(ValidatorPortalAPI, "_fetch_opted_in_miners", fetch)
     return fetch
 
 
 @pytest.mark.asyncio
 async def test_successful_fetch_is_cached(monkeypatch):
-    _install_fetch(monkeypatch, OPTED_IN)
+    _install_fake_fetch(monkeypatch, OPTED_IN_MINERS)
 
     miners = await ValidatorPortalAPI.get_opted_in_miners()
 
-    assert miners == OPTED_IN
-    assert ValidatorPortalAPI._last_good == OPTED_IN
+    assert miners == OPTED_IN_MINERS
+    assert ValidatorPortalAPI._last_good_opted_in_miners == OPTED_IN_MINERS
 
 
 @pytest.mark.asyncio
 async def test_failed_fetch_serves_last_good(monkeypatch):
-    _install_fetch(monkeypatch, OPTED_IN, TimeoutError("portal timed out"))
+    _install_fake_fetch(monkeypatch, OPTED_IN_MINERS, TimeoutError("portal timed out"))
 
     await ValidatorPortalAPI.get_opted_in_miners()
     miners = await ValidatorPortalAPI.get_opted_in_miners()
 
-    assert miners == OPTED_IN
+    assert miners == OPTED_IN_MINERS
 
 
 @pytest.mark.asyncio
 async def test_failed_fetch_without_cache_returns_none(monkeypatch):
-    _install_fetch(monkeypatch, TimeoutError("portal timed out"))
+    _install_fake_fetch(monkeypatch, TimeoutError("portal timed out"))
 
     miners = await ValidatorPortalAPI.get_opted_in_miners()
 
@@ -79,17 +81,17 @@ async def test_failed_fetch_without_cache_returns_none(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_empty_response_keeps_populated_cache(monkeypatch):
-    _install_fetch(monkeypatch, OPTED_IN, [])
+    _install_fake_fetch(monkeypatch, OPTED_IN_MINERS, [])
 
     await ValidatorPortalAPI.get_opted_in_miners()
     miners = await ValidatorPortalAPI.get_opted_in_miners()
 
-    assert miners == OPTED_IN
+    assert miners == OPTED_IN_MINERS
 
 
 @pytest.mark.asyncio
 async def test_empty_response_without_cache_is_accepted(monkeypatch):
-    _install_fetch(monkeypatch, [])
+    _install_fake_fetch(monkeypatch, [])
 
     miners = await ValidatorPortalAPI.get_opted_in_miners()
 
@@ -99,7 +101,7 @@ async def test_empty_response_without_cache_is_accepted(monkeypatch):
 @pytest.mark.asyncio
 async def test_blank_portal_url_returns_empty_list(monkeypatch):
     monkeypatch.setattr(settings, "MINER_PORTAL_REST_API_URL", "")
-    fetch = _install_fetch(monkeypatch, OPTED_IN)
+    fetch = _install_fake_fetch(monkeypatch, OPTED_IN_MINERS)
 
     miners = await ValidatorPortalAPI.get_opted_in_miners()
 
@@ -116,77 +118,89 @@ class _FakeResponse:
     async def json(self):
         return self._json_body
 
-    async def text(self):
+    async def text(self) -> str:
         return self._text_body
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> "_FakeResponse":
         return self
 
-    async def __aexit__(self, *args):
+    async def __aexit__(self, *args) -> bool:
         return False
 
 
 class _FakeSession:
     last_url: str | None = None
-    last_headers: dict | None = None
+    last_headers: dict[str, str] | None = None
 
     def __init__(self, response: _FakeResponse):
         self._response = response
 
-    def get(self, url, headers=None):
+    def get(self, url: str, headers: dict[str, str] | None = None) -> _FakeResponse:
         _FakeSession.last_url = url
         _FakeSession.last_headers = headers
         return self._response
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> "_FakeSession":
         return self
 
-    async def __aexit__(self, *args):
+    async def __aexit__(self, *args) -> bool:
         return False
 
 
 @pytest.fixture
-def portal_http(monkeypatch):
-    # replaces the wallet and aiohttp session so _fetch runs for real
+def install_portal_response(monkeypatch):
+    # replaces the wallet and aiohttp session so the real fetch runs against a fake portal
     keypair = bittensor.Keypair.create_from_uri("//LiumTestValidator")
     fake_wallet = Mock()
     fake_wallet.get_hotkey.return_value = keypair
     monkeypatch.setattr(type(settings), "get_bittensor_wallet", lambda self: fake_wallet)
 
-    def install_response(response: _FakeResponse):
+    def install(response: _FakeResponse) -> None:
         monkeypatch.setattr(aiohttp, "ClientSession", lambda timeout: _FakeSession(response))
 
-    return install_response
+    return install
 
 
 @pytest.mark.asyncio
-async def test_fetch_raises_on_http_error(portal_http):
-    portal_http(_FakeResponse(status=502, text_body="Bad gateway"))
+async def test_fetch_raises_on_http_error(install_portal_response):
+    install_portal_response(_FakeResponse(status=502, text_body="Bad gateway"))
 
     with pytest.raises(RuntimeError, match="502"):
-        await ValidatorPortalAPI._fetch("https://portal.test/validators/opted-in")
+        await ValidatorPortalAPI._fetch_opted_in_miners("https://portal.test/validators/opted-in")
 
 
 @pytest.mark.asyncio
-async def test_fetch_raises_on_non_list_body(portal_http):
-    portal_http(_FakeResponse(status=200, json_body={"success": True, "data": OPTED_IN}))
+async def test_fetch_raises_on_non_list_body(install_portal_response):
+    install_portal_response(
+        _FakeResponse(status=200, json_body={"success": True, "data": OPTED_IN_RECORDS})
+    )
 
     with pytest.raises(RuntimeError, match="expected a list"):
-        await ValidatorPortalAPI._fetch("https://portal.test/validators/opted-in")
+        await ValidatorPortalAPI._fetch_opted_in_miners("https://portal.test/validators/opted-in")
 
 
 @pytest.mark.asyncio
-async def test_fetch_sends_signature_headers_and_returns_list(portal_http):
-    portal_http(_FakeResponse(status=200, json_body=OPTED_IN))
+async def test_fetch_raises_on_record_missing_a_field(install_portal_response):
+    install_portal_response(_FakeResponse(status=200, json_body=[{"miner_hotkey": "hotkey-a"}]))
 
-    miners = await ValidatorPortalAPI._fetch("https://portal.test/validators/opted-in")
+    with pytest.raises(ValidationError):
+        await ValidatorPortalAPI._fetch_opted_in_miners("https://portal.test/validators/opted-in")
 
-    assert miners == OPTED_IN
+
+@pytest.mark.asyncio
+async def test_fetch_sends_signature_headers_and_returns_parsed_miners(install_portal_response):
+    install_portal_response(_FakeResponse(status=200, json_body=OPTED_IN_RECORDS))
+
+    miners = await ValidatorPortalAPI._fetch_opted_in_miners(
+        "https://portal.test/validators/opted-in"
+    )
+
+    assert miners == OPTED_IN_MINERS
     assert _FakeSession.last_url.endswith("/validators/opted-in")
     assert set(_FakeSession.last_headers) == {"hotkey", "timestamp", "signature"}
 
 
-def _neuron(hotkey: str, uid: int, is_serving: bool):
+def _neuron(hotkey: str, uid: int, is_serving: bool) -> Mock:
     return Mock(
         hotkey=hotkey,
         uid=uid,
@@ -194,7 +208,7 @@ def _neuron(hotkey: str, uid: int, is_serving: bool):
     )
 
 
-def _client(monkeypatch, previous_miners, metagraph_neurons):
+def _subtensor_client(monkeypatch, previous_miners, metagraph_neurons) -> SubtensorClient:
     client = SubtensorClient.__new__(SubtensorClient)
     client.default_extra = {}
     client.debug_miner = None
@@ -207,7 +221,7 @@ def _client(monkeypatch, previous_miners, metagraph_neurons):
 async def test_fetch_miners_keeps_previous_list_when_portal_has_no_cache(monkeypatch):
     monkeypatch.setattr(ValidatorPortalAPI, "get_opted_in_miners", AsyncMock(return_value=None))
     previous = [_neuron("hotkey-a", 1, True), _neuron("hotkey-b", 2, True)]
-    client = _client(monkeypatch, previous, [_neuron("hotkey-c", 3, True)])
+    client = _subtensor_client(monkeypatch, previous, [_neuron("hotkey-c", 3, True)])
 
     await client.fetch_miners()
 
@@ -218,8 +232,23 @@ async def test_fetch_miners_keeps_previous_list_when_portal_has_no_cache(monkeyp
 async def test_fetch_miners_falls_back_to_metagraph_when_no_previous_list(monkeypatch):
     monkeypatch.setattr(ValidatorPortalAPI, "get_opted_in_miners", AsyncMock(return_value=None))
     serving = _neuron("hotkey-c", 3, True)
-    client = _client(monkeypatch, [], [serving, _neuron("hotkey-a", 1, False)])
+    client = _subtensor_client(monkeypatch, [], [serving, _neuron("hotkey-a", 1, False)])
 
     await client.fetch_miners()
 
     assert client.miners == [serving]
+
+
+@pytest.mark.asyncio
+async def test_fetch_miners_overrides_axon_with_central_miner_address(monkeypatch):
+    monkeypatch.setattr(
+        ValidatorPortalAPI, "get_opted_in_miners", AsyncMock(return_value=OPTED_IN_MINERS)
+    )
+    opted_in = _neuron("hotkey-a", 1, True)
+    plain = _neuron("hotkey-c", 3, True)
+    client = _subtensor_client(monkeypatch, [], [opted_in, plain])
+
+    await client.fetch_miners()
+
+    assert (opted_in.axon_info.ip, opted_in.axon_info.port) == ("10.0.0.1", 8000)
+    assert (plain.axon_info.ip, plain.axon_info.port) == ("0.0.0.0", 0)

--- a/neurons/validators/tests/test_validator_portal_api.py
+++ b/neurons/validators/tests/test_validator_portal_api.py
@@ -1,10 +1,10 @@
-"""Tests for the ValidatorPortalAPI last-good cache (DAH-2518).
+"""Tests for the ValidatorPortalAPI last-good list and its use in `fetch_miners` (DAH-2518).
 
 A portal outage used to return an empty opted-in list, which `fetch_miners` could not tell
 apart from a real mass opt-out: the opt-in miners then lost their central-miner axon and
-dropped out of the validated fleet. The cache must serve the last successful answer on
-failure, report None only when nothing was ever cached, and keep a populated list when the
-portal answers 200 with an empty body.
+dropped out of the validated fleet. The stored answer must serve the last successful list on
+failure, report None whenever no populated list was ever stored, and survive a 200 that
+carries an empty list.
 """
 
 from unittest.mock import AsyncMock, Mock
@@ -19,6 +19,7 @@ from clients.validator_portal_api import OptedInMiner, ValidatorPortalAPI
 from core.config import settings
 
 OPTED_IN_RECORDS = [
+    # miner_coldkey is sent by the portal and deliberately not modelled by the validator
     {
         "miner_hotkey": "hotkey-a",
         "miner_coldkey": "cold-a",
@@ -33,31 +34,32 @@ OPTED_IN_RECORDS = [
     },
 ]
 OPTED_IN_MINERS = [OptedInMiner.model_validate(record) for record in OPTED_IN_RECORDS]
+VALIDATOR_KEYPAIR = bittensor.Keypair.create_from_uri("//LiumTestValidator")
 
 
 @pytest.fixture(autouse=True)
 def reset_portal_cache(monkeypatch):
-    ValidatorPortalAPI._last_good_opted_in_miners = None
-    ValidatorPortalAPI._last_good_fetched_at = None
+    # monkeypatch, not plain assignment: the last-good list lives on the class, so a test
+    # that populates it would otherwise leak into every later test in the session
+    monkeypatch.setattr(ValidatorPortalAPI, "_last_good_opted_in_miners", None)
+    monkeypatch.setattr(ValidatorPortalAPI, "_last_good_fetched_at", None)
     monkeypatch.setattr(settings, "MINER_PORTAL_REST_API_URL", "https://portal.test/")
-    yield
 
 
-def _install_fake_fetch(monkeypatch, *results):
-    # each call returns the next result; an Exception instance is raised instead
+def _install_fake_fetch(monkeypatch, *results: list[OptedInMiner] | Exception) -> AsyncMock:
+    # AsyncMock raises a side effect that is an Exception and returns anything else
     fetch = AsyncMock(side_effect=list(results))
     monkeypatch.setattr(ValidatorPortalAPI, "_fetch_opted_in_miners", fetch)
     return fetch
 
 
 @pytest.mark.asyncio
-async def test_successful_fetch_is_cached(monkeypatch):
+async def test_successful_fetch_returns_the_parsed_list(monkeypatch):
     _install_fake_fetch(monkeypatch, OPTED_IN_MINERS)
 
     miners = await ValidatorPortalAPI.get_opted_in_miners()
 
     assert miners == OPTED_IN_MINERS
-    assert ValidatorPortalAPI._last_good_opted_in_miners == OPTED_IN_MINERS
 
 
 @pytest.mark.asyncio
@@ -74,6 +76,33 @@ async def test_failed_fetch_serves_last_good(monkeypatch):
 async def test_failed_fetch_without_cache_returns_none(monkeypatch):
     _install_fake_fetch(monkeypatch, TimeoutError("portal timed out"))
 
+    miners = await ValidatorPortalAPI.get_opted_in_miners()
+
+    assert miners is None
+
+
+@pytest.mark.asyncio
+async def test_recovered_portal_replaces_the_cached_list(monkeypatch):
+    moved_miner = [
+        OptedInMiner.model_validate({**OPTED_IN_RECORDS[0], "central_miner_ip": "10.0.0.9"})
+    ]
+    fetch = _install_fake_fetch(
+        monkeypatch, OPTED_IN_MINERS, TimeoutError("portal timed out"), moved_miner
+    )
+
+    await ValidatorPortalAPI.get_opted_in_miners()
+    await ValidatorPortalAPI.get_opted_in_miners()
+    miners = await ValidatorPortalAPI.get_opted_in_miners()
+
+    assert miners == moved_miner
+    assert fetch.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_empty_response_is_not_kept_as_last_good(monkeypatch):
+    _install_fake_fetch(monkeypatch, [], TimeoutError("portal timed out"))
+
+    await ValidatorPortalAPI.get_opted_in_miners()
     miners = await ValidatorPortalAPI.get_opted_in_miners()
 
     assert miners is None
@@ -110,12 +139,12 @@ async def test_blank_portal_url_returns_empty_list(monkeypatch):
 
 
 class _FakeResponse:
-    def __init__(self, status: int, json_body=None, text_body: str = ""):
+    def __init__(self, status: int, json_body: list | dict | None = None, text_body: str = ""):
         self.status = status
         self._json_body = json_body
         self._text_body = text_body
 
-    async def json(self):
+    async def json(self) -> list | dict | None:
         return self._json_body
 
     async def text(self) -> str:
@@ -129,15 +158,14 @@ class _FakeResponse:
 
 
 class _FakeSession:
-    last_url: str | None = None
-    last_headers: dict[str, str] | None = None
-
     def __init__(self, response: _FakeResponse):
         self._response = response
+        self.last_url: str | None = None
+        self.last_headers: dict[str, str] | None = None
 
     def get(self, url: str, headers: dict[str, str] | None = None) -> _FakeResponse:
-        _FakeSession.last_url = url
-        _FakeSession.last_headers = headers
+        self.last_url = url
+        self.last_headers = headers
         return self._response
 
     async def __aenter__(self) -> "_FakeSession":
@@ -150,13 +178,14 @@ class _FakeSession:
 @pytest.fixture
 def install_portal_response(monkeypatch):
     # replaces the wallet and aiohttp session so the real fetch runs against a fake portal
-    keypair = bittensor.Keypair.create_from_uri("//LiumTestValidator")
     fake_wallet = Mock()
-    fake_wallet.get_hotkey.return_value = keypair
+    fake_wallet.get_hotkey.return_value = VALIDATOR_KEYPAIR
     monkeypatch.setattr(type(settings), "get_bittensor_wallet", lambda self: fake_wallet)
 
-    def install(response: _FakeResponse) -> None:
-        monkeypatch.setattr(aiohttp, "ClientSession", lambda timeout: _FakeSession(response))
+    def install(response: _FakeResponse) -> _FakeSession:
+        session = _FakeSession(response)
+        monkeypatch.setattr(aiohttp, "ClientSession", lambda timeout: session)
+        return session
 
     return install
 
@@ -189,26 +218,45 @@ async def test_fetch_raises_on_record_missing_a_field(install_portal_response):
 
 @pytest.mark.asyncio
 async def test_fetch_sends_signature_headers_and_returns_parsed_miners(install_portal_response):
-    install_portal_response(_FakeResponse(status=200, json_body=OPTED_IN_RECORDS))
+    session = install_portal_response(_FakeResponse(status=200, json_body=OPTED_IN_RECORDS))
 
     miners = await ValidatorPortalAPI._fetch_opted_in_miners(
         "https://portal.test/validators/opted-in"
     )
 
     assert miners == OPTED_IN_MINERS
-    assert _FakeSession.last_url.endswith("/validators/opted-in")
-    assert set(_FakeSession.last_headers) == {"hotkey", "timestamp", "signature"}
-
-
-def _neuron(hotkey: str, uid: int, is_serving: bool) -> Mock:
-    return Mock(
-        hotkey=hotkey,
-        uid=uid,
-        axon_info=Mock(ip="0.0.0.0", port=0, is_serving=is_serving),
+    assert session.last_url.endswith("/validators/opted-in")
+    assert set(session.last_headers) == {"hotkey", "timestamp", "signature"}
+    # signing the wrong payload would be a permanent 401, i.e. a permanent fallback
+    assert VALIDATOR_KEYPAIR.verify(
+        session.last_headers["timestamp"], bytes.fromhex(session.last_headers["signature"][2:])
     )
 
 
-def _subtensor_client(monkeypatch, previous_miners, metagraph_neurons) -> SubtensorClient:
+class _FakeAxonInfo:
+    """Stand-in for `bittensor.AxonInfo`, where `is_serving` is a property over `ip`.
+
+    That link is the whole mechanism: overwriting `ip` with the central-miner address is
+    what keeps an opt-in miner inside the `is_serving` filter. A Mock with a fixed
+    `is_serving` attribute would let the filter regress while the tests stayed green.
+    """
+
+    def __init__(self, ip: str, port: int):
+        self.ip = ip
+        self.port = port
+
+    @property
+    def is_serving(self) -> bool:
+        return self.ip != "0.0.0.0"
+
+
+def _neuron(hotkey: str, uid: int, ip: str, port: int = 4444) -> Mock:
+    return Mock(hotkey=hotkey, uid=uid, axon_info=_FakeAxonInfo(ip, port))
+
+
+def _subtensor_client(
+    monkeypatch, previous_miners: list[Mock], metagraph_neurons: list[Mock]
+) -> SubtensorClient:
     client = SubtensorClient.__new__(SubtensorClient)
     client.default_extra = {}
     client.debug_miner = None
@@ -218,21 +266,13 @@ def _subtensor_client(monkeypatch, previous_miners, metagraph_neurons) -> Subten
 
 
 @pytest.mark.asyncio
-async def test_fetch_miners_keeps_previous_list_when_portal_has_no_cache(monkeypatch):
+async def test_fetch_miners_still_tracks_the_metagraph_when_portal_has_no_cache(monkeypatch):
+    # None only ever happens before the portal answered once, so the previous list was
+    # itself built without opt-in routing - freezing it would cost metagraph churn for free
     monkeypatch.setattr(ValidatorPortalAPI, "get_opted_in_miners", AsyncMock(return_value=None))
-    previous = [_neuron("hotkey-a", 1, True), _neuron("hotkey-b", 2, True)]
-    client = _subtensor_client(monkeypatch, previous, [_neuron("hotkey-c", 3, True)])
-
-    await client.fetch_miners()
-
-    assert client.miners == previous
-
-
-@pytest.mark.asyncio
-async def test_fetch_miners_falls_back_to_metagraph_when_no_previous_list(monkeypatch):
-    monkeypatch.setattr(ValidatorPortalAPI, "get_opted_in_miners", AsyncMock(return_value=None))
-    serving = _neuron("hotkey-c", 3, True)
-    client = _subtensor_client(monkeypatch, [], [serving, _neuron("hotkey-a", 1, False)])
+    serving = _neuron("hotkey-c", 3, "1.2.3.4")
+    previous = [_neuron("hotkey-a", 1, "10.0.0.1")]
+    client = _subtensor_client(monkeypatch, previous, [serving, _neuron("hotkey-b", 2, "0.0.0.0")])
 
     await client.fetch_miners()
 
@@ -240,15 +280,17 @@ async def test_fetch_miners_falls_back_to_metagraph_when_no_previous_list(monkey
 
 
 @pytest.mark.asyncio
-async def test_fetch_miners_overrides_axon_with_central_miner_address(monkeypatch):
+async def test_fetch_miners_keeps_opted_in_miner_that_serves_no_axon_of_its_own(monkeypatch):
     monkeypatch.setattr(
         ValidatorPortalAPI, "get_opted_in_miners", AsyncMock(return_value=OPTED_IN_MINERS)
     )
-    opted_in = _neuron("hotkey-a", 1, True)
-    plain = _neuron("hotkey-c", 3, True)
+    # an opt-in miner publishes 0.0.0.0 on chain and is reachable only via the central miner
+    opted_in = _neuron("hotkey-a", 1, "0.0.0.0", port=0)
+    plain = _neuron("hotkey-c", 3, "1.2.3.4")
     client = _subtensor_client(monkeypatch, [], [opted_in, plain])
 
     await client.fetch_miners()
 
     assert (opted_in.axon_info.ip, opted_in.axon_info.port) == ("10.0.0.1", 8000)
-    assert (plain.axon_info.ip, plain.axon_info.port) == ("0.0.0.0", 0)
+    assert (plain.axon_info.ip, plain.axon_info.port) == ("1.2.3.4", 4444)
+    assert client.miners == [opted_in, plain]

--- a/neurons/validators/tests/test_validator_portal_api.py
+++ b/neurons/validators/tests/test_validator_portal_api.py
@@ -1,0 +1,225 @@
+"""Tests for the ValidatorPortalAPI last-good cache (DAH-2518).
+
+A portal outage used to return an empty opted-in list, which `fetch_miners` could not tell
+apart from a real mass opt-out: the opt-in miners then lost their central-miner axon and
+dropped out of the validated fleet. The cache must serve the last successful answer on
+failure, report None only when nothing was ever cached, and keep a populated list when the
+portal answers 200 with an empty body.
+"""
+
+from unittest.mock import AsyncMock, Mock
+
+import aiohttp
+import bittensor
+import pytest
+
+from clients.subtensor_client import SubtensorClient
+from clients.validator_portal_api import ValidatorPortalAPI
+from core.config import settings
+
+OPTED_IN = [
+    {
+        "miner_hotkey": "hotkey-a",
+        "miner_coldkey": "cold-a",
+        "central_miner_ip": "10.0.0.1",
+        "central_miner_port": 8000,
+    },
+    {
+        "miner_hotkey": "hotkey-b",
+        "miner_coldkey": "cold-b",
+        "central_miner_ip": "10.0.0.1",
+        "central_miner_port": 8000,
+    },
+]
+
+
+@pytest.fixture(autouse=True)
+def reset_cache(monkeypatch):
+    ValidatorPortalAPI._last_good = None
+    ValidatorPortalAPI._last_good_fetched_at = None
+    monkeypatch.setattr(settings, "MINER_PORTAL_REST_API_URL", "https://portal.test/")
+    yield
+
+
+def _install_fetch(monkeypatch, *results):
+    # each call returns the next result; an Exception instance is raised instead
+    fetch = AsyncMock(side_effect=list(results))
+    monkeypatch.setattr(ValidatorPortalAPI, "_fetch", fetch)
+    return fetch
+
+
+@pytest.mark.asyncio
+async def test_successful_fetch_is_cached(monkeypatch):
+    _install_fetch(monkeypatch, OPTED_IN)
+
+    miners = await ValidatorPortalAPI.get_opted_in_miners()
+
+    assert miners == OPTED_IN
+    assert ValidatorPortalAPI._last_good == OPTED_IN
+
+
+@pytest.mark.asyncio
+async def test_failed_fetch_serves_last_good(monkeypatch):
+    _install_fetch(monkeypatch, OPTED_IN, TimeoutError("portal timed out"))
+
+    await ValidatorPortalAPI.get_opted_in_miners()
+    miners = await ValidatorPortalAPI.get_opted_in_miners()
+
+    assert miners == OPTED_IN
+
+
+@pytest.mark.asyncio
+async def test_failed_fetch_without_cache_returns_none(monkeypatch):
+    _install_fetch(monkeypatch, TimeoutError("portal timed out"))
+
+    miners = await ValidatorPortalAPI.get_opted_in_miners()
+
+    assert miners is None
+
+
+@pytest.mark.asyncio
+async def test_empty_response_keeps_populated_cache(monkeypatch):
+    _install_fetch(monkeypatch, OPTED_IN, [])
+
+    await ValidatorPortalAPI.get_opted_in_miners()
+    miners = await ValidatorPortalAPI.get_opted_in_miners()
+
+    assert miners == OPTED_IN
+
+
+@pytest.mark.asyncio
+async def test_empty_response_without_cache_is_accepted(monkeypatch):
+    _install_fetch(monkeypatch, [])
+
+    miners = await ValidatorPortalAPI.get_opted_in_miners()
+
+    assert miners == []
+
+
+@pytest.mark.asyncio
+async def test_blank_portal_url_returns_empty_list(monkeypatch):
+    monkeypatch.setattr(settings, "MINER_PORTAL_REST_API_URL", "")
+    fetch = _install_fetch(monkeypatch, OPTED_IN)
+
+    miners = await ValidatorPortalAPI.get_opted_in_miners()
+
+    assert miners == []
+    assert fetch.await_count == 0
+
+
+class _FakeResponse:
+    def __init__(self, status: int, json_body=None, text_body: str = ""):
+        self.status = status
+        self._json_body = json_body
+        self._text_body = text_body
+
+    async def json(self):
+        return self._json_body
+
+    async def text(self):
+        return self._text_body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class _FakeSession:
+    last_url: str | None = None
+    last_headers: dict | None = None
+
+    def __init__(self, response: _FakeResponse):
+        self._response = response
+
+    def get(self, url, headers=None):
+        _FakeSession.last_url = url
+        _FakeSession.last_headers = headers
+        return self._response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+@pytest.fixture
+def portal_http(monkeypatch):
+    # replaces the wallet and aiohttp session so _fetch runs for real
+    keypair = bittensor.Keypair.create_from_uri("//LiumTestValidator")
+    fake_wallet = Mock()
+    fake_wallet.get_hotkey.return_value = keypair
+    monkeypatch.setattr(type(settings), "get_bittensor_wallet", lambda self: fake_wallet)
+
+    def install_response(response: _FakeResponse):
+        monkeypatch.setattr(aiohttp, "ClientSession", lambda timeout: _FakeSession(response))
+
+    return install_response
+
+
+@pytest.mark.asyncio
+async def test_fetch_raises_on_http_error(portal_http):
+    portal_http(_FakeResponse(status=502, text_body="Bad gateway"))
+
+    with pytest.raises(RuntimeError, match="502"):
+        await ValidatorPortalAPI._fetch("https://portal.test/validators/opted-in")
+
+
+@pytest.mark.asyncio
+async def test_fetch_raises_on_non_list_body(portal_http):
+    portal_http(_FakeResponse(status=200, json_body={"success": True, "data": OPTED_IN}))
+
+    with pytest.raises(RuntimeError, match="expected a list"):
+        await ValidatorPortalAPI._fetch("https://portal.test/validators/opted-in")
+
+
+@pytest.mark.asyncio
+async def test_fetch_sends_signature_headers_and_returns_list(portal_http):
+    portal_http(_FakeResponse(status=200, json_body=OPTED_IN))
+
+    miners = await ValidatorPortalAPI._fetch("https://portal.test/validators/opted-in")
+
+    assert miners == OPTED_IN
+    assert _FakeSession.last_url.endswith("/validators/opted-in")
+    assert set(_FakeSession.last_headers) == {"hotkey", "timestamp", "signature"}
+
+
+def _neuron(hotkey: str, uid: int, is_serving: bool):
+    return Mock(
+        hotkey=hotkey,
+        uid=uid,
+        axon_info=Mock(ip="0.0.0.0", port=0, is_serving=is_serving),
+    )
+
+
+def _client(monkeypatch, previous_miners, metagraph_neurons):
+    client = SubtensorClient.__new__(SubtensorClient)
+    client.default_extra = {}
+    client.debug_miner = None
+    client.miners = previous_miners
+    monkeypatch.setattr(client, "get_metagraph", lambda: Mock(neurons=metagraph_neurons))
+    return client
+
+
+@pytest.mark.asyncio
+async def test_fetch_miners_keeps_previous_list_when_portal_has_no_cache(monkeypatch):
+    monkeypatch.setattr(ValidatorPortalAPI, "get_opted_in_miners", AsyncMock(return_value=None))
+    previous = [_neuron("hotkey-a", 1, True), _neuron("hotkey-b", 2, True)]
+    client = _client(monkeypatch, previous, [_neuron("hotkey-c", 3, True)])
+
+    await client.fetch_miners()
+
+    assert client.miners == previous
+
+
+@pytest.mark.asyncio
+async def test_fetch_miners_falls_back_to_metagraph_when_no_previous_list(monkeypatch):
+    monkeypatch.setattr(ValidatorPortalAPI, "get_opted_in_miners", AsyncMock(return_value=None))
+    serving = _neuron("hotkey-c", 3, True)
+    client = _client(monkeypatch, [], [serving, _neuron("hotkey-a", 1, False)])
+
+    await client.fetch_miners()
+
+    assert client.miners == [serving]


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2518](https://app.notion.com/p/Validator-cache-the-portal-s-last-good-opted-in-miner-list-3abb8bfdbde98181a62cea55cd675a2b)

---

## Problem

`ValidatorPortalAPI.get_opted_in_miners()` returned `[]` on every failure — timeout, non-200, any
exception, and even a non-list response body. An empty list is indistinguishable from "nobody has
opted in", so `SubtensorClient.fetch_miners()` skipped the central-miner axon override and the
opt-in miners either fell out of the `axon_info.is_serving` filter or got addressed at their dead
on-chain axon.

During the provider-portal outage on 2026-07-28, 04:13–05:17 UTC this silently shrank the validated
fleet for an hour:

```
Timeout fetching opted-in miners from portal
  url=http://miner-portal-backend-service.miner-portal-backend:8000/api/validators/opted-in
[fetch_miners] Found 0 opted-in miners from portal     # normally 52
[fetch_miners] Found 137 miners                        # normally 165
[sync] All Jobs finished  total_executors=268          # normally 372
```

Roughly 100 machines went unvalidated while `successful_executors == total_executors` throughout, so
no failure rate moved and nothing alerted.

## Solution

Keep the last successful portal answer in memory and serve it when a fetch fails, so a portal outage
degrades to stale-but-correct routing instead of a truncated fleet. `None` now means "the portal is
unavailable and nothing was ever cached" — a state the caller must not read as "zero opted-in
miners". Mirrors the miner-side snapshot cache introduced in DAH-2469 (`MinerPortalAPI`), minus the
TTL and single-flight lock: there is exactly one caller here, running every ~132s from a single
background task.

## Changes

- `ValidatorPortalAPI` keeps `_last_good` / `_last_good_fetched_at` and serves the cached list on any
  fetch failure, logging the failure once with `error_type` and `cached_age_seconds`.
- `get_opted_in_miners()` returns `list[dict] | None`; `None` only when the fetch failed and nothing
  is cached. A blank `MINER_PORTAL_REST_API_URL` still returns `[]` — that is a deliberate opt-out of
  portal routing, not an outage.
- A 200 response with an empty body no longer replaces a populated cache: a sudden "nobody is opted
  in" is far more likely a portal bug than a real mass opt-out.
- `_fetch()` now raises instead of silently returning `[]` on a non-200 or a non-list body — the
  latter was the same fail-open bug in another dress.
- `SubtensorClient.fetch_miners()` keeps its previous miner list when the portal is unavailable with
  nothing cached; with no previous list it proceeds on metagraph data only and logs an error, because
  a truncated fleet still beats an empty one.
- Renamed the follow-up log line to `[fetch_miners] Applying opt-in routing for N miners` — the old
  "…opted-in miners from portal" wording claimed freshness for a list that may have come from cache.
- New `tests/test_validator_portal_api.py` (11 tests).

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

None. The portal-side hardening that this outage also calls for (liveness/readiness probes on
`miner-portal-backend`) is tracked separately as DAH-2516.

## Risks

- The cache is process-local, so a validator restart during a portal outage starts cold and the
  fleet still shrinks for that window. Accepted trade-off — a Redis-backed cache was considered and
  deliberately dropped as too much wiring for a static class.
- Nothing clears a populated cache except a process restart, so a genuine mass opt-out would keep
  routing to stale central-miner addresses until the validator restarts. Considered acceptable:
  routing to a stale opt-in address is far less damaging than dropping the miners entirely.
- The `[fetch_miners] Found N opted-in miners from portal` log line is gone. Anything grepping for it
  (dashboards, alerts) needs to move to the new wording or to the new error line.
- Blast radius is limited to which miners the validator selects; scoring, weights and the rent path
  are untouched.

## Test Cases

### Test Case 1 — cache serves a portal outage

**Actions** `pdm run pytest tests/test_validator_portal_api.py` — one successful fetch, then a
`TimeoutError` from `_fetch`.

**Expected Output** The second call returns the first call's list, not `[]`. With no prior success it
returns `None`.

### Test Case 2 — empty 200 does not wipe a populated cache

**Actions** Successful fetch of 2 miners, then a fetch returning `[]`.

**Expected Output** The cached 2 miners are returned; a warning names the cache age.

### Test Case 3 — `fetch_miners` guard

**Actions** `get_opted_in_miners()` patched to return `None`, once with a populated `self.miners` and
once with an empty one.

**Expected Output** Populated: the previous list is kept untouched. Empty: falls back to the serving
neurons from the metagraph rather than to nothing.

### Test Case 4 — full validator suite

**Actions** `pdm run pytest -q` in `neurons/validators`.

**Expected Output** `1240 passed, 8 skipped`. Three failures in `tests/test_sshd_bootstrap_script.py`
are pre-existing on `origin/main` and unrelated to this branch.

## Checklist

- [x] Proper labels added — `bug`. This repo has no `ready-review` / `require-qa` /
  `breaking-changes` labels; PR is still a draft, so review is not requested yet.
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
