### PR TITLE
DAH-2514, stop the obfuscator from renaming imports and builtins it never rebinds

### DIFF
--- a/neurons/validators/src/miner_jobs/obfuscator.py
+++ b/neurons/validators/src/miner_jobs/obfuscator.py
@@ -1,4 +1,5 @@
 import ast
+import builtins
 from ast import Name, FunctionDef
 import random
 import string
@@ -26,7 +27,8 @@ python_keywords = [
     'NVML_ERROR_MEMORY', 'NVML_ERROR_UNKNOWN', 'Exception', 'wrapper', 'args', 'kwargs', 'wraps', 'sys',
     'c_char_p', 'AttributeError', '_nvmlLib_refcount', 'nvmlLib', 'CDLL', 'os', 'tempfile', 'NVMLError',
     'OSError', 'c_uint', 'byref', 'create_string_buffer', 'c_int',  'setattr', 'subprocess', 'RuntimeError', 'hashlib',
-    'iter', 'next', 'repr', 'exc', 'e', 're', 'psutil', 'shutil', 'b64encode', 'Fernet', 'json', 'machine_specs', 'hasattr', 'bool'
+    'iter', 'next', 'repr', 'exc', 'e', 're', 'psutil', 'shutil', 'b64encode', 'Fernet', 'json', 'machine_specs', 'hasattr', 'bool',
+    'glob', 'socket', 'http'
 ]
 
 
@@ -91,8 +93,12 @@ class FunctionContentObfuscator(ast.NodeTransformer):
         self.name_mapping = {**args_mapping}
 
     def visit_Name(self, node: Name):
+        # rename a name only when it is ours to rename: renaming a builtin or an untouched
+        # import leaves the usage pointing at a name nothing ever assigns
         if not node.id.startswith('__') and node.id not in python_keywords:
             if node.id not in self.name_mapping:
+                if hasattr(builtins, node.id):
+                    return node
                 self.name_mapping[node.id] = generate_random_name()
             node.id = self.name_mapping[node.id]
 

--- a/neurons/validators/tests/test_scrape_obfuscation_names.py
+++ b/neurons/validators/tests/test_scrape_obfuscation_names.py
@@ -1,0 +1,74 @@
+"""The obfuscator renames every name in a function body that is not on its allowlist, but it never
+touches an `import` statement — an alias is not a Name node. So a module the scrape imports and the
+allowlist does not carry keeps its import intact while every usage becomes a random name nothing
+assigns, and the whole call raises NameError at runtime.
+
+That is how DAH-2514 shipped: `glob` and `socket` arrived with the docker disk breakdown, were not
+on the allowlist, and `hard_disk.images/containers/volumes` came back null on all 347 prod
+executors. Nothing failed loudly — the scrape swallowed it into an error key.
+
+The check is on the obfuscated output, not on the allowlist: it stays true whatever the next import
+happens to be called.
+"""
+
+import ast
+import builtins
+import importlib
+from pathlib import Path
+
+import pytest
+from miner_jobs.obfuscator import obfuscate_code
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+
+
+def _names_bound_anywhere(tree: ast.Module) -> set[str]:
+    """Every name the module itself makes readable, plus builtins and star-import contents.
+
+    Scope is deliberately ignored — a name bound in one function and read in another is not what
+    this test is looking for. Renaming a usage while leaving its binding alone leaves the name
+    bound nowhere at all, and that is what is being caught.
+    """
+    bound = set(dir(builtins))
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and any(alias.name == "*" for alias in node.names):
+            bound |= set(dir(importlib.import_module(node.module)))
+        elif isinstance(node, ast.alias):
+            bound.add((node.asname or node.name).split(".")[0])
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store | ast.Del):
+            bound.add(node.id)
+        elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            bound.add(node.name)
+        elif isinstance(node, ast.arg):
+            bound.add(node.arg)
+        elif isinstance(node, ast.ExceptHandler) and node.name:
+            bound.add(node.name)
+        elif isinstance(node, ast.Global | ast.Nonlocal):
+            bound |= set(node.names)
+
+    return bound
+
+
+@pytest.fixture
+def obfuscated() -> ast.Module:
+    return ast.parse(obfuscate_code((SRC / "miner_jobs" / "machine_scrape.py").read_text()))
+
+
+def test_obfuscated_scrape_reads_no_name_it_never_binds(obfuscated: ast.Module) -> None:
+    # Arrange
+    bound = _names_bound_anywhere(obfuscated)
+
+    # Act
+    unbound = {
+        node.id
+        for node in ast.walk(obfuscated)
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load) and node.id not in bound
+    }
+
+    # Assert
+    assert not unbound, (
+        f"obfuscated machine_scrape reads names nothing binds: {sorted(unbound)}. "
+        "A module imported by the scrape has to be listed in obfuscator.python_keywords, "
+        "otherwise its usages are renamed and its import is not."
+    )


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2514](https://app.notion.com/p/Report-real-available-disk-in-the-validator-scrape-preallocated-filler-volumes-inflate-used-3abb8bfdbde981bfa7c4f10c3761c3fb)

---

## Problem

The docker disk breakdown shipped in #1173 (`hard_disk.images` / `containers` / `volumes`) returns null on
**every** prod node — 0 non-null values across 347 active executors carrying the keys.

The scrape itself is fine: run by hand inside an executor container it reports `LayersSize=58360172370`,
8 containers, 6 df volumes, `DockerRootDir=/var/lib/docker` and resolves the vloopback glob.

The obfuscator is what breaks it. `FunctionContentObfuscator.visit_Name` renames every `Name` node in a
function body that is not on the hand-maintained `python_keywords` allowlist, but it never touches an
`import` statement — an alias is not a `Name` node. `glob` and `socket`, introduced by the disk breakdown,
were not on that list, so their imports stayed intact while every usage became a random name nothing
assigns:

```python
import socket
...
_MMQGw.socket(_MMQGw.AF_UNIX, _MMQGw.SOCK_STREAM)   # _MMQGw is never assigned
_VDYazqBCuAwTWbu.glob(f'/proc/1/root{...}/loopback')
```

`get_docker_disk_usage()` therefore raises `NameError` on the first `docker_api_get()` call, the whole
docker half lands in `hard_disk_docker_scrape_error` and all three fields are absent. Nothing failed
loudly, so it stayed invisible.

Writing the regression test surfaced a second instance of the same bug, unrelated to the disk breakdown:
`except FileNotFoundError:` in the sysbox GPU check (`machine_scrape.py:1005`) obfuscates to
`except _HOXWQLJuS:`. `python_keywords` is a partial, hand-written list of builtins — `len`, `range`,
`OSError`, `RuntimeError` are on it, `FileNotFoundError` is not — so that except clause raises `NameError`
whenever docker is missing from `PATH`.

## Solution

Two changes to `obfuscator.py`, plus a test that keeps the whole class of bug from coming back silently.

`glob`, `socket` and `http` join the allowlist. `http` survives today only by accident:
`http.client.HTTPConnection` appears exactly once, as a class base at module level, and no visitor renames
module-level names (`ModuleObfuscator.visit_Module` does not recurse, `handle_class_def` only rewrites
bases that are `ast.Name`, `FunctionObfuscator` only defines `visit_FunctionDef`). Move that expression
inside any function and it breaks exactly like `socket` did.

A name that `builtins` already provides is no longer renamed. The allowlist check stays first, so an
argument or a module-level function named after a builtin keeps its consistent rename and only genuinely
free builtin references are left alone.

## Changes

- `neurons/validators/src/miner_jobs/obfuscator.py`: `glob`, `socket`, `http` added to `python_keywords`;
  `FunctionContentObfuscator.visit_Name` skips names provided by `builtins` unless they are already mapped.
- `neurons/validators/tests/test_scrape_obfuscation_names.py`: new — obfuscates `machine_scrape.py` and
  asserts the result reads no name that nothing in the module ever binds.

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

Follow-up in `lium-io-backend`: `hard_disk_docker_scrape_error` is not declared on `MachineSpecs`
(`apps/server/src/models/executor.py`), so Pydantic strips it. That is why this breakage left no trace in
the DB and is worth fixing separately.

## Risks

- The obfuscated scrape now keeps a handful of builtin names in the clear (`FileNotFoundError` and
  friends). That is a marginal loss of obfuscation, and most builtins the scrape uses — `len`, `range`,
  `isinstance`, `OSError` — were already in the allowlist in the clear for exactly this reason.
- The change is confined to the obfuscation pass. `machine_scrape.py` itself is untouched, so the scrape
  logic, the encryption key order and the key mapping tables are unaffected.
- The generated binary is rebuilt on every validator start via `file_encrypt_service`, so the fix reaches
  a node as soon as it runs the new validator image.

## Test Cases

### Test Case 1 — the regression test catches both bugs

**Actions** Undo each fix in memory and re-run the new test against the freshly obfuscated scrape.

**Expected Output**

```
fixed:                                       0 unbound -> []
without glob/socket/http in the allowlist:   2 unbound -> ['_CdcxNEBVGmUt', '_QPZbl']
without the builtins guard:                  1 unbound -> ['_XfYEEzY']
```

The two names in the second line are the `socket` and `glob` usages; `http` stays intact there, which is
the accident described above.

### Test Case 2 — the generated file keeps the real module names

**Actions** Run the obfuscator the way `file_encrypt_service` does:
`python src/miner_jobs/obfuscator.py src/miner_jobs/machine_scrape.py`.

**Expected Output**

```
901:class _hIJKdKGNqxYwnW(http.client.HTTPConnection):
912:        _YhJZPQnHRupxhZ.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
971:    _RIsfZMRmVqe = glob.glob(f'/proc/1/root{...}/plugins/*/rootfs{...}/loopback')
1157:    except FileNotFoundError:
```

### Test Case 3 — validator suite

**Actions** `pytest tests --ignore=tests/integration`.

**Expected Output** Green, apart from the three `test_sshd_bootstrap_script.py` failures that already fail
on `main` in a clean checkout.

## Checklist

- [x] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
