### PR TITLE
DAH-2478: ban providers for network abuse

### DIFF
--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -62,6 +62,7 @@ class ZeroIncentiveReason(StrEnum):
     """
 
     # Group A: excluded from BOTH pools
+    BANNED_NETWORK_ABUSE = "banned_network_abuse"
     SPOT_TIER = "spot_tier"
     PROVIDER_DISCORD_NOT_CONNECTED = "provider_discord_not_connected"
     NEW_RENTALS_PAUSED = "new_rentals_paused"
@@ -167,6 +168,15 @@ class MinerLogLine(BaseModel):
         )
 
     # ── Group A: excluded from BOTH pools (mining + unrented) — earns nothing ─
+
+    @staticmethod
+    def no_payout_because_banned_network_abuse(result: JobResult) -> MinerLogLine:
+        return MinerLogLine._no_payout(
+            result,
+            reason=ZeroIncentiveReason.BANNED_NETWORK_ABUSE,
+            message="Banned for network abuse. Ineligible for scoring and rentals",
+            internal_message="Executor excluded from both pools - banned for network abuse",
+        )
 
     @staticmethod
     def no_payout_because_spot_tier(result: JobResult) -> MinerLogLine:

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -368,6 +368,8 @@ class RentalPriceIncentive(DefaultIncentive):
         checks. Returns None when no hard exclusion applies (executor may still be
         gated later by the rental-pool-only soft price limit).
         """
+        if job_result.is_provider_banned:
+            return MinerLogLine.no_payout_because_banned_network_abuse(job_result)
         if job_result.is_spot:
             return MinerLogLine.no_payout_because_spot_tier(job_result)
         if is_missing_discord_after_cutoff(job_result):

--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -58,6 +58,9 @@ class RentedMachine(BaseModel):
 class RentedMachineResponse(BaseModel):
     machines: list[RentedMachine]
     banned_guids: list[str] = []
+    banned_hotkeys: list[str] = []
+    banned_coldkeys: list[str] = []
+    banned_provider_guids: list[str] = []
 
 
 class NetworkEMA(BaseModel):
@@ -97,6 +100,9 @@ class RentedExecutorsResponse(BaseModel):
     # collide. Empty for a backend that predates the field — the collision simply stays.
     filler_ports_by_executor: dict[str, list[int]] = {}
     banned_guids: list[str] = []
+    banned_hotkeys: list[str] = []
+    banned_coldkeys: list[str] = []
+    banned_provider_guids: list[str] = []
     gpu_splitting_config: dict[str, int] = {}  # executor_id → min_gpu_count_for_rental
     network_ema: dict[str, NetworkEMA] = {}  # executor_id → EMA network speeds, all active executors
     spot_executor_ids: list[str] = []  # executor_ids in spot tier (no incentive, no penalty)
@@ -109,6 +115,19 @@ class RentedExecutorsResponse(BaseModel):
     # as a special manual (bare-metal) rental. Defaults to empty so an older backend that omits the
     # field force-passes nobody (fail-closed) rather than everybody.
     manual_rental_executors: dict[str, ManualRentalInfo] = {}
+
+    def is_provider_banned(
+        self,
+        *,
+        miner_hotkey: str,
+        miner_coldkey: str | None = None,
+        gpu_uuids: list[str] | None = None,
+    ) -> bool:
+        if miner_hotkey in self.banned_hotkeys:
+            return True
+        if miner_coldkey and miner_coldkey in self.banned_coldkeys:
+            return True
+        return any(gpu_uuid in self.banned_provider_guids for gpu_uuid in (gpu_uuids or []))
 
     @field_validator("filler_containers_by_executor")
     @classmethod

--- a/neurons/validators/src/services/task/checks/__init__.py
+++ b/neurons/validators/src/services/task/checks/__init__.py
@@ -1,4 +1,5 @@
 from .banned_gpu import BannedGpuCheck
+from .banned_provider import BannedProviderCheck
 from .cached_template_verification import CachedTemplateVerificationCheck
 from .capability import CapabilityCheck
 from .collateral import CollateralCheck
@@ -29,6 +30,7 @@ from .verifyx import VerifyXCheck
 
 __all__ = [
     "BannedGpuCheck",
+    "BannedProviderCheck",
     "CachedTemplateVerificationCheck",
     "CapabilityCheck",
     "CollateralCheck",

--- a/neurons/validators/src/services/task/checks/banned_provider.py
+++ b/neurons/validators/src/services/task/checks/banned_provider.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from ..messages import BannedProviderMessages as Msg, render_message
+from ..pipeline import CheckResult, Context
+
+
+class BannedProviderCheck:
+    check_id = "gpu.validate.banned_provider"
+    fatal = True
+
+    async def run(self, ctx: Context) -> CheckResult:
+        rented_data = ctx.state.rented_data
+        gpu_uuids = [gpu_uuid for gpu_uuid in (ctx.state.gpu_uuids or "").split(",") if gpu_uuid]
+        is_banned = bool(
+            rented_data
+            and rented_data.is_provider_banned(
+                miner_hotkey=ctx.miner_hotkey,
+                miner_coldkey=ctx.miner_coldkey,
+                gpu_uuids=gpu_uuids,
+            )
+        )
+
+        if is_banned:
+            event = render_message(
+                Msg.PROVIDER_BANNED,
+                ctx=ctx,
+                check_id=self.check_id,
+                what={
+                    "miner_hotkey": ctx.miner_hotkey,
+                    "miner_coldkey": ctx.miner_coldkey,
+                    "gpu_uuids": gpu_uuids,
+                },
+            )
+            return CheckResult(
+                passed=False,
+                event=event,
+                updates={"is_provider_banned": True},
+            )
+
+        event = render_message(
+            Msg.PROVIDER_ALLOWED,
+            ctx=ctx,
+            check_id=self.check_id,
+            what={
+                "miner_hotkey": ctx.miner_hotkey,
+                "miner_coldkey": ctx.miner_coldkey,
+                "gpu_uuids": gpu_uuids,
+            },
+        )
+        return CheckResult(passed=True, event=event)

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -386,6 +386,24 @@ class BannedGpuMessages:
     )
 
 
+class BannedProviderMessages:
+    PROVIDER_BANNED = MessageTemplate(
+        event="Provider banned for network abuse",
+        reason="PROVIDER_BANNED",
+        severity="warning",
+        category="policy",
+        impact="Score set to 0; verification and active rentals retained",
+        remediation="Contact Lium support to appeal the provider ban.",
+    )
+    PROVIDER_ALLOWED = MessageTemplate(
+        event="Provider allowed",
+        reason="PROVIDER_BANNED_CHECK_OK",
+        severity="info",
+        category="policy",
+        impact="Proceed",
+    )
+
+
 class SysboxRequiredMessages:
     SYSBOX_MISSING = MessageTemplate(
         event="Sysbox required for unrented executor",

--- a/neurons/validators/src/services/task/models.py
+++ b/neurons/validators/src/services/task/models.py
@@ -34,6 +34,7 @@ class JobResult(BaseModel):
     is_rented: bool = False
     is_spot: bool = False
     is_new_rentals_paused: bool = False
+    is_provider_banned: bool = False
     provider_discord_connected: bool = True
     rental_created_at: datetime | None = None
     default_job_owner: str | None = None  # "miner" | "lium" | None; miner default job is excluded from unrented incentive

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -128,6 +128,7 @@ class Context(BaseModel):
     pipeline_id: str
     executor: ExecutorSSHInfo
     miner_hotkey: str
+    miner_coldkey: str | None = None
     miner_address: str
     miner_port: int
     ssh: asyncssh.SSHClientConnection
@@ -158,6 +159,7 @@ class Context(BaseModel):
     log_status: str = "info"
     log_text: str | None = None
     success: bool = False
+    is_provider_banned: bool = False
     tdx_attestation_passed: bool = False
     # G1 — NVIDIA CC GPU attestation outcome: True/False when verified, None when
     # not performed (non-CVM node, no evidence supplied, or NRAS undeterminable).

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -28,6 +28,7 @@ from services.ssh_service import SSHService
 
 from .checks import (
     BannedGpuCheck,
+    BannedProviderCheck,
     CachedTemplateVerificationCheck,
     CapabilityCheck,
     CollateralCheck,
@@ -178,6 +179,7 @@ class PipelineFactory:
             pipeline_id=pipeline_id,
             executor=executor_info,
             miner_hotkey=miner_info.miner_hotkey,
+            miner_coldkey=miner_info.miner_coldkey,
             miner_address=miner_info.miner_address,
             miner_port=miner_info.miner_port,
             ssh=shell.ssh_client,
@@ -256,6 +258,7 @@ class PipelineFactory:
                 NvmlDigestCheck(),
                 SpecChangeCheck(),
                 GpuFingerprintCheck(),
+                BannedProviderCheck(),
                 BannedGpuCheck(),
                 DuplicateExecutorCheck(),
                 CollateralCheck(),
@@ -324,6 +327,7 @@ class PipelineFactory:
                 NvmlDigestCheck(),
                 SpecChangeCheck(),
                 GpuFingerprintCheck(),
+                BannedProviderCheck(),
                 BannedGpuCheck(),
                 DuplicateExecutorCheck(),
                 CollateralCheck(),

--- a/neurons/validators/src/services/task/result_handler.py
+++ b/neurons/validators/src/services/task/result_handler.py
@@ -182,6 +182,7 @@ class ResultHandler:
             is_rented=context.rented,
             is_spot=is_spot,
             is_new_rentals_paused=is_new_rentals_paused,
+            is_provider_banned=context.is_provider_banned,
             provider_discord_connected=provider_discord_connected,
             rental_created_at=self._get_rental_created_at(context),
             default_job_owner=default_job_owner,

--- a/neurons/validators/tests/test_banned_provider_check.py
+++ b/neurons/validators/tests/test_banned_provider_check.py
@@ -1,0 +1,156 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from neurons.validators.src.services.task.checks.banned_provider import BannedProviderCheck
+from neurons.validators.src.services.task.messages import BannedProviderMessages as Msg
+from neurons.validators.src.services.task.pipeline import Pipeline
+from neurons.validators.src.services.task.result_handler import ResultHandler
+from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
+
+from tests.helpers import build_context_config, build_services, build_state
+
+
+def build_rented_data(
+    *,
+    banned_hotkeys: list[str] | None = None,
+    banned_coldkeys: list[str] | None = None,
+    banned_provider_guids: list[str] | None = None,
+) -> RentedExecutorsResponse:
+    return RentedExecutorsResponse(
+        executors={},
+        banned_hotkeys=banned_hotkeys or [],
+        banned_coldkeys=banned_coldkeys or [],
+        banned_provider_guids=banned_provider_guids or [],
+    )
+
+
+@pytest.mark.asyncio
+async def test_hotkey_match_fails(context_factory):
+    state = build_state(
+        gpu_uuids="gpu-1",
+        rented_data=build_rented_data(banned_hotkeys=["miner-hotkey"]),
+    )
+    ctx = context_factory(
+        services=build_services(),
+        config=build_context_config(),
+        state=state,
+        miner_hotkey="miner-hotkey",
+    )
+
+    result = await BannedProviderCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.PROVIDER_BANNED.reason
+    assert result.updates == {"is_provider_banned": True}
+
+
+@pytest.mark.asyncio
+async def test_coldkey_match_fails(context_factory):
+    state = build_state(
+        gpu_uuids="gpu-1",
+        rented_data=build_rented_data(banned_coldkeys=["miner-coldkey"]),
+    )
+    ctx = context_factory(
+        services=build_services(),
+        config=build_context_config(),
+        state=state,
+        miner_hotkey="fresh-hotkey",
+        miner_coldkey="miner-coldkey",
+    )
+
+    result = await BannedProviderCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.PROVIDER_BANNED.reason
+    assert result.updates == {"is_provider_banned": True}
+
+
+@pytest.mark.asyncio
+async def test_gpu_uuid_match_fails(context_factory):
+    state = build_state(
+        gpu_uuids="gpu-1,gpu-2",
+        rented_data=build_rented_data(banned_provider_guids=["gpu-2"]),
+    )
+    ctx = context_factory(
+        services=build_services(),
+        config=build_context_config(),
+        state=state,
+    )
+
+    result = await BannedProviderCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.PROVIDER_BANNED.reason
+    assert result.updates == {"is_provider_banned": True}
+
+
+@pytest.mark.asyncio
+async def test_clean_provider_passes(context_factory):
+    state = build_state(
+        gpu_uuids="gpu-1",
+        rented_data=build_rented_data(
+            banned_hotkeys=["other-hotkey"],
+            banned_coldkeys=["other-coldkey"],
+            banned_provider_guids=["other-gpu"],
+        ),
+    )
+    ctx = context_factory(
+        services=build_services(),
+        config=build_context_config(),
+        state=state,
+        miner_hotkey="miner-hotkey",
+        miner_coldkey="miner-coldkey",
+    )
+
+    result = await BannedProviderCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.PROVIDER_ALLOWED.reason
+    assert result.updates == {}
+
+
+@pytest.mark.asyncio
+async def test_provider_ban_preserves_verified_job_info(context_factory):
+    state = build_state(
+        rented_data=build_rented_data(banned_hotkeys=["miner-hotkey"]),
+    )
+    ctx = context_factory(
+        services=build_services(),
+        config=build_context_config(),
+        state=state,
+        miner_hotkey="miner-hotkey",
+    )
+
+    result = await BannedProviderCheck().run(ctx)
+
+    assert "clear_verified_job_info" not in result.updates
+
+
+@pytest.mark.asyncio
+async def test_provider_ban_reaches_job_result(context_factory):
+    state = build_state(
+        rented_data=build_rented_data(banned_hotkeys=["miner-hotkey"]),
+    )
+    ctx = context_factory(
+        services=build_services(),
+        config=build_context_config(),
+        state=state,
+        miner_hotkey="miner-hotkey",
+    )
+    pipeline = Pipeline(checks=[BannedProviderCheck()], sink=AsyncMock())
+
+    success, _, final_ctx = await pipeline.run(ctx)
+    job_result = await ResultHandler(redis_service=None, dry_run=True).handle_result(
+        context=final_ctx,
+        miner_info=SimpleNamespace(miner_hotkey="miner-hotkey", job_batch_id="batch-1"),
+        executor_info=ctx.executor,
+        verified_job_info={},
+        log_text="provider banned",
+        success=success,
+    )
+
+    assert success is False
+    assert final_ctx.clear_verified_job_info is False
+    assert job_result.is_provider_banned is True

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -7,7 +7,7 @@ fields, and that a line actually lands in JobResult.incentive_logs.
 import pytest
 from datura.requests.miner_requests import ExecutorSSHInfo
 from incentive.miner_incentive_log import MinerLogLine, ZeroIncentiveReason
-from incentive.rental_price import InsufficientDisk, MissingFlagshipCapability
+from incentive.rental_price import InsufficientDisk, MissingFlagshipCapability, RentalPriceIncentive
 from services.task_service import JobResult
 
 H200 = "NVIDIA H200"
@@ -17,6 +17,7 @@ def test_reason_enum_pins_the_stable_code_contract():
     # Append-only contract: dashboards and the backend (DAH-2340) key off these
     # exact strings. Renaming any value is a breaking change.
     assert {r.value for r in ZeroIncentiveReason} == {
+        "banned_network_abuse",
         "spot_tier",
         "provider_discord_not_connected",
         "new_rentals_paused",
@@ -65,6 +66,11 @@ def _job(**overrides) -> JobResult:
 @pytest.mark.parametrize(
     "build, expected_code, message_fragment",
     [
+        (
+            lambda job: MinerLogLine.no_payout_because_banned_network_abuse(job),
+            "banned_network_abuse",
+            "network abuse",
+        ),
         (lambda job: MinerLogLine.no_payout_because_spot_tier(job), "spot_tier", "spot tier"),
         (
             lambda job: MinerLogLine.no_payout_because_discord_not_connected(job),
@@ -131,6 +137,24 @@ def test_zero_reason_constructor_code_and_message(build, expected_code, message_
     assert message_fragment.lower() in line.message.lower()
     assert line.fields["reason"] == expected_code
     assert line.fields["incentive"] == 0.0
+
+
+def test_banned_network_abuse_message():
+    line = MinerLogLine.no_payout_because_banned_network_abuse(_job())
+
+    assert (
+        line.message
+        == "Banned for network abuse. Ineligible for scoring and rentals"
+    )
+
+
+def test_provider_ban_is_excluded_from_both_pools():
+    incentive = object.__new__(RentalPriceIncentive)
+
+    line = incentive._reason_excluded_from_both_pools(_job(is_provider_banned=True))
+
+    assert line is not None
+    assert line.reason is ZeroIncentiveReason.BANNED_NETWORK_ABUSE
 
 
 def test_spot_tier_carries_internal_log_message():


### PR DESCRIPTION
## Describe your changes

Adds a fatal validator check that rejects providers flagged for network abuse (hotkey, coldkey, or GPU UUID). Matching jobs get zero incentive and are kept out of scoring/rentals without tearing down an in-progress customer rental mid-check the way legacy GPU bans do.
