### PR TITLE
DAH-2182, scrape RmProfilingAdminOnly + boot_id as the ncu profiling observation

### DIFF
--- a/neurons/validators/src/miner_jobs/machine_scrape.py
+++ b/neurons/validators/src/miner_jobs/machine_scrape.py
@@ -1041,24 +1041,38 @@ NVIDIA_PARAMS_PATH = "/proc/driver/nvidia/params"
 BOOT_ID_PATH = "/proc/sys/kernel/random/boot_id"
 
 
-def check_ncu_profiling_access() -> tuple[str, str]:
-    # Host driver flag RmProfilingAdminOnly (DAH-2182): 0 -> GPU performance counters open to every
-    # workload on the host ("unrestricted"), 1 -> admin-only ("restricted"). Anything unreadable is
-    # "unknown" and MUST stay so - the backend fails closed on it; never guess a value.
+class NcuProfilingObservation:
+    # Plain class rather than a dataclass/NamedTuple: obfuscator.py only carries the imports on its
+    # allowlist into the packaged scrape, so this file must not grow new ones.
+    def __init__(self, access: str, scrape_error: str) -> None:
+        self.access = access
+        self.scrape_error = scrape_error
+
+
+def check_ncu_profiling_access() -> NcuProfilingObservation:
+    # Host driver flag RmProfilingAdminOnly: 0 -> GPU performance counters open to every workload
+    # on the host ("unrestricted"), 1 -> admin-only ("restricted"). Anything unreadable stays
+    # "unknown" - the backend fails closed on it; never guess a value.
     try:
         with open(NVIDIA_PARAMS_PATH) as params_file:
             params_content = params_file.read()
     except Exception as e:
-        return "unknown", f"Cannot read {NVIDIA_PARAMS_PATH}: {e}"
+        return NcuProfilingObservation("unknown", f"Cannot read {NVIDIA_PARAMS_PATH}: {e}")
 
     match = re.search(r"^RmProfilingAdminOnly:\s*(\d+)\s*$", params_content, re.M)
     if match is None:
-        return "unknown", "RmProfilingAdminOnly not present in nvidia driver params"
-    if match.group(1) == "0":
-        return "unrestricted", ""
-    if match.group(1) == "1":
-        return "restricted", ""
-    return "unknown", f"Unexpected RmProfilingAdminOnly value: {match.group(1)}"
+        return NcuProfilingObservation(
+            "unknown", "RmProfilingAdminOnly not present in nvidia driver params"
+        )
+
+    flag_value = match.group(1)
+    if flag_value == "0":
+        return NcuProfilingObservation("unrestricted", "")
+    if flag_value == "1":
+        return NcuProfilingObservation("restricted", "")
+    return NcuProfilingObservation(
+        "unknown", f"Unexpected RmProfilingAdminOnly value: {flag_value}"
+    )
 
 
 def get_host_boot_id() -> str:
@@ -1186,10 +1200,10 @@ def get_machine_specs():
     if not is_supported:
         data["data_storage_limit_scrape_error"] = log_text
 
-    profiling_access, log_text = check_ncu_profiling_access()
-    data["data_ncu_profiling_access"] = profiling_access
-    if log_text:
-        data["data_ncu_profiling_scrape_error"] = log_text
+    ncu_profiling = check_ncu_profiling_access()
+    data["data_ncu_profiling_access"] = ncu_profiling.access
+    if ncu_profiling.scrape_error:
+        data["data_ncu_profiling_scrape_error"] = ncu_profiling.scrape_error
     data["data_boot_id"] = get_host_boot_id()
 
     try:

--- a/neurons/validators/src/miner_jobs/machine_scrape.py
+++ b/neurons/validators/src/miner_jobs/machine_scrape.py
@@ -1037,6 +1037,40 @@ def check_storage_limit_ability() -> tuple[bool, str]:
         return False, f"An unexpected error occurred: {e}"
 
 
+NVIDIA_PARAMS_PATH = "/proc/driver/nvidia/params"
+BOOT_ID_PATH = "/proc/sys/kernel/random/boot_id"
+
+
+def check_ncu_profiling_access() -> tuple[str, str]:
+    # Host driver flag RmProfilingAdminOnly (DAH-2182): 0 -> GPU performance counters open to every
+    # workload on the host ("unrestricted"), 1 -> admin-only ("restricted"). Anything unreadable is
+    # "unknown" and MUST stay so - the backend fails closed on it; never guess a value.
+    try:
+        with open(NVIDIA_PARAMS_PATH) as params_file:
+            params_content = params_file.read()
+    except Exception as e:
+        return "unknown", f"Cannot read {NVIDIA_PARAMS_PATH}: {e}"
+
+    match = re.search(r"^RmProfilingAdminOnly:\s*(\d+)\s*$", params_content, re.M)
+    if match is None:
+        return "unknown", "RmProfilingAdminOnly not present in nvidia driver params"
+    if match.group(1) == "0":
+        return "unrestricted", ""
+    if match.group(1) == "1":
+        return "restricted", ""
+    return "unknown", f"Unexpected RmProfilingAdminOnly value: {match.group(1)}"
+
+
+def get_host_boot_id() -> str:
+    # Reboot marker: the profiling flag only changes on a driver reload/reboot, so a changed
+    # boot_id tells the backend a stale observation may have flipped (DAH-2182).
+    try:
+        with open(BOOT_ID_PATH) as boot_id_file:
+            return boot_id_file.read().strip()
+    except Exception:
+        return ""
+
+
 def get_machine_specs():
     """Get Specs of miner machine."""
     data = {}
@@ -1151,6 +1185,12 @@ def get_machine_specs():
     data["data_storage_limit_supported"] = is_supported
     if not is_supported:
         data["data_storage_limit_scrape_error"] = log_text
+
+    profiling_access, log_text = check_ncu_profiling_access()
+    data["data_ncu_profiling_access"] = profiling_access
+    if log_text:
+        data["data_ncu_profiling_scrape_error"] = log_text
+    data["data_boot_id"] = get_host_boot_id()
 
     try:
         lscpu_output = run_cmd("lscpu")

--- a/neurons/validators/src/services/file_encrypt_service.py
+++ b/neurons/validators/src/services/file_encrypt_service.py
@@ -123,6 +123,9 @@ ORIGINAL_KEYS = {
     'data_sysbox_runtime_scrape_error': "sysbox_runtime_scrape_error",
     'data_storage_limit_supported': "storage_limit_supported",
     'data_storage_limit_scrape_error': "storage_limit_scrape_error",
+    'data_ncu_profiling_access': "ncu_profiling_access",
+    'data_ncu_profiling_scrape_error': "ncu_profiling_scrape_error",
+    'data_boot_id': "boot_id",
 }
 
 
@@ -275,6 +278,11 @@ class FileEncryptService:
             'data_sysbox_runtime': "",
             'data_storage_limit_scrape_error': "",
             'data_storage_limit_supported': "",
+            # DAH-2182: keep any longer key BEFORE its prefix — the replacement sweep is a naive
+            # sequential str.replace in dict order (none of these three prefix each other).
+            'data_ncu_profiling_scrape_error': "",
+            'data_ncu_profiling_access': "",
+            'data_boot_id': "",
         }
 
         # Generate dictionary key mapping on validator side

--- a/neurons/validators/src/services/file_encrypt_service.py
+++ b/neurons/validators/src/services/file_encrypt_service.py
@@ -187,6 +187,8 @@ class FileEncryptService:
         return "_" + "".join(random.choices(string.ascii_letters, k=length))
 
     def generate_key_mappings(self):
+        # Order is load-bearing: ecrypt_miner_job_files() substitutes these keys with a sequential
+        # str.replace in dict order, so no key may be a strict prefix of a LATER one.
         all_keys = {
             "gpu.name": "",
             "gpu.uuid": "",
@@ -278,8 +280,6 @@ class FileEncryptService:
             'data_sysbox_runtime': "",
             'data_storage_limit_scrape_error': "",
             'data_storage_limit_supported': "",
-            # DAH-2182: keep any longer key BEFORE its prefix — the replacement sweep is a naive
-            # sequential str.replace in dict order (none of these three prefix each other).
             'data_ncu_profiling_scrape_error': "",
             'data_ncu_profiling_access': "",
             'data_boot_id': "",

--- a/neurons/validators/tests/helpers.py
+++ b/neurons/validators/tests/helpers.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import ast
+from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock
 
 from datura.requests.miner_requests import ExecutorSSHInfo
-
 from neurons.validators.src.services.task.pipeline import (
     Context,
     ContextConfig,
@@ -12,6 +14,28 @@ from neurons.validators.src.services.task.pipeline import (
 )
 
 
+def _definition_name(node: ast.stmt) -> str:
+    if isinstance(node, ast.FunctionDef | ast.ClassDef):
+        return node.name
+    if isinstance(node, ast.Assign) and isinstance(node.targets[0], ast.Name):
+        return node.targets[0].id
+    return ""
+
+
+def build_scrape_namespace(
+    source_path: Path, helper_names: set[str], seed_namespace: dict[str, Any]
+) -> dict[str, Any]:
+    # the named top-level definitions of a standalone script, executed in a namespace of their own
+    tree = ast.parse(source_path.read_text())
+    kept_definitions = [node for node in tree.body if _definition_name(node) in helper_names]
+    assert {_definition_name(node) for node in kept_definitions} == helper_names, (
+        f"{source_path.name} no longer defines all of {sorted(helper_names)} at module level"
+    )
+
+    namespace = dict(seed_namespace)
+    kept_module = ast.Module(body=kept_definitions, type_ignores=[])
+    exec(compile(kept_module, source_path.stem, "exec"), namespace)
+    return namespace
 
 
 class DummyScoreCalc:

--- a/neurons/validators/tests/test_scrape_disk_breakdown.py
+++ b/neurons/validators/tests/test_scrape_disk_breakdown.py
@@ -17,6 +17,7 @@ import socket
 from pathlib import Path
 
 import pytest
+from neurons.validators.tests.helpers import build_scrape_namespace
 
 SRC = Path(__file__).resolve().parents[1] / "src"
 
@@ -31,26 +32,14 @@ DISK_HELPERS = {
 }
 
 
-def _definition_name(node: ast.stmt) -> str:
-    if isinstance(node, ast.FunctionDef | ast.ClassDef):
-        return node.name
-    if isinstance(node, ast.Assign) and isinstance(node.targets[0], ast.Name):
-        return node.targets[0].id
-    return ""
-
-
 @pytest.fixture
 def scrape() -> dict:
     """The disk helpers, executed in a namespace of their own."""
-    tree = ast.parse((SRC / "miner_jobs" / "machine_scrape.py").read_text())
-    kept = [node for node in tree.body if _definition_name(node) in DISK_HELPERS]
-    assert {_definition_name(node) for node in kept} == DISK_HELPERS, (
-        f"machine_scrape.py no longer defines all of {sorted(DISK_HELPERS)} at module level"
+    return build_scrape_namespace(
+        SRC / "miner_jobs" / "machine_scrape.py",
+        DISK_HELPERS,
+        {"glob": glob, "http": http, "json": json, "os": os, "socket": socket},
     )
-
-    namespace = {"glob": glob, "http": http, "json": json, "os": os, "socket": socket}
-    exec(compile(ast.Module(body=kept, type_ignores=[]), "machine_scrape_disk", "exec"), namespace)
-    return namespace
 
 
 def _stub_docker_api(scrape: dict, responses: dict) -> None:

--- a/neurons/validators/tests/test_scrape_ncu_profiling.py
+++ b/neurons/validators/tests/test_scrape_ncu_profiling.py
@@ -1,7 +1,5 @@
-"""DAH-2182: the scrape reports the host NVIDIA profiling-counter flag as a fail-closed
-observation. `RmProfilingAdminOnly: 0` in /proc/driver/nvidia/params means the counters are open
-to EVERY workload on the host — the backend then treats the node as whole-host-only. Anything
-unreadable must surface as "unknown", never as a guessed value.
+"""DAH-2182 — see check_ncu_profiling_access() in machine_scrape.py for the RmProfilingAdminOnly
+semantics these tests pin down.
 
 machine_scrape.py is a script, not a module — importing it runs the whole scrape — so the helpers
 are extracted by ast and executed in their own namespace (same pattern as
@@ -12,39 +10,26 @@ test_scrape_encryption_key_order.py does.
 import ast
 import re
 from pathlib import Path
+from typing import Any
 
 import pytest
+from neurons.validators.tests.helpers import build_scrape_namespace
 
 SRC = Path(__file__).resolve().parents[1] / "src"
 
 NCU_HELPERS = {
     "NVIDIA_PARAMS_PATH",
     "BOOT_ID_PATH",
+    "NcuProfilingObservation",
     "check_ncu_profiling_access",
     "get_host_boot_id",
 }
 
 
-def _definition_name(node: ast.stmt) -> str:
-    if isinstance(node, ast.FunctionDef | ast.ClassDef):
-        return node.name
-    if isinstance(node, ast.Assign) and isinstance(node.targets[0], ast.Name):
-        return node.targets[0].id
-    return ""
-
-
 @pytest.fixture
-def scrape() -> dict:
+def scrape() -> dict[str, Any]:
     """The ncu helpers, executed in a namespace of their own."""
-    tree = ast.parse((SRC / "miner_jobs" / "machine_scrape.py").read_text())
-    kept = [node for node in tree.body if _definition_name(node) in NCU_HELPERS]
-    assert {_definition_name(node) for node in kept} == NCU_HELPERS, (
-        f"machine_scrape.py no longer defines all of {sorted(NCU_HELPERS)} at module level"
-    )
-
-    namespace = {"re": re}
-    exec(compile(ast.Module(body=kept, type_ignores=[]), "machine_scrape_ncu", "exec"), namespace)
-    return namespace
+    return build_scrape_namespace(SRC / "miner_jobs" / "machine_scrape.py", NCU_HELPERS, {"re": re})
 
 
 @pytest.mark.parametrize(
@@ -56,34 +41,40 @@ def scrape() -> dict:
         ("NotRmProfilingAdminOnly: 0", "unknown"),  # exact-key parse, no substring match
     ],
 )
-def test_profiling_access_parses_the_exact_flag(scrape: dict, tmp_path: Path, flag_line: str, expected_access: str) -> None:
+def test_profiling_access_parses_the_exact_flag(
+    scrape: dict[str, Any], tmp_path: Path, flag_line: str, expected_access: str
+) -> None:
     # Arrange - the flag sits among other params like in the real file
-    params = tmp_path / "params"
-    params.write_text(f"ResmanDebugLevel: 4294967295\n{flag_line}\nRegistryDwords: \"\"\n")
-    scrape["NVIDIA_PARAMS_PATH"] = str(params)
+    params_file = tmp_path / "params"
+    params_file.write_text(f"ResmanDebugLevel: 4294967295\n{flag_line}\nRegistryDwords: \"\"\n")
+    scrape["NVIDIA_PARAMS_PATH"] = str(params_file)
 
     # Act
-    access, log_text = scrape["check_ncu_profiling_access"]()
+    observation = scrape["check_ncu_profiling_access"]()
 
     # Assert
-    assert access == expected_access
-    # a clean 0/1 read carries no error text; every unknown explains itself
-    assert (log_text == "") == (expected_access in ("unrestricted", "restricted"))
+    assert observation.access == expected_access
+    if expected_access == "unknown":
+        assert observation.scrape_error != ""
+    else:
+        assert observation.scrape_error == ""
 
 
-def test_profiling_access_is_unknown_when_params_file_is_missing(scrape: dict, tmp_path: Path) -> None:
+def test_profiling_access_is_unknown_when_params_file_is_missing(
+    scrape: dict[str, Any], tmp_path: Path
+) -> None:
     # Arrange - no NVIDIA driver loaded -> no params file
     scrape["NVIDIA_PARAMS_PATH"] = str(tmp_path / "does-not-exist")
 
     # Act
-    access, log_text = scrape["check_ncu_profiling_access"]()
+    observation = scrape["check_ncu_profiling_access"]()
 
     # Assert - fail closed, with the reason captured for the scrape_error key
-    assert access == "unknown"
-    assert "Cannot read" in log_text
+    assert observation.access == "unknown"
+    assert "Cannot read" in observation.scrape_error
 
 
-def test_boot_id_is_read_and_stripped(scrape: dict, tmp_path: Path) -> None:
+def test_boot_id_is_read_and_stripped(scrape: dict[str, Any], tmp_path: Path) -> None:
     # Arrange
     boot_id_file = tmp_path / "boot_id"
     boot_id_file.write_text("ec8c2436-1039-45aa-a508-bcbe865fbcd8\n")
@@ -93,7 +84,7 @@ def test_boot_id_is_read_and_stripped(scrape: dict, tmp_path: Path) -> None:
     assert scrape["get_host_boot_id"]() == "ec8c2436-1039-45aa-a508-bcbe865fbcd8"
 
 
-def test_boot_id_is_empty_when_unreadable(scrape: dict, tmp_path: Path) -> None:
+def test_boot_id_is_empty_when_unreadable(scrape: dict[str, Any], tmp_path: Path) -> None:
     # Arrange
     scrape["BOOT_ID_PATH"] = str(tmp_path / "does-not-exist")
 
@@ -116,21 +107,35 @@ def _dict_literal_keys(module: ast.Module, dict_name: str) -> list[str]:
 def test_new_keys_are_wired_through_both_obfuscation_tables() -> None:
     """A key missing from either table ships un-renamed/un-mapped — keep all three in both."""
     # Arrange
-    service = ast.parse((SRC / "services" / "file_encrypt_service.py").read_text())
+    service_module = ast.parse((SRC / "services" / "file_encrypt_service.py").read_text())
     scrape_text = (SRC / "miner_jobs" / "machine_scrape.py").read_text()
     new_keys = ["data_ncu_profiling_access", "data_ncu_profiling_scrape_error", "data_boot_id"]
 
     # Act
-    original_keys = _dict_literal_keys(service, "ORIGINAL_KEYS")
-    all_keys = _dict_literal_keys(service, "all_keys")
+    original_keys = _dict_literal_keys(service_module, "ORIGINAL_KEYS")
+    all_keys = _dict_literal_keys(service_module, "all_keys")
 
     # Assert - the scrape emits each key and both tables carry it
     for key in new_keys:
         assert f'"{key}"' in scrape_text or f"'{key}'" in scrape_text
         assert key in original_keys
         assert key in all_keys
-    # the replacement sweep is a sequential str.replace in dict order: no key of ours may be a
-    # strict prefix of a LATER key in all_keys, or the later one gets corrupted before its turn
-    for new_key in new_keys:
-        later_keys = all_keys[all_keys.index(new_key) + 1 :]
-        assert not any(later.startswith(new_key) for later in later_keys)
+
+
+def test_no_obfuscation_key_is_a_prefix_of_a_later_one() -> None:
+    """ecrypt_miner_job_files() substitutes all_keys with a sequential str.replace in dict order,
+    so an earlier key that prefixes a later one corrupts the later one before its turn."""
+    # Arrange
+    service_module = ast.parse((SRC / "services" / "file_encrypt_service.py").read_text())
+
+    # Act
+    all_keys = _dict_literal_keys(service_module, "all_keys")
+
+    # Assert
+    prefixed_pairs = [
+        (earlier, later)
+        for index, earlier in enumerate(all_keys)
+        for later in all_keys[index + 1 :]
+        if later.startswith(earlier)
+    ]
+    assert prefixed_pairs == []

--- a/neurons/validators/tests/test_scrape_ncu_profiling.py
+++ b/neurons/validators/tests/test_scrape_ncu_profiling.py
@@ -1,0 +1,136 @@
+"""DAH-2182: the scrape reports the host NVIDIA profiling-counter flag as a fail-closed
+observation. `RmProfilingAdminOnly: 0` in /proc/driver/nvidia/params means the counters are open
+to EVERY workload on the host — the backend then treats the node as whole-host-only. Anything
+unreadable must surface as "unknown", never as a guessed value.
+
+machine_scrape.py is a script, not a module — importing it runs the whole scrape — so the helpers
+are extracted by ast and executed in their own namespace (same pattern as
+test_scrape_disk_breakdown.py). The obfuscation tables are parsed from source like
+test_scrape_encryption_key_order.py does.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+
+NCU_HELPERS = {
+    "NVIDIA_PARAMS_PATH",
+    "BOOT_ID_PATH",
+    "check_ncu_profiling_access",
+    "get_host_boot_id",
+}
+
+
+def _definition_name(node: ast.stmt) -> str:
+    if isinstance(node, ast.FunctionDef | ast.ClassDef):
+        return node.name
+    if isinstance(node, ast.Assign) and isinstance(node.targets[0], ast.Name):
+        return node.targets[0].id
+    return ""
+
+
+@pytest.fixture
+def scrape() -> dict:
+    """The ncu helpers, executed in a namespace of their own."""
+    tree = ast.parse((SRC / "miner_jobs" / "machine_scrape.py").read_text())
+    kept = [node for node in tree.body if _definition_name(node) in NCU_HELPERS]
+    assert {_definition_name(node) for node in kept} == NCU_HELPERS, (
+        f"machine_scrape.py no longer defines all of {sorted(NCU_HELPERS)} at module level"
+    )
+
+    namespace = {"re": re}
+    exec(compile(ast.Module(body=kept, type_ignores=[]), "machine_scrape_ncu", "exec"), namespace)
+    return namespace
+
+
+@pytest.mark.parametrize(
+    ("flag_line", "expected_access"),
+    [
+        ("RmProfilingAdminOnly: 0", "unrestricted"),
+        ("RmProfilingAdminOnly: 1", "restricted"),
+        ("RmProfilingAdminOnly: 2", "unknown"),
+        ("NotRmProfilingAdminOnly: 0", "unknown"),  # exact-key parse, no substring match
+    ],
+)
+def test_profiling_access_parses_the_exact_flag(scrape: dict, tmp_path: Path, flag_line: str, expected_access: str) -> None:
+    # Arrange - the flag sits among other params like in the real file
+    params = tmp_path / "params"
+    params.write_text(f"ResmanDebugLevel: 4294967295\n{flag_line}\nRegistryDwords: \"\"\n")
+    scrape["NVIDIA_PARAMS_PATH"] = str(params)
+
+    # Act
+    access, log_text = scrape["check_ncu_profiling_access"]()
+
+    # Assert
+    assert access == expected_access
+    # a clean 0/1 read carries no error text; every unknown explains itself
+    assert (log_text == "") == (expected_access in ("unrestricted", "restricted"))
+
+
+def test_profiling_access_is_unknown_when_params_file_is_missing(scrape: dict, tmp_path: Path) -> None:
+    # Arrange - no NVIDIA driver loaded -> no params file
+    scrape["NVIDIA_PARAMS_PATH"] = str(tmp_path / "does-not-exist")
+
+    # Act
+    access, log_text = scrape["check_ncu_profiling_access"]()
+
+    # Assert - fail closed, with the reason captured for the scrape_error key
+    assert access == "unknown"
+    assert "Cannot read" in log_text
+
+
+def test_boot_id_is_read_and_stripped(scrape: dict, tmp_path: Path) -> None:
+    # Arrange
+    boot_id_file = tmp_path / "boot_id"
+    boot_id_file.write_text("ec8c2436-1039-45aa-a508-bcbe865fbcd8\n")
+    scrape["BOOT_ID_PATH"] = str(boot_id_file)
+
+    # Act / Assert
+    assert scrape["get_host_boot_id"]() == "ec8c2436-1039-45aa-a508-bcbe865fbcd8"
+
+
+def test_boot_id_is_empty_when_unreadable(scrape: dict, tmp_path: Path) -> None:
+    # Arrange
+    scrape["BOOT_ID_PATH"] = str(tmp_path / "does-not-exist")
+
+    # Act / Assert
+    assert scrape["get_host_boot_id"]() == ""
+
+
+def _dict_literal_keys(module: ast.Module, dict_name: str) -> list[str]:
+    """Keys of the single dict literal assigned to `dict_name`, in source order."""
+    for node in ast.walk(module):
+        if (
+            isinstance(node, ast.Assign)
+            and getattr(node.targets[0], "id", "") == dict_name
+            and isinstance(node.value, ast.Dict)
+        ):
+            return [key.value for key in node.value.keys]
+    raise AssertionError(f"{dict_name} dict literal not found")
+
+
+def test_new_keys_are_wired_through_both_obfuscation_tables() -> None:
+    """A key missing from either table ships un-renamed/un-mapped — keep all three in both."""
+    # Arrange
+    service = ast.parse((SRC / "services" / "file_encrypt_service.py").read_text())
+    scrape_text = (SRC / "miner_jobs" / "machine_scrape.py").read_text()
+    new_keys = ["data_ncu_profiling_access", "data_ncu_profiling_scrape_error", "data_boot_id"]
+
+    # Act
+    original_keys = _dict_literal_keys(service, "ORIGINAL_KEYS")
+    all_keys = _dict_literal_keys(service, "all_keys")
+
+    # Assert - the scrape emits each key and both tables carry it
+    for key in new_keys:
+        assert f'"{key}"' in scrape_text or f"'{key}'" in scrape_text
+        assert key in original_keys
+        assert key in all_keys
+    # the replacement sweep is a sequential str.replace in dict order: no key of ours may be a
+    # strict prefix of a LATER key in all_keys, or the later one gets corrupted before its turn
+    for new_key in new_keys:
+        later_keys = all_keys[all_keys.index(new_key) + 1 :]
+        assert not any(later.startswith(new_key) for later in later_keys)


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2182](https://app.notion.com/p/Enable-NCU-profiling-counters-on-executor-hosts-375b8bfdbde981d3a4d9d584e37cc034)

---

## Problem

The backend (companion PR in lium-io-backend) needs to know whether a host's GPU performance counters are open (`RmProfilingAdminOnly: 0` — renters can run `ncu`; the host becomes whole-host-only) — but the machine scrape does not read the NVIDIA driver params at all today.

## Solution

The scrape reports a fail-closed observation, following the existing `sysbox_runtime` / `storage_limit_supported` host-wide capability pattern:

- `check_ncu_profiling_access()` reads `/proc/driver/nvidia/params` (the executor container is privileged with `pid: host`, so this is host state) and parses the EXACT key `RmProfilingAdminOnly`: `0 → "unrestricted"`, `1 → "restricted"`, missing file / missing line / unexpected value → `"unknown"` + error text. Unknown is never guessed into a value — the backend fails closed on it.
- `get_host_boot_id()` reads `/proc/sys/kernel/random/boot_id` — the flag only changes on a driver reload/reboot, so a changed boot_id marks a possibly-flipped stale observation.
- Emits `data_ncu_profiling_access`, `data_ncu_profiling_scrape_error` (only on failure), `data_boot_id`; both obfuscation key tables carry the three keys (longer-before-prefix ordering preserved for the sequential replace sweep; the three new keys prefix neither each other nor any existing key).

No new imports → no `python_keywords` allowlist change; `obfuscated_machine_scrape.py` is runtime-generated (gitignored), so deploying the validator is sufficient.

## Changes

- `miner_jobs/machine_scrape.py`: `check_ncu_profiling_access()`, `get_host_boot_id()`, wired into `get_machine_specs()` beside the sysbox/storage-limit block
- `services/file_encrypt_service.py`: three entries in `ORIGINAL_KEYS` and in `generate_key_mappings()`'s `all_keys`
- `tests/test_scrape_ncu_profiling.py`: parser matrix (0/1/2/absent line/absent file/substring key), boot_id read/strip, both-tables wiring + prefix-safety test (parse-don't-import pattern)

## Deployment Steps

Use GitHub Action (validator redeploy). Ship AFTER the backend PR (which declares the fields on `MachineSpecs` — otherwise the values are pydantic-stripped on upsert; either order is still safe, absence of data = today's behavior).

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

- lium-io-backend: https://github.com/Datura-ai/lium-io-backend/pull/848

## Risks

- Obfuscation plumbing is the classic silent-loss spot; covered by `test_new_keys_are_wired_through_both_obfuscation_tables` and the pre-existing `test_scrape_obfuscation_names` guard (which proves the new module-level names survive the AST rename).
- The scrape runs on every validation cycle; the new check is two file reads, no subprocess, no NVML call.

## Test Cases

### Test Case 1 — parser matrix

**Actions**: run `check_ncu_profiling_access()` against fixture params files: `RmProfilingAdminOnly: 0`, `: 1`, `: 2`, `NotRmProfilingAdminOnly: 0`, a file without the line, a missing file.

**Expected Output**: `unrestricted`, `restricted`, `unknown`, `unknown` (exact-key parse), `unknown`, `unknown` — every unknown carries error text, clean reads carry none.

### Test Case 2 — obfuscation wiring

**Actions**: run the validators test suite (`test_scrape_ncu_profiling.py`, `test_scrape_obfuscation_names.py`).

**Expected Output**: all three `data_*` keys present in both key tables, no key prefix-corrupts a later key, obfuscated output binds every name it reads.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
