### PR TITLE
DAH-2527, exclude idle filler ports from port verification and publish in chunks

### DIFF
--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -92,6 +92,10 @@ class RentedExecutorsResponse(BaseModel):
     # processes are tolerated. Additive over the legacy map above so backend/validator deploy in any
     # order — an older backend leaves this empty and get_filler_containers falls back to the one.
     all_filler_containers_by_executor: dict[str, list[str]] = {}
+    # executor_id -> external ports its active fillers hold (DAH-2527). A filler creates no pod, so
+    # these ports never show up in executors[].pods and port verification used to probe them and
+    # collide. Empty for a backend that predates the field — the collision simply stays.
+    filler_ports_by_executor: dict[str, list[int]] = {}
     banned_guids: list[str] = []
     gpu_splitting_config: dict[str, int] = {}  # executor_id → min_gpu_count_for_rental
     network_ema: dict[str, NetworkEMA] = {}  # executor_id → EMA network speeds, all active executors
@@ -139,6 +143,10 @@ class RentedExecutorsResponse(BaseModel):
         # (skip-checks, logging). Container protection and GPU-usage tolerance use get_filler_containers.
         containers = self.get_filler_containers(executor_uuid)
         return containers[0] if containers else None
+
+    def get_filler_ports(self, executor_uuid: str) -> list[int]:
+        """External ports held by this executor's fillers, to be excluded from port verification."""
+        return self.filler_ports_by_executor.get(str(executor_uuid), [])
 
     def get_default_job_owner(self, executor_uuid: str) -> str | None:
         return self.default_job_owner_by_executor.get(str(executor_uuid))

--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -145,7 +145,6 @@ class RentedExecutorsResponse(BaseModel):
         return containers[0] if containers else None
 
     def get_filler_ports(self, executor_uuid: str) -> list[int]:
-        """External ports held by this executor's fillers, to be excluded from port verification."""
         return self.filler_ports_by_executor.get(str(executor_uuid), [])
 
     def get_default_job_owner(self, executor_uuid: str) -> str | None:

--- a/neurons/validators/src/services/executor_connectivity/orchestrator.py
+++ b/neurons/validators/src/services/executor_connectivity/orchestrator.py
@@ -33,6 +33,7 @@ class ConnectivityOrchestrator:
         sysbox_runtime: bool,
         rented_ports: list[int] | None,
         ssh_client,
+        excluded_ports: list[int] | None = None,
         log_ctx: dict | None = None,
     ) -> PortVerificationResult:
         log_ctx = {
@@ -40,8 +41,10 @@ class ConnectivityOrchestrator:
             "executor_uuid": executor_info.uuid,
             "executor_ip": executor_info.address,
         }
-        rented = set(rented_ports) if rented_ports else set()
-        ports = self.port_selector.select(executor_info, BATCH_PORT_VERIFICATION_SIZE, rented)
+        # rented ports come from pods, excluded ones from idle fillers (DAH-2527) — different
+        # sources, same meaning here: the port is taken and probing it would only collide
+        unavailable = set(rented_ports or []) | set(excluded_ports or [])
+        ports = self.port_selector.select(executor_info, BATCH_PORT_VERIFICATION_SIZE, unavailable)
 
         if not ports:
             return PortVerificationResult(

--- a/neurons/validators/src/services/executor_connectivity/orchestrator.py
+++ b/neurons/validators/src/services/executor_connectivity/orchestrator.py
@@ -31,9 +31,8 @@ class ConnectivityOrchestrator:
         executor_info: ExecutorSSHInfo,
         miner_hotkey: str,
         sysbox_runtime: bool,
-        rented_ports: list[int] | None,
+        unavailable_ports: list[int] | None,
         ssh_client,
-        excluded_ports: list[int] | None = None,
         log_ctx: dict | None = None,
     ) -> PortVerificationResult:
         log_ctx = {
@@ -41,10 +40,9 @@ class ConnectivityOrchestrator:
             "executor_uuid": executor_info.uuid,
             "executor_ip": executor_info.address,
         }
-        # rented ports come from pods, excluded ones from idle fillers (DAH-2527) — different
-        # sources, same meaning here: the port is taken and probing it would only collide
-        unavailable = set(rented_ports or []) | set(excluded_ports or [])
-        ports = self.port_selector.select(executor_info, BATCH_PORT_VERIFICATION_SIZE, unavailable)
+        ports = self.port_selector.select(
+            executor_info, BATCH_PORT_VERIFICATION_SIZE, set(unavailable_ports or [])
+        )
 
         if not ports:
             return PortVerificationResult(

--- a/neurons/validators/src/services/executor_connectivity/port_selector.py
+++ b/neurons/validators/src/services/executor_connectivity/port_selector.py
@@ -11,11 +11,11 @@ from services.port_utils import get_all_ports
 class PortSelector:
     """Selects which ports to verify."""
 
-    def select(self, executor_info: ExecutorSSHInfo, size: int, unavailable: set[int]) -> list[PortPair]:
+    def select(self, executor_info: ExecutorSSHInfo, size: int, unavailable_ports: set[int]) -> list[PortPair]:
         """Select ports to check, skipping external ports already taken by pods or fillers."""
         all_ports = get_all_ports(executor_info.port_range, executor_info.port_mappings, executor_info.ssh_port)
         available_ports = [
-            PortPair(internal, external) for internal, external in all_ports if external not in unavailable
+            PortPair(internal, external) for internal, external in all_ports if external not in unavailable_ports
         ]
         return available_ports[:size]
 

--- a/neurons/validators/src/services/executor_connectivity/port_selector.py
+++ b/neurons/validators/src/services/executor_connectivity/port_selector.py
@@ -11,9 +11,11 @@ from services.port_utils import get_all_ports
 class PortSelector:
     """Selects which ports to verify."""
 
-    def select(self, executor_info: ExecutorSSHInfo, size: int, rented: set[int]) -> list[PortPair]:
-        """Select ports to check, based on executor params and info about rented external ports."""
+    def select(self, executor_info: ExecutorSSHInfo, size: int, unavailable: set[int]) -> list[PortPair]:
+        """Select ports to check, skipping external ports already taken by pods or fillers."""
         all_ports = get_all_ports(executor_info.port_range, executor_info.port_mappings, executor_info.ssh_port)
-        available_ports = [PortPair(internal, external) for internal, external in all_ports if external not in rented]
+        available_ports = [
+            PortPair(internal, external) for internal, external in all_ports if external not in unavailable
+        ]
         return available_ports[:size]
 

--- a/neurons/validators/src/services/executor_connectivity/port_verifiers.py
+++ b/neurons/validators/src/services/executor_connectivity/port_verifiers.py
@@ -204,13 +204,18 @@ class FallbackVerifier:
 
 
 class SemiBatchVerifier:
-    """Verifies ports by publishing a whole batch in ONE container via -p.
+    """Verifies ports by publishing them via -p, in one container per chunk.
 
     Middle tier of the cascade: published ports are reached through the nat/DOCKER
     DNAT chain, so they survive a ufw default-deny INPUT policy — the same policy
     that silently drops BatchVerifier's --network=host listeners. Returns nothing
-    verified if the container cannot start, letting the caller fall through.
+    verified if every chunk fails to start, letting the caller fall through.
     """
+
+    # docker refuses the whole `run` when a single published port is already allocated, so the
+    # chunk size is the blast radius of one busy port (DAH-2527: idle fillers take the same low
+    # ports this tier probes). Ten matches the sequential tier's cap.
+    CHUNK_SIZE = 10
 
     def __init__(self, port_tester: PortTester, runner: ContainerRunner):
         self.port_tester = port_tester
@@ -225,21 +230,46 @@ class SemiBatchVerifier:
         max_ports: int = 50,
         log_ctx: dict | None = None,
     ) -> tuple[list[PortPair], list[PortPair]]:
-        """Publish up to max_ports in one container, then probe them concurrently."""
+        """Publish up to max_ports in chunked containers, then probe them concurrently."""
         log_ctx = log_ctx or {}
         ports_to_test = ports[:max_ports]
-        token = uuid.uuid4().hex
-        container_name = f"port_test_pub_{token[:8]}"
-        script = NetcatScript.batch(ports_to_test, token, 0)
-        # external differs from internal when the miner advertises port_mappings
-        publish_flags = " ".join(f"-p {port.external}:{port.internal}" for port in ports_to_test)
+        chunks = [
+            ports_to_test[start : start + self.CHUNK_SIZE]
+            for start in range(0, len(ports_to_test), self.CHUNK_SIZE)
+        ]
 
         logger.info(
             _m(
-                f"semi-batch: publishing {len(ports_to_test)} ports in one container",
+                f"semi-batch: publishing {len(ports_to_test)} ports in {len(chunks)} containers",
                 extra=get_extra_info(log_ctx),
             )
         )
+
+        chunk_results = await asyncio.gather(
+            *(self._verify_chunk(chunk, ssh_client=ssh_client, host=host, log_ctx=log_ctx) for chunk in chunks)
+        )
+        successful = [port for chunk_successful, _ in chunk_results for port in chunk_successful]
+        failed = [port for _, chunk_failed in chunk_results for port in chunk_failed]
+
+        logger.info(
+            _m(f"semi-batch: {len(successful)}/{len(ports_to_test)} verified", extra=get_extra_info(log_ctx))
+        )
+        return successful, failed
+
+    async def _verify_chunk(
+        self,
+        ports: list[PortPair],
+        *,
+        ssh_client: SSHClientConnection,
+        host: str,
+        log_ctx: dict,
+    ) -> tuple[list[PortPair], list[PortPair]]:
+        """Publish one chunk in one container; a chunk that cannot start fails only its own ports."""
+        token = uuid.uuid4().hex
+        container_name = f"port_test_pub_{token[:8]}"
+        script = NetcatScript.batch(ports, token, 0)
+        # external differs from internal when the miner advertises port_mappings
+        publish_flags = " ".join(f"-p {port.external}:{port.internal}" for port in ports)
 
         # any error below must not escape: an exception here would zero the whole
         # verification (fatal PortCountCheck) instead of falling through to the
@@ -252,21 +282,22 @@ class SemiBatchVerifier:
             if not start_result.ok:
                 logger.warning(
                     _m(
-                        f"semi-batch start failed: status={start_result.status} logs={start_result.logs}",
+                        f"semi-batch start failed for {len(ports)} ports: "
+                        f"status={start_result.status} logs={start_result.logs}",
                         extra=get_extra_info(log_ctx),
                     )
                 )
-                return [], ports_to_test
+                return [], ports
 
             started = True
             async with aiohttp.ClientSession() as session:
-                successful, failed = await self.port_tester.test_many(session, host, ports_to_test, token)
+                return await self.port_tester.test_many(session, host, ports, token)
 
         except Exception as e:
             logger.error(
                 _m(f"semi-batch: error: {str(e)[:100]}", extra=get_extra_info(log_ctx))
             )
-            return [], ports_to_test
+            return [], ports
 
         finally:
             if started:
@@ -276,8 +307,3 @@ class SemiBatchVerifier:
                     logger.warning(
                         _m(f"semi-batch: cleanup failed: {str(e)[:50]}", extra=get_extra_info(log_ctx))
                     )
-
-        logger.info(
-            _m(f"semi-batch: {len(successful)}/{len(ports_to_test)} verified", extra=get_extra_info(log_ctx))
-        )
-        return successful, failed

--- a/neurons/validators/src/services/executor_connectivity/service.py
+++ b/neurons/validators/src/services/executor_connectivity/service.py
@@ -31,6 +31,7 @@ class ExecutorConnectivityService:
         sysbox_runtime: bool = False,
         rented_ports: list[int] | None = None,
         rented_pod_names: list[str] | None = None,
+        excluded_ports: list[int] | None = None,
         log_ctx: dict | None = None,
     ) -> PortVerificationResult:
         """Verify executor port connectivity and DinD capability."""
@@ -44,6 +45,7 @@ class ExecutorConnectivityService:
                 miner_hotkey=miner_hotkey,
                 sysbox_runtime=sysbox_runtime,
                 rented_ports=rented_ports,
+                excluded_ports=excluded_ports,
                 log_ctx=log_ctx,
             )
             sysbox_result = verification.sysbox_runtime

--- a/neurons/validators/src/services/executor_connectivity/service.py
+++ b/neurons/validators/src/services/executor_connectivity/service.py
@@ -31,7 +31,7 @@ class ExecutorConnectivityService:
         sysbox_runtime: bool = False,
         rented_ports: list[int] | None = None,
         rented_pod_names: list[str] | None = None,
-        excluded_ports: list[int] | None = None,
+        filler_ports: list[int] | None = None,
         log_ctx: dict | None = None,
     ) -> PortVerificationResult:
         """Verify executor port connectivity and DinD capability."""
@@ -44,8 +44,9 @@ class ExecutorConnectivityService:
                 executor_info=executor_info,
                 miner_hotkey=miner_hotkey,
                 sysbox_runtime=sysbox_runtime,
-                rented_ports=rented_ports,
-                excluded_ports=excluded_ports,
+                # both sets are already taken on the executor, but only rented_ports means a
+                # customer rental — the sysbox fallback below reads it that way (DAH-2527)
+                unavailable_ports=(rented_ports or []) + (filler_ports or []),
                 log_ctx=log_ctx,
             )
             sysbox_result = verification.sysbox_runtime

--- a/neurons/validators/src/services/task/checks/port_connectivity.py
+++ b/neurons/validators/src/services/task/checks/port_connectivity.py
@@ -33,8 +33,8 @@ class PortConnectivityCheck:
         rented_executor = rented_data.executors.get(ctx.executor.uuid) if rented_data else None
         rented_ports = rented_executor.get_rented_ports() if rented_executor else []
         rented_pod_names = [p.container_name for p in rented_executor.pods] if rented_executor else []
-        # DAH-2527: an idle filler holds ports without creating a pod, so it has no rented_executor
-        # entry at all. Kept apart from rented_ports, which elsewhere doubles as "has a rental".
+        # DAH-2527: an idle filler holds ports without creating a pod, so an executor running only
+        # fillers has no rented_executor entry at all — hence the separate lookup.
         filler_ports = rented_data.get_filler_ports(ctx.executor.uuid) if rented_data else []
 
         connectivity_service = ctx.services.connectivity
@@ -45,7 +45,7 @@ class PortConnectivityCheck:
             ctx.state.sysbox_runtime,
             rented_ports=rented_ports,
             rented_pod_names=rented_pod_names,
-            excluded_ports=filler_ports,
+            filler_ports=filler_ports,
             log_ctx={
                 "pipeline_id": ctx.pipeline_id,
                 "job_batch_id": ctx.config.job_batch_id,

--- a/neurons/validators/src/services/task/checks/port_connectivity.py
+++ b/neurons/validators/src/services/task/checks/port_connectivity.py
@@ -33,6 +33,9 @@ class PortConnectivityCheck:
         rented_executor = rented_data.executors.get(ctx.executor.uuid) if rented_data else None
         rented_ports = rented_executor.get_rented_ports() if rented_executor else []
         rented_pod_names = [p.container_name for p in rented_executor.pods] if rented_executor else []
+        # DAH-2527: an idle filler holds ports without creating a pod, so it has no rented_executor
+        # entry at all. Kept apart from rented_ports, which elsewhere doubles as "has a rental".
+        filler_ports = rented_data.get_filler_ports(ctx.executor.uuid) if rented_data else []
 
         connectivity_service = ctx.services.connectivity
         result = await connectivity_service.verify_ports(
@@ -42,6 +45,7 @@ class PortConnectivityCheck:
             ctx.state.sysbox_runtime,
             rented_ports=rented_ports,
             rented_pod_names=rented_pod_names,
+            excluded_ports=filler_ports,
             log_ctx={
                 "pipeline_id": ctx.pipeline_id,
                 "job_batch_id": ctx.config.job_batch_id,

--- a/neurons/validators/tests/executor_connectivity/test_orchestrator.py
+++ b/neurons/validators/tests/executor_connectivity/test_orchestrator.py
@@ -54,6 +54,30 @@ async def test_orchestrator_success(sample_executor_info, mock_ssh_client, mocke
 
 
 @pytest.mark.asyncio
+async def test_orchestrator_excludes_rented_and_filler_ports(sample_executor_info, mock_ssh_client, mocker):
+    # DAH-2527: filler ports arrive separately from rented ones, but the selector must see one set
+    port_selector = mocker.Mock(spec=PortSelector)
+    port_selector.select.return_value = []
+
+    orchestrator = ConnectivityOrchestrator(
+        port_selector,
+        mocker.Mock(spec=PortProbe),
+        mocker.Mock(spec=DindProbe),
+    )
+
+    await orchestrator.verify(
+        executor_info=sample_executor_info,
+        miner_hotkey="miner",
+        sysbox_runtime=False,
+        rented_ports=[40100],
+        excluded_ports=[40001, 40003],
+        ssh_client=mock_ssh_client,
+    )
+
+    assert port_selector.select.call_args.args[2] == {40001, 40003, 40100}
+
+
+@pytest.mark.asyncio
 async def test_orchestrator_no_ports(sample_executor_info, mock_ssh_client, mocker):
     port_selector = mocker.Mock(spec=PortSelector)
     port_selector.select.return_value = []

--- a/neurons/validators/tests/executor_connectivity/test_orchestrator.py
+++ b/neurons/validators/tests/executor_connectivity/test_orchestrator.py
@@ -39,7 +39,7 @@ async def test_orchestrator_success(sample_executor_info, mock_ssh_client, mocke
         executor_info=sample_executor_info,
         miner_hotkey="miner",
         sysbox_runtime=False,
-        rented_ports=[],
+        unavailable_ports=[],
         ssh_client=mock_ssh_client,
     )
 
@@ -51,30 +51,6 @@ async def test_orchestrator_success(sample_executor_info, mock_ssh_client, mocke
     port_selector.select.assert_called_once()
     port_probe.probe.assert_called_once()
     dind_probe.verify.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_orchestrator_excludes_rented_and_filler_ports(sample_executor_info, mock_ssh_client, mocker):
-    # DAH-2527: filler ports arrive separately from rented ones, but the selector must see one set
-    port_selector = mocker.Mock(spec=PortSelector)
-    port_selector.select.return_value = []
-
-    orchestrator = ConnectivityOrchestrator(
-        port_selector,
-        mocker.Mock(spec=PortProbe),
-        mocker.Mock(spec=DindProbe),
-    )
-
-    await orchestrator.verify(
-        executor_info=sample_executor_info,
-        miner_hotkey="miner",
-        sysbox_runtime=False,
-        rented_ports=[40100],
-        excluded_ports=[40001, 40003],
-        ssh_client=mock_ssh_client,
-    )
-
-    assert port_selector.select.call_args.args[2] == {40001, 40003, 40100}
 
 
 @pytest.mark.asyncio
@@ -98,7 +74,7 @@ async def test_orchestrator_no_ports(sample_executor_info, mock_ssh_client, mock
         executor_info=sample_executor_info,
         miner_hotkey="miner",
         sysbox_runtime=False,
-        rented_ports=[],
+        unavailable_ports=[],
         ssh_client=mock_ssh_client,
     )
 
@@ -145,7 +121,7 @@ async def test_orchestrator_probe_fails_dind_ok(sample_executor_info, mock_ssh_c
         executor_info=sample_executor_info,
         miner_hotkey="miner",
         sysbox_runtime=False,
-        rented_ports=[],
+        unavailable_ports=[],
         ssh_client=mock_ssh_client,
     )
 
@@ -191,7 +167,7 @@ async def test_orchestrator_probe_ok_dind_fails(sample_executor_info, mock_ssh_c
         executor_info=sample_executor_info,
         miner_hotkey="miner",
         sysbox_runtime=True,
-        rented_ports=[],
+        unavailable_ports=[],
         ssh_client=mock_ssh_client,
     )
 

--- a/neurons/validators/tests/executor_connectivity/test_port_probe.py
+++ b/neurons/validators/tests/executor_connectivity/test_port_probe.py
@@ -49,6 +49,28 @@ async def test_port_probe_uses_semi_batch_when_batch_empty(mocker):
 
 
 @pytest.mark.asyncio
+async def test_port_probe_keeps_partial_semi_batch_result(mocker):
+    # DAH-2527: with chunked publication a busy port leaves the tier partially successful — that
+    # result must be carried forward, not thrown away for the 10-port sequential tier.
+    ports = [PortPair(9000 + i, 9000 + i) for i in range(3)]
+
+    batch = mocker.Mock()
+    batch.verify = mocker.AsyncMock(return_value=([], ports))
+    semi = mocker.Mock()
+    semi.verify = mocker.AsyncMock(return_value=(ports[:2], ports[2:]))
+    fallback = mocker.Mock()
+    fallback.verify = mocker.AsyncMock()
+
+    probe = PortProbe(batch, semi, fallback)
+
+    result = await probe.probe(ports, ssh_client=mocker.Mock(), host="127.0.0.1")
+
+    assert list(result.successful) == ports[:2]
+    assert list(result.failed) == ports[2:]
+    fallback.verify.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_port_probe_falls_through_to_fallback_when_batch_and_semi_empty(mocker):
     ports = [PortPair(9000, 9000), PortPair(9001, 9001)]
 

--- a/neurons/validators/tests/executor_connectivity/test_port_selector.py
+++ b/neurons/validators/tests/executor_connectivity/test_port_selector.py
@@ -25,7 +25,7 @@ def test_port_selector_from_mappings_excludes_ssh_and_rented():
     info = _executor_info(port_mappings=mappings)
 
     selector = PortSelector()
-    result = selector.select(info, size=5, rented={9001})
+    result = selector.select(info, size=5, unavailable={9001})
 
     ports = {(p.internal, p.external) for p in result}
     assert (22, 2200) not in ports
@@ -38,7 +38,7 @@ def test_port_selector_from_range_uses_range_list():
     info = _executor_info(port_range="9000,9001,9002")
 
     selector = PortSelector()
-    result = selector.select(info, size=2, rented=set())
+    result = selector.select(info, size=2, unavailable=set())
 
     assert len(result) == 2
     for port in result:
@@ -50,7 +50,7 @@ def test_port_selector_from_range_excludes_ssh_port():
     info = _executor_info(port_range="22,9000,9001")
 
     selector = PortSelector()
-    result = selector.select(info, size=2, rented=set())
+    result = selector.select(info, size=2, unavailable=set())
 
     assert all(p.internal != 22 for p in result)
 
@@ -59,7 +59,7 @@ def test_port_selector_default_range_when_missing():
     info = _executor_info(port_range=None)
 
     selector = PortSelector()
-    result = selector.select(info, size=3, rented=set())
+    result = selector.select(info, size=3, unavailable=set())
 
     assert len(result) == 3
     for port in result:
@@ -71,6 +71,6 @@ def test_port_selector_empty_when_all_rented():
     info = _executor_info(port_range="9000-9001")
 
     selector = PortSelector()
-    result = selector.select(info, size=2, rented={9000, 9001})
+    result = selector.select(info, size=2, unavailable={9000, 9001})
 
     assert result == []

--- a/neurons/validators/tests/executor_connectivity/test_port_selector.py
+++ b/neurons/validators/tests/executor_connectivity/test_port_selector.py
@@ -25,7 +25,7 @@ def test_port_selector_from_mappings_excludes_ssh_and_rented():
     info = _executor_info(port_mappings=mappings)
 
     selector = PortSelector()
-    result = selector.select(info, size=5, unavailable={9001})
+    result = selector.select(info, size=5, unavailable_ports={9001})
 
     ports = {(p.internal, p.external) for p in result}
     assert (22, 2200) not in ports
@@ -38,7 +38,7 @@ def test_port_selector_from_range_uses_range_list():
     info = _executor_info(port_range="9000,9001,9002")
 
     selector = PortSelector()
-    result = selector.select(info, size=2, unavailable=set())
+    result = selector.select(info, size=2, unavailable_ports=set())
 
     assert len(result) == 2
     for port in result:
@@ -50,7 +50,7 @@ def test_port_selector_from_range_excludes_ssh_port():
     info = _executor_info(port_range="22,9000,9001")
 
     selector = PortSelector()
-    result = selector.select(info, size=2, unavailable=set())
+    result = selector.select(info, size=2, unavailable_ports=set())
 
     assert all(p.internal != 22 for p in result)
 
@@ -59,7 +59,7 @@ def test_port_selector_default_range_when_missing():
     info = _executor_info(port_range=None)
 
     selector = PortSelector()
-    result = selector.select(info, size=3, unavailable=set())
+    result = selector.select(info, size=3, unavailable_ports=set())
 
     assert len(result) == 3
     for port in result:
@@ -71,6 +71,6 @@ def test_port_selector_empty_when_all_rented():
     info = _executor_info(port_range="9000-9001")
 
     selector = PortSelector()
-    result = selector.select(info, size=2, unavailable={9000, 9001})
+    result = selector.select(info, size=2, unavailable_ports={9000, 9001})
 
     assert result == []

--- a/neurons/validators/tests/executor_connectivity/test_port_verifiers.py
+++ b/neurons/validators/tests/executor_connectivity/test_port_verifiers.py
@@ -11,7 +11,7 @@ CONTAINER_START_FAILED = ContainerStartResult(
 
 
 @pytest.mark.asyncio
-async def test_semi_batch_publishes_all_ports_in_one_container(mocker):
+async def test_semi_batch_publishes_a_chunk_in_one_container(mocker):
     ports = [PortPair(9000, 9000), PortPair(9001, 9001), PortPair(9002, 9002)]
 
     runner = mocker.Mock()
@@ -69,13 +69,14 @@ async def test_semi_batch_caps_at_max_ports(mocker):
     successful, _ = await verifier.verify(ports, ssh_client=mocker.Mock(), host="1.2.3.4", max_ports=50)
 
     assert len(successful) == 50
-    tested_ports = port_tester.test_many.call_args.args[2]
-    assert len(tested_ports) == 50
+    assert runner.run.await_count == 50 / SemiBatchVerifier.CHUNK_SIZE
+    tested_ports = [port for call in port_tester.test_many.call_args_list for port in call.args[2]]
+    assert tested_ports == ports[:50]
 
 
 @pytest.mark.asyncio
-async def test_semi_batch_returns_empty_when_container_cannot_start(mocker):
-    ports = [PortPair(9000, 9000), PortPair(9001, 9001)]
+async def test_semi_batch_returns_empty_when_no_chunk_can_start(mocker):
+    ports = [PortPair(40000 + i, 40000 + i) for i in range(25)]
 
     runner = mocker.Mock()
     runner.run = mocker.AsyncMock(return_value=CONTAINER_START_FAILED)
@@ -92,6 +93,31 @@ async def test_semi_batch_returns_empty_when_container_cannot_start(mocker):
     assert failed == ports
     port_tester.test_many.assert_not_called()
     runner.cleanup.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_semi_batch_busy_port_fails_only_its_own_chunk(mocker):
+    # DAH-2527: docker refuses the whole `run` over one already-allocated port, and idle fillers
+    # take the same low ports this tier probes. One busy port must cost one chunk, not the tier.
+    ports = [PortPair(40000 + i, 40000 + i) for i in range(25)]
+
+    runner = mocker.Mock()
+    runner.run = mocker.AsyncMock(
+        side_effect=lambda ssh_client, name, script, publish_flags, timeout: (
+            CONTAINER_START_FAILED if "-p 40012:40012" in publish_flags else CONTAINER_STARTED
+        )
+    )
+    runner.cleanup = mocker.AsyncMock()
+
+    port_tester = mocker.Mock()
+    port_tester.test_many = mocker.AsyncMock(side_effect=lambda session, host, tested, token: (tested, []))
+
+    verifier = SemiBatchVerifier(port_tester, runner)
+
+    successful, failed = await verifier.verify(ports, ssh_client=mocker.Mock(), host="1.2.3.4")
+
+    assert successful == ports[:10] + ports[20:]
+    assert failed == ports[10:20]
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/executor_connectivity/test_service.py
+++ b/neurons/validators/tests/executor_connectivity/test_service.py
@@ -85,3 +85,39 @@ async def test_verify_ports_non_ok_status_skips_persist(
     assert result.elapsed_sec is not None
 
     orchestrator.verify.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_verify_ports_merges_rented_and_filler_ports(
+    mock_ssh_client,
+    sample_executor_info,
+    mocker,
+):
+    # DAH-2527: filler ports arrive separately so rented_ports keeps meaning "has a rental",
+    # but the orchestrator below must receive them as one set of taken ports
+    orchestrator = mocker.Mock()
+    orchestrator.verify = mocker.AsyncMock(
+        return_value=PortVerificationResult(
+            selected_ports=tuple(),
+            successful_ports=tuple(),
+            failed_ports=tuple(),
+            dind_port=None,
+            dind_ok=False,
+            sysbox_runtime=False,
+            status="no_ports",
+        )
+    )
+
+    executor_service = ExecutorConnectivityService(orchestrator=orchestrator)
+
+    await executor_service.verify_ports(
+        mock_ssh_client,
+        "test_miner",
+        sample_executor_info,
+        rented_ports=[40100],
+        filler_ports=[40001, 40003],
+    )
+
+    passed = orchestrator.verify.call_args.kwargs
+    assert set(passed["unavailable_ports"]) == {40001, 40003, 40100}
+    assert "rented_ports" not in passed

--- a/neurons/validators/tests/test_port_connectivity_check.py
+++ b/neurons/validators/tests/test_port_connectivity_check.py
@@ -1,6 +1,7 @@
 import pytest
 from dataclasses import dataclass, field
 
+from neurons.validators.src.protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from neurons.validators.src.services.executor_connectivity.models import PortPair, PortVerificationResult
 from neurons.validators.src.services.task.checks.port_connectivity import PortConnectivityCheck
 from neurons.validators.src.services.task.messages import PortConnectivityMessages as Msg
@@ -60,6 +61,7 @@ class DummyConnectivityService:
         sysbox_runtime: bool,
         rented_ports: list[int] | None = None,
         rented_pod_names: list[str] | None = None,
+        excluded_ports: list[int] | None = None,
         log_ctx: dict | None = None,
     ) -> PortVerificationResult:
         """Mock method that mimics the real connectivity service."""
@@ -68,6 +70,8 @@ class DummyConnectivityService:
             "miner_hotkey": miner_hotkey,
             "executor_uuid": executor_info.uuid,
             "sysbox_runtime": sysbox_runtime,
+            "rented_ports": rented_ports,
+            "excluded_ports": excluded_ports,
         }
 
         if self.verified_port_count:
@@ -185,6 +189,35 @@ async def test_port_connectivity_check(
                 assert result.updates["state"].verified_port_count == 100
             else:
                 assert result.updates["state"].verified_port_count == 0
+
+
+@pytest.mark.asyncio
+async def test_port_connectivity_passes_filler_ports_as_exclusions(context_factory):
+    """DAH-2527: an idle filler holds ports without creating a pod, so this executor has no entry
+    in rented_data.executors at all. Its ports must still reach verification as exclusions, and
+    must not arrive as rented_ports — a non-empty rented_ports means "has a rental" downstream."""
+    connectivity_service = DummyConnectivityService(success=True, verified_port_count=3)
+    services = build_services(
+        redis=DummyRedis(),
+        backend=DummyBackendService(),
+        connectivity=connectivity_service,
+    )
+    state = build_state(
+        rented_data=RentedExecutorsResponse(
+            executors={},
+            filler_ports_by_executor={"executor-123": [40001, 40003]},
+        )
+    )
+    ctx = context_factory(
+        services=services,
+        config=build_context_config(job_batch_id="batch-123"),
+        state=state,
+    )
+
+    await PortConnectivityCheck().run(ctx)
+
+    assert connectivity_service.called_with["excluded_ports"] == [40001, 40003]
+    assert connectivity_service.called_with["rented_ports"] == []
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_port_connectivity_check.py
+++ b/neurons/validators/tests/test_port_connectivity_check.py
@@ -61,7 +61,7 @@ class DummyConnectivityService:
         sysbox_runtime: bool,
         rented_ports: list[int] | None = None,
         rented_pod_names: list[str] | None = None,
-        excluded_ports: list[int] | None = None,
+        filler_ports: list[int] | None = None,
         log_ctx: dict | None = None,
     ) -> PortVerificationResult:
         """Mock method that mimics the real connectivity service."""
@@ -71,7 +71,7 @@ class DummyConnectivityService:
             "executor_uuid": executor_info.uuid,
             "sysbox_runtime": sysbox_runtime,
             "rented_ports": rented_ports,
-            "excluded_ports": excluded_ports,
+            "filler_ports": filler_ports,
         }
 
         if self.verified_port_count:
@@ -216,7 +216,7 @@ async def test_port_connectivity_passes_filler_ports_as_exclusions(context_facto
 
     await PortConnectivityCheck().run(ctx)
 
-    assert connectivity_service.called_with["excluded_ports"] == [40001, 40003]
+    assert connectivity_service.called_with["filler_ports"] == [40001, 40003]
     assert connectivity_service.called_with["rented_ports"] == []
 
 


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2527](https://www.notion.so/Port-verification-collides-with-idle-fillers-exclude-filler-ports-and-publish-in-chunks-3acb8bfdbde981b89fdad1cb224fefa1)

---

## Problem

Three H200 executors (`152.236.142.238/240/241`) report 5–6 verified ports out of a ~1000-port
range, every validation cycle, for hours. Two independent causes stack:

1. **Idle fillers hold the ports we probe.** `PortSelector.select` sorts the port range ascending
   and takes the first N; DPHN fillers take the lowest free ports as well, so the collision is
   deterministic, not unlucky. The validator cannot see them: a filler creates no `pod` row, so
   `rented_ports` (built from `RentedPod.ports_mapping`) is empty for these executors. On `.240`
   the filler ports right now are 40001, 40003, 40005, 40008, 40009, 40025, 40050, 40057 — the
   first ones the selector picks.
2. **`SemiBatchVerifier` died atomically on the first busy port.** It published all 50 candidates
   in a single `docker run`, and docker refuses the whole run when one published port is already
   allocated (`Bind for 0.0.0.0:40001 failed: port is already allocated`). One busy port returned
   zero verified ports for the entire tier, and the cascade fell through to `FallbackVerifier`,
   which tests 10 ports one at a time — half of those busy too.

(The `--network=host` tier is separately dead on these hosts — `progress: 0/300 verified` twice per
cycle, a provider-side firewall dropping raw host listeners. That is out of scope here; it caps the
ceiling at 50 ports rather than 300.)

## Solution

Backend-supplied exclusions plus a smaller blast radius per busy port.

The backend now sends `filler_ports_by_executor` (see the compute-app PR below) — an exact list of
the external ports every active filler holds on an executor. It rides the same channel as
`all_filler_containers_by_executor` (DAH-2465) and is additive with an empty default, so backend
and validator can deploy in either order.

The validator carries those ports as a **separate** `filler_ports` argument rather than folding
them into `rented_ports`. That distinction is load-bearing: a non-empty `rented_ports` is read as
"this executor has a customer rental" by `ExecutorConnectivityService`'s sysbox fallback, and
`len(pods) > 0` gates `port_count`, `sysbox_required`, `rented_machine`, `rental_verification`,
`capability`, `verifyx`, `inspector` and `result_handler`. Filler ports must exclude candidates
without routing these machines down the rented branch.

The split therefore stops exactly where it stops meaning something. `ExecutorConnectivityService` is
the last layer that reads `rented_ports` as a rental flag, so it is also the layer that merges the
two lists; everything below it receives one `unavailable_ports` list and only needs to know "this
external port is taken, don't probe it".

Separately, `SemiBatchVerifier` now publishes in chunks of 10, one container per chunk, run
concurrently. A port that is busy anyway — a filler restarting between the snapshot and the probe,
a leaked `port_test_` container, a pod container that outlived its rental — now costs one chunk
instead of the whole tier.

Expected on the dirtiest machine (`.240`), chunks of 10 over the first 50 candidates, before the
exclusions even land:

```
40000–40009  fails   (40001, 40003, 40005, 40008, 40009 busy)
40010–40019  ok      → 10
40020–40029  fails   (40025 busy)
40030–40039  ok      → 10
40040–40049  ok      → 10
```

30 verified from chunking alone; with the exclusions in place those two chunks stop failing at all.

## Changes

- `protocol/vc_protocol/compute_requests.py` — mirror `filler_ports_by_executor` with a
  `get_filler_ports(executor_uuid)` accessor, defaulting to `{}` so an older backend contributes
  no exclusions.
- `services/task/checks/port_connectivity.py` — read the filler ports off `rented_data` (which
  works even though the executor has no `executors` entry at all) and pass them as `filler_ports`.
- `services/executor_connectivity/service.py` — new `filler_ports` argument, merged with
  `rented_ports` into the single `unavailable_ports` list handed to the orchestrator.
- `services/executor_connectivity/orchestrator.py` — `rented_ports` becomes `unavailable_ports`;
  the orchestrator no longer knows which of the two sources a port came from.
- `services/executor_connectivity/port_selector.py` — rename the third parameter `rented` →
  `unavailable_ports`: it now receives pod ports *and* filler ports, and the old name lied.
- `services/executor_connectivity/port_verifiers.py` — `SemiBatchVerifier` splits its candidates
  into `CHUNK_SIZE = 10` chunks and runs one container per chunk via `asyncio.gather`, each with
  its own token and its own cleanup. A chunk that fails to start contributes only its own ports to
  `failed`.

Deliberately **not** changed:

- `port_probe.py`. Its cascade already falls through only when a tier verifies *zero* ports, so a
  partial semi-batch result is carried forward as is.
- No single-port retry over failed chunks. It would run the ~15 s sequential tier in cases where it
  never ran before (partial success), for at most ten extra ports, while the exclusions remove the
  collisions that poison chunks in the first place.
- No randomized or high-end candidate selection — it would move the probed ports every cycle and
  destroy comparability between cycles.

## Deployment Steps

Use GitHub Action. Deploy order does not matter: the field is additive with an empty default on
both sides. A new validator against an old backend simply gets no exclusions and keeps the current
behaviour; an old validator against a new backend ignores the extra field.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

- compute-app: https://github.com/Datura-ai/lium-io-backend/pull/840

## Risks

- **More containers per verification cycle.** The semi-batch tier now starts up to 5 `port_test_pub_*`
  containers instead of 1, concurrently over one asyncssh connection. Each still carries the same
  20 s self-kill window and its own cleanup in `finally`, so a missed cleanup self-heals as before;
  a crash mid-flight now strands 5 short-lived containers instead of 1.
- **`ConnectivityOrchestrator.verify` renames a required argument** (`rented_ports` →
  `unavailable_ports`). It has exactly one production caller, `ExecutorConnectivityService`, which
  is updated in the same commit; the orchestrator tests are updated too. `verify_ports` keeps
  `rented_ports` unchanged, so nothing outside `executor_connectivity/` sees the rename.
- **Wrong filler ports would shrink the candidate pool.** The exclusions come straight from
  `FillerRun.port_maps`; a stale row would remove a handful of ports from a ~1000-port range, which
  the selector simply skips over. Low impact.
- **A filler in `STARTING` contributes no exclusions.** The backend writes `port_maps` at the
  transition to `RUNNING`, while the rented-executors query also returns `STARTING` runs younger
  than 15 min. Such a filler already holds its ports but ships none, so the validator can still
  probe them — chunking is what keeps that from costing more than one chunk.
- The dead `--network=host` tier on these hosts is untouched — these executors stay capped at 50
  probed ports until that firewall story is handled separately.

## Test Cases

### Test Case 1 — a busy port fails only its own chunk

**Actions** `test_semi_batch_busy_port_fails_only_its_own_chunk` — 25 candidate ports, the runner
refuses to start any container whose publish flags include `-p 40012:40012`.

**Expected Output** ports 0–9 and 20–24 verified, ports 10–19 failed. Previously all 25 failed.

### Test Case 2 — filler ports reach the exclusion set

**Actions** `test_verify_ports_merges_rented_and_filler_ports` calls `verify_ports` with
`rented_ports=[40100]` and `filler_ports=[40001, 40003]`;
`test_port_connectivity_passes_filler_ports_as_exclusions` builds a `RentedExecutorsResponse` with
an **empty** `executors` dict (the filler-only case) and
`filler_ports_by_executor={"executor-123": [40001, 40003]}`.

**Expected Output** the orchestrator receives `unavailable_ports` covering `{40001, 40003, 40100}`
and no `rented_ports` at all; the check calls `verify_ports` with `filler_ports=[40001, 40003]` and
`rented_ports=[]`.

### Test Case 3 — no regression in the tier's failure modes

**Actions** existing `test_semi_batch_returns_empty_when_run_raises` /
`_when_test_many_raises` / `_survives_cleanup_failure`, plus
`test_semi_batch_returns_empty_when_no_chunk_can_start` extended to 25 ports across 3 chunks, and
`test_port_probe_keeps_partial_semi_batch_result`.

**Expected Output** exceptions never escape the tier (an escaping one would zero the whole
verification and trip the fatal `PortCount` check); an all-chunks-fail run returns empty rather
than raising; a partial semi-batch result does not trigger the sequential tier.

### Test Case 4 — full suite

**Actions** `pdm run pytest` in `neurons/validators`.

**Expected Output** 1233 passed, 3 failed — the 3 failures are in
`tests/test_sshd_bootstrap_script.py` and reproduce identically on unmodified `main`.
`ruff check` over the touched trees reports the same 19 pre-existing findings as before the change.

## Checklist

- [x] Proper labels — this repo has no `ready-review`/`require-qa` labels defined; nothing to add
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described

