### PR TITLE
DAH-2528 - add occupancy-aware bucket fallback for split-capable idle nodes

### DIFF
--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -28,7 +28,9 @@ WHAT THIS CATALOG HOLDS — every `MinerLogLine` the miner-facing log block
 
 2. CALCULATION REPORTS — the per-cycle score/incentive lines every scored node gets:
      mining_score_calculated, mining_incentive_calculated,
-     rental_incentive_calculated, mining_score_missing (internal-error case)
+     rental_incentive_calculated, mining_score_missing (internal-error case),
+     unrented_bucket_reassigned (DAH-2528: node rated against its split tier
+     because its own GPU-count tier was over capacity)
 
 The scoring code (rental_price.py / default.py) detects each condition where its
 data naturally lives (some per-executor upfront, some only after cohort aggregation),
@@ -373,6 +375,29 @@ class MinerLogLine(BaseModel):
                 "burn_share": result.burn_share,
                 "incentive": result.incentive,
                 "total_rental_cost": result.total_rental_cost,
+            },
+        )
+
+    @staticmethod
+    def unrented_bucket_reassigned(result: JobResult) -> MinerLogLine:
+        # DAH-2528 report line, not a zero reason: the node is paid, in a better bucket.
+        return MinerLogLine(
+            message=(
+                f"Unrented incentive: the {result.bucket_reassigned_from}x "
+                f"{result.gpu_model} tier was over its capacity when this executor "
+                f"was placed, so it is rated against its {result.count_bucket}x "
+                f"split tier, which had free capacity and pays a better rate."
+            ),
+            fields={
+                "executor_id": str(result.executor_info.uuid),
+                "gpu_model": result.gpu_model,
+                "gpu_count": result.gpu_count,
+                "event": "unrented_bucket_reassigned",
+                "bucket_reassigned_from": result.bucket_reassigned_from,
+                "bucket_reassigned_from_multiplier": result.bucket_reassigned_from_multiplier,
+                "count_bucket": result.count_bucket,
+                "max_cap": result.max_cap,
+                "unrented_cap_multiplier": result.unrented_cap_multiplier,
             },
         )
 

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -136,9 +136,11 @@ class RentalPriceIncentive(DefaultIncentive):
     - Phase 2: Calculate dynamic emission splits based on rental costs
     - Phase 3: Distribute weights across burn/mining/rental pools
 
-    Cap dilution is applied per `(base_model, gpu_count_bucket)`. Buckets are
-    derived from each executor's `gpu_splitting_min_count` (when GPU splitting
-    is enabled) or its `gpu_count`.
+    Cap dilution is applied per `(base_model, gpu_count_bucket)`. An executor is
+    rated against its `gpu_count` bucket; a split-capable executor falls back to
+    its `gpu_splitting_min_count` tier when the `gpu_count` bucket has no cap
+    configured, or (DAH-2528) when that bucket is over cap and the whole node
+    fits under the split tier's cap.
     """
 
     price_provider: PriceProvider = PriceProvider()
@@ -160,6 +162,9 @@ class RentalPriceIncentive(DefaultIncentive):
         self.unrented_count_by_bucket: dict[tuple[str, int], int] = {}
         self._weighted_rate_sum_by_bucket: dict[tuple[str, int], float] = {}
         self.cap_multiplier_by_bucket: dict[tuple[str, int], float] = {}
+        # DAH-2528: split-capable idle executors pinned to their gpu_count bucket,
+        # revisited once per-bucket fill is known. Items: (base_model, result).
+        self._split_fallback_candidates: list[tuple[str, JobResult]] = []
         self.total_rental_cost = 0.0
         self.rental_share = 0.0
         self.rental_share_raw = 0.0
@@ -331,9 +336,12 @@ class RentalPriceIncentive(DefaultIncentive):
 
     async def _pre_process_job_result(self, hotkey: str, result: JobResult) -> None:
         """Aggregate per-`(base_model, bucket)` metrics for the rental-share
-        algorithm. Bucket resolution is symmetric with the rate-resolution path
-        so split-capable executors land in the bucket of their
-        `gpu_splitting_min_count`.
+        algorithm. A split-capable executor lands in its `gpu_count` bucket when
+        that bucket has a configured cap (falling back to its
+        `gpu_splitting_min_count` tier only when it has none); its rate is the
+        best of the bundle rate and the min-count rate. Occupancy-aware
+        reassignment happens later in `_reassign_split_candidates`, once every
+        bucket's fill is known.
         """
         if not result.is_successful:
             return
@@ -386,11 +394,80 @@ class RentalPriceIncentive(DefaultIncentive):
                     * result.driver_multiplier
                 )
 
+                # DAH-2528: a split-capable node pinned to its gpu_count bucket may
+                # still be moved to its split tier if the bucket turns out over cap.
+                if (
+                    result.supports_gpu_splitting
+                    and result.gpu_splitting_min_count
+                    and bucket == result.gpu_count
+                    and bucket != result.gpu_splitting_min_count
+                ):
+                    self._split_fallback_candidates.append((base_model, result))
+
+    def _reassign_split_candidates(self) -> None:
+        """DAH-2528: occupancy-aware bucket fallback for split-capable idle executors.
+
+        `_resolve_bucket` pins a split-capable executor to its `gpu_count` bucket
+        whenever that bucket has a configured cap, no matter how crowded it is. This
+        second pass runs once every bucket's fill is known: it moves a node out of an
+        over-cap `gpu_count` bucket into its `gpu_splitting_min_count` tier, but only
+        when the whole node fits under the target cap — a move never pushes the target
+        over cap, so nodes already rated there are never diluted by a newcomer. Greedy
+        in ascending executor-uuid order, so an unchanged fleet reproduces identical
+        assignments every cycle.
+        """
+        candidates = sorted(
+            self._split_fallback_candidates,
+            key=lambda item: str(item[1].executor_info.uuid),
+        )
+        for base_model, result in candidates:
+            src_bucket = result.count_bucket
+            tgt_bucket = result.gpu_splitting_min_count
+            cap_spec = self.config.max_unrented_gpus.get(base_model, {})
+            src_cap = cap_spec.get(src_bucket, 0)
+            tgt_cap = cap_spec.get(tgt_bucket, 0)
+            if tgt_cap <= 0:
+                continue
+            src_key = (base_model, src_bucket)
+            tgt_key = (base_model, tgt_bucket)
+            src_count = self.unrented_count_by_bucket.get(src_key, 0)
+            if src_count <= src_cap:
+                # source bucket pays full weight already (or emptied by earlier moves)
+                continue
+            tgt_count = self.unrented_count_by_bucket.get(tgt_key, 0)
+            if tgt_count + result.gpu_count > tgt_cap:
+                # the whole node must fit: never over-fill the target
+                continue
+            # Admission implies the move pays strictly better: the target ends at or
+            # under cap (multiplier exactly 1.0) while the source is strictly over
+            # cap (multiplier < 1.0).
+            src_multiplier = min(src_count, src_cap) / src_count
+
+            weighted_rate = (
+                result.gpu_count
+                * result.hourly_rate
+                * result.sysbox_multiplier
+                * result.driver_multiplier
+            )
+            self.unrented_count_by_bucket[src_key] = src_count - result.gpu_count
+            self._weighted_rate_sum_by_bucket[src_key] -= weighted_rate
+            self.unrented_count_by_bucket[tgt_key] = tgt_count + result.gpu_count
+            self._weighted_rate_sum_by_bucket[tgt_key] = (
+                self._weighted_rate_sum_by_bucket.get(tgt_key, 0.0) + weighted_rate
+            )
+            result.bucket_reassigned_from = src_bucket
+            result.bucket_reassigned_from_multiplier = src_multiplier
+            result.count_bucket = tgt_bucket
+            result.max_cap = tgt_cap
+
     async def _on_finish_pre_process(self) -> None:
         """Callback after pre-processing all job results.
 
         - Calculate rental share
         """
+        # DAH-2528: rebalance split-capable nodes before multipliers are computed.
+        self._reassign_split_candidates()
+
         # Step 1: cap multiplier per (base_model, bucket).
         for (base_model, bucket), unrented_count in self.unrented_count_by_bucket.items():
             max_cap = self.config.max_unrented_gpus.get(base_model, {}).get(bucket, 0)
@@ -482,6 +559,11 @@ class RentalPriceIncentive(DefaultIncentive):
         # update incentive logs
         report: MinerLogLine = MinerLogLine.rental_incentive_calculated(hotkey, result, bucket)
         result.incentive_logs.append(report.to_log_line())
+
+        # DAH-2528: tell the miner why the node was rated against its split tier
+        if result.bucket_reassigned_from is not None:
+            reassigned: MinerLogLine = MinerLogLine.unrented_bucket_reassigned(result)
+            result.incentive_logs.append(reassigned.to_log_line())
 
         self._explain_zero_effective_rate(result, bucket)
 

--- a/neurons/validators/src/services/task/models.py
+++ b/neurons/validators/src/services/task/models.py
@@ -58,6 +58,8 @@ class JobResult(BaseModel):
     hourly_rate: float | None = None                  # Hourly rate for the executor in this cycle for scoring logic
     max_cap: int | None = None                        # Max cap for GPU counts in this cycle for scoring logic
     count_bucket: int | None = None                    # gpu_count_bucket the executor is accounted against; 0 = aggregate-cap path
+    bucket_reassigned_from: int | None = None          # DAH-2528: gpu_count bucket the executor left because it was over cap
+    bucket_reassigned_from_multiplier: float | None = None  # source bucket's cap multiplier at reassignment time
     total_unrented_by_gpu_type: float | None = None          # Weighted GPU count for the executor in this cycle for scoring logic
     cap_dilution_applied: bool | None = None           # Whether the cap dilution is applied for the executor in this cycle for scoring logic
     eligible_for_rental_share: bool = False
@@ -112,6 +114,8 @@ class JobResult(BaseModel):
                 "effective_rate": self.effective_rate,
                 "total_rental_cost": self.total_rental_cost,
                 "count_bucket": self.count_bucket,
+                "bucket_reassigned_from": self.bucket_reassigned_from,
+                "bucket_reassigned_from_multiplier": self.bucket_reassigned_from_multiplier,
                 "max_cap": self.max_cap,
                 "total_unrented_by_gpu_type": self.total_unrented_by_gpu_type,
                 "cap_dilution_applied": self.cap_dilution_applied,

--- a/neurons/validators/tests/test_rental_price_estimate.py
+++ b/neurons/validators/tests/test_rental_price_estimate.py
@@ -473,3 +473,45 @@ async def test_precompute_all_estimates_returns_both_rented_and_unrented_without
         (1, True),
         (8, False),
     ]
+
+
+# ── DAH-2528: estimate follows the occupancy-aware bucket fallback ───────────
+
+@pytest.mark.asyncio
+async def test_estimate_executor_split_fallback_when_bucket_over_cap(
+    rental_config, mock_redis, mock_price_provider, monkeypatch
+):
+    """A split-capable hypothetical node whose gpu_count bucket is over cap in the
+    snapshot is estimated against its min-count tier — the same reassignment the
+    real cycle would apply — while a non-splitting twin stays diluted in place.
+    """
+    # Arrange — two real idle 8×H200 rigs put the 8× bucket at 16/8 (over cap).
+    job_results = {
+        "miner_a": [_make_job("exec-a", "H200", 8, is_rented=False)],
+        "miner_b": [_make_job("exec-b", "H200", 8, is_rented=False)],
+    }
+    incentive = _make_incentive(rental_config, mock_redis, mock_price_provider, job_results, monkeypatch)
+    await incentive.calculate_mining_scores()
+    snapshot = incentive.get_snapshot()
+
+    # Act — estimate the same hypothetical node with and without splitting.
+    estimator_split = RentalPriceIncentive(
+        rental_config, mock_redis, jobs_results={}, total_gpu_model_count_map={}, snapshot=snapshot,
+    )
+    result_split = await estimator_split.estimate_executor(
+        ExecutorEstimateParams(gpu_model="H200", gpu_count=8, is_rented=False, gpu_splitting=True, gpu_splitting_min_count=1)
+    )
+    estimator_no_split = RentalPriceIncentive(
+        rental_config, mock_redis, jobs_results={}, total_gpu_model_count_map={}, snapshot=snapshot,
+    )
+    result_no_split = await estimator_no_split.estimate_executor(
+        ExecutorEstimateParams(gpu_model="H200", gpu_count=8, is_rented=False)
+    )
+
+    # Assert — the split node is rated in the empty 1× tier at full weight...
+    assert result_split.count_bucket == 1
+    assert result_split.unrented_cap_multiplier == pytest.approx(1.0)
+    # ...while the non-splitting twin lands in the over-cap 8× bucket, diluted (8/24).
+    assert result_no_split.count_bucket == 8
+    assert result_no_split.unrented_cap_multiplier == pytest.approx(8 / 24)
+    assert result_split.usd_per_epoch > result_no_split.usd_per_epoch > 0

--- a/neurons/validators/tests/test_rental_price_incentive_flow.py
+++ b/neurons/validators/tests/test_rental_price_incentive_flow.py
@@ -2457,8 +2457,12 @@ async def test_pcc_case5_single_8xB200_full_payout(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_pcc_8xB200_split_prefers_8_bucket(monkeypatch):
-    """8×B200 splitting + min_count=1 should land in the 8× bucket (configured)
-    instead of being forced into the 1× bucket and diluting its subsidy.
+    """8×B200 splitting + min_count=1 lands in the 8× bucket when it has a cap.
+
+    With the default caps the solo node fills the 8× bucket exactly to cap
+    (multiplier 1.0), so the DAH-2528 occupancy-aware fallback must NOT move it
+    either — reassignment only triggers when the source bucket is strictly over
+    cap (see the test_pcc_2528_* cases).
     """
     config = _make_pcc_config()
     jobs = {
@@ -2908,3 +2912,239 @@ async def test_rental_price_miner_default_job_unrented_earns_nothing(
     # The miner's own job must not dilute the legitimate unrented bucket (only plain + lium_job count)
     assert lium_job.total_unrented_by_gpu_type == 16
     assert plain.total_unrented_by_gpu_type == 16
+
+
+# ── DAH-2528: occupancy-aware bucket fallback for split-capable idle nodes ────
+
+PCC_2528_CAPS = {**PCC_PER_COUNT_CAPS, "B200": {1: 10, 8: 8}}
+
+
+@pytest.mark.asyncio
+async def test_pcc_2528_split_node_falls_back_when_8_bucket_over_cap(monkeypatch):
+    """The 8× bucket is over cap and the 1× tier is empty: the split-capable node
+    moves whole into the 1× tier at full multiplier; non-splitting siblings stay
+    diluted, and the source bucket's multiplier improves by the freed GPUs.
+    """
+    config = _make_pcc_config(caps=PCC_2528_CAPS)
+    jobs = {
+        "miner_a": [_make_pcc_job(
+            "exec-a", "NVIDIA B200", 8,
+            supports_gpu_splitting=True, gpu_splitting_min_count=1,
+        )],
+        "miner_b": [_make_pcc_job("exec-b", "NVIDIA B200", 8)],
+        "miner_c": [_make_pcc_job("exec-c", "NVIDIA B200", 8)],
+    }
+
+    incentive = await _run_pcc_incentive(config, jobs, monkeypatch)
+
+    # Mover: whole node (8 GPUs) rated against the 1× tier at full weight.
+    mover = jobs["miner_a"][0]
+    assert mover.count_bucket == 1
+    assert mover.max_cap == 10
+    assert mover.bucket_reassigned_from == 8
+    assert mover.bucket_reassigned_from_multiplier == pytest.approx(8 / 24)
+    assert mover.unrented_cap_multiplier == pytest.approx(1.0)
+    assert mover.effective_rate == pytest.approx(PCC_HOURLY_RATE * PCC_SYSBOX_MULTIPLIER)
+    assert mover.cap_dilution_applied is False
+    assert any("unrented_bucket_reassigned" in line for line in mover.incentive_logs)
+
+    # Bucket fills after the move: 1× holds the mover, 8× keeps the two others.
+    assert incentive.unrented_count_by_bucket[("B200", 1)] == 8
+    assert incentive.unrented_count_by_bucket[("B200", 8)] == 16
+    assert incentive.cap_multiplier_by_bucket[("B200", 1)] == pytest.approx(1.0)
+    assert incentive.cap_multiplier_by_bucket[("B200", 8)] == pytest.approx(0.5)
+
+    # Non-splitting siblings stay in the 8× bucket, diluted, and are never reassigned.
+    for hk in ("miner_b", "miner_c"):
+        stayer = jobs[hk][0]
+        assert stayer.count_bucket == 8
+        assert stayer.bucket_reassigned_from is None
+        assert stayer.effective_rate == pytest.approx(0.5 * PCC_HOURLY_RATE * PCC_SYSBOX_MULTIPLIER)
+        assert not any("unrented_bucket_reassigned" in line for line in stayer.incentive_logs)
+
+    # Snapshot persists the post-move fills, so estimates see the same state.
+    by_bucket = incentive.get_snapshot().rental.by_bucket
+    assert by_bucket["B200·1"].unrented_count == 8
+    assert by_bucket["B200·1"].cap_multiplier == pytest.approx(1.0)
+    assert by_bucket["B200·8"].unrented_count == 16
+    assert by_bucket["B200·8"].cap_multiplier == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_pcc_2528_no_move_when_whole_node_does_not_fit_target(monkeypatch):
+    """Strict admission: the whole node must fit under the target cap. With 3 native
+    1× nodes already in the tier (cap 10), an 8-GPU candidate would make 11 — it
+    stays in its over-cap 8× bucket and the 1× incumbents keep full weight.
+    """
+    config = _make_pcc_config(caps=PCC_2528_CAPS)
+    jobs = {
+        "miner_a": [_make_pcc_job(
+            "exec-a", "NVIDIA B200", 8,
+            supports_gpu_splitting=True, gpu_splitting_min_count=1,
+        )],
+        "miner_b": [_make_pcc_job("exec-b", "NVIDIA B200", 8)],
+        "miner_c": [
+            _make_pcc_job("exec-c1", "NVIDIA B200", 1),
+            _make_pcc_job("exec-c2", "NVIDIA B200", 1),
+            _make_pcc_job("exec-c3", "NVIDIA B200", 1),
+        ],
+    }
+
+    incentive = await _run_pcc_incentive(config, jobs, monkeypatch)
+
+    candidate = jobs["miner_a"][0]
+    assert candidate.count_bucket == 8
+    assert candidate.bucket_reassigned_from is None
+    assert candidate.effective_rate == pytest.approx(0.5 * PCC_HOURLY_RATE * PCC_SYSBOX_MULTIPLIER)
+    assert not any("unrented_bucket_reassigned" in line for line in candidate.incentive_logs)
+
+    assert incentive.unrented_count_by_bucket[("B200", 1)] == 3
+    assert incentive.unrented_count_by_bucket[("B200", 8)] == 16
+    assert incentive.cap_multiplier_by_bucket[("B200", 1)] == pytest.approx(1.0)
+    assert incentive.cap_multiplier_by_bucket[("B200", 8)] == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_pcc_2528_greedy_stops_when_source_no_longer_over_cap(monkeypatch):
+    """Two split-capable 8× nodes over an 8-GPU cap: the lowest-uuid one moves,
+    which brings the source back to cap, so the second stays — and both end at
+    full multiplier. Rerunning an identical fleet reproduces the same assignment.
+    """
+    def make_jobs():
+        return {
+            "miner_a": [_make_pcc_job(
+                "exec-a", "NVIDIA B200", 8,
+                supports_gpu_splitting=True, gpu_splitting_min_count=1,
+            )],
+            "miner_b": [_make_pcc_job(
+                "exec-b", "NVIDIA B200", 8,
+                supports_gpu_splitting=True, gpu_splitting_min_count=1,
+            )],
+        }
+
+    config = _make_pcc_config(caps=PCC_2528_CAPS)
+    jobs = make_jobs()
+    incentive = await _run_pcc_incentive(config, jobs, monkeypatch)
+
+    mover, stayer = jobs["miner_a"][0], jobs["miner_b"][0]
+    assert mover.count_bucket == 1
+    assert mover.bucket_reassigned_from == 8
+    assert stayer.count_bucket == 8
+    assert stayer.bucket_reassigned_from is None
+    # After the move both buckets sit exactly at (or under) cap: nobody is diluted.
+    assert mover.unrented_cap_multiplier == pytest.approx(1.0)
+    assert stayer.unrented_cap_multiplier == pytest.approx(1.0)
+    assert incentive.unrented_count_by_bucket[("B200", 1)] == 8
+    assert incentive.unrented_count_by_bucket[("B200", 8)] == 8
+
+    # Determinism: an identical fleet produces identical bucket assignments.
+    jobs_rerun = make_jobs()
+    await _run_pcc_incentive(config, jobs_rerun, monkeypatch)
+    for hk in jobs:
+        assert jobs_rerun[hk][0].count_bucket == jobs[hk][0].count_bucket
+        assert jobs_rerun[hk][0].bucket_reassigned_from == jobs[hk][0].bucket_reassigned_from
+
+
+@pytest.mark.asyncio
+async def test_pcc_2528_no_move_when_source_at_cap(monkeypatch):
+    """Reassignment needs a strictly over-cap source: a bucket exactly at cap pays
+    full weight already, so the split-capable node stays put.
+    """
+    config = _make_pcc_config(caps=PCC_2528_CAPS)
+    jobs = {
+        "miner_a": [_make_pcc_job(
+            "exec-a", "NVIDIA B200", 8,
+            supports_gpu_splitting=True, gpu_splitting_min_count=1,
+        )],
+    }
+
+    incentive = await _run_pcc_incentive(config, jobs, monkeypatch)
+
+    result = jobs["miner_a"][0]
+    assert result.count_bucket == 8
+    assert result.bucket_reassigned_from is None
+    assert result.unrented_cap_multiplier == pytest.approx(1.0)
+    assert ("B200", 1) not in incentive.unrented_count_by_bucket
+
+
+@pytest.mark.asyncio
+async def test_pcc_2528_move_lands_exactly_at_target_cap_with_incumbents(monkeypatch):
+    """A move that fills the target exactly to cap is admitted, and the native 1×
+    incumbents keep full weight — the newcomer never dilutes them.
+    """
+    config = _make_pcc_config(caps=PCC_2528_CAPS)
+    jobs = {
+        "miner_a": [_make_pcc_job(
+            "exec-a", "NVIDIA B200", 8,
+            supports_gpu_splitting=True, gpu_splitting_min_count=1,
+        )],
+        "miner_b": [_make_pcc_job("exec-b", "NVIDIA B200", 8)],
+        "miner_c": [
+            _make_pcc_job("exec-c1", "NVIDIA B200", 1),
+            _make_pcc_job("exec-c2", "NVIDIA B200", 1),
+        ],
+    }
+
+    incentive = await _run_pcc_incentive(config, jobs, monkeypatch)
+
+    mover = jobs["miner_a"][0]
+    assert mover.count_bucket == 1
+    assert mover.bucket_reassigned_from == 8
+    # 2 incumbents + 8 = 10 == cap: admitted, everyone in the tier at full weight.
+    assert incentive.unrented_count_by_bucket[("B200", 1)] == 10
+    assert incentive.cap_multiplier_by_bucket[("B200", 1)] == pytest.approx(1.0)
+    for native in jobs["miner_c"]:
+        assert native.effective_rate == pytest.approx(PCC_HOURLY_RATE * PCC_SYSBOX_MULTIPLIER)
+
+
+@pytest.mark.asyncio
+async def test_pcc_2528_source_bucket_emptied_by_move(monkeypatch):
+    """With cap 8×=4, a single split-capable 8× node over-fills its own bucket and
+    moves out entirely, leaving the source at 0 GPUs — no division error, and the
+    snapshot and total_rental_cost stay consistent.
+    """
+    config = _make_pcc_config(caps={**PCC_PER_COUNT_CAPS, "B200": {1: 10, 8: 4}})
+    jobs = {
+        "miner_a": [_make_pcc_job(
+            "exec-a", "NVIDIA B200", 8,
+            supports_gpu_splitting=True, gpu_splitting_min_count=1,
+        )],
+    }
+
+    incentive = await _run_pcc_incentive(config, jobs, monkeypatch)
+
+    mover = jobs["miner_a"][0]
+    assert mover.count_bucket == 1
+    assert mover.bucket_reassigned_from == 8
+    assert mover.bucket_reassigned_from_multiplier == pytest.approx(4 / 8)
+    assert mover.unrented_cap_multiplier == pytest.approx(1.0)
+    assert incentive.unrented_count_by_bucket[("B200", 8)] == 0
+    assert incentive.unrented_count_by_bucket[("B200", 1)] == 8
+    # The emptied source contributes nothing; the whole cost is the mover at full rate.
+    assert incentive.total_rental_cost == pytest.approx(8 * PCC_HOURLY_RATE * PCC_SYSBOX_MULTIPLIER)
+    by_bucket = incentive.get_snapshot().rental.by_bucket
+    assert by_bucket["B200·8"].unrented_count == 0
+    assert by_bucket["B200·1"].unrented_count == 8
+
+
+@pytest.mark.asyncio
+async def test_pcc_2528_no_move_when_split_tier_has_no_cap(monkeypatch):
+    """A min-count tier with no configured cap can never receive a fallback move:
+    the candidate stays in its over-cap gpu_count bucket, diluted.
+    """
+    config = _make_pcc_config(caps={**PCC_PER_COUNT_CAPS, "B200": {8: 8}})
+    jobs = {
+        "miner_a": [_make_pcc_job(
+            "exec-a", "NVIDIA B200", 8,
+            supports_gpu_splitting=True, gpu_splitting_min_count=1,
+        )],
+        "miner_b": [_make_pcc_job("exec-b", "NVIDIA B200", 8)],
+    }
+
+    incentive = await _run_pcc_incentive(config, jobs, monkeypatch)
+
+    candidate = jobs["miner_a"][0]
+    assert candidate.count_bucket == 8
+    assert candidate.bucket_reassigned_from is None
+    assert candidate.unrented_cap_multiplier == pytest.approx(0.5)
+    assert ("B200", 1) not in incentive.unrented_count_by_bucket


### PR DESCRIPTION
## Describe your changes

**Problem.** Bucket assignment for the unrented (idle) incentive ignores how full a bucket already is. `_resolve_bucket` pins a split-capable executor to its `gpu_count` bucket whenever that bucket has a configured cap — even when it is over cap and the node's split tier sits empty. Measured in prod (job cycle 2026-07-29 08:49:24 UTC): H200·8 at 128/64 GPUs (`cap_multiplier` 0.500, 16 executors each at incentive 0.007602590530147434) while H200·1 sat at 0/10.

**Fix.** A second, occupancy-aware pass (`_reassign_split_candidates`, run at the top of `_on_finish_pre_process`, before cap multipliers are computed):

- Candidates: idle, rental-eligible, split-capable executors initially placed in their `gpu_count` bucket.
- A node moves **whole** (all `gpu_count` GPUs + its weighted-rate contribution) into its `gpu_splitting_min_count` tier only when the source bucket is **strictly over cap**, the target tier has a positive cap, and the whole node **fits at or under the target cap** (strict admission — a move never over-fills the target, so incumbents are never diluted by a newcomer). Admission implies the mover always improves: target pays exactly 1.0, over-cap source pays < 1.0.
- Greedy in ascending executor-uuid order with fills recomputed after every accepted move, so an unchanged fleet reproduces byte-identical assignments every cycle.
- New miner-facing report line `unrented_bucket_reassigned` (fields: `event`, `bucket_reassigned_from`, `bucket_reassigned_from_multiplier`, `count_bucket`, `max_cap`, `unrented_cap_multiplier`) explains why the node was rated in another tier. Not a `ZeroIncentiveReason` — the node is paid, in a better bucket.
- `estimate_executor` / `precompute_all_estimates` inherit the rule automatically (same 3-stage pipeline, fresh instance per estimate), and `get_snapshot()` persists post-move fills — portal estimates stay equal to what the validator pays.
- Corrected the stale `_pre_process_job_result` / class docstrings that claimed split-capable executors land in their `gpu_splitting_min_count` bucket.

**Scope note (intended behavior, agreed with task owner).** Strict admission strands headroom smaller than a node (e.g. 8-GPU rigs leave 2 of 10 slots in the 1× tier unused), and with prod caps `{1: 10, 8: 64}` the fallback only fires while the 1× tier holds ≤ 2 GPUs and `gpu_splitting_min_count == 1`. A node's bucket may flip between cycles when other miners' 1× nodes arrive — the new log line makes each flip explainable. Non-splitting nodes, the reverse direction, and partial rentals (DAH-2467) are out of scope.

**Verification run:** full validator suite **1286 passed, 8 skipped**; 8 new tests + 1 updated (fallback happens / strict admission rejects / lands exactly at cap / greedy stops when source back at cap / deterministic rerun / source emptied to zero / unconfigured split tier / estimate parity); zero net-new `ruff@0.5.1` violations on touched files.

**Pre-deploy verification (from the task spec):**
1. Unit: construct a fleet where a model's 8 bucket is over cap and its 1 bucket has headroom. Assert a split-capable idle 8x node resolves to bucket 1 with all 8 GPUs counted there, and a non-splitting 8x node still resolves to bucket 8. ✅ `test_pcc_2528_split_node_falls_back_when_8_bucket_over_cap`
2. Unit: with the target bucket already at cap, assert the split-capable node stays in bucket 8 — no reassignment that makes things worse. ✅ `test_pcc_2528_no_move_when_whole_node_does_not_fit_target`
3. Staging: lower the 8 cap so the bucket is over-filled, register a split-capable idle node, force a job cycle. The incentive log shows the node in bucket 1, carries the reassignment reason, and its cap_multiplier is higher than the 8 bucket's.
4. Staging: run two consecutive cycles with an unchanged fleet and confirm byte-identical bucket assignments — no flapping.

**Post-deploy verification (from the task spec):**
- +1 d — validator incentive logs contain reassignment events (`event: unrented_bucket_reassigned`); for every reassigned executor the target-bucket cap_multiplier exceeds its source-bucket value, and no executor changes bucket between consecutive cycles while the fleet is unchanged.
- +7 d — mean cap_multiplier across active buckets rises against the 2026-07-29 08:49:24 UTC baseline (H200·8 = 0.500, H200·1 absent, RTX 5090·1 = 0.909), the count of unrented GPUs paid at full weight increases, and total_rental_cost still clears the burn-emission cap.

## Issue ticket number and link

[DAH-2528 — Idle incentive: occupancy-aware bucket fallback for GPU-splitting nodes](https://app.notion.com/p/Idle-incentive-occupancy-aware-bucket-fallback-for-GPU-splitting-nodes-3acb8bfdbde9814e89a5ce806036b8af)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?