### PR TITLE
Fix executor database restart policy

### DIFF
--- a/neurons/executor/docker-compose.app.dev.yml
+++ b/neurons/executor/docker-compose.app.dev.yml
@@ -1,6 +1,7 @@
 services:
   db:
     image: postgres:14.0-alpine
+    restart: always
     healthcheck:
       test: pg_isready -U postgres || exit 1
     environment:

--- a/neurons/executor/docker-compose.app.yml
+++ b/neurons/executor/docker-compose.app.yml
@@ -1,6 +1,7 @@
 services:
   db:
     image: postgres:14.0-alpine
+    restart: always
     healthcheck:
       test: pg_isready -U postgres || exit 1
     environment:

--- a/neurons/executor/tests/test_compose_restart_policy.py
+++ b/neurons/executor/tests/test_compose_restart_policy.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+EXECUTOR_DIR = Path(__file__).resolve().parents[1]
+COMPOSE_PATHS = [
+    EXECUTOR_DIR / "docker-compose.app.yml",
+    EXECUTOR_DIR / "docker-compose.app.dev.yml",
+]
+
+
+@pytest.mark.parametrize("compose_path", COMPOSE_PATHS, ids=lambda path: path.name)
+def test_database_restarts_after_host_reboot(compose_path: Path) -> None:
+    compose = yaml.safe_load(compose_path.read_text())
+
+    assert compose["services"]["db"]["restart"] == "always"


### PR DESCRIPTION
## Summary

- add `restart: always` to the PostgreSQL service in the deployed production and development executor app Compose files
- add a regression test that checks the database restart policy in both deployed app Compose variants

## Why

The executor and monitor containers restart automatically after a host reboot, but their PostgreSQL dependency did not. This left the application containers in a restart loop until an operator manually started the Compose stack.

## Impact

PostgreSQL now returns automatically after host reboots, allowing the dependent executor stack to recover without manual intervention.

## Testing

- `./.venv/bin/python -m pytest tests/test_compose_restart_policy.py tests/test_monitor_gpu_access.py` (4 passed)
- `git diff --check`

Closes #1183
