### PR TITLE
DAH-2521, add robust executor backup and restore runner

### DIFF
--- a/neurons/executor/Dockerfile
+++ b/neurons/executor/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get update \
      pkg-config \
      speedtest-cli \
      ssh \
+     tar \
+     util-linux \
   && install -m 0755 -d /etc/apt/keyrings \
   && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
   && chmod a+r /etc/apt/keyrings/docker.gpg \

--- a/neurons/executor/Dockerfile
+++ b/neurons/executor/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /root/app
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
      build-essential \
+     bzip2 \
      ca-certificates \
      curl \
      e2fsprogs \
@@ -30,6 +31,16 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends docker-ce-cli \
   && rm -rf /var/lib/apt/lists/* \
   && docker --version
+
+ARG RESTIC_VERSION=0.19.1
+ARG RESTIC_LINUX_AMD64_SHA256=f415415624dcc452f2a02b8c33641791a8c6d6d3b65bbb3543fcf9a25151585c
+RUN curl -fsSLo /tmp/restic.bz2 \
+      "https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_amd64.bz2" \
+  && echo "${RESTIC_LINUX_AMD64_SHA256}  /tmp/restic.bz2" | sha256sum -c - \
+  && bunzip2 /tmp/restic.bz2 \
+  && install -m 0755 /tmp/restic /usr/local/bin/restic \
+  && rm -f /tmp/restic \
+  && test "$(restic version | awk '{print $2}')" = "${RESTIC_VERSION}"
 
 RUN pip install -U pdm
 ENV PDM_CHECK_UPDATE=false

--- a/neurons/executor/README.md
+++ b/neurons/executor/README.md
@@ -2,7 +2,7 @@
 
 ## Restic storage-runner proof of concept
 
-The executor image contains a checksum-verified restic binary and an operation-scoped runner at `src/storage_runner.py`. The runner is the proof-of-concept data path for direct restic backup and restore without sending archive bytes through Docker stdout.
+The executor image contains a checksum-verified restic binary and an operation-scoped runner at `src/storage_runner.py`. The runner is the proof-of-concept data path for backup and restore without staging a temporary archive on the customer's disk.
 
 It accepts JSON from standard input or a mode-`0600` file:
 
@@ -15,11 +15,11 @@ An example request is available in `storage-operation.example.json`. Repository 
 Supported PoC workspace modes:
 
 - `plain_volume`: starts a sibling helper from the current executor image, mounts the named volume read-only for backup or read-write for restore, disables Docker log persistence, and runs restic directly against S3.
-- `encrypted_running`: validates the expected rental container, `/lium-cipher` volume mount, process cgroup, and live `fuse.gocryptfs` plaintext mount before running executor-controlled restic through that container's `/proc/<pid>/root` view.
+- `encrypted_running`: validates the expected rental container, `/lium-cipher` volume mount, process cgroup, and live `fuse.gocryptfs` plaintext mount. A short-lived executor helper then enters only the rental's user namespace and accesses the verified plaintext path without copying tools or S3 credentials into the rental.
 
-For restore, set `action` to `restore`, provide the exact hexadecimal `snapshot_id`, and set `workspace.requested_path` to a new or empty destination. The runner rejects a non-empty destination.
+For restore, set `action` to `restore`, provide the exact hexadecimal `snapshot_id`, and set `workspace.requested_path` to a new or empty destination. The runner rejects a non-empty destination. Restore data is streamed from restic directly into tar extraction, with pipeline failure propagation and periodic byte progress; it is never materialized as a local tar file.
 
-JSON lines on stdout contain normalized `restic`, `diagnostic`, and terminal `result` events. Restic exit code 3 is returned as `COMPLETED` with `result_quality=PARTIAL` only when the final JSON summary includes a snapshot ID.
+JSON lines on stdout contain normalized `restic`, `diagnostic`, heartbeat, and terminal `result` events. Restic exit code 3 is returned as `COMPLETED` with `result_quality=PARTIAL` only when the final JSON summary includes a snapshot ID. S3 backend concurrency defaults to 64 based on staging measurements and can be set from 1 through 128 with `repository.s3_connections`.
 
 **[Executor Documentation](https://docs.lium.io/bittensor-subnet/executor)**
 

--- a/neurons/executor/README.md
+++ b/neurons/executor/README.md
@@ -1,5 +1,26 @@
 # Executor
 
+## Restic storage-runner proof of concept
+
+The executor image contains a checksum-verified restic binary and an operation-scoped runner at `src/storage_runner.py`. The runner is the proof-of-concept data path for direct restic backup and restore without sending archive bytes through Docker stdout.
+
+It accepts JSON from standard input or a mode-`0600` file:
+
+```bash
+pdm run python src/storage_runner.py --spec storage-operation.json
+```
+
+An example request is available in `storage-operation.example.json`. Repository locations are not accepted from the request: the runner derives the isolated prefix as `restic/v1/pods/<pod-id>/` inside the supplied user backup bucket.
+
+Supported PoC workspace modes:
+
+- `plain_volume`: starts a sibling helper from the current executor image, mounts the named volume read-only for backup or read-write for restore, disables Docker log persistence, and runs restic directly against S3.
+- `encrypted_running`: validates the expected rental container, `/lium-cipher` volume mount, process cgroup, and live `fuse.gocryptfs` plaintext mount before running executor-controlled restic through that container's `/proc/<pid>/root` view.
+
+For restore, set `action` to `restore`, provide the exact hexadecimal `snapshot_id`, and set `workspace.requested_path` to a new or empty destination. The runner rejects a non-empty destination.
+
+JSON lines on stdout contain normalized `restic`, `diagnostic`, and terminal `result` events. Restic exit code 3 is returned as `COMPLETED` with `result_quality=PARTIAL` only when the final JSON summary includes a snapshot ID.
+
 **[Executor Documentation](https://docs.lium.io/bittensor-subnet/executor)**
 
 ## Setup project
@@ -147,4 +168,3 @@ The above command should show the `nvidia-smi` result if sysbox is installed cor
 ```shell
 sudo systemctl restart docker
 ```
-

--- a/neurons/executor/src/storage/__init__.py
+++ b/neurons/executor/src/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Executor-side backup and restore runner."""

--- a/neurons/executor/src/storage/models.py
+++ b/neurons/executor/src/storage/models.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import PurePosixPath
+from typing import Mapping
+from uuid import UUID
+
+
+class StorageAction(StrEnum):
+    BACKUP = "backup"
+    RESTORE = "restore"
+
+
+class WorkspaceMode(StrEnum):
+    PLAIN_VOLUME = "plain_volume"
+    ENCRYPTED_RUNNING = "encrypted_running"
+
+
+class OperationResultQuality(StrEnum):
+    FULL = "FULL"
+    PARTIAL = "PARTIAL"
+
+
+class OperationSpecError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class RepositorySpec:
+    bucket: str
+    access_key_id: str = field(repr=False)
+    secret_access_key: str = field(repr=False)
+    password: str = field(repr=False)
+    session_token: str | None = field(default=None, repr=False)
+    region: str = "us-east-1"
+    endpoint: str = "s3.amazonaws.com"
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "RepositorySpec":
+        return cls(
+            bucket=_required_string(value, "bucket"),
+            access_key_id=_required_string(value, "access_key_id"),
+            secret_access_key=_required_string(value, "secret_access_key"),
+            password=_required_string(value, "password"),
+            session_token=_optional_nullable_string(value, "session_token"),
+            region=_optional_string(value, "region", "us-east-1"),
+            endpoint=_optional_string(value, "endpoint", "s3.amazonaws.com"),
+        )
+
+    def url_for_pod(self, pod_id: UUID) -> str:
+        endpoint = self.endpoint.rstrip("/")
+        prefix = f"restic/v1/pods/{pod_id}"
+        return f"s3:{endpoint}/{self.bucket}/{prefix}"
+
+
+@dataclass(frozen=True)
+class WorkspaceSpec:
+    mode: WorkspaceMode
+    volume_name: str
+    volume_path: PurePosixPath
+    requested_path: PurePosixPath
+    container_name: str | None = None
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "WorkspaceSpec":
+        try:
+            mode = WorkspaceMode(_required_string(value, "mode"))
+        except ValueError as error:
+            supported = ", ".join(item.value for item in WorkspaceMode)
+            raise OperationSpecError(f"workspace.mode must be one of: {supported}") from error
+
+        container_name = _optional_nullable_string(value, "container_name")
+        if mode is WorkspaceMode.ENCRYPTED_RUNNING and not container_name:
+            raise OperationSpecError("workspace.container_name is required for encrypted_running")
+
+        return cls(
+            mode=mode,
+            volume_name=_safe_identifier(_required_string(value, "volume_name"), "workspace.volume_name"),
+            volume_path=_absolute_path(_required_string(value, "volume_path"), "workspace.volume_path"),
+            requested_path=_absolute_path(_required_string(value, "requested_path"), "workspace.requested_path"),
+            container_name=_safe_identifier(container_name, "workspace.container_name") if container_name else None,
+        )
+
+
+@dataclass(frozen=True)
+class StorageOperationSpec:
+    operation_id: UUID
+    pod_id: UUID
+    action: StorageAction
+    repository: RepositorySpec
+    workspace: WorkspaceSpec
+    snapshot_id: str | None = None
+    progress_interval_seconds: float = 10.0
+    heartbeat_interval_seconds: float = 30.0
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "StorageOperationSpec":
+        try:
+            operation_id = UUID(_required_string(value, "operation_id"))
+            pod_id = UUID(_required_string(value, "pod_id"))
+        except ValueError as error:
+            raise OperationSpecError("operation_id and pod_id must be UUIDs") from error
+
+        try:
+            action = StorageAction(_required_string(value, "action"))
+        except ValueError as error:
+            raise OperationSpecError("action must be backup or restore") from error
+
+        repository_value = _required_mapping(value, "repository")
+        workspace_value = _required_mapping(value, "workspace")
+        snapshot_id = _optional_nullable_string(value, "snapshot_id")
+        if action is StorageAction.RESTORE and not snapshot_id:
+            raise OperationSpecError("snapshot_id is required for restore")
+        if snapshot_id and not re.fullmatch(r"[0-9a-f]{8,64}", snapshot_id):
+            raise OperationSpecError("snapshot_id must be a hexadecimal restic snapshot ID")
+
+        interval_value = value.get("progress_interval_seconds", 10.0)
+        if not isinstance(interval_value, int | float) or isinstance(interval_value, bool):
+            raise OperationSpecError("progress_interval_seconds must be a number")
+        if interval_value < 0:
+            raise OperationSpecError("progress_interval_seconds must not be negative")
+
+        heartbeat_value = value.get("heartbeat_interval_seconds", 30.0)
+        if not isinstance(heartbeat_value, int | float) or isinstance(heartbeat_value, bool):
+            raise OperationSpecError("heartbeat_interval_seconds must be a number")
+        if heartbeat_value <= 0:
+            raise OperationSpecError("heartbeat_interval_seconds must be positive")
+
+        return cls(
+            operation_id=operation_id,
+            pod_id=pod_id,
+            action=action,
+            repository=RepositorySpec.from_mapping(repository_value),
+            workspace=WorkspaceSpec.from_mapping(workspace_value),
+            snapshot_id=snapshot_id,
+            progress_interval_seconds=float(interval_value),
+            heartbeat_interval_seconds=float(heartbeat_value),
+        )
+
+
+def _required_mapping(value: Mapping[str, object], key: str) -> Mapping[str, object]:
+    item = value.get(key)
+    if not isinstance(item, Mapping):
+        raise OperationSpecError(f"{key} must be an object")
+    return item
+
+
+def _required_string(value: Mapping[str, object], key: str) -> str:
+    item = value.get(key)
+    if not isinstance(item, str) or not item.strip():
+        raise OperationSpecError(f"{key} must be a non-empty string")
+    return item.strip()
+
+
+def _optional_string(value: Mapping[str, object], key: str, default: str) -> str:
+    item = value.get(key, default)
+    if not isinstance(item, str) or not item.strip():
+        raise OperationSpecError(f"{key} must be a non-empty string")
+    return item.strip()
+
+
+def _optional_nullable_string(value: Mapping[str, object], key: str) -> str | None:
+    item = value.get(key)
+    if item is None:
+        return None
+    if not isinstance(item, str) or not item.strip():
+        raise OperationSpecError(f"{key} must be a non-empty string when provided")
+    return item.strip()
+
+
+def _safe_identifier(value: str, key: str) -> str:
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}", value):
+        raise OperationSpecError(f"{key} contains unsupported characters")
+    return value
+
+
+def _absolute_path(value: str, key: str) -> PurePosixPath:
+    path = PurePosixPath(value)
+    if not path.is_absolute() or ".." in path.parts:
+        raise OperationSpecError(f"{key} must be an absolute path without '..'")
+    return path

--- a/neurons/executor/src/storage/models.py
+++ b/neurons/executor/src/storage/models.py
@@ -36,6 +36,7 @@ class RepositorySpec:
     session_token: str | None = field(default=None, repr=False)
     region: str = "us-east-1"
     endpoint: str = "s3.amazonaws.com"
+    s3_connections: int = 64
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, object]) -> "RepositorySpec":
@@ -47,6 +48,13 @@ class RepositorySpec:
             session_token=_optional_nullable_string(value, "session_token"),
             region=_optional_string(value, "region", "us-east-1"),
             endpoint=_optional_string(value, "endpoint", "s3.amazonaws.com"),
+            s3_connections=_optional_bounded_integer(
+                value,
+                "s3_connections",
+                default=64,
+                minimum=1,
+                maximum=128,
+            ),
         )
 
     def url_for_pod(self, pod_id: UUID) -> str:
@@ -168,6 +176,22 @@ def _optional_nullable_string(value: Mapping[str, object], key: str) -> str | No
     if not isinstance(item, str) or not item.strip():
         raise OperationSpecError(f"{key} must be a non-empty string when provided")
     return item.strip()
+
+
+def _optional_bounded_integer(
+    value: Mapping[str, object],
+    key: str,
+    *,
+    default: int,
+    minimum: int,
+    maximum: int,
+) -> int:
+    item = value.get(key, default)
+    if not isinstance(item, int) or isinstance(item, bool):
+        raise OperationSpecError(f"{key} must be an integer")
+    if item < minimum or item > maximum:
+        raise OperationSpecError(f"{key} must be between {minimum} and {maximum}")
+    return item
 
 
 def _safe_identifier(value: str, key: str) -> str:

--- a/neurons/executor/src/storage/restic.py
+++ b/neurons/executor/src/storage/restic.py
@@ -11,7 +11,30 @@ from dataclasses import dataclass
 from typing import IO, Callable, Mapping
 
 from storage.models import OperationResultQuality, StorageAction, StorageOperationSpec
-from storage.workspace import DockerVolumeWorkspace, LocalWorkspace, ResolvedWorkspace
+from storage.workspace import (
+    DockerUserNamespaceWorkspace,
+    DockerVolumeWorkspace,
+    LocalWorkspace,
+    ResolvedWorkspace,
+)
+
+
+RESTORE_CHECKPOINT_PREFIX = "LIUM_RESTORE_CHECKPOINT_"
+TAR_RECORD_SIZE_BYTES = 20 * 512
+TAR_CHECKPOINT_RECORDS = 1024
+ENCRYPTED_BACKUP_SCRIPT = 'cd "$1"; shift; exec "$@"'
+
+
+def _restore_pipeline_script(*, extended_metadata: bool) -> str:
+    metadata_options = '--acls --xattrs --xattrs-include="*" ' if extended_metadata else ""
+    return (
+        'mkdir -p -- "$4"; '
+        '"$1" --no-cache -o "$2" dump --archive tar "$3" / | '
+        'tar --extract --file - --directory "$4" --preserve-permissions '
+        f'--same-owner --numeric-owner {metadata_options}'
+        f'--blocking-factor=20 --checkpoint={TAR_CHECKPOINT_RECORDS} '
+        f'--checkpoint-action=echo={RESTORE_CHECKPOINT_PREFIX}%u'
+    )
 
 
 class ResticOperationError(RuntimeError):
@@ -24,6 +47,12 @@ class ResticResult:
     result_quality: OperationResultQuality | None
     snapshot_id: str | None
     exit_code: int
+
+
+@dataclass(frozen=True)
+class RestoreStats:
+    total_size: int
+    total_file_count: int
 
 
 class JsonEventWriter:
@@ -118,7 +147,7 @@ class ResticStorageRunner:
 
     def _ensure_repository(self) -> None:
         probe = subprocess.run(
-            [self._restic_binary, "--no-cache", "snapshots", "--json"],
+            self._restic_command(["snapshots", "--json"]),
             env=self._environment,
             capture_output=True,
             text=True,
@@ -130,7 +159,7 @@ class ResticStorageRunner:
             raise ResticOperationError(f"restic repository probe failed with exit {probe.returncode}: {detail}")
 
         initialized = subprocess.run(
-            [self._restic_binary, "init", "--json"],
+            self._restic_command(["init", "--json"]),
             env=self._environment,
             capture_output=True,
             text=True,
@@ -139,7 +168,7 @@ class ResticStorageRunner:
             return
 
         retry_probe = subprocess.run(
-            [self._restic_binary, "--no-cache", "snapshots", "--json"],
+            self._restic_command(["snapshots", "--json"]),
             env=self._environment,
             capture_output=True,
             text=True,
@@ -173,11 +202,46 @@ class ResticStorageRunner:
         snapshot_id = self._operation.snapshot_id
         if not snapshot_id:
             raise ResticOperationError("restore requires a snapshot ID")
-        command = ["restore", "--json", f"{snapshot_id}:/", "--target", self._workspace_path()]
-        exit_code, _ = self._stream(command, working_directory=False)
+        restore_stats = self._restore_stats(snapshot_id)
+        command, cwd = self._restore_execution_command(snapshot_id)
+        exit_code, _ = self._stream_command(command, cwd, restore_stats=restore_stats)
         if exit_code != 0:
             raise ResticOperationError(f"restic restore failed with exit {exit_code}")
+        self._events.restic_event(
+            {
+                "message_type": "summary",
+                "percent_done": 1,
+                "total_files": restore_stats.total_file_count,
+                "files_restored": restore_stats.total_file_count,
+                "total_bytes": restore_stats.total_size,
+                "bytes_restored": restore_stats.total_size,
+            }
+        )
         return ResticResult("COMPLETED", OperationResultQuality.FULL, snapshot_id, exit_code)
+
+    def _restore_stats(self, snapshot_id: str) -> RestoreStats:
+        result = subprocess.run(
+            self._restic_command(["stats", "--json", "--mode", "restore-size", snapshot_id]),
+            env=self._environment,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            detail = _redact(result.stderr or result.stdout, self._secret_values())
+            raise ResticOperationError(
+                f"restic restore size lookup failed with exit {result.returncode}: {detail}"
+            )
+        try:
+            payload = json.loads(result.stdout)
+            total_size = payload["total_size"]
+            total_file_count = payload["total_file_count"]
+        except (json.JSONDecodeError, KeyError, TypeError) as error:
+            raise ResticOperationError("restic restore size lookup returned invalid JSON") from error
+        if not isinstance(total_size, int) or total_size < 0:
+            raise ResticOperationError("restic restore size lookup returned an invalid total_size")
+        if not isinstance(total_file_count, int) or total_file_count < 0:
+            raise ResticOperationError("restic restore size lookup returned an invalid total_file_count")
+        return RestoreStats(total_size=total_size, total_file_count=total_file_count)
 
     def _stream(
         self,
@@ -185,6 +249,16 @@ class ResticStorageRunner:
         working_directory: bool,
     ) -> tuple[int, Mapping[str, object] | None]:
         command, cwd = self._execution_command(restic_arguments, working_directory)
+        return self._stream_command(command, cwd)
+
+    def _stream_command(
+        self,
+        command: list[str],
+        cwd: str | None,
+        *,
+        restore_stats: RestoreStats | None = None,
+    ) -> tuple[int, Mapping[str, object] | None]:
+        started_at = time.monotonic()
         process = subprocess.Popen(
             command,
             cwd=cwd,
@@ -222,6 +296,13 @@ class ResticStorageRunner:
             line = raw_line.strip()
             if not line:
                 continue
+            checkpoint = _restore_checkpoint(line)
+            if checkpoint is not None and restore_stats is not None:
+                self._events.restic_event(
+                    _restore_progress(checkpoint, restore_stats, time.monotonic() - started_at)
+                )
+                self._events.heartbeat_if_due()
+                continue
             try:
                 payload = json.loads(line)
             except json.JSONDecodeError:
@@ -244,23 +325,105 @@ class ResticStorageRunner:
         restic_arguments: list[str],
         working_directory: bool,
     ) -> tuple[list[str], str | None]:
+        restic_command = self._restic_command(restic_arguments)
         if isinstance(self._workspace, LocalWorkspace):
             cwd = str(self._workspace.path) if working_directory else None
-            return [self._restic_binary, "--no-cache", *restic_arguments], cwd
+            return restic_command, cwd
+
+        if isinstance(self._workspace, DockerUserNamespaceWorkspace):
+            if working_directory:
+                namespace_command = [
+                    "/bin/sh",
+                    "-c",
+                    ENCRYPTED_BACKUP_SCRIPT,
+                    "sh",
+                    str(self._workspace.path),
+                    *restic_command,
+                ]
+            else:
+                namespace_command = restic_command
+            return self._encrypted_helper_command(namespace_command), None
 
         volume_mode = "ro" if self._workspace.read_only else "rw"
-        container_name = f"lium-storage-{str(self._operation.operation_id)[:12]}"
         command = [
+            *self._docker_helper_base(),
+            "--security-opt",
+            "no-new-privileges",
+            "-v",
+            f"{self._workspace.volume_name}:/workspace:{volume_mode}",
+        ]
+        if working_directory:
+            command.extend(["--workdir", str(self._workspace.path)])
+        command.extend(
+            [
+                "--entrypoint",
+                self._restic_binary,
+                self._workspace.image,
+                *restic_command[1:],
+            ]
+        )
+        return command, None
+
+    def _restore_execution_command(self, snapshot_id: str) -> tuple[list[str], str | None]:
+        extended_metadata = not isinstance(self._workspace, DockerUserNamespaceWorkspace)
+        pipeline_command = [
+            "/bin/bash",
+            "-o",
+            "pipefail",
+            "-c",
+            _restore_pipeline_script(extended_metadata=extended_metadata),
+            "bash",
+            self._restic_binary,
+            self._s3_connection_option(),
+            snapshot_id,
+            self._workspace_path(),
+        ]
+        if isinstance(self._workspace, LocalWorkspace):
+            return pipeline_command, None
+        if isinstance(self._workspace, DockerUserNamespaceWorkspace):
+            return self._encrypted_helper_command(pipeline_command), None
+        return [
+            *self._docker_helper_base(),
+            "--security-opt",
+            "no-new-privileges",
+            "-v",
+            f"{self._workspace.volume_name}:/workspace:rw",
+            "--entrypoint",
+            "/bin/bash",
+            self._workspace.image,
+            *pipeline_command[1:],
+        ], None
+
+    def _encrypted_helper_command(self, namespace_command: list[str]) -> list[str]:
+        if not isinstance(self._workspace, DockerUserNamespaceWorkspace):
+            raise ResticOperationError("encrypted helper requested for a non-encrypted workspace")
+        return [
+            *self._docker_helper_base(),
+            "--pid",
+            "host",
+            "--privileged",
+            "--security-opt",
+            "label=disable",
+            "--entrypoint",
+            "/usr/bin/nsenter",
+            self._workspace.image,
+            "-t",
+            str(self._workspace.pid),
+            "-U",
+            "--",
+            *namespace_command,
+        ]
+
+    def _docker_helper_base(self) -> list[str]:
+        return [
             self._docker_binary,
             "run",
             "--rm",
             "--name",
-            container_name,
+            f"lium-storage-{str(self._operation.operation_id)[:12]}",
             "--log-driver",
             "none",
             "--read-only",
-            "--security-opt",
-            "no-new-privileges",
             "--tmpfs",
             "/tmp:rw,nosuid,nodev,size=268435456",
             "-e",
@@ -277,21 +440,19 @@ class ResticStorageRunner:
             "RESTIC_PASSWORD",
             "-e",
             "RESTIC_HOST",
-            "-v",
-            f"{self._workspace.volume_name}:/workspace:{volume_mode}",
         ]
-        if working_directory:
-            command.extend(["--workdir", str(self._workspace.path)])
-        command.extend(
-            [
-                "--entrypoint",
-                self._restic_binary,
-                self._workspace.image,
-                "--no-cache",
-                *restic_arguments,
-            ]
-        )
-        return command, None
+
+    def _restic_command(self, arguments: list[str]) -> list[str]:
+        return [
+            self._restic_binary,
+            "--no-cache",
+            "-o",
+            self._s3_connection_option(),
+            *arguments,
+        ]
+
+    def _s3_connection_option(self) -> str:
+        return f"s3.connections={self._operation.repository.s3_connections}"
 
     def _workspace_path(self) -> str:
         if isinstance(self._workspace, LocalWorkspace):
@@ -332,6 +493,40 @@ def _snapshot_id(summary: Mapping[str, object] | None) -> str | None:
         return None
     value = summary.get("snapshot_id")
     return value if isinstance(value, str) and value else None
+
+
+def _restore_checkpoint(line: str) -> int | None:
+    marker_index = line.find(RESTORE_CHECKPOINT_PREFIX)
+    if marker_index < 0:
+        return None
+    value = line[marker_index + len(RESTORE_CHECKPOINT_PREFIX) :].strip()
+    try:
+        checkpoint = int(value)
+    except ValueError:
+        return None
+    return checkpoint if checkpoint >= 0 else None
+
+
+def _restore_progress(
+    checkpoint: int,
+    stats: RestoreStats,
+    seconds_elapsed: float,
+) -> dict[str, object]:
+    archive_bytes = checkpoint * TAR_RECORD_SIZE_BYTES
+    if stats.total_size == 0:
+        percent_done = 0.99
+        bytes_restored = 0
+    else:
+        percent_done = min(archive_bytes / stats.total_size, 0.99)
+        bytes_restored = min(archive_bytes, stats.total_size)
+    return {
+        "message_type": "status",
+        "seconds_elapsed": int(seconds_elapsed),
+        "percent_done": percent_done,
+        "total_files": stats.total_file_count,
+        "total_bytes": stats.total_size,
+        "bytes_restored": bytes_restored,
+    }
 
 
 def _redact(value: str, secrets: tuple[str, ...]) -> str:

--- a/neurons/executor/src/storage/restic.py
+++ b/neurons/executor/src/storage/restic.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import json
+import os
+import queue
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from typing import IO, Callable, Mapping
+
+from storage.models import OperationResultQuality, StorageAction, StorageOperationSpec
+from storage.workspace import DockerVolumeWorkspace, LocalWorkspace, ResolvedWorkspace
+
+
+class ResticOperationError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ResticResult:
+    status: str
+    result_quality: OperationResultQuality | None
+    snapshot_id: str | None
+    exit_code: int
+
+
+class JsonEventWriter:
+    def __init__(
+        self,
+        operation_id: str,
+        progress_interval_seconds: float,
+        heartbeat_interval_seconds: float = 30.0,
+        output: IO[str] = sys.stdout,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._operation_id = operation_id
+        self._progress_interval_seconds = progress_interval_seconds
+        self._heartbeat_interval_seconds = heartbeat_interval_seconds
+        self._output = output
+        self._clock = clock
+        self._last_progress_at: float | None = None
+        self._last_heartbeat_at = self._clock()
+
+    def restic_event(self, payload: Mapping[str, object]) -> None:
+        message_type = payload.get("message_type")
+        if message_type == "status" and not self._progress_due():
+            return
+        self._write({"event": "restic", "operation_id": self._operation_id, "payload": dict(payload)})
+
+    def diagnostic(self, message: str) -> None:
+        self._write({"event": "diagnostic", "operation_id": self._operation_id, "message": message})
+
+    def heartbeat_if_due(self) -> None:
+        now = self._clock()
+        if now - self._last_heartbeat_at < self._heartbeat_interval_seconds:
+            return
+        self._last_heartbeat_at = now
+        self._write({"event": "heartbeat", "operation_id": self._operation_id})
+
+    @property
+    def heartbeat_interval_seconds(self) -> float:
+        return self._heartbeat_interval_seconds
+
+    def result(self, result: ResticResult) -> None:
+        self._write(
+            {
+                "event": "result",
+                "operation_id": self._operation_id,
+                "status": result.status,
+                "result_quality": result.result_quality.value if result.result_quality else None,
+                "snapshot_id": result.snapshot_id,
+                "exit_code": result.exit_code,
+            }
+        )
+
+    def _progress_due(self) -> bool:
+        now = self._clock()
+        if self._last_progress_at is None or now - self._last_progress_at >= self._progress_interval_seconds:
+            self._last_progress_at = now
+            return True
+        return False
+
+    def _write(self, payload: Mapping[str, object]) -> None:
+        self._output.write(json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n")
+        self._output.flush()
+
+
+class ResticStorageRunner:
+    def __init__(
+        self,
+        operation: StorageOperationSpec,
+        workspace: ResolvedWorkspace,
+        restic_binary: str = "/usr/local/bin/restic",
+        docker_binary: str = "/usr/bin/docker",
+        event_writer: JsonEventWriter | None = None,
+    ) -> None:
+        self._operation = operation
+        self._workspace = workspace
+        self._restic_binary = restic_binary
+        self._docker_binary = docker_binary
+        self._events = event_writer or JsonEventWriter(
+            str(operation.operation_id),
+            operation.progress_interval_seconds,
+            operation.heartbeat_interval_seconds,
+        )
+        self._environment = self._build_environment()
+
+    def run(self) -> ResticResult:
+        self._ensure_repository()
+        if self._operation.action is StorageAction.BACKUP:
+            result = self._backup()
+        else:
+            result = self._restore()
+        self._events.result(result)
+        return result
+
+    def _ensure_repository(self) -> None:
+        probe = subprocess.run(
+            [self._restic_binary, "--no-cache", "snapshots", "--json"],
+            env=self._environment,
+            capture_output=True,
+            text=True,
+        )
+        if probe.returncode == 0:
+            return
+        if probe.returncode != 10:
+            detail = _redact(probe.stderr or probe.stdout, self._secret_values())
+            raise ResticOperationError(f"restic repository probe failed with exit {probe.returncode}: {detail}")
+
+        initialized = subprocess.run(
+            [self._restic_binary, "init", "--json"],
+            env=self._environment,
+            capture_output=True,
+            text=True,
+        )
+        if initialized.returncode == 0:
+            return
+
+        retry_probe = subprocess.run(
+            [self._restic_binary, "--no-cache", "snapshots", "--json"],
+            env=self._environment,
+            capture_output=True,
+            text=True,
+        )
+        if retry_probe.returncode != 0:
+            detail = _redact(initialized.stderr or initialized.stdout, self._secret_values())
+            raise ResticOperationError(f"restic repository initialization failed: {detail}")
+
+    def _backup(self) -> ResticResult:
+        command = [
+            "backup",
+            "--json",
+            "--host",
+            f"lium-pod-{self._operation.pod_id}",
+            "--tag",
+            f"lium-operation:{self._operation.operation_id}",
+            ".",
+        ]
+        exit_code, summary = self._stream(command, working_directory=True)
+        snapshot_id = _snapshot_id(summary)
+        if exit_code == 0 and snapshot_id:
+            return ResticResult("COMPLETED", OperationResultQuality.FULL, snapshot_id, exit_code)
+        if exit_code == 3 and snapshot_id:
+            return ResticResult("COMPLETED", OperationResultQuality.PARTIAL, snapshot_id, exit_code)
+        raise ResticOperationError(
+            f"restic backup failed with exit {exit_code}"
+            + (" without a snapshot ID" if not snapshot_id else "")
+        )
+
+    def _restore(self) -> ResticResult:
+        snapshot_id = self._operation.snapshot_id
+        if not snapshot_id:
+            raise ResticOperationError("restore requires a snapshot ID")
+        command = ["restore", "--json", f"{snapshot_id}:/", "--target", self._workspace_path()]
+        exit_code, _ = self._stream(command, working_directory=False)
+        if exit_code != 0:
+            raise ResticOperationError(f"restic restore failed with exit {exit_code}")
+        return ResticResult("COMPLETED", OperationResultQuality.FULL, snapshot_id, exit_code)
+
+    def _stream(
+        self,
+        restic_arguments: list[str],
+        working_directory: bool,
+    ) -> tuple[int, Mapping[str, object] | None]:
+        command, cwd = self._execution_command(restic_arguments, working_directory)
+        process = subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=self._environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        summary: Mapping[str, object] | None = None
+        if process.stdout is None:
+            process.kill()
+            raise ResticOperationError("restic output stream was not created")
+
+        output_lines: queue.Queue[str | None] = queue.Queue()
+
+        def read_output() -> None:
+            try:
+                for raw_line in process.stdout:
+                    output_lines.put(raw_line)
+            finally:
+                output_lines.put(None)
+
+        output_reader = threading.Thread(target=read_output, name="restic-output", daemon=True)
+        output_reader.start()
+
+        while True:
+            try:
+                raw_line = output_lines.get(timeout=self._events.heartbeat_interval_seconds)
+            except queue.Empty:
+                self._events.heartbeat_if_due()
+                continue
+            if raw_line is None:
+                break
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                self._events.diagnostic(_redact(line, self._secret_values()))
+                continue
+            if not isinstance(payload, dict):
+                self._events.diagnostic("restic emitted a non-object JSON message")
+                continue
+            self._events.restic_event(payload)
+            self._events.heartbeat_if_due()
+            if payload.get("message_type") == "summary":
+                summary = payload
+
+        exit_code = process.wait()
+        output_reader.join(timeout=1)
+        return exit_code, summary
+
+    def _execution_command(
+        self,
+        restic_arguments: list[str],
+        working_directory: bool,
+    ) -> tuple[list[str], str | None]:
+        if isinstance(self._workspace, LocalWorkspace):
+            cwd = str(self._workspace.path) if working_directory else None
+            return [self._restic_binary, "--no-cache", *restic_arguments], cwd
+
+        volume_mode = "ro" if self._workspace.read_only else "rw"
+        container_name = f"lium-storage-{str(self._operation.operation_id)[:12]}"
+        command = [
+            self._docker_binary,
+            "run",
+            "--rm",
+            "--name",
+            container_name,
+            "--log-driver",
+            "none",
+            "--read-only",
+            "--security-opt",
+            "no-new-privileges",
+            "--tmpfs",
+            "/tmp:rw,nosuid,nodev,size=268435456",
+            "-e",
+            "AWS_ACCESS_KEY_ID",
+            "-e",
+            "AWS_SECRET_ACCESS_KEY",
+            "-e",
+            "AWS_SESSION_TOKEN",
+            "-e",
+            "AWS_DEFAULT_REGION",
+            "-e",
+            "RESTIC_REPOSITORY",
+            "-e",
+            "RESTIC_PASSWORD",
+            "-e",
+            "RESTIC_HOST",
+            "-v",
+            f"{self._workspace.volume_name}:/workspace:{volume_mode}",
+        ]
+        if working_directory:
+            command.extend(["--workdir", str(self._workspace.path)])
+        command.extend(
+            [
+                "--entrypoint",
+                self._restic_binary,
+                self._workspace.image,
+                "--no-cache",
+                *restic_arguments,
+            ]
+        )
+        return command, None
+
+    def _workspace_path(self) -> str:
+        if isinstance(self._workspace, LocalWorkspace):
+            return str(self._workspace.path)
+        return str(self._workspace.path)
+
+    def _build_environment(self) -> dict[str, str]:
+        repository = self._operation.repository
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "AWS_ACCESS_KEY_ID": repository.access_key_id,
+                "AWS_SECRET_ACCESS_KEY": repository.secret_access_key,
+                "AWS_DEFAULT_REGION": repository.region,
+                "RESTIC_REPOSITORY": repository.url_for_pod(self._operation.pod_id),
+                "RESTIC_PASSWORD": repository.password,
+                "RESTIC_HOST": f"lium-pod-{self._operation.pod_id}",
+            }
+        )
+        if repository.session_token:
+            environment["AWS_SESSION_TOKEN"] = repository.session_token
+        else:
+            environment.pop("AWS_SESSION_TOKEN", None)
+        return environment
+
+    def _secret_values(self) -> tuple[str, ...]:
+        repository = self._operation.repository
+        return (
+            repository.access_key_id,
+            repository.secret_access_key,
+            repository.session_token or "",
+            repository.password,
+        )
+
+
+def _snapshot_id(summary: Mapping[str, object] | None) -> str | None:
+    if not summary:
+        return None
+    value = summary.get("snapshot_id")
+    return value if isinstance(value, str) and value else None
+
+
+def _redact(value: str, secrets: tuple[str, ...]) -> str:
+    for secret in secrets:
+        if secret:
+            value = value.replace(secret, "[REDACTED]")
+    return _bounded_message(value)
+
+
+def _bounded_message(value: str, limit: int = 2000) -> str:
+    compact = " ".join(value.split())
+    if len(compact) <= limit:
+        return compact
+    return compact[:limit] + "…"

--- a/neurons/executor/src/storage/workspace.py
+++ b/neurons/executor/src/storage/workspace.py
@@ -28,7 +28,17 @@ class DockerVolumeWorkspace:
     read_only: bool
 
 
-ResolvedWorkspace = LocalWorkspace | DockerVolumeWorkspace
+@dataclass(frozen=True)
+class DockerUserNamespaceWorkspace:
+    image: str
+    container_name: str
+    container_id: str
+    pid: int
+    path: PurePosixPath
+    read_only: bool
+
+
+ResolvedWorkspace = LocalWorkspace | DockerVolumeWorkspace | DockerUserNamespaceWorkspace
 
 
 @dataclass(frozen=True)
@@ -54,11 +64,8 @@ class WorkspaceResolver:
         return self._resolve_encrypted_running(operation)
 
     def _resolve_plain_volume(self, operation: StorageOperationSpec) -> DockerVolumeWorkspace:
-        image = self._environ.get("LIUM_STORAGE_HELPER_IMAGE")
-        if not image:
-            image = self._current_executor_image()
         workspace = DockerVolumeWorkspace(
-            image=image,
+            image=self._helper_image(),
             volume_name=operation.workspace.volume_name,
             path=_map_requested_path(
                 operation.workspace.requested_path,
@@ -71,7 +78,7 @@ class WorkspaceResolver:
             self._require_empty_plain_restore_target(workspace)
         return workspace
 
-    def _resolve_encrypted_running(self, operation: StorageOperationSpec) -> LocalWorkspace:
+    def _resolve_encrypted_running(self, operation: StorageOperationSpec) -> DockerUserNamespaceWorkspace:
         container_name = operation.workspace.container_name
         if not container_name:
             raise WorkspaceResolutionError("encrypted workspace is missing container_name")
@@ -85,30 +92,48 @@ class WorkspaceResolver:
             operation.workspace.requested_path,
             operation.workspace.volume_path,
         )
-        visible_path = self._proc_root / str(identity.pid) / "root" / str(requested_path).lstrip("/")
-        if operation.action is StorageAction.BACKUP:
-            if not visible_path.is_dir():
-                raise WorkspaceResolutionError(f"backup source is not a directory: {requested_path}")
-        else:
-            _require_new_or_empty_directory(visible_path, requested_path)
+        visible_path = (
+            PurePosixPath(str(self._proc_root))
+            / str(identity.pid)
+            / "root"
+            / requested_path.relative_to("/")
+        )
+        image = self._helper_image()
+        self._validate_encrypted_path(
+            image=image,
+            pid=identity.pid,
+            visible_path=visible_path,
+            requested_path=requested_path,
+            action=operation.action,
+        )
 
         confirmed_identity, _ = self._inspect_running_container(container_name)
         if confirmed_identity != identity:
             raise WorkspaceResolutionError("rental container changed while resolving encrypted workspace")
-        return LocalWorkspace(path=visible_path)
+        return DockerUserNamespaceWorkspace(
+            image=image,
+            container_name=container_name,
+            container_id=identity.container_id,
+            pid=identity.pid,
+            path=visible_path,
+            read_only=operation.action is StorageAction.BACKUP,
+        )
+
+    def _helper_image(self) -> str:
+        return self._environ.get("LIUM_STORAGE_HELPER_IMAGE") or self._current_executor_image()
 
     def _current_executor_image(self) -> str:
         container_id = self._environ.get("HOSTNAME")
         if not container_id:
             raise WorkspaceResolutionError(
-                "plain volume mode requires workspace.helper_image or LIUM_STORAGE_HELPER_IMAGE"
+                "storage helper requires LIUM_STORAGE_HELPER_IMAGE or the current executor image"
             )
         result = self._run_docker(
-            ["inspect", "-f", "{{.Config.Image}}", container_id],
+            ["inspect", "-f", "{{.Image}}", container_id],
             "resolve current executor image",
         )
         image = result.stdout.strip()
-        if not image:
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", image):
             raise WorkspaceResolutionError("current executor image could not be resolved")
         return image
 
@@ -141,6 +166,63 @@ class WorkspaceResolver:
         )
         if result.returncode != 0:
             raise WorkspaceResolutionError(f"restore target must be new or empty: {workspace.path}")
+
+    def _validate_encrypted_path(
+        self,
+        *,
+        image: str,
+        pid: int,
+        visible_path: PurePosixPath,
+        requested_path: PurePosixPath,
+        action: StorageAction,
+    ) -> None:
+        if action is StorageAction.BACKUP:
+            check_script = 'test -d "$1"'
+            error = f"backup source is not a directory: {requested_path}"
+        else:
+            check_script = (
+                'target="$1"; '
+                'if [ ! -e "$target" ]; then exit 0; fi; '
+                'if [ ! -d "$target" ]; then exit 20; fi; '
+                'if find "$target" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then exit 21; fi'
+            )
+            error = f"restore target must be new or empty: {requested_path}"
+
+        result = subprocess.run(
+            [
+                self._docker_binary,
+                "run",
+                "--rm",
+                "--log-driver",
+                "none",
+                "--pid",
+                "host",
+                "--privileged",
+                "--security-opt",
+                "label=disable",
+                "--read-only",
+                "--network",
+                "none",
+                "--tmpfs",
+                "/tmp:rw,nosuid,nodev,size=67108864",
+                "--entrypoint",
+                "/usr/bin/nsenter",
+                image,
+                "-t",
+                str(pid),
+                "-U",
+                "--",
+                "/bin/sh",
+                "-c",
+                check_script,
+                "sh",
+                str(visible_path),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise WorkspaceResolutionError(error)
 
     def _inspect_running_container(self, container_name: str) -> tuple[ContainerIdentity, Mapping[str, object]]:
         result = self._run_docker(["inspect", container_name], "inspect rental container")
@@ -232,18 +314,6 @@ def _path_within_volume(requested_path: PurePosixPath, volume_path: PurePosixPat
             f"requested path {requested_path} is outside volume path {volume_path}"
         ) from error
     return requested_path
-
-
-def _require_new_or_empty_directory(visible_path: Path, logical_path: PurePosixPath) -> None:
-    if not visible_path.exists():
-        return
-    if not visible_path.is_dir():
-        raise WorkspaceResolutionError(f"restore target is not a directory: {logical_path}")
-    try:
-        next(visible_path.iterdir())
-    except StopIteration:
-        return
-    raise WorkspaceResolutionError(f"restore target must be new or empty: {logical_path}")
 
 
 def _unescape_mountinfo(value: str) -> str:

--- a/neurons/executor/src/storage/workspace.py
+++ b/neurons/executor/src/storage/workspace.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Mapping, Sequence
+
+from storage.models import StorageAction, StorageOperationSpec, WorkspaceMode
+
+
+class WorkspaceResolutionError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class LocalWorkspace:
+    path: Path
+
+
+@dataclass(frozen=True)
+class DockerVolumeWorkspace:
+    image: str
+    volume_name: str
+    path: PurePosixPath
+    read_only: bool
+
+
+ResolvedWorkspace = LocalWorkspace | DockerVolumeWorkspace
+
+
+@dataclass(frozen=True)
+class ContainerIdentity:
+    container_id: str
+    pid: int
+
+
+class WorkspaceResolver:
+    def __init__(
+        self,
+        docker_binary: str = "/usr/bin/docker",
+        proc_root: Path = Path("/proc"),
+        environ: Mapping[str, str] | None = None,
+    ) -> None:
+        self._docker_binary = docker_binary
+        self._proc_root = proc_root
+        self._environ = dict(os.environ if environ is None else environ)
+
+    def resolve(self, operation: StorageOperationSpec) -> ResolvedWorkspace:
+        if operation.workspace.mode is WorkspaceMode.PLAIN_VOLUME:
+            return self._resolve_plain_volume(operation)
+        return self._resolve_encrypted_running(operation)
+
+    def _resolve_plain_volume(self, operation: StorageOperationSpec) -> DockerVolumeWorkspace:
+        image = self._environ.get("LIUM_STORAGE_HELPER_IMAGE")
+        if not image:
+            image = self._current_executor_image()
+        workspace = DockerVolumeWorkspace(
+            image=image,
+            volume_name=operation.workspace.volume_name,
+            path=_map_requested_path(
+                operation.workspace.requested_path,
+                operation.workspace.volume_path,
+                PurePosixPath("/workspace"),
+            ),
+            read_only=operation.action is StorageAction.BACKUP,
+        )
+        if operation.action is StorageAction.RESTORE:
+            self._require_empty_plain_restore_target(workspace)
+        return workspace
+
+    def _resolve_encrypted_running(self, operation: StorageOperationSpec) -> LocalWorkspace:
+        container_name = operation.workspace.container_name
+        if not container_name:
+            raise WorkspaceResolutionError("encrypted workspace is missing container_name")
+
+        identity, inspection = self._inspect_running_container(container_name)
+        self._verify_cipher_volume_mount(inspection, operation.workspace.volume_name)
+        self._verify_container_cgroup(identity)
+        self._verify_gocryptfs_mount(identity.pid, operation.workspace.volume_path)
+
+        requested_path = _path_within_volume(
+            operation.workspace.requested_path,
+            operation.workspace.volume_path,
+        )
+        visible_path = self._proc_root / str(identity.pid) / "root" / str(requested_path).lstrip("/")
+        if operation.action is StorageAction.BACKUP:
+            if not visible_path.is_dir():
+                raise WorkspaceResolutionError(f"backup source is not a directory: {requested_path}")
+        else:
+            _require_new_or_empty_directory(visible_path, requested_path)
+
+        confirmed_identity, _ = self._inspect_running_container(container_name)
+        if confirmed_identity != identity:
+            raise WorkspaceResolutionError("rental container changed while resolving encrypted workspace")
+        return LocalWorkspace(path=visible_path)
+
+    def _current_executor_image(self) -> str:
+        container_id = self._environ.get("HOSTNAME")
+        if not container_id:
+            raise WorkspaceResolutionError(
+                "plain volume mode requires workspace.helper_image or LIUM_STORAGE_HELPER_IMAGE"
+            )
+        result = self._run_docker(
+            ["inspect", "-f", "{{.Config.Image}}", container_id],
+            "resolve current executor image",
+        )
+        image = result.stdout.strip()
+        if not image:
+            raise WorkspaceResolutionError("current executor image could not be resolved")
+        return image
+
+    def _require_empty_plain_restore_target(self, workspace: DockerVolumeWorkspace) -> None:
+        check_script = (
+            'target="$1"; '
+            'if [ ! -e "$target" ]; then exit 0; fi; '
+            'if [ ! -d "$target" ]; then exit 20; fi; '
+            'if find "$target" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then exit 21; fi'
+        )
+        result = subprocess.run(
+            [
+                self._docker_binary,
+                "run",
+                "--rm",
+                "--log-driver",
+                "none",
+                "-v",
+                f"{workspace.volume_name}:/workspace:rw",
+                "--entrypoint",
+                "sh",
+                workspace.image,
+                "-c",
+                check_script,
+                "sh",
+                str(workspace.path),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise WorkspaceResolutionError(f"restore target must be new or empty: {workspace.path}")
+
+    def _inspect_running_container(self, container_name: str) -> tuple[ContainerIdentity, Mapping[str, object]]:
+        result = self._run_docker(["inspect", container_name], "inspect rental container")
+        try:
+            payload = json.loads(result.stdout)
+            inspection = payload[0]
+            state = inspection["State"]
+            container_id = inspection["Id"]
+            pid = state["Pid"]
+            running = state["Running"]
+        except (json.JSONDecodeError, IndexError, KeyError, TypeError) as error:
+            raise WorkspaceResolutionError("docker inspect returned an invalid rental description") from error
+
+        if running is not True or not isinstance(pid, int) or pid <= 0:
+            raise WorkspaceResolutionError(f"rental container {container_name} is not running")
+        if not isinstance(container_id, str) or not re.fullmatch(r"[0-9a-f]{64}", container_id):
+            raise WorkspaceResolutionError("docker inspect returned an invalid container ID")
+        if not isinstance(inspection, Mapping):
+            raise WorkspaceResolutionError("docker inspect returned an invalid container object")
+        return ContainerIdentity(container_id=container_id, pid=pid), inspection
+
+    def _verify_cipher_volume_mount(self, inspection: Mapping[str, object], volume_name: str) -> None:
+        mounts = inspection.get("Mounts")
+        if not isinstance(mounts, Sequence):
+            raise WorkspaceResolutionError("docker inspect did not include rental mounts")
+        for mount in mounts:
+            if not isinstance(mount, Mapping):
+                continue
+            if mount.get("Name") == volume_name and mount.get("Destination") == "/lium-cipher":
+                return
+        raise WorkspaceResolutionError(
+            f"expected encrypted volume {volume_name} is not mounted at /lium-cipher"
+        )
+
+    def _verify_container_cgroup(self, identity: ContainerIdentity) -> None:
+        cgroup_path = self._proc_root / str(identity.pid) / "cgroup"
+        try:
+            cgroup = cgroup_path.read_text()
+        except OSError as error:
+            raise WorkspaceResolutionError("cannot read rental process cgroup") from error
+        if identity.container_id not in cgroup and identity.container_id[:12] not in cgroup:
+            raise WorkspaceResolutionError("rental PID cgroup does not match the expected container")
+
+    def _verify_gocryptfs_mount(self, pid: int, expected_mount: PurePosixPath) -> None:
+        mountinfo_path = self._proc_root / str(pid) / "mountinfo"
+        try:
+            lines = mountinfo_path.read_text().splitlines()
+        except OSError as error:
+            raise WorkspaceResolutionError("cannot read rental mount information") from error
+
+        expected = str(expected_mount)
+        for line in lines:
+            fields = line.split()
+            if "-" not in fields or len(fields) < 10:
+                continue
+            separator = fields.index("-")
+            mount_point = _unescape_mountinfo(fields[4])
+            filesystem_type = fields[separator + 1]
+            if mount_point == expected and filesystem_type == "fuse.gocryptfs":
+                return
+        raise WorkspaceResolutionError(f"{expected} is not a live fuse.gocryptfs mount")
+
+    def _run_docker(self, arguments: list[str], label: str) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            [self._docker_binary, *arguments],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            message = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+            raise WorkspaceResolutionError(f"{label} failed: {message}")
+        return result
+
+
+def _map_requested_path(
+    requested_path: PurePosixPath,
+    volume_path: PurePosixPath,
+    mounted_root: PurePosixPath,
+) -> PurePosixPath:
+    relative = _path_within_volume(requested_path, volume_path).relative_to(volume_path)
+    return mounted_root / relative
+
+
+def _path_within_volume(requested_path: PurePosixPath, volume_path: PurePosixPath) -> PurePosixPath:
+    try:
+        requested_path.relative_to(volume_path)
+    except ValueError as error:
+        raise WorkspaceResolutionError(
+            f"requested path {requested_path} is outside volume path {volume_path}"
+        ) from error
+    return requested_path
+
+
+def _require_new_or_empty_directory(visible_path: Path, logical_path: PurePosixPath) -> None:
+    if not visible_path.exists():
+        return
+    if not visible_path.is_dir():
+        raise WorkspaceResolutionError(f"restore target is not a directory: {logical_path}")
+    try:
+        next(visible_path.iterdir())
+    except StopIteration:
+        return
+    raise WorkspaceResolutionError(f"restore target must be new or empty: {logical_path}")
+
+
+def _unescape_mountinfo(value: str) -> str:
+    replacements = {"\\040": " ", "\\011": "\t", "\\012": "\n", "\\134": "\\"}
+    for escaped, unescaped in replacements.items():
+        value = value.replace(escaped, unescaped)
+    return value

--- a/neurons/executor/src/storage_runner.py
+++ b/neurons/executor/src/storage_runner.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import argparse
+import json
+import stat
+import sys
+from pathlib import Path
+from typing import Mapping
+
+from storage.models import OperationSpecError, StorageOperationSpec
+from storage.restic import JsonEventWriter, ResticOperationError, ResticResult, ResticStorageRunner
+from storage.workspace import WorkspaceResolutionError, WorkspaceResolver
+
+
+def main() -> int:
+    arguments = _parse_arguments()
+    event_writer: JsonEventWriter | None = None
+    try:
+        payload = _load_operation(arguments.spec)
+        operation = StorageOperationSpec.from_mapping(payload)
+        event_writer = JsonEventWriter(
+            str(operation.operation_id),
+            operation.progress_interval_seconds,
+            operation.heartbeat_interval_seconds,
+        )
+        workspace = WorkspaceResolver().resolve(operation)
+        ResticStorageRunner(operation, workspace, event_writer=event_writer).run()
+        return 0
+    except (OperationSpecError, WorkspaceResolutionError, ResticOperationError, OSError) as error:
+        if event_writer:
+            event_writer.diagnostic(str(error))
+            event_writer.result(ResticResult("FAILED", None, None, 1))
+        else:
+            print(json.dumps({"event": "result", "status": "FAILED", "message": str(error)}))
+        return 1
+
+
+def _parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run one Lium restic backup or restore operation")
+    parser.add_argument(
+        "--spec",
+        default="-",
+        help="operation JSON file with mode 0600, or '-' to read JSON from stdin",
+    )
+    return parser.parse_args()
+
+
+def _load_operation(spec_path: str) -> Mapping[str, object]:
+    if spec_path == "-":
+        return _parse_object(sys.stdin.read())
+
+    path = Path(spec_path)
+    mode = stat.S_IMODE(path.stat().st_mode)
+    if mode & 0o077:
+        raise OperationSpecError(f"operation spec must not be group/world accessible: {oct(mode)}")
+    return _parse_object(path.read_text())
+
+
+def _parse_object(value: str) -> Mapping[str, object]:
+    try:
+        payload = json.loads(value)
+    except json.JSONDecodeError as error:
+        raise OperationSpecError("operation spec is not valid JSON") from error
+    if not isinstance(payload, Mapping):
+        raise OperationSpecError("operation spec must contain a JSON object")
+    return payload
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/neurons/executor/storage-operation.example.json
+++ b/neurons/executor/storage-operation.example.json
@@ -1,0 +1,22 @@
+{
+  "operation_id": "11111111-1111-4111-8111-111111111111",
+  "pod_id": "22222222-2222-4222-8222-222222222222",
+  "action": "backup",
+  "progress_interval_seconds": 10,
+  "heartbeat_interval_seconds": 30,
+  "repository": {
+    "bucket": "example-user-backup-bucket",
+    "access_key_id": "replace-at-runtime",
+    "secret_access_key": "replace-at-runtime",
+    "session_token": "optional-temporary-token",
+    "password": "replace-at-runtime",
+    "region": "us-east-1",
+    "endpoint": "s3.amazonaws.com"
+  },
+  "workspace": {
+    "mode": "plain_volume",
+    "volume_name": "example-customer-volume",
+    "volume_path": "/root",
+    "requested_path": "/root/checkpoints"
+  }
+}

--- a/neurons/executor/storage-operation.example.json
+++ b/neurons/executor/storage-operation.example.json
@@ -11,7 +11,8 @@
     "session_token": "optional-temporary-token",
     "password": "replace-at-runtime",
     "region": "us-east-1",
-    "endpoint": "s3.amazonaws.com"
+    "endpoint": "s3.amazonaws.com",
+    "s3_connections": 64
   },
   "workspace": {
     "mode": "plain_volume",

--- a/neurons/executor/tests/test_storage_runner.py
+++ b/neurons/executor/tests/test_storage_runner.py
@@ -9,8 +9,14 @@ from uuid import UUID
 import pytest
 
 from storage.models import OperationSpecError, OperationResultQuality, StorageOperationSpec
-from storage.restic import JsonEventWriter, ResticStorageRunner
-from storage.workspace import DockerVolumeWorkspace, LocalWorkspace, WorkspaceResolutionError, WorkspaceResolver
+from storage.restic import JsonEventWriter, ResticStorageRunner, RestoreStats
+from storage.workspace import (
+    DockerUserNamespaceWorkspace,
+    DockerVolumeWorkspace,
+    LocalWorkspace,
+    WorkspaceResolutionError,
+    WorkspaceResolver,
+)
 
 
 OPERATION_ID = UUID("11111111-1111-4111-8111-111111111111")
@@ -45,6 +51,7 @@ def _operation_payload(
             "secret_access_key": "secret-key",
             "session_token": "session-token",
             "password": "repository-password",
+            "s3_connections": 64,
         },
         "workspace": workspace,
     }
@@ -63,6 +70,17 @@ def test_restore_requires_snapshot_id() -> None:
     payload["snapshot_id"] = None
 
     with pytest.raises(OperationSpecError, match="snapshot_id is required"):
+        StorageOperationSpec.from_mapping(payload)
+
+
+@pytest.mark.parametrize("value", [0, 129, 1.5, True])
+def test_s3_connections_must_be_a_bounded_integer(value: object) -> None:
+    payload = _operation_payload()
+    repository = payload["repository"]
+    assert isinstance(repository, dict)
+    repository["s3_connections"] = value
+
+    with pytest.raises(OperationSpecError, match="s3_connections"):
         StorageOperationSpec.from_mapping(payload)
 
 
@@ -127,14 +145,35 @@ def test_encrypted_workspace_resolves_verified_plaintext_view(
         ]
     )
 
-    monkeypatch.setattr(
-        "storage.workspace.subprocess.run",
-        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=inspection, stderr=""),
+    commands: list[list[str]] = []
+
+    def run_docker(command: list[str], **kwargs: object) -> SimpleNamespace:
+        commands.append(command)
+        stdout = inspection if command[1] == "inspect" else ""
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr("storage.workspace.subprocess.run", run_docker)
+
+    workspace = WorkspaceResolver(
+        docker_binary="docker",
+        proc_root=tmp_path,
+        environ={"LIUM_STORAGE_HELPER_IMAGE": "executor:test"},
+    ).resolve(operation)
+
+    assert workspace == DockerUserNamespaceWorkspace(
+        image="executor:test",
+        container_name="rental-pod",
+        container_id=CONTAINER_ID,
+        pid=4321,
+        path=PurePosixPath(str(plaintext)),
+        read_only=True,
     )
-
-    workspace = WorkspaceResolver(docker_binary="docker", proc_root=tmp_path, environ={}).resolve(operation)
-
-    assert workspace == LocalWorkspace(plaintext)
+    preflight = next(command for command in commands if command[1] == "run")
+    assert preflight[preflight.index("--pid") + 1] == "host"
+    assert "--privileged" in preflight
+    assert preflight[preflight.index("--entrypoint") + 1] == "/usr/bin/nsenter"
+    assert "-U" in preflight
+    assert "-m" not in preflight
 
 
 def test_encrypted_workspace_fails_closed_without_gocryptfs_mount(
@@ -162,7 +201,11 @@ def test_encrypted_workspace_fails_closed_without_gocryptfs_mount(
     )
 
     with pytest.raises(WorkspaceResolutionError, match="not a live fuse.gocryptfs mount"):
-        WorkspaceResolver(docker_binary="docker", proc_root=tmp_path, environ={}).resolve(operation)
+        WorkspaceResolver(
+            docker_binary="docker",
+            proc_root=tmp_path,
+            environ={"LIUM_STORAGE_HELPER_IMAGE": "executor:test"},
+        ).resolve(operation)
 
 
 def test_encrypted_workspace_fails_closed_when_pid_cgroup_does_not_match(
@@ -191,7 +234,11 @@ def test_encrypted_workspace_fails_closed_when_pid_cgroup_does_not_match(
     )
 
     with pytest.raises(WorkspaceResolutionError, match="PID cgroup does not match"):
-        WorkspaceResolver(docker_binary="docker", proc_root=tmp_path, environ={}).resolve(operation)
+        WorkspaceResolver(
+            docker_binary="docker",
+            proc_root=tmp_path,
+            environ={"LIUM_STORAGE_HELPER_IMAGE": "executor:test"},
+        ).resolve(operation)
 
 
 def test_encrypted_workspace_fails_closed_when_container_restarts_during_resolution(
@@ -228,13 +275,20 @@ def test_encrypted_workspace_fails_closed_when_container_restarts_during_resolut
             ),
         ]
     )
-    monkeypatch.setattr(
-        "storage.workspace.subprocess.run",
-        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=next(inspections), stderr=""),
-    )
+
+    def run_docker(command: list[str], **kwargs: object) -> SimpleNamespace:
+        if command[1] == "inspect":
+            return SimpleNamespace(returncode=0, stdout=next(inspections), stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("storage.workspace.subprocess.run", run_docker)
 
     with pytest.raises(WorkspaceResolutionError, match="container changed"):
-        WorkspaceResolver(docker_binary="docker", proc_root=tmp_path, environ={}).resolve(operation)
+        WorkspaceResolver(
+            docker_binary="docker",
+            proc_root=tmp_path,
+            environ={"LIUM_STORAGE_HELPER_IMAGE": "executor:test"},
+        ).resolve(operation)
 
 
 class _FakePopen:
@@ -279,7 +333,7 @@ def test_exit_code_three_with_snapshot_is_completed_partial(
     assert '"result_quality":"PARTIAL"' in output.getvalue()
 
 
-def test_docker_restore_writes_to_requested_directory() -> None:
+def test_docker_restore_streams_directly_to_requested_directory() -> None:
     operation = StorageOperationSpec.from_mapping(_operation_payload(action="restore"))
     workspace = DockerVolumeWorkspace(
         image="executor:test",
@@ -289,11 +343,96 @@ def test_docker_restore_writes_to_requested_directory() -> None:
     )
     runner = ResticStorageRunner(operation, workspace)
 
-    command, _ = runner._execution_command(
-        ["restore", "--json", f"{SNAPSHOT_ID}:/", "--target", "/workspace/restored"],
-        working_directory=False,
-    )
+    command, _ = runner._restore_execution_command(SNAPSHOT_ID)
 
     assert "customer-volume:/workspace:rw" in command
     assert "--workdir" not in command
-    assert f"{SNAPSHOT_ID}:/" in command
+    assert SNAPSHOT_ID in command
+    assert "/workspace/restored" in command
+    assert "pipefail" in command
+    pipeline = command[command.index("-c") + 1]
+    assert "dump --archive tar" in pipeline
+    assert "LIUM_RESTORE_CHECKPOINT_%u" in pipeline
+    assert "--acls --xattrs" in pipeline
+
+
+def test_encrypted_backup_enters_only_the_rental_user_namespace() -> None:
+    operation = StorageOperationSpec.from_mapping(_operation_payload(mode="encrypted_running"))
+    workspace = DockerUserNamespaceWorkspace(
+        image="executor:test",
+        container_name="rental-pod",
+        container_id=CONTAINER_ID,
+        pid=4321,
+        path=PurePosixPath("/proc/4321/root/root/checkpoints"),
+        read_only=True,
+    )
+    runner = ResticStorageRunner(operation, workspace)
+
+    command, cwd = runner._execution_command(["backup", "--json", "."], working_directory=True)
+
+    assert cwd is None
+    assert command[command.index("--pid") + 1] == "host"
+    assert "--privileged" in command
+    assert command[command.index("--security-opt") + 1] == "label=disable"
+    assert command[command.index("--entrypoint") + 1] == "/usr/bin/nsenter"
+    assert command[command.index("-t") + 1] == "4321"
+    assert "-U" in command
+    assert "-m" not in command
+    assert "/proc/4321/root/root/checkpoints" in command
+    assert "s3.connections=64" in command
+
+
+def test_encrypted_restore_uses_namespace_path_without_unsupported_acl_flags() -> None:
+    operation = StorageOperationSpec.from_mapping(
+        _operation_payload(action="restore", mode="encrypted_running")
+    )
+    workspace = DockerUserNamespaceWorkspace(
+        image="executor:test",
+        container_name="rental-pod",
+        container_id=CONTAINER_ID,
+        pid=4321,
+        path=PurePosixPath("/proc/4321/root/root/restored"),
+        read_only=False,
+    )
+    runner = ResticStorageRunner(operation, workspace)
+
+    command, cwd = runner._restore_execution_command(SNAPSHOT_ID)
+
+    assert cwd is None
+    assert command[command.index("--entrypoint") + 1] == "/usr/bin/nsenter"
+    assert command[command.index("-t") + 1] == "4321"
+    assert "/proc/4321/root/root/restored" in command
+    pipeline = command[command.index("-c") + 1]
+    assert "dump --archive tar" in pipeline
+    assert "--acls" not in pipeline
+    assert "--xattrs" not in pipeline
+
+
+class _FakeRestorePopen:
+    def __init__(self, command: list[str], *args: object, **kwargs: object) -> None:
+        self.stdout = iter(["tar: LIUM_RESTORE_CHECKPOINT_1024\n"])
+
+    def wait(self) -> int:
+        return 0
+
+    def kill(self) -> None:
+        return None
+
+
+def test_restore_checkpoint_emits_bounded_progress(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    operation = StorageOperationSpec.from_mapping(_operation_payload(action="restore"))
+    output = io.StringIO()
+    events = JsonEventWriter(str(OPERATION_ID), 0, output=output)
+    runner = ResticStorageRunner(operation, LocalWorkspace(tmp_path), event_writer=events)
+    monkeypatch.setattr("storage.restic.subprocess.Popen", _FakeRestorePopen)
+
+    exit_code, _ = runner._stream_command(
+        ["restore-test"],
+        None,
+        restore_stats=RestoreStats(total_size=20 * 1024 * 1024, total_file_count=3),
+    )
+
+    assert exit_code == 0
+    event = json.loads(output.getvalue())
+    assert event["payload"]["percent_done"] == 0.5
+    assert event["payload"]["bytes_restored"] == 10 * 1024 * 1024

--- a/neurons/executor/tests/test_storage_runner.py
+++ b/neurons/executor/tests/test_storage_runner.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path, PurePosixPath
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+
+from storage.models import OperationSpecError, OperationResultQuality, StorageOperationSpec
+from storage.restic import JsonEventWriter, ResticStorageRunner
+from storage.workspace import DockerVolumeWorkspace, LocalWorkspace, WorkspaceResolutionError, WorkspaceResolver
+
+
+OPERATION_ID = UUID("11111111-1111-4111-8111-111111111111")
+POD_ID = UUID("22222222-2222-4222-8222-222222222222")
+SNAPSHOT_ID = "a" * 64
+CONTAINER_ID = "b" * 64
+
+
+def _operation_payload(
+    *,
+    action: str = "backup",
+    mode: str = "plain_volume",
+    requested_path: str = "/root/checkpoints",
+) -> dict[str, object]:
+    workspace: dict[str, object] = {
+        "mode": mode,
+        "volume_name": "customer-volume",
+        "volume_path": "/root",
+        "requested_path": requested_path,
+    }
+    if mode == "encrypted_running":
+        workspace["container_name"] = "rental-pod"
+    return {
+        "operation_id": str(OPERATION_ID),
+        "pod_id": str(POD_ID),
+        "action": action,
+        "snapshot_id": SNAPSHOT_ID if action == "restore" else None,
+        "progress_interval_seconds": 0,
+        "repository": {
+            "bucket": "backup-bucket",
+            "access_key_id": "access-key",
+            "secret_access_key": "secret-key",
+            "session_token": "session-token",
+            "password": "repository-password",
+        },
+        "workspace": workspace,
+    }
+
+
+def test_operation_derives_repository_from_pod() -> None:
+    operation = StorageOperationSpec.from_mapping(_operation_payload())
+
+    assert operation.repository.url_for_pod(operation.pod_id) == (
+        f"s3:s3.amazonaws.com/backup-bucket/restic/v1/pods/{POD_ID}"
+    )
+
+
+def test_restore_requires_snapshot_id() -> None:
+    payload = _operation_payload(action="restore")
+    payload["snapshot_id"] = None
+
+    with pytest.raises(OperationSpecError, match="snapshot_id is required"):
+        StorageOperationSpec.from_mapping(payload)
+
+
+def test_requested_path_must_stay_inside_volume() -> None:
+    operation = StorageOperationSpec.from_mapping(_operation_payload(requested_path="/etc"))
+
+    with pytest.raises(WorkspaceResolutionError, match="outside volume path"):
+        WorkspaceResolver(environ={"LIUM_STORAGE_HELPER_IMAGE": "executor:test"}).resolve(operation)
+
+
+def test_plain_backup_uses_read_only_volume_and_keeps_secrets_out_of_arguments() -> None:
+    operation = StorageOperationSpec.from_mapping(_operation_payload())
+    workspace = WorkspaceResolver(environ={"LIUM_STORAGE_HELPER_IMAGE": "executor:test"}).resolve(operation)
+    runner = ResticStorageRunner(operation, workspace)
+
+    command, cwd = runner._execution_command(["backup", "--json", "."], working_directory=True)
+
+    assert cwd is None
+    assert "customer-volume:/workspace:ro" in command
+    assert command[command.index("--workdir") + 1] == "/workspace/checkpoints"
+    assert command[command.index("--log-driver") + 1] == "none"
+    assert "AWS_ACCESS_KEY_ID" in command
+    assert "AWS_SESSION_TOKEN" in command
+    assert "access-key" not in command
+    assert "secret-key" not in command
+    assert "repository-password" not in command
+    assert "session-token" not in command
+    assert runner._environment["AWS_SESSION_TOKEN"] == "session-token"
+
+
+def test_plain_restore_rejects_nonempty_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    operation = StorageOperationSpec.from_mapping(_operation_payload(action="restore"))
+
+    monkeypatch.setattr(
+        "storage.workspace.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=21, stdout="", stderr=""),
+    )
+
+    with pytest.raises(WorkspaceResolutionError, match="new or empty"):
+        WorkspaceResolver(environ={"LIUM_STORAGE_HELPER_IMAGE": "executor:test"}).resolve(operation)
+
+
+def test_encrypted_workspace_resolves_verified_plaintext_view(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    operation = StorageOperationSpec.from_mapping(_operation_payload(mode="encrypted_running"))
+    process_root = tmp_path / "4321"
+    plaintext = process_root / "root" / "root" / "checkpoints"
+    plaintext.mkdir(parents=True)
+    (process_root / "cgroup").write_text(f"0::/docker/{CONTAINER_ID}\n")
+    (process_root / "mountinfo").write_text(
+        "36 25 0:32 / /root rw,nosuid,nodev - fuse.gocryptfs gocryptfs rw,user_id=0\n"
+    )
+    inspection = json.dumps(
+        [
+            {
+                "Id": CONTAINER_ID,
+                "State": {"Running": True, "Pid": 4321},
+                "Mounts": [{"Name": "customer-volume", "Destination": "/lium-cipher"}],
+            }
+        ]
+    )
+
+    monkeypatch.setattr(
+        "storage.workspace.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=inspection, stderr=""),
+    )
+
+    workspace = WorkspaceResolver(docker_binary="docker", proc_root=tmp_path, environ={}).resolve(operation)
+
+    assert workspace == LocalWorkspace(plaintext)
+
+
+def test_encrypted_workspace_fails_closed_without_gocryptfs_mount(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    operation = StorageOperationSpec.from_mapping(_operation_payload(mode="encrypted_running"))
+    process_root = tmp_path / "4321"
+    (process_root / "root" / "root" / "checkpoints").mkdir(parents=True)
+    (process_root / "cgroup").write_text(f"0::/docker/{CONTAINER_ID}\n")
+    (process_root / "mountinfo").write_text("36 25 0:32 / /root rw - ext4 /dev/sda rw\n")
+    inspection = json.dumps(
+        [
+            {
+                "Id": CONTAINER_ID,
+                "State": {"Running": True, "Pid": 4321},
+                "Mounts": [{"Name": "customer-volume", "Destination": "/lium-cipher"}],
+            }
+        ]
+    )
+
+    monkeypatch.setattr(
+        "storage.workspace.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=inspection, stderr=""),
+    )
+
+    with pytest.raises(WorkspaceResolutionError, match="not a live fuse.gocryptfs mount"):
+        WorkspaceResolver(docker_binary="docker", proc_root=tmp_path, environ={}).resolve(operation)
+
+
+def test_encrypted_workspace_fails_closed_when_pid_cgroup_does_not_match(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    operation = StorageOperationSpec.from_mapping(_operation_payload(mode="encrypted_running"))
+    process_root = tmp_path / "4321"
+    (process_root / "root" / "root" / "checkpoints").mkdir(parents=True)
+    (process_root / "cgroup").write_text("0::/docker/not-the-rental\n")
+    (process_root / "mountinfo").write_text(
+        "36 25 0:32 / /root rw,nosuid,nodev - fuse.gocryptfs gocryptfs rw,user_id=0\n"
+    )
+    inspection = json.dumps(
+        [
+            {
+                "Id": CONTAINER_ID,
+                "State": {"Running": True, "Pid": 4321},
+                "Mounts": [{"Name": "customer-volume", "Destination": "/lium-cipher"}],
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        "storage.workspace.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=inspection, stderr=""),
+    )
+
+    with pytest.raises(WorkspaceResolutionError, match="PID cgroup does not match"):
+        WorkspaceResolver(docker_binary="docker", proc_root=tmp_path, environ={}).resolve(operation)
+
+
+def test_encrypted_workspace_fails_closed_when_container_restarts_during_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    operation = StorageOperationSpec.from_mapping(_operation_payload(mode="encrypted_running"))
+    process_root = tmp_path / "4321"
+    plaintext = process_root / "root" / "root" / "checkpoints"
+    plaintext.mkdir(parents=True)
+    (process_root / "cgroup").write_text(f"0::/docker/{CONTAINER_ID}\n")
+    (process_root / "mountinfo").write_text(
+        "36 25 0:32 / /root rw,nosuid,nodev - fuse.gocryptfs gocryptfs rw,user_id=0\n"
+    )
+    inspections = iter(
+        [
+            json.dumps(
+                [
+                    {
+                        "Id": CONTAINER_ID,
+                        "State": {"Running": True, "Pid": 4321},
+                        "Mounts": [{"Name": "customer-volume", "Destination": "/lium-cipher"}],
+                    }
+                ]
+            ),
+            json.dumps(
+                [
+                    {
+                        "Id": CONTAINER_ID,
+                        "State": {"Running": True, "Pid": 9999},
+                        "Mounts": [{"Name": "customer-volume", "Destination": "/lium-cipher"}],
+                    }
+                ]
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        "storage.workspace.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=next(inspections), stderr=""),
+    )
+
+    with pytest.raises(WorkspaceResolutionError, match="container changed"):
+        WorkspaceResolver(docker_binary="docker", proc_root=tmp_path, environ={}).resolve(operation)
+
+
+class _FakePopen:
+    def __init__(self, command: list[str], *args: object, **kwargs: object) -> None:
+        self.command = command
+        self.cwd = kwargs.get("cwd")
+        self.stdout = iter(
+            [
+                '{"message_type":"status","percent_done":0.5}\n',
+                f'{{"message_type":"summary","snapshot_id":"{SNAPSHOT_ID}"}}\n',
+            ]
+        )
+
+    def wait(self) -> int:
+        return 3
+
+    def kill(self) -> None:
+        return None
+
+
+def test_exit_code_three_with_snapshot_is_completed_partial(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    operation = StorageOperationSpec.from_mapping(_operation_payload())
+    output = io.StringIO()
+    events = JsonEventWriter(str(OPERATION_ID), 0, output=output)
+    workspace = LocalWorkspace(tmp_path)
+    runner = ResticStorageRunner(operation, workspace, event_writer=events)
+
+    monkeypatch.setattr(
+        "storage.restic.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="[]", stderr=""),
+    )
+    monkeypatch.setattr("storage.restic.subprocess.Popen", _FakePopen)
+
+    result = runner.run()
+
+    assert result.status == "COMPLETED"
+    assert result.result_quality is OperationResultQuality.PARTIAL
+    assert result.snapshot_id == SNAPSHOT_ID
+    assert '"result_quality":"PARTIAL"' in output.getvalue()
+
+
+def test_docker_restore_writes_to_requested_directory() -> None:
+    operation = StorageOperationSpec.from_mapping(_operation_payload(action="restore"))
+    workspace = DockerVolumeWorkspace(
+        image="executor:test",
+        volume_name="customer-volume",
+        path=PurePosixPath("/workspace/restored"),
+        read_only=False,
+    )
+    runner = ResticStorageRunner(operation, workspace)
+
+    command, _ = runner._execution_command(
+        ["restore", "--json", f"{SNAPSHOT_ID}:/", "--target", "/workspace/restored"],
+        working_directory=False,
+    )
+
+    assert "customer-volume:/workspace:rw" in command
+    assert "--workdir" not in command
+    assert f"{SNAPSHOT_ID}:/" in command


### PR DESCRIPTION
## Background

The current backup path streams a live tar archive through Docker and the AWS CLI. For large or actively changing directories, that can produce misleading progress, excessive local disk/log growth, long-running operations, and failures that leave no independently restorable snapshot.

This PR introduces a production-shaped executor proof of concept for an incremental backup and exact-snapshot restore path. It intentionally leaves the current backup engine available while the new path is rolled out and monitored.

## What changed

- Install a checksum-verified, pinned backup binary plus explicit tar and namespace tooling in the executor image.
- Add a typed, operation-scoped runner for backup and exact-snapshot restore.
- Store each pod under an isolated repository prefix in the supplied per-user S3 bucket.
- Support configurable S3 concurrency, defaulting to the staging-tested value of 64 and bounded from 1 through 128.
- Stream normalized byte/file progress, restore byte checkpoints, heartbeats, bounded diagnostics, and terminal results.
- Treat a completed partial snapshot separately from a full success.
- Support long-lived and temporary AWS credentials without placing secret values in Docker arguments or copying them into the rental.
- Back up plain named volumes through a read-only sibling helper with Docker logging disabled, no local repository cache, and bounded temporary storage.
- Restore directly from the selected snapshot into a new or empty destination without writing a temporary archive to customer disk.
- Add a fail-closed encrypted-volume adapter that verifies the rental identity, PID/cgroup, ciphertext volume, and live gocryptfs mount, then enters only the rental user namespace from an operation-scoped helper.
- Add operation examples, executor documentation, and focused tests.

## User and developer impact

The new path avoids local archive staging and Docker-stdout data transfer, provides continuous liveness and useful progress, supports exact backup selection during restore, and allows later backups to upload only changed data. Existing backups and the legacy path are not migrated or removed by this PR.

## Validation

- Focused storage-runner tests: 18 passed.
- Complete executor suite with the updated runner: 105 passed.
- Python compilation and git diff checks pass.
- Real encrypted Sysbox/gocryptfs staging rental:
  - Backup completed successfully through the user-namespace helper.
  - Exact restore completed in 16.3 seconds for a 64 MiB incompressible model and emitted heartbeat/progress events.
  - Restored checksum, snapshot version, exclusion behavior, and symlink all matched.
  - A populated restore target was rejected before transfer.
- Isolated plain named-volume staging round trip:
  - Backup and exact restore completed successfully.
  - Source and restored 8 MiB model checksums matched; marker and symlink were preserved.
- Performance comparison on the same encrypted snapshot:
  - Native restore with 64 S3 connections: 118.7 seconds.
  - Streaming dump/extract restore with 64 S3 connections: 16–20 seconds.

The corrected runner has been exercised from a temporary path inside the existing staging executor. A new executor image still needs to be built and published from this commit before deployment.
