### PR TITLE
DAH-2520, zero the unrented incentive when total VRAM exceeds total disk

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -202,6 +202,12 @@ class Settings(BaseSettings):
     # (shadow mode) so prod impact can be observed before enforcing.
     ENABLE_UNRENTED_SOFT_PRICE_LIMIT: bool = Field(env="ENABLE_UNRENTED_SOFT_PRICE_LIMIT", default=False)
 
+    # DAH-2520 — unrented VRAM/disk sanity gate. When True, an unrented executor whose
+    # total GPU VRAM exceeds the machine's total disk loses the unrented rental incentive
+    # while staying active. When False, the breach is only logged (shadow mode) so prod
+    # impact can be observed before enforcing.
+    ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT: bool = Field(env="ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT", default=False)
+
     COLLATERAL_CONTRACT_ADDRESS: str = Field(
         env='COLLATERAL_CONTRACT_ADDRESS', default='0x8A4023FdD1eaA7b242F3723a7d096B6CC693c7C6'
     )

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -8,7 +8,7 @@ WHERE A NODE EARNS (two "pools" of subnet emission; the rest is burned):
 
 HOW A NODE PICKS A POOL:
   rented?                                              -> mining pool (always earns)
-  idle AND model in program AND price ok AND disk >= VRAM
+  idle AND model in program AND price ok AND disk >= 1.5x VRAM
                                AND capacity?            -> unrented pool (earns)
   otherwise                                            -> 0 incentive (reason below)
 
@@ -22,7 +22,7 @@ WHAT THIS CATALOG HOLDS — every `MinerLogLine` the miner-facing log block
    Group B — idle but does not qualify for the unrented pool:
      GPU model not in the unrented program (earns only when rented),
      price above the market soft limit (lower the price to earn),
-     total GPU VRAM above total disk (add disk to earn),
+     total disk below 1.5x total GPU VRAM (add disk to earn),
      no unrented capacity for that GPU-count tier this cycle,
      NVIDIA driver below the minimum, sysbox runtime not enabled
 
@@ -46,6 +46,7 @@ from pydantic import BaseModel, Field
 from core.utils import _m, _StructuredMessage, get_extra_info
 
 if TYPE_CHECKING:
+    from incentive.rental_price import InsufficientDisk
     from services.task_service import JobResult
 
 
@@ -66,7 +67,7 @@ class ZeroIncentiveReason(StrEnum):
     PRICE_ABOVE_MARKET_P90_SOFT_LIMIT = "price_above_market_p90_soft_limit"
     NO_UNRENTED_CAPACITY_FOR_GPU_COUNT = "no_unrented_capacity_for_gpu_count"
     NVIDIA_DRIVER_BELOW_MINIMUM = "nvidia_driver_below_minimum"
-    VRAM_EXCEEDS_DISK = "vram_exceeds_disk"
+    INSUFFICIENT_DISK_FOR_VRAM = "insufficient_disk_for_vram"
     SYSBOX_NOT_ENABLED = "sysbox_not_enabled"
 
 
@@ -227,23 +228,25 @@ class MinerLogLine(BaseModel):
         )
 
     @staticmethod
-    def no_payout_because_vram_exceeds_disk(
-        result: JobResult, total_vram_gb: float, total_disk_gb: float, rate: float
+    def no_payout_because_insufficient_disk_for_vram(
+        result: JobResult, measured: InsufficientDisk
     ) -> MinerLogLine:
-        required_disk_gb: float = round(total_vram_gb * rate, 1)
+        # takes the measurement whole: the two totals are interchangeable floats, and swapping
+        # them would quietly tell the miner to add disk he already has
+        required_disk_gb: float = round(measured.vram_gb * measured.rate, 1)
         return MinerLogLine._no_payout(
             result,
-            reason=ZeroIncentiveReason.VRAM_EXCEEDS_DISK,
+            reason=ZeroIncentiveReason.INSUFFICIENT_DISK_FOR_VRAM,
             message=(
-                f"No unrented incentive: this executor has {total_disk_gb} GB of total disk but "
-                f"{total_vram_gb} GB of GPU VRAM. An idle executor must have at least "
-                f"{rate}x its GPU VRAM in disk to earn the unrented incentive. Give it at least "
-                f"{required_disk_gb} GB of total disk, or rent it out to earn."
+                f"No unrented incentive: this executor has {measured.disk_gb} GB of total disk but "
+                f"{measured.vram_gb} GB of GPU VRAM. An idle executor must have at least "
+                f"{measured.rate}x its GPU VRAM in disk to earn the unrented incentive. Give it at "
+                f"least {required_disk_gb} GB of total disk, or rent it out to earn."
             ),
             extra_fields={
-                "total_vram_gb": total_vram_gb,
-                "total_disk_gb": total_disk_gb,
-                "vram_over_disk_rate": rate,
+                "total_vram_gb": measured.vram_gb,
+                "total_disk_gb": measured.disk_gb,
+                "min_disk_to_vram_rate": measured.rate,
                 "required_disk_gb": required_disk_gb,
             },
         )

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -64,6 +64,7 @@ class ZeroIncentiveReason(StrEnum):
     PRICE_ABOVE_MARKET_P90_SOFT_LIMIT = "price_above_market_p90_soft_limit"
     NO_UNRENTED_CAPACITY_FOR_GPU_COUNT = "no_unrented_capacity_for_gpu_count"
     NVIDIA_DRIVER_BELOW_MINIMUM = "nvidia_driver_below_minimum"
+    VRAM_EXCEEDS_DISK = "vram_exceeds_disk"
     SYSBOX_NOT_ENABLED = "sysbox_not_enabled"
 
 
@@ -221,6 +222,22 @@ class MinerLogLine(BaseModel):
                 "soft_limit_rate": rate,
                 "soft_limit_threshold": soft_limit,
             },
+        )
+
+    @staticmethod
+    def no_payout_because_vram_exceeds_disk(
+        result: JobResult, total_vram_gb: float, total_disk_gb: float
+    ) -> MinerLogLine:
+        return MinerLogLine._no_payout(
+            result,
+            reason=ZeroIncentiveReason.VRAM_EXCEEDS_DISK,
+            message=(
+                f"No unrented incentive: this machine has {total_disk_gb} GB of disk but "
+                f"{total_vram_gb} GB of GPU VRAM. A node with less disk than VRAM cannot hold "
+                f"the data its own GPUs work on, so it does not earn while idle. Give it more "
+                f"than {total_vram_gb} GB of disk to earn the unrented incentive."
+            ),
+            extra_fields={"total_vram_gb": total_vram_gb, "total_disk_gb": total_disk_gb},
         )
 
     @staticmethod

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -228,18 +228,24 @@ class MinerLogLine(BaseModel):
 
     @staticmethod
     def no_payout_because_vram_exceeds_disk(
-        result: JobResult, total_vram_gb: float, total_disk_gb: float
+        result: JobResult, total_vram_gb: float, total_disk_gb: float, rate: float
     ) -> MinerLogLine:
+        required_disk_gb: float = round(total_vram_gb * rate, 1)
         return MinerLogLine._no_payout(
             result,
             reason=ZeroIncentiveReason.VRAM_EXCEEDS_DISK,
             message=(
                 f"No unrented incentive: this executor has {total_disk_gb} GB of total disk but "
-                f"{total_vram_gb} GB of GPU VRAM. An idle executor must have at least as much disk "
-                f"as GPU VRAM to earn the unrented incentive. Give it at least {total_vram_gb} GB "
-                f"of total disk, or rent it out to earn."
+                f"{total_vram_gb} GB of GPU VRAM. An idle executor must have at least "
+                f"{rate}x its GPU VRAM in disk to earn the unrented incentive. Give it at least "
+                f"{required_disk_gb} GB of total disk, or rent it out to earn."
             ),
-            extra_fields={"total_vram_gb": total_vram_gb, "total_disk_gb": total_disk_gb},
+            extra_fields={
+                "total_vram_gb": total_vram_gb,
+                "total_disk_gb": total_disk_gb,
+                "vram_over_disk_rate": rate,
+                "required_disk_gb": required_disk_gb,
+            },
         )
 
     @staticmethod

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -8,7 +8,8 @@ WHERE A NODE EARNS (two "pools" of subnet emission; the rest is burned):
 
 HOW A NODE PICKS A POOL:
   rented?                                              -> mining pool (always earns)
-  idle AND model in program AND price ok AND capacity? -> unrented pool (earns)
+  idle AND model in program AND price ok AND disk >= VRAM
+                               AND capacity?            -> unrented pool (earns)
   otherwise                                            -> 0 incentive (reason below)
 
 WHAT THIS CATALOG HOLDS — every `MinerLogLine` the miner-facing log block
@@ -21,6 +22,7 @@ WHAT THIS CATALOG HOLDS — every `MinerLogLine` the miner-facing log block
    Group B — idle but does not qualify for the unrented pool:
      GPU model not in the unrented program (earns only when rented),
      price above the market soft limit (lower the price to earn),
+     total GPU VRAM above total disk (add disk to earn),
      no unrented capacity for that GPU-count tier this cycle,
      NVIDIA driver below the minimum, sysbox runtime not enabled
 
@@ -232,10 +234,10 @@ class MinerLogLine(BaseModel):
             result,
             reason=ZeroIncentiveReason.VRAM_EXCEEDS_DISK,
             message=(
-                f"No unrented incentive: this machine has {total_disk_gb} GB of disk but "
-                f"{total_vram_gb} GB of GPU VRAM. A node with less disk than VRAM cannot hold "
-                f"the data its own GPUs work on, so it does not earn while idle. Give it more "
-                f"than {total_vram_gb} GB of disk to earn the unrented incentive."
+                f"No unrented incentive: this executor has {total_disk_gb} GB of total disk but "
+                f"{total_vram_gb} GB of GPU VRAM. An idle executor must have at least as much disk "
+                f"as GPU VRAM to earn the unrented incentive. Give it at least {total_vram_gb} GB "
+                f"of total disk, or rent it out to earn."
             ),
             extra_fields={"total_vram_gb": total_vram_gb, "total_disk_gb": total_disk_gb},
         )

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -39,6 +39,13 @@ logger = get_logger(__name__)
 SOFT_LIMIT_PRICE_RATE = 1.1
 
 
+class VramOverDisk(BaseModel):
+    """Measured totals of a machine whose GPU VRAM exceeds its disk (both in GB)."""
+
+    vram_gb: float
+    disk_gb: float
+
+
 # ── Snapshot models ──────────────────────────────────────────────────────────
 
 class GpuBucketRentalState(BaseModel):
@@ -209,6 +216,39 @@ class RentalPriceIncentive(DefaultIncentive):
                     "soft_limit_threshold": p90 * SOFT_LIMIT_PRICE_RATE if p90 else None,
                     "enforced": enforced,
                     "reason": ZeroIncentiveReason.PRICE_ABOVE_MARKET_P90_SOFT_LIMIT,
+                    "pool": "rental_excluded" if enforced else "rental_kept_shadow",
+                },
+            )
+        )
+
+    def _vram_over_disk(self, result: JobResult) -> VramOverDisk | None:
+        # machine carrying more GPU VRAM than it has disk; None when it fits or the scrape is partial
+        spec = result.spec or {}
+        gpu_details = (spec.get("gpu") or {}).get("details") or []
+        vram_gb = sum(float(gpu.get("capacity") or 0) for gpu in gpu_details) / 1024  # capacity is MB
+        # total disk of the machine, not free space: free is distorted by preallocated volumes
+        disk_gb = float((spec.get("hard_disk") or {}).get("total") or 0) / 1024 ** 2  # total is kB
+        if vram_gb <= 0 or disk_gb <= 0:
+            return None  # a scrape missing either number keeps the full incentive
+        if vram_gb <= disk_gb:
+            return None
+        return VramOverDisk(vram_gb=round(vram_gb, 1), disk_gb=round(disk_gb, 1))
+
+    def _log_vram_over_disk(self, result: JobResult, measured: VramOverDisk) -> None:
+        # structured log for every unrented executor whose total VRAM exceeds its total disk
+        enforced = settings.ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT
+        logger.info(
+            _m(
+                "Unrented executor carries more GPU VRAM than total disk"
+                + ("" if enforced else " (shadow only - flag off)"),
+                extra={
+                    "executor_id": str(result.executor_info.uuid),
+                    "gpu_model": result.gpu_model,
+                    "gpu_count": result.gpu_count,
+                    "total_vram_gb": measured.vram_gb,
+                    "total_disk_gb": measured.disk_gb,
+                    "enforced": enforced,
+                    "reason": ZeroIncentiveReason.VRAM_EXCEEDS_DISK,
                     "pool": "rental_excluded" if enforced else "rental_kept_shadow",
                 },
             )
@@ -484,6 +524,21 @@ class RentalPriceIncentive(DefaultIncentive):
                 p90: float | None = shared_client.config.machine_prices_p90.get(job_result.gpu_model)
                 reason: MinerLogLine = MinerLogLine.no_payout_because_price_above_market_soft_limit(
                     job_result, p90, SOFT_LIMIT_PRICE_RATE
+                )
+                job_result.incentive_logs.append(reason.to_log_line())
+
+        # DAH-2520 VRAM/disk gate: an idle machine with less disk than GPU VRAM cannot hold
+        # the data its own GPUs work on, so it forfeits the unrented incentive (node stays
+        # active). While the flag is off we only log the would-be exclusion (shadow).
+        vram_over_disk: VramOverDisk | None = (
+            self._vram_over_disk(job_result) if eligible_for_rental_share else None
+        )
+        if vram_over_disk is not None:
+            self._log_vram_over_disk(job_result, vram_over_disk)
+            if settings.ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT:
+                eligible_for_rental_share = False
+                reason: MinerLogLine = MinerLogLine.no_payout_because_vram_exceeds_disk(
+                    job_result, vram_over_disk.vram_gb, vram_over_disk.disk_gb
                 )
                 job_result.incentive_logs.append(reason.to_log_line())
 

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -38,6 +38,11 @@ logger = get_logger(__name__)
 # this multiplier forfeits the unrented rental incentive but stays active.
 SOFT_LIMIT_PRICE_RATE = 1.1
 
+# DAH-2520 — unrented incentive VRAM/disk gate. An unrented executor whose summed
+# GPU VRAM times this multiplier exceeds total disk forfeits the unrented rental
+# incentive but stays active.
+VRAM_OVER_DISK_RATE = 1.5
+
 
 # ── Spec measurements ────────────────────────────────────────────────────────
 
@@ -247,7 +252,7 @@ class RentalPriceIncentive(DefaultIncentive):
         # round before comparing, so the numbers the miner is shown are the ones that were compared
         vram_gb = round(vram_gb, 1)
         disk_gb = round(disk_gb, 1)
-        if vram_gb <= disk_gb:
+        if vram_gb * VRAM_OVER_DISK_RATE <= disk_gb:
             return None
         return VramOverDisk(vram_gb=vram_gb, disk_gb=disk_gb)
 
@@ -568,7 +573,7 @@ class RentalPriceIncentive(DefaultIncentive):
             if settings.ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT:
                 eligible_for_rental_share = False
                 reason: MinerLogLine = MinerLogLine.no_payout_because_vram_exceeds_disk(
-                    job_result, vram_over_disk.vram_gb, vram_over_disk.disk_gb
+                    job_result, vram_over_disk.vram_gb, vram_over_disk.disk_gb, VRAM_OVER_DISK_RATE
                 )
                 job_result.incentive_logs.append(reason.to_log_line())
 

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -39,6 +39,8 @@ logger = get_logger(__name__)
 SOFT_LIMIT_PRICE_RATE = 1.1
 
 
+# ── Spec measurements ────────────────────────────────────────────────────────
+
 class VramOverDisk(BaseModel):
     """Measured totals of a machine whose GPU VRAM exceeds its disk (both in GB)."""
 
@@ -222,20 +224,50 @@ class RentalPriceIncentive(DefaultIncentive):
         )
 
     def _vram_over_disk(self, result: JobResult) -> VramOverDisk | None:
-        # machine carrying more GPU VRAM than it has disk; None when it fits or the scrape is partial
-        spec = result.spec or {}
-        gpu_details = (spec.get("gpu") or {}).get("details") or []
-        vram_gb = sum(float(gpu.get("capacity") or 0) for gpu in gpu_details) / 1024  # capacity is MB
-        # total disk of the machine, not free space: free is distorted by preallocated volumes
-        disk_gb = float((spec.get("hard_disk") or {}).get("total") or 0) / 1024 ** 2  # total is kB
+        # machine carrying more GPU VRAM than it has disk; None when it fits or the scrape is unusable
+        spec = result.spec
+        if not spec:
+            # no scrape at all: a synthetic or estimated job result, nothing to measure
+            return None
+        try:
+            gpu_details = (spec.get("gpu") or {}).get("details") or []
+            vram_gb = sum(float(gpu.get("capacity") or 0) for gpu in gpu_details) / 1024  # capacity is MB
+            # total size of the filesystem the scrape reports, not free space: free is
+            # distorted by preallocated volumes
+            disk_gb = float((spec.get("hard_disk") or {}).get("total") or 0) / 1024 ** 2  # total is kB
+        except (AttributeError, TypeError, ValueError) as exc:
+            # the scrape is produced on the miner's machine, and calculate_mining_scores has no
+            # per-result guard: raising here would cost EVERY miner this cycle's weights
+            self._log_vram_over_disk_unmeasured(result, f"unreadable scrape: {exc!r}")
+            return None
         if vram_gb <= 0 or disk_gb <= 0:
-            return None  # a scrape missing either number keeps the full incentive
+            # either number missing or zeroed: fail open, nobody loses incentive over telemetry
+            self._log_vram_over_disk_unmeasured(result, "vram or disk missing from the scrape")
+            return None
+        # round before comparing, so the numbers the miner is shown are the ones that were compared
+        vram_gb = round(vram_gb, 1)
+        disk_gb = round(disk_gb, 1)
         if vram_gb <= disk_gb:
             return None
-        return VramOverDisk(vram_gb=round(vram_gb, 1), disk_gb=round(disk_gb, 1))
+        return VramOverDisk(vram_gb=vram_gb, disk_gb=disk_gb)
+
+    def _log_vram_over_disk_unmeasured(self, result: JobResult, cause: str) -> None:
+        # gate could not run: a shadow report must not read this executor as "disk is fine"
+        logger.warning(
+            _m(
+                "Cannot measure GPU VRAM against total disk; unrented incentive kept",
+                extra={
+                    "executor_id": str(result.executor_info.uuid),
+                    "gpu_model": result.gpu_model,
+                    "gpu_count": result.gpu_count,
+                    "cause": cause,
+                    "reason": "vram_over_disk_unmeasured",
+                },
+            )
+        )
 
     def _log_vram_over_disk(self, result: JobResult, measured: VramOverDisk) -> None:
-        # structured log for every unrented executor whose total VRAM exceeds its total disk
+        # structured log for every rental-eligible unrented executor whose VRAM exceeds its disk
         enforced = settings.ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT
         logger.info(
             _m(
@@ -527,12 +559,10 @@ class RentalPriceIncentive(DefaultIncentive):
                 )
                 job_result.incentive_logs.append(reason.to_log_line())
 
-        # DAH-2520 VRAM/disk gate: an idle machine with less disk than GPU VRAM cannot hold
-        # the data its own GPUs work on, so it forfeits the unrented incentive (node stays
-        # active). While the flag is off we only log the would-be exclusion (shadow).
-        vram_over_disk: VramOverDisk | None = (
-            self._vram_over_disk(job_result) if eligible_for_rental_share else None
-        )
+        # DAH-2520 VRAM/disk gate: an idle machine with less disk than GPU VRAM is not
+        # realistically rentable, so it forfeits the unrented incentive (node stays active).
+        # While the flag is off we only log the would-be exclusion (shadow).
+        vram_over_disk = self._vram_over_disk(job_result) if eligible_for_rental_share else None
         if vram_over_disk is not None:
             self._log_vram_over_disk(job_result, vram_over_disk)
             if settings.ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT:

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -38,19 +38,20 @@ logger = get_logger(__name__)
 # this multiplier forfeits the unrented rental incentive but stays active.
 SOFT_LIMIT_PRICE_RATE = 1.1
 
-# DAH-2520 — unrented incentive VRAM/disk gate. An unrented executor whose summed
-# GPU VRAM times this multiplier exceeds total disk forfeits the unrented rental
+# DAH-2520 — unrented incentive disk/VRAM gate. An unrented executor whose total disk
+# is below its summed GPU VRAM times this multiplier forfeits the unrented rental
 # incentive but stays active.
-VRAM_OVER_DISK_RATE = 1.5
+MIN_DISK_TO_VRAM_RATE = 1.5
 
 
 # ── Spec measurements ────────────────────────────────────────────────────────
 
-class VramOverDisk(BaseModel):
-    """Measured totals of a machine whose GPU VRAM exceeds its disk (both in GB)."""
+class InsufficientDisk(BaseModel):
+    """Measured totals of a machine whose disk is below the required margin over its GPU VRAM."""
 
     vram_gb: float
     disk_gb: float
+    rate: float  # required disk-to-VRAM margin the machine failed to clear
 
 
 # ── Snapshot models ──────────────────────────────────────────────────────────
@@ -228,8 +229,9 @@ class RentalPriceIncentive(DefaultIncentive):
             )
         )
 
-    def _vram_over_disk(self, result: JobResult) -> VramOverDisk | None:
-        # machine carrying more GPU VRAM than it has disk; None when it fits or the scrape is unusable
+    def _insufficient_disk(self, result: JobResult) -> InsufficientDisk | None:
+        # machine whose disk is below the required margin over its GPU VRAM; None when it
+        # clears the margin or the scrape is unusable
         spec = result.spec
         if not spec:
             # no scrape at all: a synthetic or estimated job result, nothing to measure
@@ -243,40 +245,40 @@ class RentalPriceIncentive(DefaultIncentive):
         except (AttributeError, TypeError, ValueError) as exc:
             # the scrape is produced on the miner's machine, and calculate_mining_scores has no
             # per-result guard: raising here would cost EVERY miner this cycle's weights
-            self._log_vram_over_disk_unmeasured(result, f"unreadable scrape: {exc!r}")
+            self._log_insufficient_disk_unmeasured(result, f"unreadable scrape: {exc!r}")
             return None
         if vram_gb <= 0 or disk_gb <= 0:
             # either number missing or zeroed: fail open, nobody loses incentive over telemetry
-            self._log_vram_over_disk_unmeasured(result, "vram or disk missing from the scrape")
+            self._log_insufficient_disk_unmeasured(result, "vram or disk missing from the scrape")
             return None
         # round before comparing, so the numbers the miner is shown are the ones that were compared
         vram_gb = round(vram_gb, 1)
         disk_gb = round(disk_gb, 1)
-        if vram_gb * VRAM_OVER_DISK_RATE <= disk_gb:
+        if vram_gb * MIN_DISK_TO_VRAM_RATE <= disk_gb:
             return None
-        return VramOverDisk(vram_gb=vram_gb, disk_gb=disk_gb)
+        return InsufficientDisk(vram_gb=vram_gb, disk_gb=disk_gb, rate=MIN_DISK_TO_VRAM_RATE)
 
-    def _log_vram_over_disk_unmeasured(self, result: JobResult, cause: str) -> None:
+    def _log_insufficient_disk_unmeasured(self, result: JobResult, cause: str) -> None:
         # gate could not run: a shadow report must not read this executor as "disk is fine"
         logger.warning(
             _m(
-                "Cannot measure GPU VRAM against total disk; unrented incentive kept",
+                "Cannot measure total disk against GPU VRAM; unrented incentive kept",
                 extra={
                     "executor_id": str(result.executor_info.uuid),
                     "gpu_model": result.gpu_model,
                     "gpu_count": result.gpu_count,
                     "cause": cause,
-                    "reason": "vram_over_disk_unmeasured",
+                    "reason": "insufficient_disk_unmeasured",
                 },
             )
         )
 
-    def _log_vram_over_disk(self, result: JobResult, measured: VramOverDisk) -> None:
-        # structured log for every rental-eligible unrented executor whose VRAM exceeds its disk
+    def _log_insufficient_disk(self, result: JobResult, measured: InsufficientDisk) -> None:
+        # structured log for every rental-eligible unrented executor short on disk for its VRAM
         enforced = settings.ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT
         logger.info(
             _m(
-                "Unrented executor carries more GPU VRAM than total disk"
+                "Unrented executor has less total disk than its GPU VRAM requires"
                 + ("" if enforced else " (shadow only - flag off)"),
                 extra={
                     "executor_id": str(result.executor_info.uuid),
@@ -284,8 +286,9 @@ class RentalPriceIncentive(DefaultIncentive):
                     "gpu_count": result.gpu_count,
                     "total_vram_gb": measured.vram_gb,
                     "total_disk_gb": measured.disk_gb,
+                    "min_disk_to_vram_rate": measured.rate,
                     "enforced": enforced,
-                    "reason": ZeroIncentiveReason.VRAM_EXCEEDS_DISK,
+                    "reason": ZeroIncentiveReason.INSUFFICIENT_DISK_FOR_VRAM,
                     "pool": "rental_excluded" if enforced else "rental_kept_shadow",
                 },
             )
@@ -564,16 +567,16 @@ class RentalPriceIncentive(DefaultIncentive):
                 )
                 job_result.incentive_logs.append(reason.to_log_line())
 
-        # DAH-2520 VRAM/disk gate: an idle machine with less disk than GPU VRAM is not
-        # realistically rentable, so it forfeits the unrented incentive (node stays active).
-        # While the flag is off we only log the would-be exclusion (shadow).
-        vram_over_disk = self._vram_over_disk(job_result) if eligible_for_rental_share else None
-        if vram_over_disk is not None:
-            self._log_vram_over_disk(job_result, vram_over_disk)
+        # DAH-2520 disk/VRAM gate: an idle machine without the required disk margin over its
+        # GPU VRAM is not realistically rentable, so it forfeits the unrented incentive (node
+        # stays active). While the flag is off we only log the would-be exclusion (shadow).
+        insufficient_disk = self._insufficient_disk(job_result) if eligible_for_rental_share else None
+        if insufficient_disk is not None:
+            self._log_insufficient_disk(job_result, insufficient_disk)
             if settings.ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT:
                 eligible_for_rental_share = False
-                reason: MinerLogLine = MinerLogLine.no_payout_because_vram_exceeds_disk(
-                    job_result, vram_over_disk.vram_gb, vram_over_disk.disk_gb, VRAM_OVER_DISK_RATE
+                reason: MinerLogLine = MinerLogLine.no_payout_because_insufficient_disk_for_vram(
+                    job_result, insufficient_disk
                 )
                 job_result.incentive_logs.append(reason.to_log_line())
 

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -90,6 +90,11 @@ def _job(**overrides) -> JobResult:
             "soft price limit",
         ),
         (
+            lambda job: MinerLogLine.no_payout_because_vram_exceeds_disk(job, 1128.0, 500.0),
+            "vram_exceeds_disk",
+            "GPU VRAM",
+        ),
+        (
             lambda job: MinerLogLine.no_payout_because_no_unrented_capacity_for_gpu_count(job, 8),
             "no_unrented_capacity_for_gpu_count",
             "no unrented-incentive capacity",
@@ -145,6 +150,17 @@ def test_soft_limit_reason_computes_threshold_and_fields():
     assert line.fields["machine_price_p90"] == 3.842
     assert "4.2262" in line.message
     assert "4.23" in line.message
+
+
+def test_vram_exceeds_disk_reason_keeps_the_two_numbers_apart():
+    # The builder takes both totals positionally; swapping them would advise the miner
+    # to add disk he already has, so the message has to name which number is which.
+    line = MinerLogLine.no_payout_because_vram_exceeds_disk(_job(), 1128.0, 500.0)
+
+    assert line.fields["total_vram_gb"] == 1128.0
+    assert line.fields["total_disk_gb"] == 500.0
+    assert "500.0 GB of total disk but 1128.0 GB of GPU VRAM" in line.message
+    assert "at least 1128.0 GB" in line.message
 
 
 def test_no_capacity_reason_carries_bucket_fields():

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -7,6 +7,7 @@ fields, and that a line actually lands in JobResult.incentive_logs.
 import pytest
 from datura.requests.miner_requests import ExecutorSSHInfo
 from incentive.miner_incentive_log import MinerLogLine, ZeroIncentiveReason
+from incentive.rental_price import InsufficientDisk
 from services.task_service import JobResult
 
 H200 = "NVIDIA H200"
@@ -25,7 +26,7 @@ def test_reason_enum_pins_the_stable_code_contract():
         "no_unrented_capacity_for_gpu_count",
         "nvidia_driver_below_minimum",
         "sysbox_not_enabled",
-        "vram_exceeds_disk",
+        "insufficient_disk_for_vram",
     }
 
 
@@ -90,8 +91,10 @@ def _job(**overrides) -> JobResult:
             "soft price limit",
         ),
         (
-            lambda job: MinerLogLine.no_payout_because_vram_exceeds_disk(job, 1128.0, 500.0, 1.5),
-            "vram_exceeds_disk",
+            lambda job: MinerLogLine.no_payout_because_insufficient_disk_for_vram(
+                job, InsufficientDisk(vram_gb=1128.0, disk_gb=500.0, rate=1.5)
+            ),
+            "insufficient_disk_for_vram",
             "GPU VRAM",
         ),
         (
@@ -152,10 +155,12 @@ def test_soft_limit_reason_computes_threshold_and_fields():
     assert "4.23" in line.message
 
 
-def test_vram_exceeds_disk_reason_keeps_the_two_numbers_apart():
-    # The builder takes both totals positionally; swapping them would advise the miner
-    # to add disk he already has, so the message has to name which number is which.
-    line = MinerLogLine.no_payout_because_vram_exceeds_disk(_job(), 1128.0, 500.0, 1.5)
+def test_insufficient_disk_reason_keeps_the_two_numbers_apart():
+    # The builder takes the measurement whole, but the message still has to name which
+    # number is which: reading them the wrong way advises the miner to add disk he has.
+    line = MinerLogLine.no_payout_because_insufficient_disk_for_vram(
+        _job(), InsufficientDisk(vram_gb=1128.0, disk_gb=500.0, rate=1.5)
+    )
 
     assert line.fields["total_vram_gb"] == 1128.0
     assert line.fields["total_disk_gb"] == 500.0

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -25,6 +25,7 @@ def test_reason_enum_pins_the_stable_code_contract():
         "no_unrented_capacity_for_gpu_count",
         "nvidia_driver_below_minimum",
         "sysbox_not_enabled",
+        "vram_exceeds_disk",
     }
 
 

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -90,7 +90,7 @@ def _job(**overrides) -> JobResult:
             "soft price limit",
         ),
         (
-            lambda job: MinerLogLine.no_payout_because_vram_exceeds_disk(job, 1128.0, 500.0),
+            lambda job: MinerLogLine.no_payout_because_vram_exceeds_disk(job, 1128.0, 500.0, 1.5),
             "vram_exceeds_disk",
             "GPU VRAM",
         ),
@@ -155,12 +155,12 @@ def test_soft_limit_reason_computes_threshold_and_fields():
 def test_vram_exceeds_disk_reason_keeps_the_two_numbers_apart():
     # The builder takes both totals positionally; swapping them would advise the miner
     # to add disk he already has, so the message has to name which number is which.
-    line = MinerLogLine.no_payout_because_vram_exceeds_disk(_job(), 1128.0, 500.0)
+    line = MinerLogLine.no_payout_because_vram_exceeds_disk(_job(), 1128.0, 500.0, 1.5)
 
     assert line.fields["total_vram_gb"] == 1128.0
     assert line.fields["total_disk_gb"] == 500.0
     assert "500.0 GB of total disk but 1128.0 GB of GPU VRAM" in line.message
-    assert "at least 1128.0 GB" in line.message
+    assert "at least 1692.0 GB" in line.message
 
 
 def test_no_capacity_reason_carries_bucket_fields():

--- a/neurons/validators/tests/test_unrented_insufficient_disk.py
+++ b/neurons/validators/tests/test_unrented_insufficient_disk.py
@@ -1,7 +1,7 @@
-"""DAH-2520 — unrented incentive VRAM/disk gate.
+"""DAH-2520 — unrented incentive disk/VRAM gate.
 
-An unrented executor whose total GPU VRAM times VRAM_OVER_DISK_RATE exceeds the
-machine's total disk forfeits the unrented rental incentive while staying active.
+An unrented executor whose total disk is below its total GPU VRAM times
+MIN_DISK_TO_VRAM_RATE forfeits the unrented rental incentive while staying active.
 Enforcement is gated by ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT; while the flag is
 off the breach is only logged (shadow mode) and the payout is unchanged.
 """
@@ -69,12 +69,12 @@ def _make_job(
     )
 
 
-def test_vram_over_disk_detects_machine_short_on_disk():
+def test_insufficient_disk_detects_machine_short_on_disk():
     # Arrange — 8 x 141 GB = 1128 GB VRAM on a 500 GB disk
     incentive = _build_incentive()
 
     # Act
-    measured = incentive._vram_over_disk(_make_job())
+    measured = incentive._insufficient_disk(_make_job())
 
     # Assert
     assert measured is not None
@@ -82,34 +82,34 @@ def test_vram_over_disk_detects_machine_short_on_disk():
     assert measured.disk_gb == 500.0
 
 
-def test_vram_over_disk_ignores_machine_with_enough_disk():
+def test_insufficient_disk_ignores_machine_with_enough_disk():
     # Arrange — same VRAM, 2 TB disk
     incentive = _build_incentive()
 
     # Act
-    measured = incentive._vram_over_disk(_make_job(disk_gb=2048.0))
+    measured = incentive._insufficient_disk(_make_job(disk_gb=2048.0))
 
     # Assert
     assert measured is None
 
 
-def test_vram_over_disk_at_ratio_threshold_is_not_flagged():
-    # Arrange — disk exactly equals VRAM * VRAM_OVER_DISK_RATE; only strictly more is flagged
+def test_insufficient_disk_at_ratio_threshold_is_not_flagged():
+    # Arrange — disk exactly equals VRAM * MIN_DISK_TO_VRAM_RATE; only strictly more is flagged
     incentive = _build_incentive()
 
     # Act
-    measured = incentive._vram_over_disk(_make_job(vram_gb_per_gpu=100.0, gpu_count=2, disk_gb=300.0))
+    measured = incentive._insufficient_disk(_make_job(vram_gb_per_gpu=100.0, gpu_count=2, disk_gb=300.0))
 
     # Assert
     assert measured is None
 
 
-def test_vram_over_disk_equal_totals_is_flagged():
+def test_insufficient_disk_equal_totals_is_flagged():
     # Arrange — equal VRAM and disk no longer clears the 1.5x margin
     incentive = _build_incentive()
 
     # Act
-    measured = incentive._vram_over_disk(_make_job(vram_gb_per_gpu=100.0, gpu_count=2, disk_gb=200.0))
+    measured = incentive._insufficient_disk(_make_job(vram_gb_per_gpu=100.0, gpu_count=2, disk_gb=200.0))
 
     # Assert
     assert measured is not None
@@ -127,11 +127,11 @@ def test_vram_over_disk_equal_totals_is_flagged():
         {"vram_gb_per_gpu": None, "disk_gb": None},  # no scrape at all
     ],
 )
-def test_vram_over_disk_partial_scrape_is_never_flagged(job_kwargs):
+def test_insufficient_disk_partial_scrape_is_never_flagged(job_kwargs):
     # A missing number must not cost a miner the incentive — fail open.
     incentive = _build_incentive()
 
-    measured = incentive._vram_over_disk(_make_job(**job_kwargs))
+    measured = incentive._insufficient_disk(_make_job(**job_kwargs))
 
     assert measured is None
 
@@ -147,9 +147,9 @@ def test_estimated_job_result_is_not_logged_as_unmeasured(caplog):
     incentive = _build_incentive()
 
     with caplog.at_level(logging.WARNING):
-        incentive._vram_over_disk(_make_job(vram_gb_per_gpu=None, disk_gb=None))
+        incentive._insufficient_disk(_make_job(vram_gb_per_gpu=None, disk_gb=None))
 
-    assert "vram_over_disk_unmeasured" not in _logged_reasons(caplog)
+    assert "insufficient_disk_unmeasured" not in _logged_reasons(caplog)
 
 
 def test_unreadable_scrape_is_logged_as_unmeasured(caplog):
@@ -157,9 +157,9 @@ def test_unreadable_scrape_is_logged_as_unmeasured(caplog):
     incentive = _build_incentive()
 
     with caplog.at_level(logging.WARNING):
-        incentive._vram_over_disk(_make_job(disk_gb=None))
+        incentive._insufficient_disk(_make_job(disk_gb=None))
 
-    assert "vram_over_disk_unmeasured" in _logged_reasons(caplog)
+    assert "insufficient_disk_unmeasured" in _logged_reasons(caplog)
 
 
 MALFORMED_SPECS: list[dict] = [
@@ -173,12 +173,12 @@ MALFORMED_SPECS: list[dict] = [
 
 
 @pytest.mark.parametrize("spec", MALFORMED_SPECS)
-def test_vram_over_disk_survives_a_malformed_scrape(spec):
+def test_insufficient_disk_survives_a_malformed_scrape(spec):
     # The scrape is produced on the miner's machine and calculate_mining_scores has no
     # per-result guard, so a malformed value must fail open instead of raising.
     incentive = _build_incentive()
 
-    measured = incentive._vram_over_disk(_make_job(spec=spec))
+    measured = incentive._insufficient_disk(_make_job(spec=spec))
 
     assert measured is None
 
@@ -195,12 +195,12 @@ async def test_malformed_scrape_never_breaks_scoring(monkeypatch, spec):
     assert result.eligible_for_rental_share is True
 
 
-def test_vram_over_disk_reports_the_numbers_it_compared():
+def test_insufficient_disk_reports_the_numbers_it_compared():
     # Rounding happens before the comparison: raw 200.03 * 1.5 = 300.045 GB would exceed
     # 300.0 GB disk, but rounded to 200.0 GB VRAM it clears the 1.5x margin exactly.
     incentive = _build_incentive()
 
-    measured = incentive._vram_over_disk(
+    measured = incentive._insufficient_disk(
         _make_job(vram_gb_per_gpu=200.03, gpu_count=1, disk_gb=300.0)
     )
 
@@ -226,7 +226,7 @@ async def test_shadow_mode_keeps_rental_eligibility(monkeypatch):
 
     # Assert — still eligible for the unrented rental pool, nothing told to the miner
     assert result.eligible_for_rental_share is True
-    assert "vram_exceeds_disk" not in "\n".join(result.incentive_logs)
+    assert "insufficient_disk_for_vram" not in "\n".join(result.incentive_logs)
 
 
 @pytest.mark.asyncio
@@ -239,7 +239,7 @@ async def test_shadow_mode_emits_the_measurement_log(monkeypatch, caplog):
     with caplog.at_level(logging.INFO):
         await incentive.calculate_executor_score(_make_job())
 
-    breach = next(r.msg for r in caplog.records if r.msg.extra.get("reason") == "vram_exceeds_disk")
+    breach = next(r.msg for r in caplog.records if r.msg.extra.get("reason") == "insufficient_disk_for_vram")
     assert "shadow only - flag off" in breach.message
     assert breach.extra["total_vram_gb"] == 1128.0
     assert breach.extra["total_disk_gb"] == 500.0
@@ -271,7 +271,7 @@ async def test_enforced_appends_customer_facing_incentive_log(monkeypatch):
     result = await incentive.calculate_executor_score(_make_job())
 
     log = "\n".join(result.incentive_logs)
-    assert "vram_exceeds_disk" in log
+    assert "insufficient_disk_for_vram" in log
     assert "1128.0" in log  # total VRAM
     assert "500.0" in log   # total disk
 
@@ -297,4 +297,4 @@ async def test_rented_executor_is_not_gated(monkeypatch):
 
     result = await incentive.calculate_executor_score(_make_job(is_rented=True))
 
-    assert "vram_exceeds_disk" not in "\n".join(result.incentive_logs)
+    assert "insufficient_disk_for_vram" not in "\n".join(result.incentive_logs)

--- a/neurons/validators/tests/test_unrented_vram_over_disk.py
+++ b/neurons/validators/tests/test_unrented_vram_over_disk.py
@@ -1,0 +1,193 @@
+"""DAH-2520 — unrented incentive VRAM/disk gate.
+
+An unrented executor whose total GPU VRAM exceeds the machine's total disk
+forfeits the unrented rental incentive while staying active. Enforcement is
+gated by ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT; while the flag is off the breach
+is only logged (shadow mode) and the payout is unchanged.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from datura.requests.miner_requests import ExecutorSSHInfo
+
+from core.config import settings
+from incentive.config import IncentiveConfig
+from incentive.rental_price import RentalPriceIncentive
+from services.task_service import JobResult
+
+H200 = "NVIDIA H200"  # base model H200 is rental-eligible by default
+
+GB_IN_MB = 1024
+GB_IN_KB = 1024 ** 2
+
+
+def _build_incentive() -> RentalPriceIncentive:
+    return RentalPriceIncentive(IncentiveConfig(), AsyncMock(), {}, {})
+
+
+def _make_job(
+    *,
+    vram_gb_per_gpu: float | None = 141.0,
+    gpu_count: int = 8,
+    disk_gb: float | None = 500.0,
+    is_rented: bool = False,
+) -> JobResult:
+    spec: dict = {}
+    if vram_gb_per_gpu is not None:
+        spec["gpu"] = {
+            "details": [{"capacity": vram_gb_per_gpu * GB_IN_MB} for _ in range(gpu_count)]
+        }
+    if disk_gb is not None:
+        spec["hard_disk"] = {"total": disk_gb * GB_IN_KB}
+
+    return JobResult(
+        spec=spec,
+        executor_info=ExecutorSSHInfo(
+            uuid="exec-1",
+            address="10.0.0.1",
+            port=8080,
+            ssh_username="root",
+            ssh_port=22,
+            python_path="/usr/bin/python3",
+            root_dir="/tmp",
+            price_per_gpu=1.0,
+        ),
+        score=1.0,
+        job_score=1.0,
+        job_batch_id="batch",
+        log_status="success",
+        log_text="ok",
+        gpu_model=H200,
+        gpu_count=gpu_count,
+        is_rented=is_rented,
+        collateral_deposited=True,
+        sysbox_runtime=True,
+    )
+
+
+def test_vram_over_disk_detects_machine_short_on_disk():
+    # Arrange — 8 x 141 GB = 1128 GB VRAM on a 500 GB disk
+    incentive = _build_incentive()
+
+    # Act
+    measured = incentive._vram_over_disk(_make_job())
+
+    # Assert
+    assert measured is not None
+    assert measured.vram_gb == 1128.0
+    assert measured.disk_gb == 500.0
+
+
+def test_vram_over_disk_ignores_machine_with_enough_disk():
+    # Arrange — same VRAM, 2 TB disk
+    incentive = _build_incentive()
+
+    # Act
+    measured = incentive._vram_over_disk(_make_job(disk_gb=2048.0))
+
+    # Assert
+    assert measured is None
+
+
+def test_vram_over_disk_equal_is_not_flagged():
+    # Arrange — disk exactly equals VRAM; only strictly more VRAM is flagged
+    incentive = _build_incentive()
+
+    # Act
+    measured = incentive._vram_over_disk(_make_job(vram_gb_per_gpu=100.0, gpu_count=2, disk_gb=200.0))
+
+    # Assert
+    assert measured is None
+
+
+@pytest.mark.parametrize(
+    "job_kwargs",
+    [
+        {"disk_gb": None},          # scrape has no hard_disk block
+        {"vram_gb_per_gpu": None},  # scrape has no gpu details
+        {"disk_gb": 0.0},           # unreadable disk reported as 0
+    ],
+)
+def test_vram_over_disk_partial_scrape_is_never_flagged(job_kwargs):
+    # A missing number must not cost a miner the incentive — fail open.
+    incentive = _build_incentive()
+
+    measured = incentive._vram_over_disk(_make_job(**job_kwargs))
+
+    assert measured is None
+
+
+def test_enforcement_defaults_to_shadow_mode():
+    # Rollout contract: first deploy must be shadow-only, so the flag default
+    # (not the env-resolved value) must stay False.
+    default = type(settings).model_fields["ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT"].default
+
+    assert default is False
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_keeps_rental_eligibility(monkeypatch):
+    # Arrange — VRAM over disk but flag off → shadow only
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT", False)
+    incentive = _build_incentive()
+
+    # Act
+    result = await incentive.calculate_executor_score(_make_job())
+
+    # Assert — still eligible for the unrented rental pool, nothing told to the miner
+    assert result.eligible_for_rental_share is True
+    assert "vram_exceeds_disk" not in "\n".join(result.incentive_logs)
+
+
+@pytest.mark.asyncio
+async def test_enforced_drops_rental_eligibility(monkeypatch):
+    # Arrange — VRAM over disk and flag on
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT", True)
+    incentive = _build_incentive()
+
+    # Act
+    result = await incentive.calculate_executor_score(_make_job())
+
+    # Assert — excluded from the rental pool, no mining either (active but no incentive)
+    assert result.eligible_for_rental_share is False
+    assert result.mining_score == 0
+
+
+@pytest.mark.asyncio
+async def test_enforced_appends_customer_facing_incentive_log(monkeypatch):
+    # DAH-2327: the zero-incentive reason must reach the customer-facing incentive log
+    # with both numbers, so the miner knows how much disk to add.
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT", True)
+    incentive = _build_incentive()
+
+    result = await incentive.calculate_executor_score(_make_job())
+
+    log = "\n".join(result.incentive_logs)
+    assert "vram_exceeds_disk" in log
+    assert "1128.0" in log  # total VRAM
+    assert "500.0" in log   # total disk
+
+
+@pytest.mark.asyncio
+async def test_enough_disk_keeps_eligibility_when_enforced(monkeypatch):
+    # Arrange — flag on but the machine has more disk than VRAM
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT", True)
+    incentive = _build_incentive()
+
+    # Act
+    result = await incentive.calculate_executor_score(_make_job(disk_gb=2048.0))
+
+    # Assert
+    assert result.eligible_for_rental_share is True
+
+
+@pytest.mark.asyncio
+async def test_rented_executor_is_not_gated(monkeypatch):
+    # A rented machine earns from the rented path and must not be touched by this gate.
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT", True)
+    incentive = _build_incentive()
+
+    result = await incentive.calculate_executor_score(_make_job(is_rented=True))
+
+    assert "vram_exceeds_disk" not in "\n".join(result.incentive_logs)

--- a/neurons/validators/tests/test_unrented_vram_over_disk.py
+++ b/neurons/validators/tests/test_unrented_vram_over_disk.py
@@ -6,6 +6,7 @@ gated by ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT; while the flag is off the breach
 is only logged (shadow mode) and the payout is unchanged.
 """
 
+import logging
 from unittest.mock import AsyncMock
 
 import pytest
@@ -18,8 +19,8 @@ from services.task_service import JobResult
 
 H200 = "NVIDIA H200"  # base model H200 is rental-eligible by default
 
-GB_IN_MB = 1024
-GB_IN_KB = 1024 ** 2
+MB_PER_GB = 1024
+KB_PER_GB = 1024 ** 2
 
 
 def _build_incentive() -> RentalPriceIncentive:
@@ -32,14 +33,16 @@ def _make_job(
     gpu_count: int = 8,
     disk_gb: float | None = 500.0,
     is_rented: bool = False,
+    spec: dict | None = None,
 ) -> JobResult:
-    spec: dict = {}
-    if vram_gb_per_gpu is not None:
-        spec["gpu"] = {
-            "details": [{"capacity": vram_gb_per_gpu * GB_IN_MB} for _ in range(gpu_count)]
-        }
-    if disk_gb is not None:
-        spec["hard_disk"] = {"total": disk_gb * GB_IN_KB}
+    if spec is None:
+        spec = {}
+        if vram_gb_per_gpu is not None:
+            spec["gpu"] = {
+                "details": [{"capacity": vram_gb_per_gpu * MB_PER_GB} for _ in range(gpu_count)]
+            }
+        if disk_gb is not None:
+            spec["hard_disk"] = {"total": disk_gb * KB_PER_GB}
 
     return JobResult(
         spec=spec,
@@ -104,9 +107,11 @@ def test_vram_over_disk_equal_is_not_flagged():
 @pytest.mark.parametrize(
     "job_kwargs",
     [
-        {"disk_gb": None},          # scrape has no hard_disk block
-        {"vram_gb_per_gpu": None},  # scrape has no gpu details
-        {"disk_gb": 0.0},           # unreadable disk reported as 0
+        {"disk_gb": None},                          # scrape has no hard_disk block
+        {"vram_gb_per_gpu": None},                  # scrape has no gpu details
+        {"disk_gb": 0.0},                           # unreadable disk reported as 0
+        {"spec": {"hard_disk": {"total": 1}, "gpu": {"details": []}}},  # gpu list came back empty
+        {"vram_gb_per_gpu": None, "disk_gb": None},  # no scrape at all
     ],
 )
 def test_vram_over_disk_partial_scrape_is_never_flagged(job_kwargs):
@@ -114,6 +119,77 @@ def test_vram_over_disk_partial_scrape_is_never_flagged(job_kwargs):
     incentive = _build_incentive()
 
     measured = incentive._vram_over_disk(_make_job(**job_kwargs))
+
+    assert measured is None
+
+
+def _logged_reasons(caplog) -> list[str]:
+    # the reason codes of the structured lines captured so far; _m keeps them off the message
+    return [r.msg.extra.get("reason") for r in caplog.records if hasattr(r.msg, "extra")]
+
+
+def test_estimated_job_result_is_not_logged_as_unmeasured(caplog):
+    # estimate_executor builds a spec-less JobResult for every GPU model every cycle;
+    # warning on those would drown the shadow measurement this log exists to feed.
+    incentive = _build_incentive()
+
+    with caplog.at_level(logging.WARNING):
+        incentive._vram_over_disk(_make_job(vram_gb_per_gpu=None, disk_gb=None))
+
+    assert "vram_over_disk_unmeasured" not in _logged_reasons(caplog)
+
+
+def test_unreadable_scrape_is_logged_as_unmeasured(caplog):
+    # A machine that reports no disk must be distinguishable from one that passed the gate.
+    incentive = _build_incentive()
+
+    with caplog.at_level(logging.WARNING):
+        incentive._vram_over_disk(_make_job(disk_gb=None))
+
+    assert "vram_over_disk_unmeasured" in _logged_reasons(caplog)
+
+
+MALFORMED_SPECS: list[dict] = [
+    {"gpu": {"details": [{"capacity": "141 GB"}]}, "hard_disk": {"total": 1}},  # unparsable number
+    {"gpu": {"details": [{"capacity": {"total": 1}}]}, "hard_disk": {"total": 1}},  # nested object
+    {"gpu": ["details"], "hard_disk": {"total": 1}},                            # gpu is a list
+    {"gpu": {"details": 8}, "hard_disk": {"total": 1}},                         # details not iterable
+    {"gpu": {"details": ["141"]}, "hard_disk": {"total": 1}},                   # entry is not a dict
+    {"gpu": {"details": [{"capacity": 1}]}, "hard_disk": "500"},                # hard_disk is a string
+]
+
+
+@pytest.mark.parametrize("spec", MALFORMED_SPECS)
+def test_vram_over_disk_survives_a_malformed_scrape(spec):
+    # The scrape is produced on the miner's machine and calculate_mining_scores has no
+    # per-result guard, so a malformed value must fail open instead of raising.
+    incentive = _build_incentive()
+
+    measured = incentive._vram_over_disk(_make_job(spec=spec))
+
+    assert measured is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("spec", MALFORMED_SPECS)
+async def test_malformed_scrape_never_breaks_scoring(monkeypatch, spec):
+    # Raising out of calculate_executor_score would cost EVERY miner this cycle's weights.
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT", True)
+    incentive = _build_incentive()
+
+    result = await incentive.calculate_executor_score(_make_job(spec=spec))
+
+    assert result.eligible_for_rental_share is True
+
+
+def test_vram_over_disk_reports_the_numbers_it_compared():
+    # Rounding happens before the comparison, so the miner is never told to add disk
+    # he already has: 500.04 GB VRAM against 500.0 GB disk both render as 500.0.
+    incentive = _build_incentive()
+
+    measured = incentive._vram_over_disk(
+        _make_job(vram_gb_per_gpu=500.04, gpu_count=1, disk_gb=500.0)
+    )
 
     assert measured is None
 
@@ -138,6 +214,24 @@ async def test_shadow_mode_keeps_rental_eligibility(monkeypatch):
     # Assert — still eligible for the unrented rental pool, nothing told to the miner
     assert result.eligible_for_rental_share is True
     assert "vram_exceeds_disk" not in "\n".join(result.incentive_logs)
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_emits_the_measurement_log(monkeypatch, caplog):
+    # The shadow log is the whole deliverable of the first deploy: the rollout decision
+    # is made from these fields, so they are a dashboard contract.
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT", False)
+    incentive = _build_incentive()
+
+    with caplog.at_level(logging.INFO):
+        await incentive.calculate_executor_score(_make_job())
+
+    breach = next(r.msg for r in caplog.records if r.msg.extra.get("reason") == "vram_exceeds_disk")
+    assert "shadow only - flag off" in breach.message
+    assert breach.extra["total_vram_gb"] == 1128.0
+    assert breach.extra["total_disk_gb"] == 500.0
+    assert breach.extra["enforced"] is False
+    assert breach.extra["pool"] == "rental_kept_shadow"
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_unrented_vram_over_disk.py
+++ b/neurons/validators/tests/test_unrented_vram_over_disk.py
@@ -1,9 +1,9 @@
 """DAH-2520 — unrented incentive VRAM/disk gate.
 
-An unrented executor whose total GPU VRAM exceeds the machine's total disk
-forfeits the unrented rental incentive while staying active. Enforcement is
-gated by ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT; while the flag is off the breach
-is only logged (shadow mode) and the payout is unchanged.
+An unrented executor whose total GPU VRAM times VRAM_OVER_DISK_RATE exceeds the
+machine's total disk forfeits the unrented rental incentive while staying active.
+Enforcement is gated by ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT; while the flag is
+off the breach is only logged (shadow mode) and the payout is unchanged.
 """
 
 import logging
@@ -93,15 +93,28 @@ def test_vram_over_disk_ignores_machine_with_enough_disk():
     assert measured is None
 
 
-def test_vram_over_disk_equal_is_not_flagged():
-    # Arrange — disk exactly equals VRAM; only strictly more VRAM is flagged
+def test_vram_over_disk_at_ratio_threshold_is_not_flagged():
+    # Arrange — disk exactly equals VRAM * VRAM_OVER_DISK_RATE; only strictly more is flagged
+    incentive = _build_incentive()
+
+    # Act
+    measured = incentive._vram_over_disk(_make_job(vram_gb_per_gpu=100.0, gpu_count=2, disk_gb=300.0))
+
+    # Assert
+    assert measured is None
+
+
+def test_vram_over_disk_equal_totals_is_flagged():
+    # Arrange — equal VRAM and disk no longer clears the 1.5x margin
     incentive = _build_incentive()
 
     # Act
     measured = incentive._vram_over_disk(_make_job(vram_gb_per_gpu=100.0, gpu_count=2, disk_gb=200.0))
 
     # Assert
-    assert measured is None
+    assert measured is not None
+    assert measured.vram_gb == 200.0
+    assert measured.disk_gb == 200.0
 
 
 @pytest.mark.parametrize(
@@ -183,12 +196,12 @@ async def test_malformed_scrape_never_breaks_scoring(monkeypatch, spec):
 
 
 def test_vram_over_disk_reports_the_numbers_it_compared():
-    # Rounding happens before the comparison, so the miner is never told to add disk
-    # he already has: 500.04 GB VRAM against 500.0 GB disk both render as 500.0.
+    # Rounding happens before the comparison: raw 200.03 * 1.5 = 300.045 GB would exceed
+    # 300.0 GB disk, but rounded to 200.0 GB VRAM it clears the 1.5x margin exactly.
     incentive = _build_incentive()
 
     measured = incentive._vram_over_disk(
-        _make_job(vram_gb_per_gpu=500.04, gpu_count=1, disk_gb=500.0)
+        _make_job(vram_gb_per_gpu=200.03, gpu_count=1, disk_gb=300.0)
     )
 
     assert measured is None


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2520](https://app.notion.com/p/Validator-zero-unrented-incentive-when-total-VRAM-exceeds-total-disk-3abb8bfdbde9816faf49d2473bc497de)

---

## Problem

The unrented (idle) incentive pays idle machines so a renter can pick them up. A node without
enough disk to hold the data its own GPUs work on is not realistically rentable — yet it collects
idle emission today.

Prod right now (359 active + verified executors, all measurable): **1** node has less disk than
VRAM, **2** are below the 1.5x margin this PR enforces, 8 are below 2x.

- `a5c4c96f-d2cf-45d2-8d36-607cce56429b` — 8x H100 80GB HBM3, 637.2 GB VRAM / 483.3 GB disk (0.76x)
- `eaf781b7-e1f9-431d-ba2b-c486262a6e2e` — 8x RTX PRO 6000 Blackwell, 764.7 GB VRAM / 865.2 GB disk (1.13x)

Worth knowing before the flag is flipped: six H200 nodes of one hotkey
(`5DhzqmmkD99d8MFbEEFgtQYSUWyYHRLNJKpVjYQFn5d6hJsv`) sit at exactly 1.54x (1123.2 GB VRAM /
1731.4 GB disk) — just above the threshold.

## Solution

Gate the unrented pool on a disk/VRAM sanity check inside `RentalPriceIncentive`, mirroring the
DAH-2250 soft price limit: an otherwise-eligible idle executor whose total disk is below
`MIN_DISK_TO_VRAM_RATE` (1.5) times its summed GPU VRAM loses `eligible_for_rental_share`, stays
active, and is told why in its incentive log.

Both numbers already ride on `JobResult.spec` (`gpu.details[].capacity` in MB, `hard_disk.total`
in kB), so there is no new scrape and no protocol change.

Enforcement is off by default: with `ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT=false` the validator only
emits a shadow log line, so prod impact can be measured before any payout changes.

## Changes

- `incentive/rental_price.py` — `InsufficientDisk` model, `_insufficient_disk()` detector,
  `_log_insufficient_disk()` shadow log and `_log_insufficient_disk_unmeasured()` for scrapes the
  gate cannot read; the gate runs in `calculate_executor_score` right after the soft price limit.
- `core/config.py` — new `ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT` flag, default `False`.
- `incentive/miner_incentive_log.py` — `ZeroIncentiveReason.INSUFFICIENT_DISK_FOR_VRAM`
  (append-only enum) and `no_payout_because_insufficient_disk_for_vram()`, which takes the whole
  measurement and quotes both numbers so the miner knows how much disk to add.
- `tests/test_unrented_insufficient_disk.py` — 31 tests; `tests/test_miner_incentive_log.py` — pin
  the new reason code in the stable-contract test.

Deliberate choices:

- Compares against **total** disk, not free space: free/used are distorted by preallocated volumes
  (DAH-2514), total is not.
- A scrape missing either number is never flagged — fail open, a miner never loses incentive over
  missing telemetry; the unmeasurable case is logged separately so a shadow report cannot read it
  as "disk is fine".
- A malformed scrape can never raise out of the gate: `calculate_mining_scores` has no per-result
  guard, so one bad spec would cost every miner the cycle's weights.
- Rented executors are untouched: the gate sits inside the idle-and-eligible branch only.
- Disk exactly equal to 1.5x VRAM clears the gate; only strictly less is flagged.

## Deployment Steps

Use GitHub Action. Ships in shadow mode; flip `ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT=true` in a
separate step once the shadow log confirms the expected nodes.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

None.

## Risks

- **Open review point (not addressed in this PR):** the backend picks filler nodes without reading
  `eligible_for_rental_share` (`default_job/runner.py` → `get_idle_executors_without_miner_default_job`),
  so a gated node keeps running Lium's Dolphin/PEARL fillers while earning nothing. The one node the
  gate zeroes today (`a5c4c96f-d2cf-45d2-8d36-607cce56429b`) is running 4 DPHN fillers right now.
  Needs a decision before the flag is flipped: exempt nodes with a Lium default job in the validator
  (`default_job_owner == "lium"` is already on `JobResult`), or mirror the gate in the backend's
  filler selection.
- With the flag on, a wrong or truncated `gpu.details` list would under-count VRAM and silently
  keep an executor in the pool (fail-open direction, not a payout loss).
- Six H200 nodes sit at 1.54x, so a change in which filesystem the scrape reports would pull them
  under the threshold in one cycle.
- No effect while the flag is off other than one extra log line per affected idle executor.

## Test Cases

### Test Case 1 — unit

**Actions** `pdm run pytest tests/test_unrented_insufficient_disk.py` in `neurons/validators/`.

**Expected Output** 31 passed: detection at 1128 GB VRAM vs 500 GB disk, disk exactly at the 1.5x
margin not flagged, equal totals flagged, partial scrape (no disk / no gpu details / disk 0) not
flagged, malformed scrapes never raise out of scoring, flag default is `False`, shadow mode keeps
eligibility and logs nothing to the miner, enforcement drops eligibility and appends
`insufficient_disk_for_vram` with both numbers, enough-disk and rented executors untouched.

### Test Case 2 — full validator suite

**Actions** `pdm run pytest tests/` in `neurons/validators/`.

**Expected Output** 1253 passed. The 3 failures in `test_sshd_bootstrap_script.py` and 9 errors in
`test_port_mapping_dao.py` are pre-existing on `main` (bash sshd harness and a missing DB), untouched
by this branch.

### Test Case 3 — staging

**Actions** Deployed this branch to staging via `staging_branch_deployment.yml`
(run 30380313276, image `lium-staging-validator:92c024d`).

**Expected Output** Validator pod healthy; over 20 minutes it completed 122 rental-share
calculations and emission splits with no error from the incentive path. Live specs in the validator
flow carry both fields (`hard_disk.total = 101430960` kB, `capacity = 49140.0` MB), confirming the
gate reads real data rather than failing open. Staging has no machine short on disk, so enforcement
itself is covered by the unit tests only.

## Checklist

- [ ] Proper labels added — this repo has no `ready-review` / `require-qa` labels; `ready_for_deploy` goes on after approval
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
