### PR TITLE
DAH-2545, recover encrypted-volume pods after host reboot and report it

### DIFF
--- a/neurons/validators/src/clients/backend_client.py
+++ b/neurons/validators/src/clients/backend_client.py
@@ -19,6 +19,7 @@ from protocol.vc_protocol.compute_requests import (
     ExecutorHealthCheckResponse,
     FillerRunActiveResponse,
     NvmlReportAckResponse,
+    PodHostRebootRecoveredResponse,
     PodRentalActiveResponse,
     RentedExecutorsResponse,
 )
@@ -248,6 +249,22 @@ class BackendClient:
         return await self.get(
             f"/internal/pods/{pod_id}/rental-active",
             PodRentalActiveResponse,
+            timeout=10,
+        )
+
+    async def report_pod_host_reboot_recovered(
+        self, pod_id: str, container_finished_at: str
+    ) -> PodHostRebootRecoveredResponse | None:
+        """Tell the backend a pod was revived after its host rebooted, so the renter can be told.
+
+        container_finished_at is the container's exit time, which the backend uses to recognise
+        the same downtime reported by a later cycle while keeping a genuine second reboot of the
+        same pod a separate event. Older backends 404 and the caller treats that as nothing to do.
+        """
+        return await self.post(
+            f"/internal/pods/{pod_id}/host-reboot-recovered",
+            PodHostRebootRecoveredResponse,
+            json_data={"container_finished_at": container_finished_at},
             timeout=10,
         )
 

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -368,10 +368,13 @@ class Settings(BaseSettings):
     
     ENABLE_VOLUME_ENCRYPTION: bool = Field(env="ENABLE_VOLUME_ENCRYPTION", default=True)
     VOLUME_MASTER_SECRET: str | None = Field(env="VOLUME_MASTER_SECRET", default=None)
-    # DAH-2545 kill switch: reviving a pod whose volume is encrypted touches customer data on an
-    # untrusted host, so it has to be switchable without waiting for a rollout. Off means encrypted
-    # pods keep the pre-DAH-2545 behaviour — skipped, and the miner keeps the POD_NOT_RUNNING verdict.
-    RECOVER_ENCRYPTED_VOLUMES: bool = Field(env="RECOVER_ENCRYPTED_VOLUMES", default=True)
+    # DAH-2545 switch, off until the plaintext window is closed. A restarted container runs its own
+    # entrypoint and startup_commands before gocryptfs can be mounted into it, so writes to the
+    # plaintext path in that window land unencrypted in the container's upper layer on the miner's
+    # disk. The same window exists on the pod-creation path today; until it is closed for both,
+    # encrypted pods keep the pre-DAH-2545 behaviour — skipped, and the miner keeps the
+    # POD_NOT_RUNNING verdict.
+    RECOVER_ENCRYPTED_VOLUMES: bool = Field(env="RECOVER_ENCRYPTED_VOLUMES", default=False)
 
     DEPLOY_ENV: Literal["PROD", "LOCAL", "STAGE"] = Field(env="DEPLOY_ENV", default="PROD")
 

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -368,6 +368,10 @@ class Settings(BaseSettings):
     
     ENABLE_VOLUME_ENCRYPTION: bool = Field(env="ENABLE_VOLUME_ENCRYPTION", default=True)
     VOLUME_MASTER_SECRET: str | None = Field(env="VOLUME_MASTER_SECRET", default=None)
+    # DAH-2545 kill switch: reviving a pod whose volume is encrypted touches customer data on an
+    # untrusted host, so it has to be switchable without waiting for a rollout. Off means encrypted
+    # pods keep the pre-DAH-2545 behaviour — skipped, and the miner keeps the POD_NOT_RUNNING verdict.
+    RECOVER_ENCRYPTED_VOLUMES: bool = Field(env="RECOVER_ENCRYPTED_VOLUMES", default=True)
 
     DEPLOY_ENV: Literal["PROD", "LOCAL", "STAGE"] = Field(env="DEPLOY_ENV", default="PROD")
 

--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -158,6 +158,15 @@ class RentedExecutorsResponse(BaseModel):
 class PodRentalActiveResponse(BaseModel):
     active: bool
     rental_closed_at: datetime | None = None
+    # DAH-2545: where an encrypted rental volume is mounted in plaintext inside the container.
+    # Nothing on the host records it, so without this the validator cannot remount gocryptfs when
+    # it revives a pod. Absent — an older backend, or a pod it does not know — means recovery of an
+    # encrypted volume must stand down rather than guess a path.
+    local_volume_path: str | None = None
+
+
+class PodHostRebootRecoveredResponse(BaseModel):
+    recorded: bool
 
 
 class FillerRunActiveResponse(BaseModel):

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -455,6 +455,13 @@ def _xor_wrap_passphrase(passphrase: str) -> tuple[str, str]:
     return pad.hex(), wrapped.hex()
 
 
+def _is_under_cipher_mount(path: str) -> bool:
+    # whether a plaintext path collides with the ciphertext mount. A descendant is as unusable as
+    # the mount itself: mounting the plaintext view inside the ciphertext it is decrypting is not
+    # something recovery should attempt on customer data.
+    return path == _LIUM_CIPHER_MOUNT or path.startswith(f"{_LIUM_CIPHER_MOUNT}/")
+
+
 def _gocryptfs_missing_config_branch(allow_init: bool) -> str:
     if allow_init:
         return f'  gocryptfs -init {_LIUM_CIPHER_MOUNT} -passfile "$_pf"'
@@ -5186,7 +5193,7 @@ class DockerService:
             settings.RECOVER_ENCRYPTED_VOLUMES
             and bool(local_volume_path)
             and bool(_PLAINTEXT_PATH_RE.fullmatch(local_volume_path or ""))
-            and local_volume_path != _LIUM_CIPHER_MOUNT
+            and not _is_under_cipher_mount(local_volume_path or "")
             and bool(settings.VOLUME_MASTER_SECRET)
         )
 

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import enum
 import ipaddress
 import logging
 import math
@@ -197,6 +198,15 @@ _LOCAL_VOLUME_TIMEOUT_MAX_SEC = 180
 _FILLER_EXTERNAL_PORT_OFFSET = 20
 _LIUM_CIPHER_MOUNT = "/lium-cipher"
 _ENCRYPTED_VOLUME_IMAGE_LABEL = "lium.volume_encryption.enable"
+# a plaintext mount path we are willing to act on: absolute, normalised, not the root itself and
+# never the ciphertext mount. Anything else is refused rather than chmod-ed or mounted over.
+_PLAINTEXT_PATH_RE = re.compile(r"^(/[A-Za-z0-9._-]+)+$")
+
+
+class _VolumeEncryptionState(enum.Enum):
+    ENCRYPTED = "encrypted"
+    PLAIN = "plain"
+    UNKNOWN = "unknown"
 _DOCKER_NO_SUCH_CONTAINER_PHRASE = "No such container"
 _DOCKER_REMOVAL_IN_PROGRESS_PHRASES = ("409", "removal", "already in progress")
 HOST_KEY_REQUIRED_EXTRA = {
@@ -444,6 +454,16 @@ def _xor_wrap_passphrase(passphrase: str) -> tuple[str, str]:
     return pad.hex(), wrapped.hex()
 
 
+def _gocryptfs_missing_config_branch(allow_init: bool) -> str:
+    if allow_init:
+        return f'  gocryptfs -init {_LIUM_CIPHER_MOUNT} -passfile "$_pf"'
+    return (
+        f'  echo "gocryptfs.conf missing under {_LIUM_CIPHER_MOUNT};'
+        ' refusing to re-initialise an existing rental volume" >&2\n'
+        "  exit 1"
+    )
+
+
 def _build_gocryptfs_setup_and_mount_script(
     plaintext_path: str,
     *,
@@ -452,7 +472,12 @@ def _build_gocryptfs_setup_and_mount_script(
     pad_var: str,
     wrapped_var: str,
     passfile_path: str,
+    allow_init: bool = True,
 ) -> str:
+    # allow_init=False belongs to recovery: a pod that is being revived already had its volume
+    # initialised, so a missing gocryptfs.conf means the ciphertext is gone. Re-initialising it
+    # there would hand the customer an empty volume, log the recovery as a success and spare the
+    # miner the penalty for data they destroyed.
     plaintext = shlex.quote(plaintext_path)
     passfile = shlex.quote(passfile_path)
     mount_check = (
@@ -481,7 +506,7 @@ chmod 600 "$_pf"
 unset _esc _x _y {pad_var} {wrapped_var}
 mkdir -p {_LIUM_CIPHER_MOUNT} {plaintext}
 if [ ! -f {_LIUM_CIPHER_MOUNT}/gocryptfs.conf ]; then
-  gocryptfs -init {_LIUM_CIPHER_MOUNT} -passfile "$_pf"
+{_gocryptfs_missing_config_branch(allow_init)}
 fi
 if ! {mount_check}; then
   gocryptfs {_LIUM_CIPHER_MOUNT} {plaintext} -passfile "$_pf" -o allow_other -nonempty
@@ -1968,6 +1993,7 @@ class DockerService:
         pod_id: str,
         log_tag: str,
         log_extra: dict,
+        allow_init: bool = True,
     ) -> None:
         passphrase = VolumeKeyDeriver.from_settings(settings).material(pod_id).passphrase
 
@@ -2039,6 +2065,7 @@ class DockerService:
             pad_var=pad_var,
             wrapped_var=wrapped_var,
             passfile_path=passfile_path,
+            allow_init=allow_init,
         )
         setup_heredoc = f"__SETUP_{uuid4().hex}__"
         upload_cmd = (
@@ -5008,6 +5035,7 @@ class DockerService:
                         pod_id=pod_id,
                         log_tag=f"start_container_{pod_id}",
                         log_extra=default_extra,
+                        allow_init=False,
                     )
             ssh_bootstrap_ok = await self.install_open_ssh_server_and_start_ssh_service_with_rental_docker(
                 docker_client=docker_client,
@@ -5056,14 +5084,27 @@ class DockerService:
 
         log_extra = {**default_extra, "container_name": container_name}
         try:
-            if await self._holds_encrypted_local_volume(ssh_client, container_name):
-                if not self._can_remount_encrypted_volume(local_volume_path):
+            encryption_state = await self._local_volume_encryption_state(
+                ssh_client, container_name
+            )
+            if encryption_state is not _VolumeEncryptionState.PLAIN:
+                if encryption_state is _VolumeEncryptionState.UNKNOWN or not (
+                    self._can_remount_encrypted_volume(local_volume_path)
+                ):
                     logger.warning(
                         _m(
                             "POD_STALE_MOUNT_RECOVERY_SKIPPED_ENCRYPTED_VOLUME",
-                            extra=get_extra_info(log_extra),
+                            extra=get_extra_info({
+                                **log_extra,
+                                "volume_encryption_state": encryption_state.value,
+                            }),
                         )
                     )
+                    return False
+                # local_volume_path is validated by _can_remount_encrypted_volume above
+                if not await self._seal_plaintext_dir_before_start(
+                    ssh_client, container_name, local_volume_path or "", log_extra
+                ):
                     return False
             repaired_volume = await self._repair_stale_mountpoint_of_container_volume(
                 ssh_client,
@@ -5130,35 +5171,90 @@ class DockerService:
         )
         return True
 
-    def _can_remount_encrypted_volume(self, local_volume_path: str | None) -> bool:
-        # whether recovery has everything it needs to put a gocryptfs volume back the way the
-        # customer had it. Both inputs are checked before the container is started, because the
-        # remount only happens after `docker start`: a missing one would leave the pod flapping
-        # up and down once a cycle. VOLUME_MASTER_SECRET must be the one the volume was created
-        # with — another validator's secret derives a passphrase that simply will not mount.
-        return bool(local_volume_path) and bool(settings.VOLUME_MASTER_SECRET)
-
-    async def _holds_encrypted_local_volume(
+    async def _seal_plaintext_dir_before_start(
         self,
         ssh_client: asyncssh.SSHClientConnection,
         container_name: str,
+        plaintext_path: str,
+        log_extra: dict[str, Any],
     ) -> bool:
+        # make the plaintext dir unwritable on the host BEFORE the container starts, so nothing the
+        # pod runs on its own — startup_commands, an image that brings up its own sshd, a customer
+        # session — can write there in the window between `docker start` and the gocryptfs mount.
+        # Those writes would land in the container's upper layer, which is the miner's disk, and
+        # gocryptfs mounts with -nonempty, so they would then be shadowed: invisible to the
+        # customer, readable by the miner, forever. The mount lands on top and the mode of the
+        # directory underneath stops mattering; if the mount never happens, the dir stays sealed,
+        # which is the safe end state.
+        upper_dir_result = await ssh_client.run(
+            f"/usr/bin/docker inspect {shlex.quote(container_name)} "
+            "--format '{{.GraphDriver.Data.UpperDir}}'",
+            timeout=_VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC,
+        )
+        upper_dir = (upper_dir_result.stdout or "").strip()
+        if getattr(upper_dir_result, "exit_status", 0) != 0 or not _PLAINTEXT_PATH_RE.fullmatch(
+            upper_dir
+        ):
+            logger.warning(
+                _m(
+                    "POD_STALE_MOUNT_RECOVERY_SEAL_FAILED",
+                    extra=get_extra_info({**log_extra, "reason": "upper_dir_unavailable"}),
+                )
+            )
+            return False
+
+        sealed_dir = f"{upper_dir}{plaintext_path}"
+        seal_result = await ssh_client.run(
+            f"mkdir -p {shlex.quote(sealed_dir)} && chmod 000 {shlex.quote(sealed_dir)}",
+            timeout=_VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC,
+        )
+        if getattr(seal_result, "exit_status", 0) != 0:
+            logger.warning(
+                _m(
+                    "POD_STALE_MOUNT_RECOVERY_SEAL_FAILED",
+                    extra=get_extra_info({**log_extra, "reason": "chmod_failed"}),
+                )
+            )
+            return False
+        return True
+
+    def _can_remount_encrypted_volume(self, local_volume_path: str | None) -> bool:
+        # whether recovery has everything it needs to put a gocryptfs volume back the way the
+        # customer had it. All three are checked before the container is started, because the
+        # remount only happens after `docker start`: a missing one would leave the pod flapping
+        # up and down once a cycle. VOLUME_MASTER_SECRET must be the one the volume was created
+        # with — another validator's secret derives a passphrase that simply will not mount.
+        return (
+            settings.RECOVER_ENCRYPTED_VOLUMES
+            and bool(local_volume_path)
+            and bool(_PLAINTEXT_PATH_RE.fullmatch(local_volume_path or ""))
+            and local_volume_path != _LIUM_CIPHER_MOUNT
+            and bool(settings.VOLUME_MASTER_SECRET)
+        )
+
+    async def _local_volume_encryption_state(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        container_name: str,
+    ) -> _VolumeEncryptionState:
         # whether the pod's rental volume is gocryptfs-encrypted, which recovery may only touch
         # when it knows the plaintext path. An encrypted volume is mounted as the ciphertext at
         # /lium-cipher and the plaintext path the customer actually uses is recorded nowhere on the
         # host; DAH-2545 carries it in the backend's rental-active response. Remounting at the
         # /root default would silently turn a custom path into an ordinary container dir, so
-        # writes to it would land unencrypted on the miner's disk. Fails closed: an inspect that
-        # does not answer counts as encrypted, and without a path the miner keeps the
-        # POD_NOT_RUNNING verdict.
+        # writes to it would land unencrypted on the miner's disk. An inspect that does not answer
+        # is UNKNOWN rather than ENCRYPTED: recovery stands down either way, but a pod we could not
+        # even look at must not be started on the strength of a path we cannot match to a volume.
         inspect_result = await ssh_client.run(
             f"/usr/bin/docker inspect {shlex.quote(container_name)} "
             '--format \'{{range .Mounts}}{{println .Destination}}{{end}}\'',
             timeout=_VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC,
         )
         if getattr(inspect_result, "exit_status", 0) != 0:
-            return True
-        return _LIUM_CIPHER_MOUNT in (inspect_result.stdout or "").split()
+            return _VolumeEncryptionState.UNKNOWN
+        if _LIUM_CIPHER_MOUNT in (inspect_result.stdout or "").split():
+            return _VolumeEncryptionState.ENCRYPTED
+        return _VolumeEncryptionState.PLAIN
 
     async def _repair_stale_mountpoint_of_container_volume(
         self,

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -198,9 +198,8 @@ _LOCAL_VOLUME_TIMEOUT_MAX_SEC = 180
 _FILLER_EXTERNAL_PORT_OFFSET = 20
 _LIUM_CIPHER_MOUNT = "/lium-cipher"
 _ENCRYPTED_VOLUME_IMAGE_LABEL = "lium.volume_encryption.enable"
-# a plaintext mount path we are willing to act on: absolute, no "." or ".." segment, not the root
-# itself and never the ciphertext mount. The path comes from a customer-authored template, where
-# the backend only requires a leading slash, so it is refused here rather than mounted over.
+# the path comes from a customer-authored template and the backend only requires a leading slash,
+# so anything that is not a plain absolute path is refused here rather than mounted over
 _PLAINTEXT_PATH_RE = re.compile(r"^(?:/(?!\.{1,2}(?:/|$))[A-Za-z0-9._-]+)+$")
 
 
@@ -208,6 +207,8 @@ class _VolumeEncryptionState(enum.Enum):
     ENCRYPTED = "encrypted"
     PLAIN = "plain"
     UNKNOWN = "unknown"
+
+
 _DOCKER_NO_SUCH_CONTAINER_PHRASE = "No such container"
 _DOCKER_REMOVAL_IN_PROGRESS_PHRASES = ("409", "removal", "already in progress")
 HOST_KEY_REQUIRED_EXTRA = {
@@ -455,14 +456,28 @@ def _xor_wrap_passphrase(passphrase: str) -> tuple[str, str]:
     return pad.hex(), wrapped.hex()
 
 
-def _is_under_cipher_mount(path: str) -> bool:
-    # whether a plaintext path collides with the ciphertext mount. A descendant is as unusable as
-    # the mount itself: mounting the plaintext view inside the ciphertext it is decrypting is not
-    # something recovery should attempt on customer data.
-    return path == _LIUM_CIPHER_MOUNT or path.startswith(f"{_LIUM_CIPHER_MOUNT}/")
+def _can_remount_encrypted_volume(local_volume_path: str | None) -> bool:
+    # whether recovery has everything it needs to put a gocryptfs volume back the way the customer
+    # had it. Checked before the container is started, because the remount only happens after
+    # `docker start`: a missing piece would leave the pod flapping up and down once a cycle.
+    # VOLUME_MASTER_SECRET must be the one the volume was created with — another validator's secret
+    # derives a passphrase that simply will not mount. A plaintext path at or under the ciphertext
+    # mount is refused as well: mounting the plaintext view inside the ciphertext it is decrypting
+    # is not something recovery should attempt on customer data.
+    if not (
+        settings.RECOVER_ENCRYPTED_VOLUMES
+        and settings.VOLUME_MASTER_SECRET
+        and local_volume_path
+    ):
+        return False
+    if local_volume_path == _LIUM_CIPHER_MOUNT or local_volume_path.startswith(
+        f"{_LIUM_CIPHER_MOUNT}/"
+    ):
+        return False
+    return _PLAINTEXT_PATH_RE.fullmatch(local_volume_path) is not None
 
 
-def _gocryptfs_missing_config_branch(allow_init: bool) -> str:
+def _shell_branch_when_gocryptfs_config_missing(allow_init: bool) -> str:
     if allow_init:
         return f'  gocryptfs -init {_LIUM_CIPHER_MOUNT} -passfile "$_pf"'
     return (
@@ -482,10 +497,11 @@ def _build_gocryptfs_setup_and_mount_script(
     passfile_path: str,
     allow_init: bool = True,
 ) -> str:
-    # allow_init=False belongs to recovery: a pod that is being revived already had its volume
-    # initialised, so a missing gocryptfs.conf means the ciphertext is gone. Re-initialising it
-    # there would hand the customer an empty volume, log the recovery as a success and spare the
-    # miner the penalty for data they destroyed.
+    # allow_init=False belongs to every start of a container that already exists — stale-mount
+    # recovery and the backend's own start_container alike: such a volume was initialised at create
+    # time, so a missing gocryptfs.conf means the ciphertext is gone. Re-initialising it there would
+    # hand the customer an empty volume, report the start as a success and spare the miner the
+    # penalty for data they destroyed. Only pod creation initialises.
     plaintext = shlex.quote(plaintext_path)
     passfile = shlex.quote(passfile_path)
     mount_check = (
@@ -514,7 +530,7 @@ chmod 600 "$_pf"
 unset _esc _x _y {pad_var} {wrapped_var}
 mkdir -p {_LIUM_CIPHER_MOUNT} {plaintext}
 if [ ! -f {_LIUM_CIPHER_MOUNT}/gocryptfs.conf ]; then
-{_gocryptfs_missing_config_branch(allow_init)}
+{_shell_branch_when_gocryptfs_config_missing(allow_init)}
 fi
 if ! {mount_check}; then
   gocryptfs {_LIUM_CIPHER_MOUNT} {plaintext} -passfile "$_pf" -o allow_other -nonempty
@@ -5006,7 +5022,6 @@ class DockerService:
         # A falsy local_volume_path means the caller does not know the plaintext path, which is only
         # safe for a pod without an encrypted volume: mounting gocryptfs at a guessed path would
         # leave the customer's real path an ordinary container dir, writing plaintext to the host.
-        # An empty string counts as unknown for the same reason a missing value does.
         pkey = asyncssh.import_private_key(private_key)
         async with self.rental_docker_client_factory.connect(
             executor_info=executor_info,
@@ -5095,20 +5110,20 @@ class DockerService:
             encryption_state = await self._local_volume_encryption_state(
                 ssh_client, container_name
             )
-            if encryption_state is not _VolumeEncryptionState.PLAIN:
-                if encryption_state is _VolumeEncryptionState.UNKNOWN or not (
-                    self._can_remount_encrypted_volume(local_volume_path)
-                ):
-                    logger.warning(
-                        _m(
-                            "POD_STALE_MOUNT_RECOVERY_SKIPPED_ENCRYPTED_VOLUME",
-                            extra=get_extra_info({
-                                **log_extra,
-                                "volume_encryption_state": encryption_state.value,
-                            }),
-                        )
+            if encryption_state is _VolumeEncryptionState.UNKNOWN or (
+                encryption_state is _VolumeEncryptionState.ENCRYPTED
+                and not _can_remount_encrypted_volume(local_volume_path)
+            ):
+                logger.warning(
+                    _m(
+                        "POD_STALE_MOUNT_RECOVERY_SKIPPED_ENCRYPTED_VOLUME",
+                        extra=get_extra_info({
+                            **log_extra,
+                            "volume_encryption_state": encryption_state.value,
+                        }),
                     )
-                    return False
+                )
+                return False
             repaired_volume = await self._repair_stale_mountpoint_of_container_volume(
                 ssh_client,
                 container_name,
@@ -5182,20 +5197,6 @@ class DockerService:
             _m("POD_STALE_MOUNT_RECOVERED", extra=get_extra_info(log_extra))
         )
         return True
-
-    def _can_remount_encrypted_volume(self, local_volume_path: str | None) -> bool:
-        # whether recovery has everything it needs to put a gocryptfs volume back the way the
-        # customer had it. All three are checked before the container is started, because the
-        # remount only happens after `docker start`: a missing one would leave the pod flapping
-        # up and down once a cycle. VOLUME_MASTER_SECRET must be the one the volume was created
-        # with — another validator's secret derives a passphrase that simply will not mount.
-        return (
-            settings.RECOVER_ENCRYPTED_VOLUMES
-            and bool(local_volume_path)
-            and bool(_PLAINTEXT_PATH_RE.fullmatch(local_volume_path or ""))
-            and not _is_under_cipher_mount(local_volume_path or "")
-            and bool(settings.VOLUME_MASTER_SECRET)
-        )
 
     async def _local_volume_encryption_state(
         self,

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -4968,9 +4968,10 @@ class DockerService:
         # drops: the gocryptfs plaintext mount of an encrypted rental volume, and the sshd the
         # customer connects through. A failed remount raises and the caller decides how to report
         # it; a failed sshd bootstrap only warns, because the pod itself is up either way.
-        # local_volume_path=None means the caller does not know the plaintext path, which is only
+        # A falsy local_volume_path means the caller does not know the plaintext path, which is only
         # safe for a pod without an encrypted volume: mounting gocryptfs at a guessed path would
         # leave the customer's real path an ordinary container dir, writing plaintext to the host.
+        # An empty string counts as unknown for the same reason a missing value does.
         pkey = asyncssh.import_private_key(private_key)
         async with self.rental_docker_client_factory.connect(
             executor_info=executor_info,
@@ -4994,7 +4995,7 @@ class DockerService:
                     container_name,
                 )
                 if encrypted_volume_name:
-                    if local_volume_path is None:
+                    if not local_volume_path:
                         raise RuntimeError(
                             f"{container_name} holds an encrypted volume but no plaintext path "
                             "was supplied; refusing to remount it at a guessed path"
@@ -5042,6 +5043,7 @@ class DockerService:
         container_name: str,
         pod_id: str,
         container_error: str | None,
+        local_volume_path: str | None,
         default_extra: dict[str, Any],
     ) -> bool:
         # DAH-2306: bring back a still-rented pod the host could not auto-restart after a reboot.
@@ -5055,13 +5057,14 @@ class DockerService:
         log_extra = {**default_extra, "container_name": container_name}
         try:
             if await self._holds_encrypted_local_volume(ssh_client, container_name):
-                logger.warning(
-                    _m(
-                        "POD_STALE_MOUNT_RECOVERY_SKIPPED_ENCRYPTED_VOLUME",
-                        extra=get_extra_info(log_extra),
+                if not self._can_remount_encrypted_volume(local_volume_path):
+                    logger.warning(
+                        _m(
+                            "POD_STALE_MOUNT_RECOVERY_SKIPPED_ENCRYPTED_VOLUME",
+                            extra=get_extra_info(log_extra),
+                        )
                     )
-                )
-                return False
+                    return False
             repaired_volume = await self._repair_stale_mountpoint_of_container_volume(
                 ssh_client,
                 container_name,
@@ -5100,7 +5103,7 @@ class DockerService:
                 private_key=private_key,
                 known_hosts_policy=known_hosts_policy,
                 container_name=container_name,
-                local_volume_path=None,
+                local_volume_path=local_volume_path,
                 pod_id=pod_id,
                 default_extra=log_extra,
             )
@@ -5127,18 +5130,27 @@ class DockerService:
         )
         return True
 
+    def _can_remount_encrypted_volume(self, local_volume_path: str | None) -> bool:
+        # whether recovery has everything it needs to put a gocryptfs volume back the way the
+        # customer had it. Both inputs are checked before the container is started, because the
+        # remount only happens after `docker start`: a missing one would leave the pod flapping
+        # up and down once a cycle. VOLUME_MASTER_SECRET must be the one the volume was created
+        # with — another validator's secret derives a passphrase that simply will not mount.
+        return bool(local_volume_path) and bool(settings.VOLUME_MASTER_SECRET)
+
     async def _holds_encrypted_local_volume(
         self,
         ssh_client: asyncssh.SSHClientConnection,
         container_name: str,
     ) -> bool:
-        # whether the pod's rental volume is gocryptfs-encrypted, which recovery has to refuse.
-        # An encrypted volume is mounted as the ciphertext at /lium-cipher and the plaintext path
-        # the customer actually uses comes from the create request, which is recorded nowhere on
-        # the host and is not in the backend's rental-active response either. Remounting at the
+        # whether the pod's rental volume is gocryptfs-encrypted, which recovery may only touch
+        # when it knows the plaintext path. An encrypted volume is mounted as the ciphertext at
+        # /lium-cipher and the plaintext path the customer actually uses is recorded nowhere on the
+        # host; DAH-2545 carries it in the backend's rental-active response. Remounting at the
         # /root default would silently turn a custom path into an ordinary container dir, so
         # writes to it would land unencrypted on the miner's disk. Fails closed: an inspect that
-        # does not answer counts as encrypted, and the miner keeps the POD_NOT_RUNNING verdict.
+        # does not answer counts as encrypted, and without a path the miner keeps the
+        # POD_NOT_RUNNING verdict.
         inspect_result = await ssh_client.run(
             f"/usr/bin/docker inspect {shlex.quote(container_name)} "
             '--format \'{{range .Mounts}}{{println .Destination}}{{end}}\'',

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -198,9 +198,10 @@ _LOCAL_VOLUME_TIMEOUT_MAX_SEC = 180
 _FILLER_EXTERNAL_PORT_OFFSET = 20
 _LIUM_CIPHER_MOUNT = "/lium-cipher"
 _ENCRYPTED_VOLUME_IMAGE_LABEL = "lium.volume_encryption.enable"
-# a plaintext mount path we are willing to act on: absolute, normalised, not the root itself and
-# never the ciphertext mount. Anything else is refused rather than chmod-ed or mounted over.
-_PLAINTEXT_PATH_RE = re.compile(r"^(/[A-Za-z0-9._-]+)+$")
+# a plaintext mount path we are willing to act on: absolute, no "." or ".." segment, not the root
+# itself and never the ciphertext mount. The path comes from a customer-authored template, where
+# the backend only requires a leading slash, so it is refused here rather than mounted over.
+_PLAINTEXT_PATH_RE = re.compile(r"^(?:/(?!\.{1,2}(?:/|$))[A-Za-z0-9._-]+)+$")
 
 
 class _VolumeEncryptionState(enum.Enum):
@@ -5101,11 +5102,6 @@ class DockerService:
                         )
                     )
                     return False
-                # local_volume_path is validated by _can_remount_encrypted_volume above
-                if not await self._seal_plaintext_dir_before_start(
-                    ssh_client, container_name, local_volume_path or "", log_extra
-                ):
-                    return False
             repaired_volume = await self._repair_stale_mountpoint_of_container_volume(
                 ssh_client,
                 container_name,
@@ -5149,6 +5145,15 @@ class DockerService:
                 default_extra=log_extra,
             )
         except asyncio.CancelledError:
+            # the whole check runs under an outer timeout, so a cancellation can land between
+            # `docker start` and the gocryptfs remount and leave the container up with its
+            # plaintext path unmounted — exactly the state the Exception branch below stops. The
+            # stop is shielded because an unshielded await in a cancelled task never runs; the
+            # cancellation itself still propagates.
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.shield(
+                    self._stop_half_recovered_container(ssh_client, container_name)
+                )
             raise
         except Exception as exc:
             container_stopped = await self._stop_half_recovered_container(
@@ -5169,53 +5174,6 @@ class DockerService:
         logger.info(
             _m("POD_STALE_MOUNT_RECOVERED", extra=get_extra_info(log_extra))
         )
-        return True
-
-    async def _seal_plaintext_dir_before_start(
-        self,
-        ssh_client: asyncssh.SSHClientConnection,
-        container_name: str,
-        plaintext_path: str,
-        log_extra: dict[str, Any],
-    ) -> bool:
-        # make the plaintext dir unwritable on the host BEFORE the container starts, so nothing the
-        # pod runs on its own — startup_commands, an image that brings up its own sshd, a customer
-        # session — can write there in the window between `docker start` and the gocryptfs mount.
-        # Those writes would land in the container's upper layer, which is the miner's disk, and
-        # gocryptfs mounts with -nonempty, so they would then be shadowed: invisible to the
-        # customer, readable by the miner, forever. The mount lands on top and the mode of the
-        # directory underneath stops mattering; if the mount never happens, the dir stays sealed,
-        # which is the safe end state.
-        upper_dir_result = await ssh_client.run(
-            f"/usr/bin/docker inspect {shlex.quote(container_name)} "
-            "--format '{{.GraphDriver.Data.UpperDir}}'",
-            timeout=_VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC,
-        )
-        upper_dir = (upper_dir_result.stdout or "").strip()
-        if getattr(upper_dir_result, "exit_status", 0) != 0 or not _PLAINTEXT_PATH_RE.fullmatch(
-            upper_dir
-        ):
-            logger.warning(
-                _m(
-                    "POD_STALE_MOUNT_RECOVERY_SEAL_FAILED",
-                    extra=get_extra_info({**log_extra, "reason": "upper_dir_unavailable"}),
-                )
-            )
-            return False
-
-        sealed_dir = f"{upper_dir}{plaintext_path}"
-        seal_result = await ssh_client.run(
-            f"mkdir -p {shlex.quote(sealed_dir)} && chmod 000 {shlex.quote(sealed_dir)}",
-            timeout=_VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC,
-        )
-        if getattr(seal_result, "exit_status", 0) != 0:
-            logger.warning(
-                _m(
-                    "POD_STALE_MOUNT_RECOVERY_SEAL_FAILED",
-                    extra=get_extra_info({**log_extra, "reason": "chmod_failed"}),
-                )
-            )
-            return False
         return True
 
     def _can_remount_encrypted_volume(self, local_volume_path: str | None) -> bool:

--- a/neurons/validators/src/services/task/checks/rented_machine.py
+++ b/neurons/validators/src/services/task/checks/rented_machine.py
@@ -202,6 +202,7 @@ class TenantEnforcementCheck:
                     container_name=pod_container_name,
                     pod_id=pod_id,
                     diagnostics=diagnostics,
+                    local_volume_path=rental_active.local_volume_path if rental_active else None,
                     extra=extra,
                 )
                 if outcome.failure:
@@ -280,6 +281,7 @@ class TenantEnforcementCheck:
         container_name: str,
         pod_id: str,
         diagnostics: dict[str, object],
+        local_volume_path: str | None,
         extra: dict[str, Any],
     ) -> _DownedPodOutcome:
         # a rented pod found not running: heal it when it carries the DAH-2306 reboot signature,
@@ -289,11 +291,13 @@ class TenantEnforcementCheck:
         if self.recover_stale_pods:
             try:
                 if await _recover_pod_after_stale_vloopback_mount(
-                    ctx, container_name, pod_id, diagnostics
+                    ctx, container_name, pod_id, diagnostics, local_volume_path
                 ):
                     # Re-read the pod, so the recovered container's own SSH keys are what gets
                     # reported and a start that did not stick still lands on POD_NOT_RUNNING.
                     pod_running, ssh_pub_keys = await _check_pod_running(ctx.ssh, container_name)
+                    if pod_running:
+                        await _report_host_reboot_recovery(ctx, pod_id, diagnostics)
             except (asyncssh.Error, OSError) as exc:
                 # Recovery adds SSH round-trips to the executor inside the DAH-2055 window, so
                 # losing the transport here means pod state is unknown, not "pod down".
@@ -367,11 +371,37 @@ def _executor_transport_unreachable_result(
     return CheckResult(passed=False, event=event, updates={"default_extra": extra})
 
 
+async def _report_host_reboot_recovery(
+    ctx: Context,
+    pod_id: str,
+    diagnostics: dict[str, object],
+) -> None:
+    # DAH-2545: tell the backend the pod is back, so the renter can be told their pod went down
+    # because the provider's host restarted. Never fatal: the rental has already been saved by the
+    # time this runs, and a backend that is down or too old must not turn that into a failure.
+    container_finished_at = diagnostics.get("container_finished_at")
+    if not isinstance(container_finished_at, str) or not container_finished_at:
+        return
+    try:
+        await ctx.services.backend.report_pod_host_reboot_recovered(
+            pod_id, container_finished_at
+        )
+    except Exception:
+        logger.warning(
+            _m(
+                "POD_STALE_MOUNT_RECOVERY_REPORT_FAILED",
+                extra=get_extra_info({**ctx.default_extra, "pod_id": pod_id}),
+            ),
+            exc_info=True,
+        )
+
+
 async def _recover_pod_after_stale_vloopback_mount(
     ctx: Context,
     container_name: str,
     pod_id: str,
     diagnostics: dict[str, object],
+    local_volume_path: str | None,
 ) -> bool:
     # DAH-2306: heal a still-rented pod the host could not auto-restart after a reboot, before the
     # miner is penalised for it. Best effort in every direction — a recovery that cannot run, or
@@ -390,6 +420,7 @@ async def _recover_pod_after_stale_vloopback_mount(
             container_name=container_name,
             pod_id=pod_id,
             container_error=container_error if isinstance(container_error, str) else None,
+            local_volume_path=local_volume_path,
             default_extra=ctx.default_extra,
         )
     except (asyncssh.Error, OSError):

--- a/neurons/validators/src/services/task/checks/rented_machine.py
+++ b/neurons/validators/src/services/task/checks/rented_machine.py
@@ -296,8 +296,9 @@ class TenantEnforcementCheck:
                     # Re-read the pod, so the recovered container's own SSH keys are what gets
                     # reported and a start that did not stick still lands on POD_NOT_RUNNING.
                     pod_running, ssh_pub_keys = await _check_pod_running(ctx.ssh, container_name)
-                    if pod_running:
-                        await _report_host_reboot_recovery(ctx, pod_id, diagnostics)
+                    container_finished_at = diagnostics.get("container_finished_at")
+                    if pod_running and isinstance(container_finished_at, str):
+                        await _report_host_reboot_recovery(ctx, pod_id, container_finished_at)
             except (asyncssh.Error, OSError) as exc:
                 # Recovery adds SSH round-trips to the executor inside the DAH-2055 window, so
                 # losing the transport here means pod state is unknown, not "pod down".
@@ -374,13 +375,13 @@ def _executor_transport_unreachable_result(
 async def _report_host_reboot_recovery(
     ctx: Context,
     pod_id: str,
-    diagnostics: dict[str, object],
+    container_finished_at: str | None,
 ) -> None:
     # DAH-2545: tell the backend the pod is back, so the renter can be told their pod went down
     # because the provider's host restarted. Never fatal: the rental has already been saved by the
     # time this runs, and a backend that is down or too old must not turn that into a failure.
-    container_finished_at = diagnostics.get("container_finished_at")
-    if not isinstance(container_finished_at, str) or not container_finished_at:
+    # An unknown exit time is nothing to report: it is the key the backend deduplicates on.
+    if not container_finished_at:
         return
     try:
         await ctx.services.backend.report_pod_host_reboot_recovered(

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import shutil
@@ -5693,18 +5694,12 @@ def _asyncssh_timeout_error() -> asyncssh.TimeoutError:
 def _recovery_ssh_client(
     volume_names: str = "volume_pod-1\n",
     mount_destinations: str = "/root\n",
-    upper_dir: str = "/var/lib/docker/overlay2/abc123/diff",
 ) -> AsyncMock:
     # the recovery path inspects the container for where its volumes are mounted (an encrypted pod
-    # shows /lium-cipher), for their names, and — for an encrypted pod — for the upper layer whose
-    # plaintext dir is sealed before the start.
+    # shows /lium-cipher) and for their names.
     async def run(command, *_args, **_kwargs):
         if ".Destination" in command:
             stdout = mount_destinations
-        elif ".GraphDriver.Data.UpperDir" in command:
-            stdout = f"{upper_dir}\n"
-        elif command.startswith("mkdir -p"):
-            stdout = ""
         else:
             stdout = volume_names
         return _make_ssh_command_result(stdout=stdout)
@@ -5845,6 +5840,7 @@ async def test_recover_pod_remounts_an_encrypted_volume_at_the_path_the_backend_
 ):
     # DAH-2545: with the plaintext path in hand the encrypted pod is recoverable, and the path is
     # handed on untouched — a guessed one would write the customer's data out in the clear
+    monkeypatch.setattr(docker_service_module.settings, "RECOVER_ENCRYPTED_VOLUMES", True)
     monkeypatch.setattr(
         docker_service_module.settings,
         "VOLUME_MASTER_SECRET",
@@ -5853,21 +5849,7 @@ async def test_recover_pod_remounts_an_encrypted_volume_at_the_path_the_backend_
     repair_mountpoint = AsyncMock(return_value=True)
     monkeypatch.setattr(docker_service, "repair_stale_vloopback_mountpoint", repair_mountpoint)
     ssh_client = _recovery_ssh_client(mount_destinations="/lium-cipher\n/mnt\n")
-
-    def seal_commands() -> list[str]:
-        return [
-            call.args[0]
-            for call in ssh_client.run.await_args_list
-            if call.args[0].startswith("mkdir -p")
-        ]
-
-    sealed_before_start = False
-
-    async def record_seal_state(**_kwargs):
-        nonlocal sealed_before_start
-        sealed_before_start = bool(seal_commands())
-
-    start_existing_container = AsyncMock(side_effect=record_seal_state)
+    start_existing_container = AsyncMock()
     monkeypatch.setattr(docker_service, "start_existing_container", start_existing_container)
     monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
     monkeypatch.setattr("services.docker_service.require_rental_docker_ssh_host_key", Mock())
@@ -5878,13 +5860,6 @@ async def test_recover_pod_remounts_an_encrypted_volume_at_the_path_the_backend_
 
     assert recovered is True
     assert start_existing_container.await_args.kwargs["local_volume_path"] == "/workspace"
-    # the plaintext dir is sealed on the host BEFORE the container is started, so nothing the pod
-    # runs on its own can write there in the window before gocryptfs is mounted
-    assert sealed_before_start is True
-    assert seal_commands() == [
-        "mkdir -p /var/lib/docker/overlay2/abc123/diff/workspace "
-        "&& chmod 000 /var/lib/docker/overlay2/abc123/diff/workspace"
-    ]
 
 
 @pytest.mark.asyncio
@@ -5914,16 +5889,22 @@ async def test_recover_pod_declines_an_encrypted_volume_when_the_kill_switch_is_
     [
         pytest.param("/lium-cipher", id="the_ciphertext_mount_itself"),
         pytest.param("/workspace/../../etc", id="path_escaping_upwards"),
+        pytest.param("/..", id="nothing_but_a_parent_segment"),
+        pytest.param("/workspace/./data", id="unnormalised"),
         pytest.param("relative/path", id="not_absolute"),
         pytest.param("/", id="root"),
+        pytest.param("/work space", id="whitespace"),
     ],
 )
 @pytest.mark.asyncio
 async def test_recover_pod_declines_an_unusable_plaintext_path(
     docker_service, monkeypatch, local_volume_path
 ):
-    # the path is chmod-ed on the host and then mounted over; a path that is not a plain absolute
-    # directory under the container's upper layer must never reach either operation
+    # the path is a customer-authored template field and the backend accepts anything with a
+    # leading slash, so this gate is the only thing keeping a traversal out of the mount command.
+    # Asserted on the gate directly as well as on the outcome: the outcome alone would stay green
+    # for any of the other reasons recovery can decline.
+    monkeypatch.setattr(docker_service_module.settings, "RECOVER_ENCRYPTED_VOLUMES", True)
     monkeypatch.setattr(
         docker_service_module.settings,
         "VOLUME_MASTER_SECRET",
@@ -5933,12 +5914,35 @@ async def test_recover_pod_declines_an_unusable_plaintext_path(
     monkeypatch.setattr(docker_service, "start_existing_container", start_existing_container)
     ssh_client = _recovery_ssh_client(mount_destinations="/lium-cipher\n/mnt\n")
 
+    assert docker_service._can_remount_encrypted_volume(local_volume_path) is False
+
     recovered = await _attempt_stale_mount_recovery(
         docker_service, _STALE_MOUNT_ERROR, ssh_client, local_volume_path
     )
 
     assert recovered is False
     start_existing_container.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "local_volume_path",
+    [
+        pytest.param("/root", id="the_default"),
+        pytest.param("/workspace/data", id="nested"),
+        pytest.param("/data.v2/my-vol_1", id="punctuation_that_is_still_a_plain_name"),
+    ],
+)
+def test_a_plain_absolute_plaintext_path_is_accepted(
+    docker_service, monkeypatch, local_volume_path
+):
+    monkeypatch.setattr(docker_service_module.settings, "RECOVER_ENCRYPTED_VOLUMES", True)
+    monkeypatch.setattr(
+        docker_service_module.settings,
+        "VOLUME_MASTER_SECRET",
+        "test-master-secret-32-chars-long!!",
+    )
+
+    assert docker_service._can_remount_encrypted_volume(local_volume_path) is True
 
 
 @pytest.mark.asyncio
@@ -5966,35 +5970,39 @@ async def test_recover_pod_declines_when_the_volume_state_cannot_be_read(
 
 
 @pytest.mark.asyncio
-async def test_recover_pod_does_not_start_when_the_plaintext_dir_cannot_be_sealed(
+async def test_recover_pod_stops_the_container_when_the_start_is_cancelled(
     docker_service, monkeypatch
 ):
-    # without the seal there is an unguarded window between start and mount, so a failed seal has
-    # to stop the recovery rather than proceed without it
+    # the check runs under an outer timeout, so cancellation can land after `docker start` but
+    # before gocryptfs is remounted, leaving the customer a running pod whose plaintext path is an
+    # ordinary container dir writing to the miner's disk. The stop has to survive the cancellation.
+    monkeypatch.setattr(docker_service_module.settings, "RECOVER_ENCRYPTED_VOLUMES", True)
     monkeypatch.setattr(
         docker_service_module.settings,
         "VOLUME_MASTER_SECRET",
         "test-master-secret-32-chars-long!!",
     )
-    start_existing_container = AsyncMock()
-    monkeypatch.setattr(docker_service, "start_existing_container", start_existing_container)
-
-    async def run(command, *_args, **_kwargs):
-        if ".Destination" in command:
-            return _make_ssh_command_result(stdout="/lium-cipher\n")
-        if ".GraphDriver.Data.UpperDir" in command:
-            return _make_ssh_command_result(stdout="", exit_status=1)
-        return _make_ssh_command_result(stdout="volume_pod-1\n")
-
-    ssh_client = AsyncMock()
-    ssh_client.run = AsyncMock(side_effect=run)
-
-    recovered = await _attempt_stale_mount_recovery(
-        docker_service, _STALE_MOUNT_ERROR, ssh_client, "/workspace"
+    monkeypatch.setattr(
+        docker_service, "repair_stale_vloopback_mountpoint", AsyncMock(return_value=True)
     )
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+    monkeypatch.setattr("services.docker_service.require_rental_docker_ssh_host_key", Mock())
+    monkeypatch.setattr(
+        docker_service,
+        "start_existing_container",
+        AsyncMock(side_effect=asyncio.CancelledError()),
+    )
+    ssh_client = _recovery_ssh_client(mount_destinations="/lium-cipher\n/mnt\n")
 
-    assert recovered is False
-    start_existing_container.assert_not_awaited()
+    with pytest.raises(asyncio.CancelledError):
+        await _attempt_stale_mount_recovery(
+            docker_service, _STALE_MOUNT_ERROR, ssh_client, "/workspace"
+        )
+
+    assert any(
+        call.args[0] == "/usr/bin/docker stop pod_pod-1"
+        for call in ssh_client.run.await_args_list
+    )
 
 
 def test_gocryptfs_script_refuses_to_reinitialise_on_recovery():

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -5888,6 +5888,7 @@ async def test_recover_pod_declines_an_encrypted_volume_when_the_kill_switch_is_
     "local_volume_path",
     [
         pytest.param("/lium-cipher", id="the_ciphertext_mount_itself"),
+        pytest.param("/lium-cipher/data", id="inside_the_ciphertext_mount"),
         pytest.param("/workspace/../../etc", id="path_escaping_upwards"),
         pytest.param("/..", id="nothing_but_a_parent_segment"),
         pytest.param("/workspace/./data", id="unnormalised"),

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -2491,6 +2491,9 @@ async def test_start_container_remounts_when_container_state_is_encrypted(docker
             "executor_ssh_username": "root",
             "executor_ssh_port": 2200,
         },
+        # an existing container's volume was initialised at create time: a missing gocryptfs.conf
+        # here means the ciphertext is gone, and re-initialising would hide that
+        allow_init=False,
     )
 
 
@@ -5690,11 +5693,20 @@ def _asyncssh_timeout_error() -> asyncssh.TimeoutError:
 def _recovery_ssh_client(
     volume_names: str = "volume_pod-1\n",
     mount_destinations: str = "/root\n",
+    upper_dir: str = "/var/lib/docker/overlay2/abc123/diff",
 ) -> AsyncMock:
-    # the recovery path inspects the container twice: once for where its volumes are mounted
-    # (an encrypted pod shows /lium-cipher) and once for their names.
+    # the recovery path inspects the container for where its volumes are mounted (an encrypted pod
+    # shows /lium-cipher), for their names, and — for an encrypted pod — for the upper layer whose
+    # plaintext dir is sealed before the start.
     async def run(command, *_args, **_kwargs):
-        stdout = mount_destinations if ".Destination" in command else volume_names
+        if ".Destination" in command:
+            stdout = mount_destinations
+        elif ".GraphDriver.Data.UpperDir" in command:
+            stdout = f"{upper_dir}\n"
+        elif command.startswith("mkdir -p"):
+            stdout = ""
+        else:
+            stdout = volume_names
         return _make_ssh_command_result(stdout=stdout)
 
     ssh_client = AsyncMock()
@@ -5840,11 +5852,25 @@ async def test_recover_pod_remounts_an_encrypted_volume_at_the_path_the_backend_
     )
     repair_mountpoint = AsyncMock(return_value=True)
     monkeypatch.setattr(docker_service, "repair_stale_vloopback_mountpoint", repair_mountpoint)
-    start_existing_container = AsyncMock()
+    ssh_client = _recovery_ssh_client(mount_destinations="/lium-cipher\n/mnt\n")
+
+    def seal_commands() -> list[str]:
+        return [
+            call.args[0]
+            for call in ssh_client.run.await_args_list
+            if call.args[0].startswith("mkdir -p")
+        ]
+
+    sealed_before_start = False
+
+    async def record_seal_state(**_kwargs):
+        nonlocal sealed_before_start
+        sealed_before_start = bool(seal_commands())
+
+    start_existing_container = AsyncMock(side_effect=record_seal_state)
     monkeypatch.setattr(docker_service, "start_existing_container", start_existing_container)
     monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
     monkeypatch.setattr("services.docker_service.require_rental_docker_ssh_host_key", Mock())
-    ssh_client = _recovery_ssh_client(mount_destinations="/lium-cipher\n/mnt\n")
 
     recovered = await _attempt_stale_mount_recovery(
         docker_service, _STALE_MOUNT_ERROR, ssh_client, "/workspace"
@@ -5852,6 +5878,153 @@ async def test_recover_pod_remounts_an_encrypted_volume_at_the_path_the_backend_
 
     assert recovered is True
     assert start_existing_container.await_args.kwargs["local_volume_path"] == "/workspace"
+    # the plaintext dir is sealed on the host BEFORE the container is started, so nothing the pod
+    # runs on its own can write there in the window before gocryptfs is mounted
+    assert sealed_before_start is True
+    assert seal_commands() == [
+        "mkdir -p /var/lib/docker/overlay2/abc123/diff/workspace "
+        "&& chmod 000 /var/lib/docker/overlay2/abc123/diff/workspace"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_recover_pod_declines_an_encrypted_volume_when_the_kill_switch_is_off(
+    docker_service, monkeypatch
+):
+    monkeypatch.setattr(docker_service_module.settings, "RECOVER_ENCRYPTED_VOLUMES", False)
+    monkeypatch.setattr(
+        docker_service_module.settings,
+        "VOLUME_MASTER_SECRET",
+        "test-master-secret-32-chars-long!!",
+    )
+    start_existing_container = AsyncMock()
+    monkeypatch.setattr(docker_service, "start_existing_container", start_existing_container)
+    ssh_client = _recovery_ssh_client(mount_destinations="/lium-cipher\n/mnt\n")
+
+    recovered = await _attempt_stale_mount_recovery(
+        docker_service, _STALE_MOUNT_ERROR, ssh_client, "/workspace"
+    )
+
+    assert recovered is False
+    start_existing_container.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "local_volume_path",
+    [
+        pytest.param("/lium-cipher", id="the_ciphertext_mount_itself"),
+        pytest.param("/workspace/../../etc", id="path_escaping_upwards"),
+        pytest.param("relative/path", id="not_absolute"),
+        pytest.param("/", id="root"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_recover_pod_declines_an_unusable_plaintext_path(
+    docker_service, monkeypatch, local_volume_path
+):
+    # the path is chmod-ed on the host and then mounted over; a path that is not a plain absolute
+    # directory under the container's upper layer must never reach either operation
+    monkeypatch.setattr(
+        docker_service_module.settings,
+        "VOLUME_MASTER_SECRET",
+        "test-master-secret-32-chars-long!!",
+    )
+    start_existing_container = AsyncMock()
+    monkeypatch.setattr(docker_service, "start_existing_container", start_existing_container)
+    ssh_client = _recovery_ssh_client(mount_destinations="/lium-cipher\n/mnt\n")
+
+    recovered = await _attempt_stale_mount_recovery(
+        docker_service, _STALE_MOUNT_ERROR, ssh_client, local_volume_path
+    )
+
+    assert recovered is False
+    start_existing_container.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recover_pod_declines_when_the_volume_state_cannot_be_read(
+    docker_service, monkeypatch
+):
+    # an inspect that does not answer leaves us unable to tell an encrypted pod from a plain one:
+    # starting it on the strength of a path we cannot match to a volume is not safe
+    monkeypatch.setattr(
+        docker_service_module.settings,
+        "VOLUME_MASTER_SECRET",
+        "test-master-secret-32-chars-long!!",
+    )
+    start_existing_container = AsyncMock()
+    monkeypatch.setattr(docker_service, "start_existing_container", start_existing_container)
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result(stdout="", exit_status=1))
+
+    recovered = await _attempt_stale_mount_recovery(
+        docker_service, _STALE_MOUNT_ERROR, ssh_client, "/workspace"
+    )
+
+    assert recovered is False
+    start_existing_container.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recover_pod_does_not_start_when_the_plaintext_dir_cannot_be_sealed(
+    docker_service, monkeypatch
+):
+    # without the seal there is an unguarded window between start and mount, so a failed seal has
+    # to stop the recovery rather than proceed without it
+    monkeypatch.setattr(
+        docker_service_module.settings,
+        "VOLUME_MASTER_SECRET",
+        "test-master-secret-32-chars-long!!",
+    )
+    start_existing_container = AsyncMock()
+    monkeypatch.setattr(docker_service, "start_existing_container", start_existing_container)
+
+    async def run(command, *_args, **_kwargs):
+        if ".Destination" in command:
+            return _make_ssh_command_result(stdout="/lium-cipher\n")
+        if ".GraphDriver.Data.UpperDir" in command:
+            return _make_ssh_command_result(stdout="", exit_status=1)
+        return _make_ssh_command_result(stdout="volume_pod-1\n")
+
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(side_effect=run)
+
+    recovered = await _attempt_stale_mount_recovery(
+        docker_service, _STALE_MOUNT_ERROR, ssh_client, "/workspace"
+    )
+
+    assert recovered is False
+    start_existing_container.assert_not_awaited()
+
+
+def test_gocryptfs_script_refuses_to_reinitialise_on_recovery():
+    # a missing gocryptfs.conf on an existing rental means the ciphertext is gone; re-initialising
+    # would hand the customer an empty volume and log the recovery as a success
+    script = docker_service_module._build_gocryptfs_setup_and_mount_script(
+        "/workspace",
+        pad_hex="00",
+        wrapped_hex="00",
+        pad_var="_a",
+        wrapped_var="_b",
+        passfile_path="/tmp/pf",
+        allow_init=False,
+    )
+
+    assert "gocryptfs -init" not in script
+    assert "exit 1" in script
+
+
+def test_gocryptfs_script_still_initialises_at_create_time():
+    script = docker_service_module._build_gocryptfs_setup_and_mount_script(
+        "/workspace",
+        pad_hex="00",
+        wrapped_hex="00",
+        pad_var="_a",
+        wrapped_var="_b",
+        passfile_path="/tmp/pf",
+    )
+
+    assert "gocryptfs -init /lium-cipher" in script
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -5915,7 +5915,7 @@ async def test_recover_pod_declines_an_unusable_plaintext_path(
     monkeypatch.setattr(docker_service, "start_existing_container", start_existing_container)
     ssh_client = _recovery_ssh_client(mount_destinations="/lium-cipher\n/mnt\n")
 
-    assert docker_service._can_remount_encrypted_volume(local_volume_path) is False
+    assert docker_service_module._can_remount_encrypted_volume(local_volume_path) is False
 
     recovered = await _attempt_stale_mount_recovery(
         docker_service, _STALE_MOUNT_ERROR, ssh_client, local_volume_path
@@ -5933,9 +5933,7 @@ async def test_recover_pod_declines_an_unusable_plaintext_path(
         pytest.param("/data.v2/my-vol_1", id="punctuation_that_is_still_a_plain_name"),
     ],
 )
-def test_a_plain_absolute_plaintext_path_is_accepted(
-    docker_service, monkeypatch, local_volume_path
-):
+def test_a_plain_absolute_plaintext_path_is_accepted(monkeypatch, local_volume_path):
     monkeypatch.setattr(docker_service_module.settings, "RECOVER_ENCRYPTED_VOLUMES", True)
     monkeypatch.setattr(
         docker_service_module.settings,
@@ -5943,7 +5941,7 @@ def test_a_plain_absolute_plaintext_path_is_accepted(
         "test-master-secret-32-chars-long!!",
     )
 
-    assert docker_service._can_remount_encrypted_volume(local_volume_path) is True
+    assert docker_service_module._can_remount_encrypted_volume(local_volume_path) is True
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -5706,6 +5706,7 @@ async def _attempt_stale_mount_recovery(
     docker_service: DockerService,
     container_error: str | None,
     ssh_client: AsyncMock | None = None,
+    local_volume_path: str | None = None,
 ) -> bool:
     return await docker_service.recover_pod_after_stale_vloopback_mount(
         ssh_client=ssh_client if ssh_client is not None else _recovery_ssh_client(),
@@ -5715,6 +5716,7 @@ async def _attempt_stale_mount_recovery(
         container_name="pod_pod-1",
         pod_id="pod-1",
         container_error=container_error,
+        local_volume_path=local_volume_path,
         default_extra={},
     )
 
@@ -5775,8 +5777,17 @@ async def test_recover_pod_repairs_then_starts_through_the_full_start_path(
     assert start_kwargs["local_volume_path"] is None
 
 
+@pytest.mark.parametrize(
+    "local_volume_path",
+    [
+        pytest.param(None, id="path_absent"),
+        pytest.param("", id="path_empty_string"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_recover_pod_declines_an_encrypted_volume(docker_service, monkeypatch):
+async def test_recover_pod_declines_an_encrypted_volume_without_a_plaintext_path(
+    docker_service, monkeypatch, local_volume_path
+):
     # the plaintext path of an encrypted volume is recorded nowhere on the host, and remounting
     # gocryptfs at the /root default would write a custom path out in the clear
     repair_mountpoint = AsyncMock(return_value=True)
@@ -5786,12 +5797,61 @@ async def test_recover_pod_declines_an_encrypted_volume(docker_service, monkeypa
     ssh_client = _recovery_ssh_client(mount_destinations="/lium-cipher\n/mnt\n")
 
     recovered = await _attempt_stale_mount_recovery(
-        docker_service, _STALE_MOUNT_ERROR, ssh_client
+        docker_service, _STALE_MOUNT_ERROR, ssh_client, local_volume_path
     )
 
     assert recovered is False
     repair_mountpoint.assert_not_awaited()
     start_existing_container.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recover_pod_declines_an_encrypted_volume_without_the_master_secret(
+    docker_service, monkeypatch
+):
+    # the passphrase is derived from VOLUME_MASTER_SECRET; without it the remount can only fail
+    # after the container is already up, leaving the pod flapping once a cycle
+    monkeypatch.setattr(docker_service_module.settings, "VOLUME_MASTER_SECRET", None)
+    repair_mountpoint = AsyncMock(return_value=True)
+    monkeypatch.setattr(docker_service, "repair_stale_vloopback_mountpoint", repair_mountpoint)
+    start_existing_container = AsyncMock()
+    monkeypatch.setattr(docker_service, "start_existing_container", start_existing_container)
+    ssh_client = _recovery_ssh_client(mount_destinations="/lium-cipher\n/mnt\n")
+
+    recovered = await _attempt_stale_mount_recovery(
+        docker_service, _STALE_MOUNT_ERROR, ssh_client, "/workspace"
+    )
+
+    assert recovered is False
+    repair_mountpoint.assert_not_awaited()
+    start_existing_container.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recover_pod_remounts_an_encrypted_volume_at_the_path_the_backend_supplied(
+    docker_service, monkeypatch
+):
+    # DAH-2545: with the plaintext path in hand the encrypted pod is recoverable, and the path is
+    # handed on untouched — a guessed one would write the customer's data out in the clear
+    monkeypatch.setattr(
+        docker_service_module.settings,
+        "VOLUME_MASTER_SECRET",
+        "test-master-secret-32-chars-long!!",
+    )
+    repair_mountpoint = AsyncMock(return_value=True)
+    monkeypatch.setattr(docker_service, "repair_stale_vloopback_mountpoint", repair_mountpoint)
+    start_existing_container = AsyncMock()
+    monkeypatch.setattr(docker_service, "start_existing_container", start_existing_container)
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+    monkeypatch.setattr("services.docker_service.require_rental_docker_ssh_host_key", Mock())
+    ssh_client = _recovery_ssh_client(mount_destinations="/lium-cipher\n/mnt\n")
+
+    recovered = await _attempt_stale_mount_recovery(
+        docker_service, _STALE_MOUNT_ERROR, ssh_client, "/workspace"
+    )
+
+    assert recovered is True
+    assert start_existing_container.await_args.kwargs["local_volume_path"] == "/workspace"
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_rented_machine_check.py
+++ b/neurons/validators/tests/test_rented_machine_check.py
@@ -128,6 +128,7 @@ class DummySSHClient:
         self.should_raise = should_raise
         self.raise_on_run = raise_on_run
         self.commands_called: list[str] = []
+        self.container_finished_at = "2026-08-03T16:59:21.514042646Z"
 
     async def run(self, command: str):
         """Mock SSH run command."""
@@ -144,6 +145,14 @@ class DummySSHClient:
             result.stdout = "container_id_123" if self.pod_running else ""
         elif "authorized_keys" in command:
             result.stdout = "\n".join(self.ssh_keys) if self.ssh_keys else ""
+        elif "docker inspect" in command:
+            result.stdout = json.dumps(
+                {
+                    "Status": "exited",
+                    "ExitCode": 255,
+                    "FinishedAt": self.container_finished_at,
+                }
+            )
         else:
             result.stdout = ""
 
@@ -168,15 +177,25 @@ class DummyScoreCalculator:
 
 
 class DummyBackendClient:
-    def __init__(self, *, active: bool | None = True):
+    def __init__(self, *, active: bool | None = True, local_volume_path: str | None = None):
         self.active = active
+        self.local_volume_path = local_volume_path
         self.called_with: list[str] = []
+        self.host_reboot_recoveries: list[tuple[str, str]] = []
 
     async def get_pod_rental_active(self, pod_id: str):
         self.called_with.append(pod_id)
         if self.active is None:
             return None
-        return Mock(active=self.active, rental_closed_at=None)
+        return Mock(
+            active=self.active,
+            rental_closed_at=None,
+            local_volume_path=self.local_volume_path,
+        )
+
+    async def report_pod_host_reboot_recovered(self, pod_id: str, container_finished_at: str):
+        self.host_reboot_recoveries.append((pod_id, container_finished_at))
+        return Mock(recorded=True)
 
 
 @pytest.mark.parametrize(
@@ -835,6 +854,7 @@ def build_recovery_context(
     docker: AsyncMock,
     *,
     private_key: str | None = "ssh-key",
+    backend: DummyBackendClient | None = None,
 ) -> Context:
     rented_data = build_rented_data(
         "executor-123",
@@ -843,7 +863,7 @@ def build_recovery_context(
     services = build_services(
         score_calculator=DummyScoreCalculator(actual_score=1.0, job_score=1.0, warning=""),
         container_cleanup=MockContainerCleanup(),
-        backend=DummyBackendClient(active=True),
+        backend=backend if backend is not None else DummyBackendClient(active=True),
         pod_recovery=docker,
     )
     return context_factory(
@@ -883,6 +903,69 @@ async def test_tenant_enforcement_passes_when_pod_recovered_from_stale_mount(con
     assert result.updates["ssh_pub_keys"] == ["ssh-rsa recovered"]
     assert result.updates["default_extra"]["recovered_pods"] == ["pod_pod-1"]
     assert docker.recover_pod_after_stale_vloopback_mount.await_args.kwargs["pod_id"] == "pod-1"
+
+
+@pytest.mark.asyncio
+async def test_tenant_enforcement_hands_recovery_the_backend_plaintext_path(context_factory):
+    # DAH-2545: an encrypted pod can only be revived at the path the backend recorded at create
+    # time, so whatever rental-active returns has to reach the recovery untouched
+    ssh = DummySSHClient(pod_running=False, ssh_keys=["ssh-rsa recovered"])
+    docker = AsyncMock()
+
+    async def bring_pod_back_up(**kwargs):
+        ssh.pod_running = True
+        return True
+
+    docker.recover_pod_after_stale_vloopback_mount.side_effect = bring_pod_back_up
+    backend = DummyBackendClient(active=True, local_volume_path="/workspace")
+    ctx = build_recovery_context(context_factory, ssh, docker, backend=backend)
+
+    result = await TenantEnforcementCheck().run(ctx)
+
+    assert result.passed is True
+    recovery_kwargs = docker.recover_pod_after_stale_vloopback_mount.await_args.kwargs
+    assert recovery_kwargs["local_volume_path"] == "/workspace"
+
+
+@pytest.mark.asyncio
+async def test_tenant_enforcement_reports_recovery_to_the_backend(context_factory):
+    # the renter has to learn their pod went down because the provider's host restarted
+    ssh = DummySSHClient(pod_running=False, ssh_keys=["ssh-rsa recovered"])
+    docker = AsyncMock()
+
+    async def bring_pod_back_up(**kwargs):
+        ssh.pod_running = True
+        return True
+
+    docker.recover_pod_after_stale_vloopback_mount.side_effect = bring_pod_back_up
+    backend = DummyBackendClient(active=True)
+    ctx = build_recovery_context(context_factory, ssh, docker, backend=backend)
+
+    result = await TenantEnforcementCheck().run(ctx)
+
+    assert result.passed is True
+    assert backend.host_reboot_recoveries == [("pod-1", ssh.container_finished_at)]
+
+
+@pytest.mark.asyncio
+async def test_tenant_enforcement_survives_a_failed_recovery_report(context_factory):
+    # the rental is already saved by then; a backend that is down must not undo that
+    ssh = DummySSHClient(pod_running=False, ssh_keys=["ssh-rsa recovered"])
+    docker = AsyncMock()
+
+    async def bring_pod_back_up(**kwargs):
+        ssh.pod_running = True
+        return True
+
+    docker.recover_pod_after_stale_vloopback_mount.side_effect = bring_pod_back_up
+    backend = DummyBackendClient(active=True)
+    backend.report_pod_host_reboot_recovered = AsyncMock(side_effect=RuntimeError("backend down"))
+    ctx = build_recovery_context(context_factory, ssh, docker, backend=backend)
+
+    result = await TenantEnforcementCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.ALREADY_RENTED.reason
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
DAH-2545, follow-up to DAH-2306.

A pod whose rental volume is gocryptfs-encrypted was skipped by stale-mount recovery, because
recovery could not know the plaintext path the customer mounts and remounting at a guessed one
would write their data out in the clear. The path is already stored on the backend as
`pod.local_volume_path`; Datura-ai/lium-io-backend#854 returns it in the rental-active response and
this PR consumes it. The passphrase is not stored anywhere and is not needed — it is derived from
`VOLUME_MASTER_SECRET` and `pod_id`.

**Deploy Datura-ai/lium-io-backend#854 first.** Against an older backend the field is simply absent
and encrypted pods keep being skipped, exactly as today.

## What is in here

- `local_volume_path` on `PodRentalActiveResponse`, passed from the rented-machine check into
  `start_existing_container` instead of the hardcoded `None`.
- `allow_init=False` on the recovery path. A pod being revived already had its volume initialised,
  so a missing `gocryptfs.conf` means the ciphertext is gone. Re-initialising there would hand the
  customer an empty volume, log the recovery as a success and spare the miner the penalty for the
  data they destroyed. It now fails instead.
- Three-state volume detection. An inspect that does not answer used to count as "encrypted", which
  was safe only while that always meant "stand down"; with a path in hand it would have meant
  starting a container whose volume we could not read. `UNKNOWN` now declines unconditionally.
- `VOLUME_MASTER_SECRET` and the plaintext path are both checked *before* `docker start`. The
  remount only happens after the start, so a missing one would leave the customer's pod flapping up
  and down once a cycle.
- Plaintext path validation: absolute, no `.` or `..` segment, not `/lium-cipher` and not inside it.
  The path is a customer-authored template field and the backend accepts anything with a leading
  slash.
- A cancellation between `docker start` and the remount now stops the container instead of leaving
  it up with an unmounted plaintext path. The whole check runs under an outer timeout, so this is
  an ordinary path, not an exotic one.
- Reports a successful recovery to the backend (`POST /internal/pods/{pod_id}/host-reboot-recovered`).
  This is **telemetry**, not a customer notification: it creates an internal event keyed on pod and
  downtime. Wiring it to an email is deliberately left out. Sent once, right after the recovery, and
  best-effort — a backend timeout drops it, and no later cycle retries, because by then the pod is
  running and recovery does not fire again. Acceptable for telemetry; it would need an outbox before
  anything customer-facing depends on it.

## Encrypted recovery ships switched off

`RECOVER_ENCRYPTED_VOLUMES` defaults to `false`, so this PR changes nothing in production until it
is deliberately turned on. The reason is a window this PR does not close:

A restarted container runs its own entrypoint and `startup_commands` the moment it starts, and
gocryptfs can only be mounted into it afterwards, over `docker exec`. Writes to the plaintext path
in that window land in the container's upper layer — the miner's disk — and gocryptfs then mounts
with `-nonempty` and *shadows* them: invisible to the customer, readable by the miner, permanently.

An earlier revision of this PR tried to close that window by `chmod 000`-ing the plaintext directory
in the container's upper layer before the start. That was wrong twice over and has been removed:

1. It does not work. The container's processes run as root and Docker grants `CAP_DAC_OVERRIDE` by
   default, which bypasses file permission checks. The write succeeds.
2. It made things worse. The path it built came from a customer-authored template, and the sanitizer
   only requires a leading slash, so a volume of `/a/../../../../../../etc` would have turned into
   `mkdir -p /etc && chmod 000 /etc` on the miner's host.

**The same window exists on the pod-creation path in production today** — `docker run` starts the
container with the customer's startup commands and the gocryptfs mount follows. It is a property of
the encryption feature, not of recovery. Closing it needs a real pre-start barrier for both paths
and is tracked separately; until then this switch stays off and encrypted pods keep the pre-DAH-2545
behaviour: skipped, with the miner keeping the `POD_NOT_RUNNING` verdict.

## Tests

`3 failed, 1418 passed, 9 skipped`. The three failures are in `test_sshd_bootstrap_script.py` and
reproduce on a clean `main`.
