### PR TITLE
DAH-2306: heal reboot-stranded pods before penalising POD_NOT_RUNNING

### DIFF
--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -102,7 +102,7 @@ class Validator:
             executor_connectivity_service=self.executor_connectivity_service,
             backend_client=self.backend_client,
             attestation_service=self.attestation_service,
-            docker_service=self.docker_service,
+            pod_recovery=self.docker_service,
         )
         self.miner_service = MinerService(
             ssh_service=ssh_service,

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -88,6 +88,11 @@ class Validator:
             ),
         )
 
+        self.docker_service = DockerService(
+            ssh_service=ssh_service,
+            redis_service=self.redis_service,
+            attestation_service=self.attestation_service,
+        )
         task_service = TaskService(
             ssh_service=ssh_service,
             redis_service=self.redis_service,
@@ -97,11 +102,7 @@ class Validator:
             executor_connectivity_service=self.executor_connectivity_service,
             backend_client=self.backend_client,
             attestation_service=self.attestation_service,
-        )
-        self.docker_service = DockerService(
-            ssh_service=ssh_service,
-            redis_service=self.redis_service,
-            attestation_service=self.attestation_service,
+            docker_service=self.docker_service,
         )
         self.miner_service = MinerService(
             ssh_service=ssh_service,

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -5018,13 +5018,13 @@ class DockerService:
         self,
         ssh_client: asyncssh.SSHClientConnection,
         container_name: str,
-        default_extra: dict,
+        log_extra: dict[str, Any],
     ) -> str | None:
         # the volume whose stale mountpoint kept the container down, read off the container itself.
         # `docker inspect` reports mounts of a stopped container, so the real name is taken from the
         # host instead of guessed from pod_id — a pod created through the edit path carries a
-        # backend-supplied volume name that no convention derives. repair_stale_vloopback_mountpoint
-        # is what decides: it accepts a candidate only if the driver is vloopback and the stale
+        # backend-supplied volume name that no convention derives. Every mount can be offered
+        # blindly: repair_stale_vloopback_mountpoint accepts only a vloopback volume whose stale
         # mountpoint dir is present and empty.
         inspect_result = await ssh_client.run(
             f"/usr/bin/docker inspect {shlex.quote(container_name)} "
@@ -5034,14 +5034,14 @@ class DockerService:
         if getattr(inspect_result, "exit_status", 0) != 0:
             return None
 
-        for candidate in (inspect_result.stdout or "").split():
+        for candidate_volume in (inspect_result.stdout or "").split():
             repaired = await self.repair_stale_vloopback_mountpoint(
                 ssh_client,
-                candidate,
-                {**default_extra, "local_volume": candidate},
+                candidate_volume,
+                {**log_extra, "local_volume": candidate_volume},
             )
             if repaired:
-                return candidate
+                return candidate_volume
         return None
 
     async def _stop_half_recovered_container(
@@ -5055,11 +5055,11 @@ class DockerService:
         # the POD_NOT_RUNNING verdict keeps matching what the customer sees. A no-op when the start
         # itself was what failed.
         try:
-            result = await ssh_client.run(
+            stop_result = await ssh_client.run(
                 f"/usr/bin/docker stop {shlex.quote(container_name)}",
                 timeout=_VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC,
             )
-            return getattr(result, "exit_status", 1) == 0
+            return getattr(stop_result, "exit_status", 1) == 0
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -186,12 +186,6 @@ _VLOOPBACK_DRIVER_PREFIX = "vloopback"
 # Shared with core.docker_utils so exactly one helper image lands on nodes.
 _VLOOPBACK_REPAIR_IMAGE = ALPINE_HELPER_IMAGE
 _VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC = 30
-# DAH-2306: plaintext path an encrypted rental volume is remounted at when a pod is recovered after
-# a reboot. The backend's own path is recorded nowhere on the host — an encrypted volume is mounted
-# at /lium-cipher, not at its plaintext path — so recovery falls back to the same default the create
-# path uses. A rental that both encrypts its volume and asks for a non-default path comes back with
-# its data under /root.
-_RECOVERED_POD_LOCAL_VOLUME_PATH = "/root"
 _DOCKER_VOLUME_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 # DAH-2475: slack kept free above a rental's requested volume before we decide the DPHN filler cache
 # has to go. Covers the image layers and scratch the pod needs beyond its own volume.
@@ -4875,7 +4869,7 @@ class DockerService:
         private_key: str,
         known_hosts_policy: asyncssh.SSHKnownHosts | None,
         container_name: str,
-        local_volume_path: str,
+        local_volume_path: str | None,
         pod_id: str,
         default_extra: dict[str, Any],
     ) -> None:
@@ -4883,6 +4877,9 @@ class DockerService:
         # drops: the gocryptfs plaintext mount of an encrypted rental volume, and the sshd the
         # customer connects through. A failed remount raises and the caller decides how to report
         # it; a failed sshd bootstrap only warns, because the pod itself is up either way.
+        # local_volume_path=None means the caller does not know the plaintext path, which is only
+        # safe for a pod without an encrypted volume: mounting gocryptfs at a guessed path would
+        # leave the customer's real path an ordinary container dir, writing plaintext to the host.
         pkey = asyncssh.import_private_key(private_key)
         async with self.rental_docker_client_factory.connect(
             executor_info=executor_info,
@@ -4906,6 +4903,11 @@ class DockerService:
                     container_name,
                 )
                 if encrypted_volume_name:
+                    if local_volume_path is None:
+                        raise RuntimeError(
+                            f"{container_name} holds an encrypted volume but no plaintext path "
+                            "was supplied; refusing to remount it at a guessed path"
+                        )
                     await self.setup_encrypted_local_volume(
                         ssh_client=ssh_client,
                         container_name=container_name,
@@ -4960,11 +4962,31 @@ class DockerService:
             return False
 
         log_extra = {**default_extra, "container_name": container_name}
-        repaired_volume = await self._repair_stale_mountpoint_of_container_volume(
-            ssh_client,
-            container_name,
-            log_extra,
-        )
+        try:
+            if await self._holds_encrypted_local_volume(ssh_client, container_name):
+                logger.warning(
+                    _m(
+                        "POD_STALE_MOUNT_RECOVERY_SKIPPED_ENCRYPTED_VOLUME",
+                        extra=get_extra_info(log_extra),
+                    )
+                )
+                return False
+            repaired_volume = await self._repair_stale_mountpoint_of_container_volume(
+                ssh_client,
+                container_name,
+                log_extra,
+            )
+        except TimeoutError:
+            # a command that did not finish in time is not a dead SSH transport: report it here so
+            # the check keeps its POD_NOT_RUNNING verdict instead of turning it into
+            # EXECUTOR_TRANSPORT_UNREACHABLE and dropping the penalty.
+            logger.warning(
+                _m(
+                    "POD_STALE_MOUNT_RECOVERY_TIMED_OUT",
+                    extra=get_extra_info(log_extra),
+                )
+            )
+            return False
         if not repaired_volume:
             logger.warning(
                 _m(
@@ -4987,7 +5009,7 @@ class DockerService:
                 private_key=private_key,
                 known_hosts_policy=known_hosts_policy,
                 container_name=container_name,
-                local_volume_path=_RECOVERED_POD_LOCAL_VOLUME_PATH,
+                local_volume_path=None,
                 pod_id=pod_id,
                 default_extra=log_extra,
             )
@@ -5013,6 +5035,27 @@ class DockerService:
             _m("POD_STALE_MOUNT_RECOVERED", extra=get_extra_info(log_extra))
         )
         return True
+
+    async def _holds_encrypted_local_volume(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        container_name: str,
+    ) -> bool:
+        # whether the pod's rental volume is gocryptfs-encrypted, which recovery has to refuse.
+        # An encrypted volume is mounted as the ciphertext at /lium-cipher and the plaintext path
+        # the customer actually uses comes from the create request, which is recorded nowhere on
+        # the host and is not in the backend's rental-active response either. Remounting at the
+        # /root default would silently turn a custom path into an ordinary container dir, so
+        # writes to it would land unencrypted on the miner's disk. Fails closed: an inspect that
+        # does not answer counts as encrypted, and the miner keeps the POD_NOT_RUNNING verdict.
+        inspect_result = await ssh_client.run(
+            f"/usr/bin/docker inspect {shlex.quote(container_name)} "
+            '--format \'{{range .Mounts}}{{println .Destination}}{{end}}\'',
+            timeout=_VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC,
+        )
+        if getattr(inspect_result, "exit_status", 0) != 0:
+            return True
+        return _LIUM_CIPHER_MOUNT in (inspect_result.stdout or "").split()
 
     async def _repair_stale_mountpoint_of_container_volume(
         self,

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -186,6 +186,12 @@ _VLOOPBACK_DRIVER_PREFIX = "vloopback"
 # Shared with core.docker_utils so exactly one helper image lands on nodes.
 _VLOOPBACK_REPAIR_IMAGE = ALPINE_HELPER_IMAGE
 _VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC = 30
+# DAH-2306: plaintext path an encrypted rental volume is remounted at when a pod is recovered after
+# a reboot. The backend's own path is recorded nowhere on the host — an encrypted volume is mounted
+# at /lium-cipher, not at its plaintext path — so recovery falls back to the same default the create
+# path uses. A rental that both encrypts its volume and asks for a non-default path comes back with
+# its data under /root.
+_RECOVERED_POD_LOCAL_VOLUME_PATH = "/root"
 _DOCKER_VOLUME_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 # DAH-2475: slack kept free above a rental's requested volume before we decide the DPHN filler cache
 # has to go. Covers the image layers and scratch the pod needs beyond its own volume.
@@ -346,9 +352,10 @@ def _is_docker_container_removal_in_progress_error(exc: Exception) -> bool:
     )
 
 
-def _is_stale_vloopback_mountpoint_error(exc: Exception) -> bool:
-    text = str(exc)
-    return all(phrase in text for phrase in _VLOOPBACK_MOUNT_ERROR_PHRASES)
+def _is_stale_vloopback_mountpoint_error(error_text: str) -> bool:
+    # Takes raw text so it serves both sources: a create-time exception, and the State.Error of a
+    # container the host already tried to auto-restart.
+    return all(phrase in error_text for phrase in _VLOOPBACK_MOUNT_ERROR_PHRASES)
 
 
 def _is_safe_docker_volume_name(volume_name: str) -> bool:
@@ -414,7 +421,7 @@ def _should_repair_stale_mountpoint(
     return (
         bool(local_volume)
         and not already_repaired
-        and _is_stale_vloopback_mountpoint_error(exc)
+        and _is_stale_vloopback_mountpoint_error(str(exc))
     )
 
 def _should_encrypt_local_volume(
@@ -4790,7 +4797,6 @@ class DockerService:
         )
 
         private_key = self.ssh_service.decrypt_payload(keypair.ss58_address, private_key)
-        pkey = asyncssh.import_private_key(private_key)
 
         known_hosts_policy: asyncssh.SSHKnownHosts | None = None
         try:
@@ -4831,60 +4837,15 @@ class DockerService:
             )
 
         try:
-            async with self.rental_docker_client_factory.connect(
+            await self.start_existing_container(
                 executor_info=executor_info,
                 private_key=private_key,
-            ) as docker_client:
-                await run_logged_rental_docker_sdk_operation(
-                    operation="start_container",
-                    log_extra=default_extra,
-                    call=lambda: docker_client.start(container_name=payload.container_name),
-                    container_name=payload.container_name,
-                )
-                async with asyncssh.connect(
-                    host=executor_info.address,
-                    port=executor_info.ssh_port,
-                    username=executor_info.ssh_username,
-                    client_keys=[pkey],
-                    known_hosts=known_hosts_policy,
-                ) as ssh_client:
-                    encrypted_volume_name = await self._encrypted_local_volume_name(
-                        docker_client,
-                        payload.container_name,
-                    )
-                    if encrypted_volume_name:
-                        await self.setup_encrypted_local_volume(
-                            ssh_client=ssh_client,
-                            container_name=payload.container_name,
-                            plaintext_path=payload.local_volume_path,
-                            volume_name=encrypted_volume_name,
-                            pod_id=payload.pod_id,
-                            log_tag=f"start_container_{payload.pod_id}",
-                            log_extra=default_extra,
-                        )
-                ssh_bootstrap_ok = await self.install_open_ssh_server_and_start_ssh_service_with_rental_docker(
-                    docker_client=docker_client,
-                    container_name=payload.container_name,
-                    log_tag=f"start_container_{payload.pod_id}",
-                    log_extra=default_extra,
-                )
-                if not ssh_bootstrap_ok:
-                    logger.warning(
-                        _m(
-                            "Docker container started but SSH bootstrap did not complete cleanly",
-                            extra=get_extra_info(
-                                {**default_extra, "container_name": payload.container_name}
-                            ),
-                        )
-                    )
-                logger.info(
-                    _m(
-                        "Started Docker Container",
-                        extra=get_extra_info(
-                            {**default_extra, "container_name": payload.container_name}
-                        ),
-                    ),
-                )
+                known_hosts_policy=known_hosts_policy,
+                container_name=payload.container_name,
+                local_volume_path=payload.local_volume_path,
+                pod_id=payload.pod_id,
+                default_extra=default_extra,
+            )
         except Exception as exc:
             log_text = _m(
                 "Failed start_container",
@@ -4906,6 +4867,148 @@ class DockerService:
                 error_type=FailedContainerErrorTypes.ContainerStartFailed,
                 error_code=FailedContainerErrorCodes.UnknownError,
             )
+
+    async def start_existing_container(
+        self,
+        *,
+        executor_info: ExecutorSSHInfo,
+        private_key: str,
+        known_hosts_policy: asyncssh.SSHKnownHosts | None,
+        container_name: str,
+        local_volume_path: str,
+        pod_id: str,
+        default_extra: dict[str, Any],
+    ) -> None:
+        # start a container that already exists and restore the two things a bare `docker start`
+        # drops: the gocryptfs plaintext mount of an encrypted rental volume, and the sshd the
+        # customer connects through. A failed remount raises and the caller decides how to report
+        # it; a failed sshd bootstrap only warns, because the pod itself is up either way.
+        pkey = asyncssh.import_private_key(private_key)
+        async with self.rental_docker_client_factory.connect(
+            executor_info=executor_info,
+            private_key=private_key,
+        ) as docker_client:
+            await run_logged_rental_docker_sdk_operation(
+                operation="start_container",
+                log_extra=default_extra,
+                call=lambda: docker_client.start(container_name=container_name),
+                container_name=container_name,
+            )
+            async with asyncssh.connect(
+                host=executor_info.address,
+                port=executor_info.ssh_port,
+                username=executor_info.ssh_username,
+                client_keys=[pkey],
+                known_hosts=known_hosts_policy,
+            ) as ssh_client:
+                encrypted_volume_name = await self._encrypted_local_volume_name(
+                    docker_client,
+                    container_name,
+                )
+                if encrypted_volume_name:
+                    await self.setup_encrypted_local_volume(
+                        ssh_client=ssh_client,
+                        container_name=container_name,
+                        plaintext_path=local_volume_path,
+                        volume_name=encrypted_volume_name,
+                        pod_id=pod_id,
+                        log_tag=f"start_container_{pod_id}",
+                        log_extra=default_extra,
+                    )
+            ssh_bootstrap_ok = await self.install_open_ssh_server_and_start_ssh_service_with_rental_docker(
+                docker_client=docker_client,
+                container_name=container_name,
+                log_tag=f"start_container_{pod_id}",
+                log_extra=default_extra,
+            )
+            if not ssh_bootstrap_ok:
+                logger.warning(
+                    _m(
+                        "Docker container started but SSH bootstrap did not complete cleanly",
+                        extra=get_extra_info(
+                            {**default_extra, "container_name": container_name}
+                        ),
+                    )
+                )
+            logger.info(
+                _m(
+                    "Started Docker Container",
+                    extra=get_extra_info(
+                        {**default_extra, "container_name": container_name}
+                    ),
+                ),
+            )
+
+    async def recover_pod_after_stale_vloopback_mount(
+        self,
+        *,
+        ssh_client: asyncssh.SSHClientConnection,
+        executor_info: ExecutorSSHInfo,
+        miner_hotkey: str,
+        private_key: str,
+        container_name: str,
+        pod_id: str,
+        container_error: str | None,
+        default_extra: dict[str, Any],
+    ) -> bool:
+        # DAH-2306: bring back a still-rented pod the host could not auto-restart after a reboot.
+        # The reboot leaves the vloopback mountpoint dir behind, dockerd's `unless-stopped` restart
+        # hits the plugin's "file exists" and the container stays down until the rental ends. Only
+        # that exact failure is recovered: a pod stopped on purpose exits with an empty State.Error
+        # and never matches, so a customer's stop is never overridden.
+        if not container_error or not _is_stale_vloopback_mountpoint_error(container_error):
+            return False
+
+        # Only the fresh-create naming convention is recovered. A pod created through the edit path
+        # keeps a backend-supplied `payload.local_volume` name that is not derivable from pod_id, so
+        # `docker volume inspect` misses, repair declines and the POD_NOT_RUNNING verdict stands.
+        local_volume = f"volume_{pod_id}"
+        log_extra = {
+            **default_extra,
+            "container_name": container_name,
+            "local_volume": local_volume,
+        }
+
+        if not await self.repair_stale_vloopback_mountpoint(ssh_client, local_volume, log_extra):
+            logger.warning(
+                _m(
+                    "POD_STALE_MOUNT_RECOVERY_REPAIR_FAILED",
+                    extra=get_extra_info(log_extra),
+                )
+            )
+            return False
+
+        try:
+            known_hosts_policy = await self._prepare_known_hosts_policy(
+                executor_info,
+                miner_hotkey,
+                log_extra,
+            )
+            require_rental_docker_ssh_host_key(executor_info)
+            await self.start_existing_container(
+                executor_info=executor_info,
+                private_key=private_key,
+                known_hosts_policy=known_hosts_policy,
+                container_name=container_name,
+                local_volume_path=_RECOVERED_POD_LOCAL_VOLUME_PATH,
+                pod_id=pod_id,
+                default_extra=log_extra,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                _m(
+                    "POD_STALE_MOUNT_RECOVERY_START_FAILED",
+                    extra=get_extra_info({**log_extra, "error": str(exc)}),
+                )
+            )
+            return False
+
+        logger.info(
+            _m("POD_STALE_MOUNT_RECOVERED", extra=get_extra_info(log_extra))
+        )
+        return True
 
     def _container_deleted(self, payload: ContainerDeleteRequest) -> ContainerDeleted:
         return ContainerDeleted(

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -4959,17 +4959,13 @@ class DockerService:
         if not container_error or not _is_stale_vloopback_mountpoint_error(container_error):
             return False
 
-        # Only the fresh-create naming convention is recovered. A pod created through the edit path
-        # keeps a backend-supplied `payload.local_volume` name that is not derivable from pod_id, so
-        # `docker volume inspect` misses, repair declines and the POD_NOT_RUNNING verdict stands.
-        local_volume = f"volume_{pod_id}"
-        log_extra = {
-            **default_extra,
-            "container_name": container_name,
-            "local_volume": local_volume,
-        }
-
-        if not await self.repair_stale_vloopback_mountpoint(ssh_client, local_volume, log_extra):
+        log_extra = {**default_extra, "container_name": container_name}
+        repaired_volume = await self._repair_stale_mountpoint_of_container_volume(
+            ssh_client,
+            container_name,
+            log_extra,
+        )
+        if not repaired_volume:
             logger.warning(
                 _m(
                     "POD_STALE_MOUNT_RECOVERY_REPAIR_FAILED",
@@ -4978,6 +4974,7 @@ class DockerService:
             )
             return False
 
+        log_extra = {**log_extra, "local_volume": repaired_volume}
         try:
             known_hosts_policy = await self._prepare_known_hosts_policy(
                 executor_info,
@@ -4997,10 +4994,17 @@ class DockerService:
         except asyncio.CancelledError:
             raise
         except Exception as exc:
-            logger.warning(
+            container_stopped = await self._stop_half_recovered_container(
+                ssh_client, container_name
+            )
+            logger.error(
                 _m(
                     "POD_STALE_MOUNT_RECOVERY_START_FAILED",
-                    extra=get_extra_info({**log_extra, "error": str(exc)}),
+                    extra=get_extra_info({
+                        **log_extra,
+                        "error": str(exc),
+                        "container_stopped": container_stopped,
+                    }),
                 )
             )
             return False
@@ -5009,6 +5013,57 @@ class DockerService:
             _m("POD_STALE_MOUNT_RECOVERED", extra=get_extra_info(log_extra))
         )
         return True
+
+    async def _repair_stale_mountpoint_of_container_volume(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        container_name: str,
+        default_extra: dict,
+    ) -> str | None:
+        # the volume whose stale mountpoint kept the container down, read off the container itself.
+        # `docker inspect` reports mounts of a stopped container, so the real name is taken from the
+        # host instead of guessed from pod_id — a pod created through the edit path carries a
+        # backend-supplied volume name that no convention derives. repair_stale_vloopback_mountpoint
+        # is what decides: it accepts a candidate only if the driver is vloopback and the stale
+        # mountpoint dir is present and empty.
+        inspect_result = await ssh_client.run(
+            f"/usr/bin/docker inspect {shlex.quote(container_name)} "
+            '--format \'{{range .Mounts}}{{if eq .Type "volume"}}{{println .Name}}{{end}}{{end}}\'',
+            timeout=_VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC,
+        )
+        if getattr(inspect_result, "exit_status", 0) != 0:
+            return None
+
+        for candidate in (inspect_result.stdout or "").split():
+            repaired = await self.repair_stale_vloopback_mountpoint(
+                ssh_client,
+                candidate,
+                {**default_extra, "local_volume": candidate},
+            )
+            if repaired:
+                return candidate
+        return None
+
+    async def _stop_half_recovered_container(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        container_name: str,
+    ) -> bool:
+        # a start that brought the container up but failed afterwards — a gocryptfs remount that did
+        # not take — leaves the customer a running pod with an empty plaintext dir, and no later
+        # cycle revisits it because recovery only fires on a stopped container. Put it back down so
+        # the POD_NOT_RUNNING verdict keeps matching what the customer sees. A no-op when the start
+        # itself was what failed.
+        try:
+            result = await ssh_client.run(
+                f"/usr/bin/docker stop {shlex.quote(container_name)}",
+                timeout=_VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC,
+            )
+            return getattr(result, "exit_status", 1) == 0
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return False
 
     def _container_deleted(self, payload: ContainerDeleteRequest) -> ContainerDeleted:
         return ContainerDeleted(

--- a/neurons/validators/src/services/ioc.py
+++ b/neurons/validators/src/services/ioc.py
@@ -54,6 +54,11 @@ async def initiate_services():
             DindProbe(DindVerifier(ioc["SSHService"])),
         ),
     )
+    ioc["DockerService"] = DockerService(
+        ssh_service=ioc["SSHService"],
+        redis_service=ioc["RedisService"],
+        attestation_service=ioc["AttestationService"],
+    )
     ioc["TaskService"] = TaskService(
         ssh_service=ioc["SSHService"],
         redis_service=ioc["RedisService"],
@@ -63,11 +68,7 @@ async def initiate_services():
         executor_connectivity_service=ioc["ExecutorConnectivityService"],
         backend_client=ioc["BackendClient"],
         attestation_service=ioc["AttestationService"],
-    )
-    ioc["DockerService"] = DockerService(
-        ssh_service=ioc["SSHService"],
-        redis_service=ioc["RedisService"],
-        attestation_service=ioc["AttestationService"],
+        docker_service=ioc["DockerService"],
     )
     ioc["MinerService"] = MinerService(
         ssh_service=ioc["SSHService"],

--- a/neurons/validators/src/services/ioc.py
+++ b/neurons/validators/src/services/ioc.py
@@ -68,7 +68,7 @@ async def initiate_services():
         executor_connectivity_service=ioc["ExecutorConnectivityService"],
         backend_client=ioc["BackendClient"],
         attestation_service=ioc["AttestationService"],
-        docker_service=ioc["DockerService"],
+        pod_recovery=ioc["DockerService"],
     )
     ioc["MinerService"] = MinerService(
         ssh_service=ioc["SSHService"],

--- a/neurons/validators/src/services/task/checks/rented_machine.py
+++ b/neurons/validators/src/services/task/checks/rented_machine.py
@@ -1,8 +1,11 @@
+import logging
 from collections.abc import Iterable
+from typing import Any
 
 import asyncssh
 
 from core.docker_utils import DockerCommand, collect_container_death_diagnostics
+from core.utils import _m, get_extra_info
 from protocol.vc_protocol.validator_requests import ResetVerifiedJobReason
 
 from ...const import (
@@ -12,6 +15,8 @@ from ...const import (
 from ..messages import TenantEnforcementMessages as Msg
 from ..messages import render_message
 from ..pipeline import CheckResult, Context
+
+logger = logging.getLogger(__name__)
 
 
 def _has_gpu_process_outside_container(rented_pods: list[str], processes: Iterable[dict]) -> bool:
@@ -137,26 +142,13 @@ class TenantEnforcementCheck:
             try:
                 pod_running, ssh_pub_keys = await _check_pod_running(ctx.ssh, pod_container_name)
             except (asyncssh.Error, OSError) as exc:
-                # SSH transport died mid-cycle. Pod state is unknown; do NOT set
-                # clear_verified_job_*: that path triggers immediate executor flip
-                # in compute-app and would punish honest miners for a network blip.
-                # Persistent unreachability is handled by the stale-executor sweep.
-                event = render_message(
-                    Msg.EXECUTOR_TRANSPORT_UNREACHABLE,
+                return _executor_transport_unreachable_result(
                     ctx=ctx,
                     check_id=self.check_id,
-                    what={
-                        "pod_id": pod_id,
-                        "container_name": pod_container_name,
-                        "executor_uuid": ctx.executor.uuid,
-                        "transport_error": repr(exc),
-                    },
+                    container_name=pod_container_name,
+                    pod_id=pod_id,
+                    transport_error=exc,
                     extra=extra,
-                )
-                return CheckResult(
-                    passed=False,
-                    event=event,
-                    updates={"default_extra": extra},
                 )
             if not pod_running:
                 diagnostics = await _collect_pod_diagnostics(ctx.ssh, pod_container_name)
@@ -188,6 +180,30 @@ class TenantEnforcementCheck:
                             "ssh_pub_keys": None,
                         },
                     )
+
+                try:
+                    if await _recover_pod_after_stale_vloopback_mount(
+                        ctx, pod_container_name, pod_id, diagnostics
+                    ):
+                        # Re-read the pod, so the recovered container's own SSH keys are what gets
+                        # reported and a start that did not stick still lands on POD_NOT_RUNNING.
+                        pod_running, ssh_pub_keys = await _check_pod_running(
+                            ctx.ssh, pod_container_name
+                        )
+                except (asyncssh.Error, OSError) as exc:
+                    # Recovery adds SSH round-trips to the executor inside the DAH-2055 window, so
+                    # losing the transport here means pod state is unknown, not "pod down".
+                    return _executor_transport_unreachable_result(
+                        ctx=ctx,
+                        check_id=self.check_id,
+                        container_name=pod_container_name,
+                        pod_id=pod_id,
+                        transport_error=exc,
+                        extra=extra,
+                    )
+                if pod_running:
+                    extra.setdefault("recovered_pods", []).append(pod_container_name)
+                    continue
 
                 event = render_message(
                     Msg.POD_NOT_RUNNING,
@@ -275,6 +291,75 @@ class TenantEnforcementCheck:
             },
             halt=True,
         )
+
+
+def _executor_transport_unreachable_result(
+    *,
+    ctx: Context,
+    check_id: str,
+    container_name: str,
+    pod_id: str,
+    transport_error: BaseException,
+    extra: dict[str, Any],
+) -> CheckResult:
+    # SSH transport died mid-cycle. Pod state is unknown; do NOT set clear_verified_job_*: that
+    # path triggers immediate executor flip in compute-app and would punish honest miners for a
+    # network blip. Persistent unreachability is handled by the stale-executor sweep.
+    event = render_message(
+        Msg.EXECUTOR_TRANSPORT_UNREACHABLE,
+        ctx=ctx,
+        check_id=check_id,
+        what={
+            "pod_id": pod_id,
+            "container_name": container_name,
+            "executor_uuid": ctx.executor.uuid,
+            "transport_error": repr(transport_error),
+        },
+        extra=extra,
+    )
+    return CheckResult(passed=False, event=event, updates={"default_extra": extra})
+
+
+async def _recover_pod_after_stale_vloopback_mount(
+    ctx: Context,
+    container_name: str,
+    pod_id: str,
+    diagnostics: dict[str, object],
+) -> bool:
+    # DAH-2306: heal a still-rented pod the host could not auto-restart after a reboot, before the
+    # miner is penalised for it. Best effort in every direction — a recovery that cannot run, or
+    # fails, simply leaves the POD_NOT_RUNNING verdict untouched. The one exception is a dead SSH
+    # transport, which propagates: the repair runs over ctx.ssh, so DAH-2055 applies here too.
+    if not ctx.executor_ssh_private_key:
+        return False
+
+    container_error = diagnostics.get("container_error")
+    try:
+        return await ctx.services.docker.recover_pod_after_stale_vloopback_mount(
+            ssh_client=ctx.ssh,
+            executor_info=ctx.executor,
+            miner_hotkey=ctx.miner_hotkey,
+            private_key=ctx.executor_ssh_private_key,
+            container_name=container_name,
+            pod_id=pod_id,
+            container_error=container_error if isinstance(container_error, str) else None,
+            default_extra=ctx.default_extra,
+        )
+    except (asyncssh.Error, OSError):
+        raise
+    except Exception as exc:
+        logger.warning(
+            _m(
+                "POD_STALE_MOUNT_RECOVERY_FAILED",
+                extra=get_extra_info({
+                    **ctx.default_extra,
+                    "container_name": container_name,
+                    "pod_id": pod_id,
+                    "error": str(exc),
+                }),
+            )
+        )
+        return False
 
 
 async def _check_pod_running(ssh_client, container_name: str) -> tuple[bool, list[str]]:

--- a/neurons/validators/src/services/task/checks/rented_machine.py
+++ b/neurons/validators/src/services/task/checks/rented_machine.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import Any
 
 import asyncssh
@@ -83,6 +84,16 @@ def _gpu_usage_violation_details(
     }
 
 
+@dataclass
+class _DownedPodOutcome:
+    """What the check does with a rented pod that was found not running."""
+
+    # None means the pod is up again and the loop moves on to the next pod.
+    failure: CheckResult | None
+    # keys of the recovered container, reported instead of the ones read before it went down.
+    ssh_pub_keys: list[str]
+
+
 class TenantEnforcementCheck:
     """Handle the specialised flow when the executor is already rented to a tenant.
 
@@ -93,6 +104,11 @@ class TenantEnforcementCheck:
 
     check_id = "executor.validate.rented_state"
     fatal = True
+
+    def __init__(self, recover_stale_pods: bool = True):
+        # A dry run reports a pod as down but must not touch the executor: the DAH-2306 recovery
+        # rmdirs a host path and starts a customer's container.
+        self.recover_stale_pods = recover_stale_pods
 
     async def run(self, ctx: Context) -> CheckResult:
         # NOTE: stale-container cleanup now runs earlier, in StaleContainerCleanupCheck
@@ -181,52 +197,17 @@ class TenantEnforcementCheck:
                         },
                     )
 
-                try:
-                    if await _recover_pod_after_stale_vloopback_mount(
-                        ctx, pod_container_name, pod_id, diagnostics
-                    ):
-                        # Re-read the pod, so the recovered container's own SSH keys are what gets
-                        # reported and a start that did not stick still lands on POD_NOT_RUNNING.
-                        pod_running, ssh_pub_keys = await _check_pod_running(
-                            ctx.ssh, pod_container_name
-                        )
-                except (asyncssh.Error, OSError) as exc:
-                    # Recovery adds SSH round-trips to the executor inside the DAH-2055 window, so
-                    # losing the transport here means pod state is unknown, not "pod down".
-                    return _executor_transport_unreachable_result(
-                        ctx=ctx,
-                        check_id=self.check_id,
-                        container_name=pod_container_name,
-                        pod_id=pod_id,
-                        transport_error=exc,
-                        extra=extra,
-                    )
-                if pod_running:
-                    extra.setdefault("recovered_pods", []).append(pod_container_name)
-                    continue
-
-                event = render_message(
-                    Msg.POD_NOT_RUNNING,
+                outcome = await self._recover_downed_pod(
                     ctx=ctx,
-                    check_id=self.check_id,
-                    remediation=f"Start container {pod_container_name} and ensure it stays healthy.",
-                    what={
-                        "pod_id": pod_id,
-                        "container_name": pod_container_name,
-                        "executor_uuid": ctx.executor.uuid,
-                        "diagnostics": diagnostics,
-                    },
+                    container_name=pod_container_name,
+                    pod_id=pod_id,
+                    diagnostics=diagnostics,
                     extra=extra,
                 )
-                return CheckResult(
-                    passed=False,
-                    event=event,
-                    updates={
-                        "default_extra": extra,
-                        "clear_verified_job_info": True,
-                        "clear_verified_job_reason": ResetVerifiedJobReason.POD_NOT_RUNNING.value,
-                    },
-                )
+                if outcome.failure:
+                    return outcome.failure
+                ssh_pub_keys = outcome.ssh_pub_keys
+                continue
 
         container_names = [pod.container_name for pod in rented_pods]
         if filler_container:
@@ -290,6 +271,72 @@ class TenantEnforcementCheck:
                 "success": True,
             },
             halt=True,
+        )
+
+    async def _recover_downed_pod(
+        self,
+        *,
+        ctx: Context,
+        container_name: str,
+        pod_id: str,
+        diagnostics: dict[str, object],
+        extra: dict[str, Any],
+    ) -> _DownedPodOutcome:
+        # a rented pod found not running: heal it when it carries the DAH-2306 reboot signature,
+        # and report POD_NOT_RUNNING only if it is still down afterwards.
+        pod_running = False
+        ssh_pub_keys: list[str] = []
+        if self.recover_stale_pods:
+            try:
+                if await _recover_pod_after_stale_vloopback_mount(
+                    ctx, container_name, pod_id, diagnostics
+                ):
+                    # Re-read the pod, so the recovered container's own SSH keys are what gets
+                    # reported and a start that did not stick still lands on POD_NOT_RUNNING.
+                    pod_running, ssh_pub_keys = await _check_pod_running(ctx.ssh, container_name)
+            except (asyncssh.Error, OSError) as exc:
+                # Recovery adds SSH round-trips to the executor inside the DAH-2055 window, so
+                # losing the transport here means pod state is unknown, not "pod down".
+                return _DownedPodOutcome(
+                    failure=_executor_transport_unreachable_result(
+                        ctx=ctx,
+                        check_id=self.check_id,
+                        container_name=container_name,
+                        pod_id=pod_id,
+                        transport_error=exc,
+                        extra=extra,
+                    ),
+                    ssh_pub_keys=[],
+                )
+
+        if pod_running:
+            extra.setdefault("recovered_pods", []).append(container_name)
+            return _DownedPodOutcome(failure=None, ssh_pub_keys=ssh_pub_keys)
+
+        event = render_message(
+            Msg.POD_NOT_RUNNING,
+            ctx=ctx,
+            check_id=self.check_id,
+            remediation=f"Start container {container_name} and ensure it stays healthy.",
+            what={
+                "pod_id": pod_id,
+                "container_name": container_name,
+                "executor_uuid": ctx.executor.uuid,
+                "diagnostics": diagnostics,
+            },
+            extra=extra,
+        )
+        return _DownedPodOutcome(
+            failure=CheckResult(
+                passed=False,
+                event=event,
+                updates={
+                    "default_extra": extra,
+                    "clear_verified_job_info": True,
+                    "clear_verified_job_reason": ResetVerifiedJobReason.POD_NOT_RUNNING.value,
+                },
+            ),
+            ssh_pub_keys=[],
         )
 
 

--- a/neurons/validators/src/services/task/checks/rented_machine.py
+++ b/neurons/validators/src/services/task/checks/rented_machine.py
@@ -335,7 +335,7 @@ async def _recover_pod_after_stale_vloopback_mount(
 
     container_error = diagnostics.get("container_error")
     try:
-        return await ctx.services.docker.recover_pod_after_stale_vloopback_mount(
+        return await ctx.services.pod_recovery.recover_pod_after_stale_vloopback_mount(
             ssh_client=ctx.ssh,
             executor_info=ctx.executor,
             miner_hotkey=ctx.miner_hotkey,

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Protocol, Tuple
+from typing import Any, Callable, List, Optional, Protocol, Tuple, runtime_checkable
 
 import asyncssh
 from pydantic import BaseModel, Field
@@ -23,14 +23,25 @@ from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from .models import ValidationEvent
 from .runner import SSHCommandRunner
 
-if TYPE_CHECKING:
-    # Deferred: docker_service imports this package, so a runtime import here is a cycle.
-    from services.docker_service import DockerService
-else:
-    # Context is a pydantic model, so the name still has to exist at runtime for it to
-    # resolve ContextServices.docker — a TYPE_CHECKING-only import leaves the model
-    # unbuildable and every validation cycle raises instead of running.
-    DockerService = Any
+@runtime_checkable
+class PodRecoverer(Protocol):
+    # The slice of DockerService the rented-machine check needs. Declared here because
+    # docker_service imports this package, so naming the class itself would be an import
+    # cycle — and Context is a pydantic model, so a TYPE_CHECKING-only name would leave it
+    # unbuildable and every validation cycle would raise instead of running.
+
+    async def recover_pod_after_stale_vloopback_mount(
+        self,
+        *,
+        ssh_client: asyncssh.SSHClientConnection,
+        executor_info: ExecutorSSHInfo,
+        miner_hotkey: str,
+        private_key: str,
+        container_name: str,
+        pod_id: str,
+        container_error: str | None,
+        default_extra: dict[str, Any],
+    ) -> bool: ...
 
 
 @dataclass(frozen=True)
@@ -46,7 +57,7 @@ class ContextServices:
     score_calculator: Callable[[str, bool, bool, str, bool, int], Tuple[float, float, str]]
     backend: BackendClient
     container_cleanup: ContainerCleanup
-    docker: "DockerService"
+    pod_recovery: PodRecoverer
 
 
 @dataclass(frozen=True)

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import Any, Callable, List, Optional, Protocol, Tuple
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Protocol, Tuple
 
 import asyncssh
 from pydantic import BaseModel, Field
@@ -23,6 +23,11 @@ from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from .models import ValidationEvent
 from .runner import SSHCommandRunner
 
+if TYPE_CHECKING:
+    # Deferred: docker_service imports this package, so a runtime import here is a cycle.
+    from services.docker_service import DockerService
+
+
 @dataclass(frozen=True)
 class ContextServices:
     ssh: SSHService
@@ -36,6 +41,7 @@ class ContextServices:
     score_calculator: Callable[[str, bool, bool, str, bool, int], Tuple[float, float, str]]
     backend: BackendClient
     container_cleanup: ContainerCleanup
+    docker: "DockerService"
 
 
 @dataclass(frozen=True)
@@ -113,6 +119,9 @@ class Context(BaseModel):
     verified: dict = {}
     settings: dict = {}
     encrypt_key: str | None = None
+    # Already decrypted: pod recovery re-runs the rental start path, which opens its own
+    # connection to the host rather than reusing `ssh`.
+    executor_ssh_private_key: str | None = None
     default_extra: dict[str, Any] = {}
     services: ContextServices
     config: ContextConfig

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -26,6 +26,11 @@ from .runner import SSHCommandRunner
 if TYPE_CHECKING:
     # Deferred: docker_service imports this package, so a runtime import here is a cycle.
     from services.docker_service import DockerService
+else:
+    # Context is a pydantic model, so the name still has to exist at runtime for it to
+    # resolve ContextServices.docker — a TYPE_CHECKING-only import leaves the model
+    # unbuildable and every validation cycle raises instead of running.
+    DockerService = Any
 
 
 @dataclass(frozen=True)

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -6,7 +6,7 @@ including context setup and check instantiation.
 
 import logging
 import uuid
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import bittensor
 from clients.backend_client import BackendClient
@@ -68,6 +68,10 @@ from .pipeline import (
 from .runner import SSHCommandRunner
 from .score_calculator import calculate_scores
 
+if TYPE_CHECKING:
+    # Deferred: docker_service imports this package, so a runtime import here is a cycle.
+    from services.docker_service import DockerService
+
 logger = logging.getLogger(__name__)
 
 JOB_LENGTH = 300
@@ -91,6 +95,7 @@ class PipelineFactory:
         collateral_contract_service: CollateralContractService,
         executor_connectivity_service: ExecutorConnectivityService,
         backend_client: BackendClient,
+        docker_service: "DockerService",
     ):
         """Initialize pipeline factory with required services.
 
@@ -102,6 +107,7 @@ class PipelineFactory:
             collateral_contract_service: Collateral contract service
             executor_connectivity_service: Executor connectivity service
             backend_client: Backend API client
+            docker_service: Docker service, for checks that repair container state
         """
         self.ssh_service = ssh_service
         self.redis_service = redis_service
@@ -111,6 +117,7 @@ class PipelineFactory:
         self.collateral_contract_service = collateral_contract_service
         self.executor_connectivity_service = executor_connectivity_service
         self.backend_client = backend_client
+        self.docker_service = docker_service
 
         dry_run = settings.DRY_RUN or settings.CONTAINER_CLEANUP_DRY_RUN
         logger.info(f"ContainerCleanup dry_run={dry_run}")
@@ -181,6 +188,7 @@ class PipelineFactory:
             verified=verified_job_info,
             settings={"version": settings.VERSION},
             encrypt_key=encrypted_files.encrypt_key,
+            executor_ssh_private_key=private_key,
             default_extra=default_extra,
             services=ContextServices(
                 ssh=self.ssh_service,
@@ -194,6 +202,7 @@ class PipelineFactory:
                 score_calculator=calculate_scores,
                 backend=self.backend_client,
                 container_cleanup=self.container_cleanup,
+                docker=self.docker_service,
             ),
             config=ContextConfig(
                 executor_root=executor_info.root_dir,

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -6,7 +6,7 @@ including context setup and check instantiation.
 
 import logging
 import uuid
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
 import bittensor
 from clients.backend_client import BackendClient
@@ -64,13 +64,10 @@ from .pipeline import (
     ContextState,
     LoggerSink,
     Pipeline,
+    PodRecoverer,
 )
 from .runner import SSHCommandRunner
 from .score_calculator import calculate_scores
-
-if TYPE_CHECKING:
-    # Deferred: docker_service imports this package, so a runtime import here is a cycle.
-    from services.docker_service import DockerService
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +92,7 @@ class PipelineFactory:
         collateral_contract_service: CollateralContractService,
         executor_connectivity_service: ExecutorConnectivityService,
         backend_client: BackendClient,
-        docker_service: "DockerService",
+        pod_recovery: PodRecoverer,
     ):
         """Initialize pipeline factory with required services.
 
@@ -107,7 +104,7 @@ class PipelineFactory:
             collateral_contract_service: Collateral contract service
             executor_connectivity_service: Executor connectivity service
             backend_client: Backend API client
-            docker_service: Docker service, for checks that repair container state
+            pod_recovery: Docker service, for checks that repair container state
         """
         self.ssh_service = ssh_service
         self.redis_service = redis_service
@@ -117,7 +114,7 @@ class PipelineFactory:
         self.collateral_contract_service = collateral_contract_service
         self.executor_connectivity_service = executor_connectivity_service
         self.backend_client = backend_client
-        self.docker_service = docker_service
+        self.pod_recovery = pod_recovery
 
         dry_run = settings.DRY_RUN or settings.CONTAINER_CLEANUP_DRY_RUN
         logger.info(f"ContainerCleanup dry_run={dry_run}")
@@ -202,7 +199,7 @@ class PipelineFactory:
                 score_calculator=calculate_scores,
                 backend=self.backend_client,
                 container_cleanup=self.container_cleanup,
-                docker=self.docker_service,
+                pod_recovery=self.pod_recovery,
             ),
             config=ContextConfig(
                 executor_root=executor_info.root_dir,

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -334,7 +334,9 @@ class PipelineFactory:
                 # Runs after PortConnectivityCheck, which overwrites ctx.state.sysbox_runtime with
                 # the authoritative probe result used for scoring (not the earlier scrape hint).
                 SysboxRequiredCheck(),
-                TenantEnforcementCheck(),
+                # recover_stale_pods=False: dry run still reports a pod as down, but must not rmdir
+                # a stale mountpoint on the host or start a customer's container (DAH-2306).
+                TenantEnforcementCheck(recover_stale_pods=False),
                 # dry_run=True: reports a ghost GPU but runs no pkill + nvidia-smi reset on the
                 # executor and leaves the shared wedge timers the production pipeline relies on.
                 GpuUsageCheck(dry_run=True),

--- a/neurons/validators/src/services/task/service.py
+++ b/neurons/validators/src/services/task/service.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 import bittensor
 from clients.backend_client import BackendClient
@@ -23,6 +23,10 @@ from .models import JobResult
 from .pipeline_factory import PipelineFactory
 from .result_handler import ResultHandler
 
+if TYPE_CHECKING:
+    # Deferred: docker_service imports this package, so a runtime import here is a cycle.
+    from services.docker_service import DockerService
+
 logger = logging.getLogger(__name__)
 
 class TaskService:
@@ -36,6 +40,7 @@ class TaskService:
         executor_connectivity_service: Annotated[ExecutorConnectivityService, Depends(ExecutorConnectivityService)],
         backend_client: Annotated[BackendClient, Depends(BackendClient)],
         attestation_service: Annotated[AttestationService, Depends(AttestationService)],
+        docker_service: "DockerService",
     ):
         self.ssh_service = ssh_service
         self.redis_service = redis_service
@@ -51,6 +56,7 @@ class TaskService:
             collateral_contract_service=collateral_contract_service,
             executor_connectivity_service=executor_connectivity_service,
             backend_client=backend_client,
+            docker_service=docker_service,
         )
 
     async def create_task(

--- a/neurons/validators/src/services/task/service.py
+++ b/neurons/validators/src/services/task/service.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Annotated
+from typing import Annotated
 
 import bittensor
 from clients.backend_client import BackendClient
@@ -20,12 +20,9 @@ from core.utils import _m, get_extra_info
 from services.ssh_service import SSHService
 
 from .models import JobResult
+from .pipeline import PodRecoverer
 from .pipeline_factory import PipelineFactory
 from .result_handler import ResultHandler
-
-if TYPE_CHECKING:
-    # Deferred: docker_service imports this package, so a runtime import here is a cycle.
-    from services.docker_service import DockerService
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +37,7 @@ class TaskService:
         executor_connectivity_service: Annotated[ExecutorConnectivityService, Depends(ExecutorConnectivityService)],
         backend_client: Annotated[BackendClient, Depends(BackendClient)],
         attestation_service: Annotated[AttestationService, Depends(AttestationService)],
-        docker_service: "DockerService",
+        pod_recovery: PodRecoverer,
     ):
         self.ssh_service = ssh_service
         self.redis_service = redis_service
@@ -56,7 +53,7 @@ class TaskService:
             collateral_contract_service=collateral_contract_service,
             executor_connectivity_service=executor_connectivity_service,
             backend_client=backend_client,
-            docker_service=docker_service,
+            pod_recovery=pod_recovery,
         )
 
     async def create_task(

--- a/neurons/validators/tests/helpers.py
+++ b/neurons/validators/tests/helpers.py
@@ -57,6 +57,9 @@ def build_context_config(**overrides) -> ContextConfig:
 
 
 def build_services(**overrides) -> ContextServices:
+    docker = AsyncMock()
+    # A bare AsyncMock would report every pod as recovered; opt in per test instead.
+    docker.recover_pod_after_stale_vloopback_mount.return_value = False
     base = dict(
         ssh=None,
         redis=None,
@@ -69,6 +72,7 @@ def build_services(**overrides) -> ContextServices:
         score_calculator=DummyScoreCalc(),
         backend=AsyncMock(),
         container_cleanup=None,
+        docker=docker,
     )
     base.update(overrides)
     return ContextServices(**base)

--- a/neurons/validators/tests/helpers.py
+++ b/neurons/validators/tests/helpers.py
@@ -57,9 +57,9 @@ def build_context_config(**overrides) -> ContextConfig:
 
 
 def build_services(**overrides) -> ContextServices:
-    docker = AsyncMock()
+    pod_recovery = AsyncMock()
     # A bare AsyncMock would report every pod as recovered; opt in per test instead.
-    docker.recover_pod_after_stale_vloopback_mount.return_value = False
+    pod_recovery.recover_pod_after_stale_vloopback_mount.return_value = False
     base = dict(
         ssh=None,
         redis=None,
@@ -72,7 +72,7 @@ def build_services(**overrides) -> ContextServices:
         score_calculator=DummyScoreCalc(),
         backend=AsyncMock(),
         container_cleanup=None,
-        docker=docker,
+        pod_recovery=pod_recovery,
     )
     base.update(overrides)
     return ContextServices(**base)

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, Mock, MagicMock, patch
 from uuid import uuid4, UUID
 from datetime import datetime
 
+import asyncssh
 from docker.errors import APIError
 import pytest
 import pytest_asyncio
@@ -5680,9 +5681,24 @@ _STALE_MOUNT_ERROR = (
 )
 
 
-def _recovery_ssh_client(volume_names: str = "volume_pod-1\n") -> AsyncMock:
+def _asyncssh_timeout_error() -> asyncssh.TimeoutError:
+    # what ssh_client.run(timeout=...) raises: it subclasses both asyncssh.Error and OSError, so
+    # every caller that treats those two as "transport died" also swallows a plain command timeout.
+    return asyncssh.TimeoutError(None, None, None, None, None, None, "", "")
+
+
+def _recovery_ssh_client(
+    volume_names: str = "volume_pod-1\n",
+    mount_destinations: str = "/root\n",
+) -> AsyncMock:
+    # the recovery path inspects the container twice: once for where its volumes are mounted
+    # (an encrypted pod shows /lium-cipher) and once for their names.
+    async def run(command, *_args, **_kwargs):
+        stdout = mount_destinations if ".Destination" in command else volume_names
+        return _make_ssh_command_result(stdout=stdout)
+
     ssh_client = AsyncMock()
-    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result(stdout=volume_names))
+    ssh_client.run = AsyncMock(side_effect=run)
     return ssh_client
 
 
@@ -5755,7 +5771,61 @@ async def test_recover_pod_repairs_then_starts_through_the_full_start_path(
     start_kwargs = start_existing_container.await_args.kwargs
     assert start_kwargs["container_name"] == "pod_pod-1"
     assert start_kwargs["pod_id"] == "pod-1"
-    assert start_kwargs["local_volume_path"] == "/root"
+    # recovery does not know the pod's plaintext path, and an unencrypted pod does not need one
+    assert start_kwargs["local_volume_path"] is None
+
+
+@pytest.mark.asyncio
+async def test_recover_pod_declines_an_encrypted_volume(docker_service, monkeypatch):
+    # the plaintext path of an encrypted volume is recorded nowhere on the host, and remounting
+    # gocryptfs at the /root default would write a custom path out in the clear
+    repair_mountpoint = AsyncMock(return_value=True)
+    monkeypatch.setattr(docker_service, "repair_stale_vloopback_mountpoint", repair_mountpoint)
+    start_existing_container = AsyncMock()
+    monkeypatch.setattr(docker_service, "start_existing_container", start_existing_container)
+    ssh_client = _recovery_ssh_client(mount_destinations="/lium-cipher\n/mnt\n")
+
+    recovered = await _attempt_stale_mount_recovery(
+        docker_service, _STALE_MOUNT_ERROR, ssh_client
+    )
+
+    assert recovered is False
+    repair_mountpoint.assert_not_awaited()
+    start_existing_container.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recover_pod_declines_when_the_container_inspect_fails(docker_service, monkeypatch):
+    # an inspect that does not answer cannot rule out an encrypted volume, so recovery stands down
+    repair_mountpoint = AsyncMock(return_value=True)
+    monkeypatch.setattr(docker_service, "repair_stale_vloopback_mountpoint", repair_mountpoint)
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result(stdout="", exit_status=1))
+
+    recovered = await _attempt_stale_mount_recovery(
+        docker_service, _STALE_MOUNT_ERROR, ssh_client
+    )
+
+    assert recovered is False
+    repair_mountpoint.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recover_pod_declines_when_a_repair_command_times_out(docker_service, monkeypatch):
+    # a timed-out command must not surface as a dead SSH transport: the check has to keep its
+    # POD_NOT_RUNNING verdict instead of turning it into EXECUTOR_TRANSPORT_UNREACHABLE
+    monkeypatch.setattr(
+        docker_service,
+        "repair_stale_vloopback_mountpoint",
+        AsyncMock(side_effect=_asyncssh_timeout_error()),
+    )
+    start_existing_container = AsyncMock()
+    monkeypatch.setattr(docker_service, "start_existing_container", start_existing_container)
+
+    recovered = await _attempt_stale_mount_recovery(docker_service, _STALE_MOUNT_ERROR)
+
+    assert recovered is False
+    start_existing_container.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -5680,11 +5680,19 @@ _STALE_MOUNT_ERROR = (
 )
 
 
+def _recovery_ssh_client(volume_names: str = "volume_pod-1\n") -> AsyncMock:
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result(stdout=volume_names))
+    return ssh_client
+
+
 async def _attempt_stale_mount_recovery(
-    docker_service: DockerService, container_error: str | None
+    docker_service: DockerService,
+    container_error: str | None,
+    ssh_client: AsyncMock | None = None,
 ) -> bool:
     return await docker_service.recover_pod_after_stale_vloopback_mount(
-        ssh_client=AsyncMock(),
+        ssh_client=ssh_client if ssh_client is not None else _recovery_ssh_client(),
         executor_info=_executor_without_host_key("executor-1"),
         miner_hotkey="miner-1",
         private_key="key",
@@ -5751,6 +5759,29 @@ async def test_recover_pod_repairs_then_starts_through_the_full_start_path(
 
 
 @pytest.mark.asyncio
+async def test_recover_pod_repairs_the_volume_the_container_actually_mounts(
+    docker_service, monkeypatch
+):
+    # an edit-path pod carries a backend-supplied volume name that pod_id does not derive
+    repair_mountpoint = AsyncMock(side_effect=lambda _ssh, volume, _extra: volume == "custom-vol")
+    monkeypatch.setattr(docker_service, "repair_stale_vloopback_mountpoint", repair_mountpoint)
+    monkeypatch.setattr(docker_service, "start_existing_container", AsyncMock())
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+    monkeypatch.setattr("services.docker_service.require_rental_docker_ssh_host_key", Mock())
+    ssh_client = _recovery_ssh_client("some-other-vol\ncustom-vol\n")
+
+    recovered = await _attempt_stale_mount_recovery(
+        docker_service, _STALE_MOUNT_ERROR, ssh_client
+    )
+
+    assert recovered is True
+    assert [call.args[1] for call in repair_mountpoint.await_args_list] == [
+        "some-other-vol",
+        "custom-vol",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_recover_pod_reports_failure_when_start_raises(docker_service, monkeypatch):
     monkeypatch.setattr(
         docker_service, "repair_stale_vloopback_mountpoint", AsyncMock(return_value=True)
@@ -5762,7 +5793,13 @@ async def test_recover_pod_reports_failure_when_start_raises(docker_service, mon
         "start_existing_container",
         AsyncMock(side_effect=RuntimeError("start failed")),
     )
+    ssh_client = _recovery_ssh_client()
 
-    recovered = await _attempt_stale_mount_recovery(docker_service, _STALE_MOUNT_ERROR)
+    recovered = await _attempt_stale_mount_recovery(
+        docker_service, _STALE_MOUNT_ERROR, ssh_client
+    )
 
     assert recovered is False
+    # the container may already be up with no plaintext mount, and no later cycle revisits a
+    # running pod — put it back down so POD_NOT_RUNNING keeps matching what the customer sees
+    assert "docker stop pod_pod-1" in ssh_client.run.await_args.args[0]

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -5672,3 +5672,97 @@ def test_gocryptfs_setup_script_xor_material_no_stdin():
     assert "-passfile" in script
     rc, stdout, stderr = _run_gocryptfs_setup_script_in_sandbox(script)
     assert rc == 0, f"stdout={stdout!r} stderr={stderr!r}"
+
+
+_STALE_MOUNT_ERROR = (
+    "error while mounting volume '': VolumeDriver.Mount: cannot create mount point dir "
+    "'/mnt/volume_pod-1': mkdir /mnt/volume_pod-1: file exists"
+)
+
+
+async def _attempt_stale_mount_recovery(
+    docker_service: DockerService, container_error: str | None
+) -> bool:
+    return await docker_service.recover_pod_after_stale_vloopback_mount(
+        ssh_client=AsyncMock(),
+        executor_info=_executor_without_host_key("executor-1"),
+        miner_hotkey="miner-1",
+        private_key="key",
+        container_name="pod_pod-1",
+        pod_id="pod-1",
+        container_error=container_error,
+        default_extra={},
+    )
+
+
+@pytest.mark.parametrize(
+    "container_error",
+    [
+        pytest.param(None, id="stopped_on_purpose_leaves_no_error"),
+        pytest.param("OCI runtime create failed: exec: no such file", id="unrelated_error"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_recover_pod_declines_without_stale_mount_signature(
+    docker_service, monkeypatch, container_error
+):
+    repair_mountpoint = AsyncMock(return_value=True)
+    monkeypatch.setattr(docker_service, "repair_stale_vloopback_mountpoint", repair_mountpoint)
+
+    recovered = await _attempt_stale_mount_recovery(docker_service, container_error)
+
+    assert recovered is False
+    repair_mountpoint.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recover_pod_does_not_start_when_repair_fails(docker_service, monkeypatch):
+    monkeypatch.setattr(
+        docker_service, "repair_stale_vloopback_mountpoint", AsyncMock(return_value=False)
+    )
+    start_existing_container = AsyncMock()
+    monkeypatch.setattr(docker_service, "start_existing_container", start_existing_container)
+
+    recovered = await _attempt_stale_mount_recovery(docker_service, _STALE_MOUNT_ERROR)
+
+    assert recovered is False
+    start_existing_container.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recover_pod_repairs_then_starts_through_the_full_start_path(
+    docker_service, monkeypatch
+):
+    repair_mountpoint = AsyncMock(return_value=True)
+    monkeypatch.setattr(docker_service, "repair_stale_vloopback_mountpoint", repair_mountpoint)
+    start_existing_container = AsyncMock()
+    monkeypatch.setattr(docker_service, "start_existing_container", start_existing_container)
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+    monkeypatch.setattr("services.docker_service.require_rental_docker_ssh_host_key", Mock())
+
+    recovered = await _attempt_stale_mount_recovery(docker_service, _STALE_MOUNT_ERROR)
+
+    assert recovered is True
+    assert repair_mountpoint.await_args.args[1] == "volume_pod-1"
+    start_kwargs = start_existing_container.await_args.kwargs
+    assert start_kwargs["container_name"] == "pod_pod-1"
+    assert start_kwargs["pod_id"] == "pod-1"
+    assert start_kwargs["local_volume_path"] == "/root"
+
+
+@pytest.mark.asyncio
+async def test_recover_pod_reports_failure_when_start_raises(docker_service, monkeypatch):
+    monkeypatch.setattr(
+        docker_service, "repair_stale_vloopback_mountpoint", AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+    monkeypatch.setattr("services.docker_service.require_rental_docker_ssh_host_key", Mock())
+    monkeypatch.setattr(
+        docker_service,
+        "start_existing_container",
+        AsyncMock(side_effect=RuntimeError("start failed")),
+    )
+
+    recovered = await _attempt_stale_mount_recovery(docker_service, _STALE_MOUNT_ERROR)
+
+    assert recovered is False

--- a/neurons/validators/tests/test_rented_machine_check.py
+++ b/neurons/validators/tests/test_rented_machine_check.py
@@ -840,7 +840,7 @@ def build_recovery_context(
         score_calculator=DummyScoreCalculator(actual_score=1.0, job_score=1.0, warning=""),
         container_cleanup=MockContainerCleanup(),
         backend=DummyBackendClient(active=True),
-        docker=docker,
+        pod_recovery=docker,
     )
     return context_factory(
         services=services,

--- a/neurons/validators/tests/test_rented_machine_check.py
+++ b/neurons/validators/tests/test_rented_machine_check.py
@@ -11,6 +11,7 @@ from neurons.validators.src.services.task.checks.rented_machine import (
 )
 from neurons.validators.src.services.task.messages import TenantEnforcementMessages as Msg
 from neurons.validators.src.services.task.pipeline import Context
+from neurons.validators.src.services.task.pipeline_factory import PipelineFactory
 
 from protocol.vc_protocol.compute_requests import RentedExecutor, RentedExecutorsResponse, RentedPod
 from protocol.vc_protocol.validator_requests import ResetVerifiedJobReason
@@ -976,6 +977,31 @@ async def test_tenant_enforcement_skips_recovery_without_private_key(context_fac
     assert result.passed is False
     assert result.event.reason_code == Msg.POD_NOT_RUNNING.reason
     docker.recover_pod_after_stale_vloopback_mount.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tenant_enforcement_skips_recovery_in_dry_run(context_factory):
+    # the dry run pipeline runs against live executors alongside production validation, so it must
+    # report the pod as down without rmdir'ing a host path or starting a customer's container
+    docker = AsyncMock()
+    docker.recover_pod_after_stale_vloopback_mount.return_value = True
+    ctx = build_recovery_context(context_factory, DummySSHClient(pod_running=False), docker)
+
+    result = await TenantEnforcementCheck(recover_stale_pods=False).run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.POD_NOT_RUNNING.reason
+    docker.recover_pod_after_stale_vloopback_mount.assert_not_awaited()
+
+
+def test_dry_run_pipeline_does_not_recover_pods():
+    recovery_flags = [
+        check.recover_stale_pods
+        for check in PipelineFactory.build_dry_run_checks()
+        if type(check).__name__ == "TenantEnforcementCheck"
+    ]
+
+    assert recovery_flags == [False]
 
 
 def test_context_annotations_resolve_at_runtime():

--- a/neurons/validators/tests/test_rented_machine_check.py
+++ b/neurons/validators/tests/test_rented_machine_check.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import asyncssh
 import pytest
@@ -10,6 +10,7 @@ from neurons.validators.src.services.task.checks.rented_machine import (
     _collect_pod_diagnostics,
 )
 from neurons.validators.src.services.task.messages import TenantEnforcementMessages as Msg
+from neurons.validators.src.services.task.pipeline import Context
 
 from protocol.vc_protocol.compute_requests import RentedExecutor, RentedExecutorsResponse, RentedPod
 from protocol.vc_protocol.validator_requests import ResetVerifiedJobReason
@@ -822,3 +823,156 @@ async def test_tenant_enforcement_allows_mapped_filler_with_customer_rental(cont
     assert result.event.reason_code == Msg.ALREADY_RENTED.reason
     assert result.updates["rented"] is True
     assert score_calculator.called_with["rented"] is True
+
+
+def build_recovery_context(
+    context_factory,
+    ssh: DummySSHClient,
+    docker: AsyncMock,
+    *,
+    private_key: str | None = "ssh-key",
+) -> Context:
+    rented_data = build_rented_data(
+        "executor-123",
+        {"containers": [{"name": "pod_pod-1", "pod_id": "pod-1"}], "owner_flag": False},
+    )
+    services = build_services(
+        score_calculator=DummyScoreCalculator(actual_score=1.0, job_score=1.0, warning=""),
+        container_cleanup=MockContainerCleanup(),
+        backend=DummyBackendClient(active=True),
+        docker=docker,
+    )
+    return context_factory(
+        services=services,
+        config=build_context_config(),
+        state=build_state(
+            gpu_processes=[],
+            gpu_details=[],
+            gpu_model="NVIDIA RTX 4090",
+            rented_data=rented_data,
+        ),
+        ssh=ssh,
+        executor_ssh_private_key=private_key,
+        collateral_deposited=True,
+        is_rental_succeed=True,
+        contract_version="v1.0.0",
+    )
+
+
+@pytest.mark.asyncio
+async def test_tenant_enforcement_passes_when_pod_recovered_from_stale_mount(context_factory):
+    ssh = DummySSHClient(pod_running=False, ssh_keys=["ssh-rsa recovered"])
+    docker = AsyncMock()
+
+    async def bring_pod_back_up(**kwargs):
+        ssh.pod_running = True
+        return True
+
+    docker.recover_pod_after_stale_vloopback_mount.side_effect = bring_pod_back_up
+    ctx = build_recovery_context(context_factory, ssh, docker)
+
+    result = await TenantEnforcementCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.ALREADY_RENTED.reason
+    assert "clear_verified_job_info" not in result.updates
+    assert result.updates["ssh_pub_keys"] == ["ssh-rsa recovered"]
+    assert result.updates["default_extra"]["recovered_pods"] == ["pod_pod-1"]
+    assert docker.recover_pod_after_stale_vloopback_mount.await_args.kwargs["pod_id"] == "pod-1"
+
+
+@pytest.mark.asyncio
+async def test_tenant_enforcement_penalises_when_recovery_declines(context_factory):
+    docker = AsyncMock()
+    docker.recover_pod_after_stale_vloopback_mount.return_value = False
+    ctx = build_recovery_context(context_factory, DummySSHClient(pod_running=False), docker)
+
+    result = await TenantEnforcementCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.POD_NOT_RUNNING.reason
+    assert result.updates["clear_verified_job_reason"] == ResetVerifiedJobReason.POD_NOT_RUNNING.value
+
+
+@pytest.mark.asyncio
+async def test_tenant_enforcement_penalises_when_pod_stays_down_after_recovery(context_factory):
+    docker = AsyncMock()
+    docker.recover_pod_after_stale_vloopback_mount.return_value = True
+    ctx = build_recovery_context(context_factory, DummySSHClient(pod_running=False), docker)
+
+    result = await TenantEnforcementCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.POD_NOT_RUNNING.reason
+
+
+@pytest.mark.asyncio
+async def test_tenant_enforcement_penalises_when_recovery_raises(context_factory):
+    docker = AsyncMock()
+    docker.recover_pod_after_stale_vloopback_mount.side_effect = RuntimeError("ssh died")
+    ctx = build_recovery_context(context_factory, DummySSHClient(pod_running=False), docker)
+
+    result = await TenantEnforcementCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.POD_NOT_RUNNING.reason
+
+
+@pytest.mark.asyncio
+async def test_tenant_enforcement_emits_transport_unreachable_when_recheck_loses_ssh(
+    context_factory,
+):
+    """DAH-2055 still holds on the recovery path: if the SSH transport dies during the
+    post-recovery re-check, pod state is unknown, so the miner must get
+    EXECUTOR_TRANSPORT_UNREACHABLE rather than a penalty or an uncaught exception."""
+    ssh = DummySSHClient(pod_running=False)
+    docker = AsyncMock()
+
+    async def start_pod_then_lose_transport(**kwargs):
+        ssh.raise_on_run = asyncssh.ConnectionLost("host rebooted again")
+        return True
+
+    docker.recover_pod_after_stale_vloopback_mount.side_effect = start_pod_then_lose_transport
+    ctx = build_recovery_context(context_factory, ssh, docker)
+
+    result = await TenantEnforcementCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.EXECUTOR_TRANSPORT_UNREACHABLE.reason
+    assert "clear_verified_job_info" not in result.updates
+    assert "clear_verified_job_reason" not in result.updates
+
+
+@pytest.mark.asyncio
+async def test_tenant_enforcement_emits_transport_unreachable_when_repair_loses_ssh(
+    context_factory,
+):
+    """The vloopback repair runs over the same ctx.ssh session, so a transport death there is
+    DAH-2055 territory too: pod state is unknown and the miner must not be penalised."""
+    docker = AsyncMock()
+    docker.recover_pod_after_stale_vloopback_mount.side_effect = asyncssh.ConnectionLost(
+        "host went away mid-repair"
+    )
+    ctx = build_recovery_context(context_factory, DummySSHClient(pod_running=False), docker)
+
+    result = await TenantEnforcementCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.EXECUTOR_TRANSPORT_UNREACHABLE.reason
+    assert "clear_verified_job_info" not in result.updates
+    assert "clear_verified_job_reason" not in result.updates
+
+
+@pytest.mark.asyncio
+async def test_tenant_enforcement_skips_recovery_without_private_key(context_factory):
+    docker = AsyncMock()
+    docker.recover_pod_after_stale_vloopback_mount.return_value = True
+    ctx = build_recovery_context(
+        context_factory, DummySSHClient(pod_running=False), docker, private_key=None
+    )
+
+    result = await TenantEnforcementCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.POD_NOT_RUNNING.reason
+    docker.recover_pod_after_stale_vloopback_mount.assert_not_awaited()

--- a/neurons/validators/tests/test_rented_machine_check.py
+++ b/neurons/validators/tests/test_rented_machine_check.py
@@ -976,3 +976,10 @@ async def test_tenant_enforcement_skips_recovery_without_private_key(context_fac
     assert result.passed is False
     assert result.event.reason_code == Msg.POD_NOT_RUNNING.reason
     docker.recover_pod_after_stale_vloopback_mount.assert_not_awaited()
+
+
+def test_context_annotations_resolve_at_runtime():
+    # Every test above builds Context with model_construct, which skips validation and hides an
+    # annotation pydantic cannot resolve. A ContextServices field typed only under TYPE_CHECKING
+    # leaves Context unbuildable, and then every real validation cycle raises instead of running.
+    assert Context.model_rebuild(force=True) is True


### PR DESCRIPTION
[Notion task](https://app.notion.com/p/Auto-recover-pods-stuck-after-host-reboot-stale-vloopback-mountpoint-POD_NOT_RUNNING-38eb8bfdbde981c7ab93c6740fb1be0d)

## What was broken

POD_NOT_RUNNING is ~23% of penalty failures (~83/350). Over a 7-day validator log window 22 of 31
POD_NOT_RUNNING pods failed with exit code 255 and
`VolumeDriver.Mount: cannot create mount point dir '/mnt/volume_<pod>': mkdir ...: file exists`,
and 20 of those coincide with a host reboot (e.g. pod `e0c58a78-532e-4283-87a0-c488a7bbe534`, host
boot 2026-06-24 16:12:28, pod finished 16:12:41).

Pods run with `--restart unless-stopped`. After a reboot dockerd auto-restarts the pod and calls the
vloopback plugin, but the mountpoint dir under `propagated-mount/volume_<pod>` survived the reboot
while the loopback mount did not, so the plugin's plain `mkdir` hits "file exists" and the container
stays down. `repair_stale_vloopback_mountpoint` (DAH-2133) already fixes exactly this, but only on
the create/rental path — nothing repaired it on the host-side auto-restart, so the pod stayed down
until the rental ended and the miner was penalised every cycle.

## How it is fixed

`TenantEnforcementCheck` now heals the pod before it penalises the miner
(`services/task/checks/rented_machine.py`). Recovery only runs when every one of these holds, and
they are what makes it safe:

- the check is not the dry-run instance (`TenantEnforcementCheck(recover_stale_pods=False)` in
  `build_dry_run_checks`) — the dry-run pipeline runs against live executors next to production
  validation and must not rmdir a host path or start a customer's container;
- the backend still reports the rental active (existing `get_pod_rental_active` call);
- the container's own `State.Error` carries all three phrases of the vloopback signature
  (`_is_stale_vloopback_mountpoint_error`, reusing `_VLOOPBACK_MOUNT_ERROR_PHRASES`);
- the pod has **no encrypted volume** — see the scope note below.

A pod a customer stopped through `ContainerStopRequest` exits cleanly with an empty `State.Error`,
so it can never match and is never resurrected.

On a match the check runs the existing `repair_stale_vloopback_mountpoint` and then restarts the
container through the **full** start path — `start_existing_container`, lifted out of
`start_container`: `docker start` plus the sshd bootstrap. A bare `docker start` was deliberately
rejected: it would report the pod "running" — and so silence the penalty — while the customer still
cannot get in, and the same method is what the create path uses to restore a gocryptfs plaintext
mount. After a successful start the pod is re-read,
so the recovered container's own SSH keys are what gets reported and a start that did not stick
still lands on POD_NOT_RUNNING.

Everything that is not the pod being down leaves the POD_NOT_RUNNING verdict alone rather than
turning it into a free pass. In particular a command that times out is reported as a failed
recovery, not as a dead transport: `asyncssh.TimeoutError` subclasses both `asyncssh.Error` and
`OSError`, so without an explicit catch it would reach the check's DAH-2055 handler and the miner
would dodge the penalty on any slow executor.

Everything else is wiring: `DockerService` and the decrypted executor SSH key are threaded into the
check context, and `DockerService` is now constructed before `TaskService` in both composition
roots. The `TYPE_CHECKING` imports in `services/task/` are load-bearing — `docker_service` imports
that package, so a runtime import back is a circular import.

## Scope note

**Encrypted volumes are out of scope.** For an encrypted rental docker mounts the ciphertext at
`/lium-cipher` and the plaintext path the customer actually uses comes from the create request —
it is recorded nowhere on the host and is not in `PodRentalActiveResponse` either. Remounting
gocryptfs at the `/root` default would leave a custom path (say `/data`) an ordinary container dir,
so everything the customer wrote there after recovery would land unencrypted on the miner's disk.
Recovery therefore inspects the container's mounts first and stands down when it sees
`/lium-cipher`, failing closed if the inspect itself does not answer. Re-enabling encrypted pods
needs `local_volume_path` on the backend's rental-active response — a separate compute-app change.

This PR also replaces the executor-side `entrypoint.sh` reconcile from the original spec. That plan
does not survive contact with the code: the runner entrypoint is not boot-only (the runner is
`restart: unless-stopped` and watchtower-managed on a 60s poll), it runs under `set -eu` after
`docker compose up --wait` so a failure there would brick the executor fleet-wide, a blanket
`docker start pod_*` would override a customer's explicit stop, and the executor host has neither
the rental ground truth nor the volume-encryption key needed to restart a pod correctly. The fix
therefore ships as a validator release, not an executor image release.

## Test plan

Unit (`cd neurons/validators && pdm run pytest tests/ -q`): 1364 passed. The 3 failures in
`tests/test_sshd_bootstrap_script.py` are a pre-existing baseline, unchanged on a clean tree.
`ruff check` on the touched files reports the same 8 errors before and after — no new lint.

- [x] service level: signature does not match -> no repair, no start
- [x] service level: no `State.Error` at all -> no repair
- [x] service level: encrypted volume (`/lium-cipher` mounted) -> no repair, no start
- [x] service level: container inspect fails -> treated as encrypted, no repair
- [x] service level: a repair command times out -> no start, POD_NOT_RUNNING preserved
- [x] service level: repair fails -> no start
- [x] service level: happy path -> repair on the volume the container actually mounts, start
      through the full path with no plaintext path
- [x] service level: start raises -> reported as not recovered, half-started container stopped
- [x] check level: recovered -> passes, no `clear_verified_job_info`, recovered pod's SSH keys reported
- [x] check level: recovery declines / pod stays down / recovery raises / no SSH key -> POD_NOT_RUNNING preserved
- [x] check level: SSH transport lost during recovery -> EXECUTOR_TRANSPORT_UNREACHABLE, not a penalty
- [x] check level: dry-run instance -> recovery never called, POD_NOT_RUNNING preserved
- [x] pipeline level: `build_dry_run_checks` carries `recover_stale_pods=False`

Pre-deploy verification on staging:

- [x] rent a pod, write a marker file into `/root`, reboot the executor host
- [x] confirm the failure signature: `docker inspect --format '{{json .State}}' pod_<id>` shows a
      non-empty `Error` with `cannot create mount point dir ... file exists`, and POD_NOT_RUNNING fires
- [x] deterministic fallback if the reboot does not reproduce it: stop the pod, `mkdir
      /var/lib/docker/plugins/<plugin_id>/propagated-mount/volume_<pod_id>`, then `docker start pod_<id>`

Post-deploy verification on staging:

- [x] on the next validation cycle the pod comes back up and no POD_NOT_RUNNING event fires
- [x] Loki carries `POD_STALE_MOUNT_RECOVERED` (failures land as
      `POD_STALE_MOUNT_RECOVERY_REPAIR_FAILED` / `_START_FAILED` / `_TIMED_OUT` /
      `POD_STALE_MOUNT_RECOVERY_FAILED`)
- [x] a healthy mounted pod on the same host is left untouched
- [ ] **re-run on an unencrypted pod.** The staging run in the comment below used an encrypted
      volume, which this revision now refuses; the shipped path needs its own run
- [ ] an encrypted pod hitting the same break logs
      `POD_STALE_MOUNT_RECOVERY_SKIPPED_ENCRYPTED_VOLUME` and still reports POD_NOT_RUNNING

Post-deploy on prod, +7 d:

- [ ] POD_NOT_RUNNING events with the `file exists` signature drop
- [ ] no rise in stale-volume or wrong-deletion errors
