### PR TITLE
DAH-2336, quarantine a host whose GPU fell off the bus, not just a driver mismatch

### DIFF
--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -6,6 +6,9 @@ from pydantic import BaseModel, RootModel, field_validator
 from services.const import FILLER_CONTAINER_PREFIX
 
 GPU_RUNTIME_NVML_MISMATCH_REASON = "GPU_RUNTIME_NVML_MISMATCH"
+# The GPU itself is gone until a host reset (post-Xid): "gpu requires reset", "unknown device",
+# "NVML unknown". Same quarantine as the mismatch above — the host cannot serve a rental either way.
+GPU_RUNTIME_DEVICE_FAULT_REASON = "GPU_RUNTIME_DEVICE_FAULT"
 
 
 class Error(BaseModel, extra="allow"):

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -16,10 +16,6 @@ from ...const import FILLER_CONTAINER_PREFIX, FILLER_LIVENESS_GRACE_MINUTES
 from ..messages import MessageTemplate, RentalVerificationMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
 
-# How bad each per-container filler verdict is, worst wins. A GPU-split node yields one verdict per
-# bundle but the pipeline emits a single event, so the node must be judged by its worst container:
-# a confirmed kill outranks an indeterminate probe, which outranks a healthy one. Anything
-# unlisted sorts as healthy.
 # Backend verdicts that quarantine the host: the GPU runtime is broken in a way no rental survives,
 # so the score is zeroed and the verified job cleared. The host returns on the next clean check.
 _GPU_RUNTIME_QUARANTINE: dict[str, tuple[MessageTemplate, str]] = {
@@ -33,6 +29,10 @@ _GPU_RUNTIME_QUARANTINE: dict[str, tuple[MessageTemplate, str]] = {
     ),
 }
 
+# How bad each per-container filler verdict is, worst wins. A GPU-split node yields one verdict per
+# bundle but the pipeline emits a single event, so the node must be judged by its worst container:
+# a confirmed kill outranks an indeterminate probe, which outranks a healthy one. Anything
+# unlisted sorts as healthy.
 _FILLER_VERDICT_SEVERITY: dict[str, int] = {
     Msg.FILLER_KILLED.reason: 3,
     Msg.FILLER_TRANSPORT_UNREACHABLE.reason: 2,

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -7,18 +7,32 @@ import asyncssh
 from core.config import settings
 from core.docker_utils import DockerCommand, collect_container_death_diagnostics
 from protocol.vc_protocol.compute_requests import (
+    GPU_RUNTIME_DEVICE_FAULT_REASON,
     GPU_RUNTIME_NVML_MISMATCH_REASON,
     FillerRunActiveResponse,
 )
 
 from ...const import FILLER_CONTAINER_PREFIX, FILLER_LIVENESS_GRACE_MINUTES
-from ..messages import RentalVerificationMessages as Msg, render_message
+from ..messages import MessageTemplate, RentalVerificationMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
 
 # How bad each per-container filler verdict is, worst wins. A GPU-split node yields one verdict per
 # bundle but the pipeline emits a single event, so the node must be judged by its worst container:
 # a confirmed kill outranks an indeterminate probe, which outranks a healthy one. Anything
 # unlisted sorts as healthy.
+# Backend verdicts that quarantine the host: the GPU runtime is broken in a way no rental survives,
+# so the score is zeroed and the verified job cleared. The host returns on the next clean check.
+_GPU_RUNTIME_QUARANTINE: dict[str, tuple[MessageTemplate, str]] = {
+    GPU_RUNTIME_NVML_MISMATCH_REASON: (
+        Msg.GPU_RUNTIME_NVML_MISMATCH,
+        "GPU runtime NVML driver/library mismatch",
+    ),
+    GPU_RUNTIME_DEVICE_FAULT_REASON: (
+        Msg.GPU_RUNTIME_DEVICE_FAULT,
+        "GPU is not addressable and needs a host reset",
+    ),
+}
+
 _FILLER_VERDICT_SEVERITY: dict[str, int] = {
     Msg.FILLER_KILLED.reason: 3,
     Msg.FILLER_TRANSPORT_UNREACHABLE.reason: 2,
@@ -169,11 +183,12 @@ class RentalVerificationCheck:
                     event=event,
                     updates={},
                 )
-            elif response.reason_code == GPU_RUNTIME_NVML_MISMATCH_REASON:
+            elif response.reason_code in _GPU_RUNTIME_QUARANTINE:
+                message, score_warning = _GPU_RUNTIME_QUARANTINE[response.reason_code]
                 details = response.details or {}
                 stderr = details.get("docker_stderr") or response.error
                 event = render_message(
-                    Msg.GPU_RUNTIME_NVML_MISMATCH,
+                    message,
                     ctx=ctx,
                     check_id=self.check_id,
                     what={
@@ -192,7 +207,7 @@ class RentalVerificationCheck:
                     updates={
                         "score": 0.0,
                         "job_score": 0.0,
-                        "score_warning": "GPU runtime NVML driver/library mismatch",
+                        "score_warning": score_warning,
                         "clear_verified_job_info": True,
                     },
                 )

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 import asyncssh
@@ -16,16 +17,22 @@ from ...const import FILLER_CONTAINER_PREFIX, FILLER_LIVENESS_GRACE_MINUTES
 from ..messages import MessageTemplate, RentalVerificationMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
 
+@dataclass(frozen=True)
+class GpuRuntimeQuarantine:
+    message: MessageTemplate
+    score_warning: str
+
+
 # Backend verdicts that quarantine the host: the GPU runtime is broken in a way no rental survives,
 # so the score is zeroed and the verified job cleared. The host returns on the next clean check.
-_GPU_RUNTIME_QUARANTINE: dict[str, tuple[MessageTemplate, str]] = {
-    GPU_RUNTIME_NVML_MISMATCH_REASON: (
-        Msg.GPU_RUNTIME_NVML_MISMATCH,
-        "GPU runtime NVML driver/library mismatch",
+_GPU_RUNTIME_QUARANTINE: dict[str, GpuRuntimeQuarantine] = {
+    GPU_RUNTIME_NVML_MISMATCH_REASON: GpuRuntimeQuarantine(
+        message=Msg.GPU_RUNTIME_NVML_MISMATCH,
+        score_warning="GPU runtime NVML driver/library mismatch",
     ),
-    GPU_RUNTIME_DEVICE_FAULT_REASON: (
-        Msg.GPU_RUNTIME_DEVICE_FAULT,
-        "GPU is not addressable and needs a host reset",
+    GPU_RUNTIME_DEVICE_FAULT_REASON: GpuRuntimeQuarantine(
+        message=Msg.GPU_RUNTIME_DEVICE_FAULT,
+        score_warning="GPU is not addressable and needs a host reset",
     ),
 }
 
@@ -184,11 +191,11 @@ class RentalVerificationCheck:
                     updates={},
                 )
             elif response.reason_code in _GPU_RUNTIME_QUARANTINE:
-                message, score_warning = _GPU_RUNTIME_QUARANTINE[response.reason_code]
+                quarantine = _GPU_RUNTIME_QUARANTINE[response.reason_code]
                 details = response.details or {}
                 stderr = details.get("docker_stderr") or response.error
                 event = render_message(
-                    message,
+                    quarantine.message,
                     ctx=ctx,
                     check_id=self.check_id,
                     what={
@@ -207,7 +214,7 @@ class RentalVerificationCheck:
                     updates={
                         "score": 0.0,
                         "job_score": 0.0,
-                        "score_warning": score_warning,
+                        "score_warning": quarantine.score_warning,
                         "clear_verified_job_info": True,
                     },
                 )

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -985,6 +985,17 @@ class RentalVerificationMessages:
             "Toolkit, and Docker runtime. Then reboot the host with `sudo reboot`."
         ),
     )
+    GPU_RUNTIME_DEVICE_FAULT = MessageTemplate(
+        event="GPU runtime health check failed",
+        reason="GPU_RUNTIME_DEVICE_FAULT",
+        severity="error",
+        category="runtime",
+        impact="New rentals are disabled because the GPU is not addressable on this host.",
+        remediation=(
+            "The GPU has entered a fatal state and needs a hard reset. Reboot the host with "
+            "`sudo reboot`, then check `nvidia-smi` and `dmesg` for Xid errors."
+        ),
+    )
     API_ERROR = MessageTemplate(
         event="Rental verification API error",
         reason="RENTAL_CHECK_API_ERROR",

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -5,6 +5,7 @@ import pytest
 from unittest.mock import Mock, patch
 
 from neurons.validators.src.protocol.vc_protocol.compute_requests import (
+    GPU_RUNTIME_DEVICE_FAULT_REASON,
     GPU_RUNTIME_NVML_MISMATCH_REASON,
     ExecutorHealthCheckResponse,
     FillerRunActiveResponse,
@@ -215,6 +216,36 @@ async def test_rental_verification_nvml_mismatch_clears_verified_job_info():
     assert "failed to initialize NVML" in result.event.what_we_saw["stderr"]
     assert result.updates["clear_verified_job_info"] is True
     assert "clear_verified_job_reason" not in result.updates
+
+
+@pytest.mark.asyncio
+async def test_rental_verification_device_fault_quarantines_the_host_too():
+    """DAH-2336: a GPU that fell off the bus is as fatal as a driver mismatch — the probe must
+    quarantine it, not fall into the generic fail branch that leaves the host rentable."""
+    stderr = "nvidia-container-cli: device error: GPU-d2d12cfb-eb9e-03f0-b007-785d32aed1b2: unknown device"
+    backend_client = DummyBackendClient(
+        response=ExecutorHealthCheckResponse(
+            success=False,
+            error=stderr,
+            details={"docker_stderr": stderr},
+            reason_code=GPU_RUNTIME_DEVICE_FAULT_REASON,
+        )
+    )
+    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
+    state = build_state(specs={"verified_ports": [8080]})
+
+    from tests.helpers import make_context
+    ctx = make_context(services=services, state=state)
+
+    with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
+        mock_settings.SKIP_RENTAL_VERIFICATION = False
+        result = await RentalVerificationCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == GPU_RUNTIME_DEVICE_FAULT_REASON
+    assert result.updates["score"] == 0.0
+    assert result.updates["clear_verified_job_info"] is True
+    assert "unknown device" in result.event.what_we_saw["stderr"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2336](https://www.notion.so/392b8bfdbde98169b210e989930cc560)

---

## Problem

`RentalVerificationCheck` quarantines a host on exactly one backend verdict:
`GPU_RUNTIME_NVML_MISMATCH`. Every other GPU-runtime fault falls into the generic fail branch, which
neither zeroes the score nor clears the verified job — the host stays rentable.

Prod evidence (14 days of `connector` logs): `nvidia-container-cli: device error: GPU-<uuid>: unknown
device` appeared on 2 hosts and never triggered a quarantine. The 2026-06-27 incident
(`nvml error: gpu requires reset`, executor `30fba1ea`, 24 failures / 8 customer pods over 90 minutes)
was the same class of fault.

## Solution

The backend now returns a second verdict, `GPU_RUNTIME_DEVICE_FAULT`, for the device-fault family
(`gpu requires reset` / `unknown device` / `NVML unknown`) — see
Datura-ai/lium-io-backend#846. This PR treats it exactly like the mismatch: score 0, job score 0,
`clear_verified_job_info`, with its own remediation text (the fix is a host reset, not a driver
reconcile).

The two verdicts now live in one `_GPU_RUNTIME_QUARANTINE` map instead of a hardcoded branch, so the
next family member is one entry, not another `elif`.

Reactivation is unchanged — the host returns after a clean verification.

## Changes

- `GPU_RUNTIME_DEVICE_FAULT_REASON` in `compute_requests.py`.
- `Msg.GPU_RUNTIME_DEVICE_FAULT` with reset-specific remediation (`sudo reboot`, check `nvidia-smi` / `dmesg` for Xid).
- `_GPU_RUNTIME_QUARANTINE` map in `rental_verification.py` replaces the single-code branch.
- 1 unit test.

## Deployment Steps

Use GitHub Action. Order does not matter: the backend PR only starts emitting the new code once
deployed, and an unknown code here is inert.

## Review Request

- [x] Just code review

## Other PRs

- Datura-ai/lium-io-backend#846 — the classifier that produces this verdict, plus the reactive
  quarantine on real rental failures (DAH-2337).

## Risks

- Slightly more quarantines: prod data suggests ~2 hosts per 14 days from this family. Each recovers
  on the next clean verification.
- Score zeroing is a miner-visible penalty. Same mechanism and blast radius as the existing mismatch path.

## Test Cases

### Test Case 1 — device fault quarantines

**Actions** Backend health check returns `success=False, reason_code=GPU_RUNTIME_DEVICE_FAULT` with the real prod stderr.

**Expected Output** `passed=False`, `score=0.0`, `clear_verified_job_info=True`, event carries the stderr.

### Test Case 2 — mismatch path unchanged

**Actions** Existing `test_rental_verification_nvml_mismatch_clears_verified_job_info`.

**Expected Output** Unchanged behaviour.

Local run: `pytest` in `neurons/validators` → 1346 passed, 3 failed. The 3 failures are in
`test_sshd_bootstrap_script.py` and reproduce on a clean `main` (verified via stash) — unrelated.

## Checklist

- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described