### PR TITLE
DAH-2546, gate 8x flagship unrented incentive on NCU profiling or real GPU split

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -237,6 +237,12 @@ class Settings(BaseSettings):
     # impact can be observed before enforcing.
     ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT: bool = Field(env="ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT", default=False)
 
+    # DAH-2546 — flagship capability gate. When True, an unrented 8x H200/B200/B300 executor
+    # with neither NCU profiling counters open nor real GPU splitting enabled loses the
+    # unrented rental incentive while staying active. When False, the breach is only logged
+    # (shadow mode) so prod impact can be observed before enforcing.
+    ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT: bool = Field(env="ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT", default=False)
+
     COLLATERAL_CONTRACT_ADDRESS: str = Field(
         env='COLLATERAL_CONTRACT_ADDRESS', default='0x8A4023FdD1eaA7b242F3723a7d096B6CC693c7C6'
     )

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -50,7 +50,7 @@ from pydantic import BaseModel, Field
 from core.utils import _m, _StructuredMessage, get_extra_info
 
 if TYPE_CHECKING:
-    from incentive.rental_price import InsufficientDisk
+    from incentive.rental_price import InsufficientDisk, MissingFlagshipCapability
     from services.task_service import JobResult
 
 
@@ -326,19 +326,23 @@ class MinerLogLine(BaseModel):
         )
 
     @staticmethod
-    def no_payout_because_flagship_without_ncu_or_split(result: JobResult) -> MinerLogLine:
+    def no_payout_because_flagship_without_ncu_or_split(
+        result: JobResult, missing: MissingFlagshipCapability
+    ) -> MinerLogLine:
         return MinerLogLine._no_payout(
             result,
             reason=ZeroIncentiveReason.FLAGSHIP_WITHOUT_NCU_OR_SPLIT,
             message=(
                 f"No unrented incentive: an idle {result.gpu_count}x {result.gpu_model} must offer "
-                "NCU profiling or GPU splitting. Open the host profiling counters "
-                "(NVreg_RestrictProfilingToAdminUsers=0, then reboot) or enable GPU splitting "
-                "with a minimum GPU count below the full node in the Miner Portal, "
+                "NCU profiling or GPU splitting. Either open the host profiling counters "
+                "(NVreg_RestrictProfilingToAdminUsers=0, then reboot), which also makes the node "
+                "rentable only as a whole host, or set a minimum GPU count below the full node in "
+                "the Miner Portal on a host that supports docker storage limits, "
                 "or rent it out to earn."
             ),
             extra_fields={
-                "ncu_profiling_access": (result.spec or {}).get("ncu_profiling_access"),
+                "ncu_profiling_access": missing.ncu_profiling_access,
+                "ncu_profiling_scrape_error": missing.ncu_profiling_scrape_error,
                 "supports_gpu_splitting": result.supports_gpu_splitting,
                 "gpu_splitting_min_count": result.gpu_splitting_min_count,
             },

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -9,6 +9,7 @@ WHERE A NODE EARNS (two "pools" of subnet emission; the rest is burned):
 HOW A NODE PICKS A POOL:
   rented?                                              -> mining pool (always earns)
   idle AND model in program AND price ok AND disk >= 1.5x VRAM
+       AND (not flagship-8x OR NCU/split offered)
                                AND capacity?            -> unrented pool (earns)
   otherwise                                            -> 0 incentive (reason below)
 
@@ -23,6 +24,7 @@ WHAT THIS CATALOG HOLDS — every `MinerLogLine` the miner-facing log block
      GPU model not in the unrented program (earns only when rented),
      price above the market soft limit (lower the price to earn),
      total disk below 1.5x total GPU VRAM (add disk to earn),
+     8x H200/B200/B300 with neither NCU profiling nor GPU splitting (offer either to earn),
      no unrented capacity for that GPU-count tier this cycle,
      NVIDIA driver below the minimum, sysbox runtime not enabled
 
@@ -71,6 +73,7 @@ class ZeroIncentiveReason(StrEnum):
     NVIDIA_DRIVER_BELOW_MINIMUM = "nvidia_driver_below_minimum"
     INSUFFICIENT_DISK_FOR_VRAM = "insufficient_disk_for_vram"
     SYSBOX_NOT_ENABLED = "sysbox_not_enabled"
+    FLAGSHIP_WITHOUT_NCU_OR_SPLIT = "flagship_without_ncu_or_split"
 
 
 class IncentiveReason(BaseModel):
@@ -320,6 +323,25 @@ class MinerLogLine(BaseModel):
                 "required for unrented incentive. Enable sysbox on this executor to earn."
             ),
             extra_fields={"sysbox_runtime": result.sysbox_runtime},
+        )
+
+    @staticmethod
+    def no_payout_because_flagship_without_ncu_or_split(result: JobResult) -> MinerLogLine:
+        return MinerLogLine._no_payout(
+            result,
+            reason=ZeroIncentiveReason.FLAGSHIP_WITHOUT_NCU_OR_SPLIT,
+            message=(
+                f"No unrented incentive: an idle {result.gpu_count}x {result.gpu_model} must offer "
+                "NCU profiling or GPU splitting. Open the host profiling counters "
+                "(NVreg_RestrictProfilingToAdminUsers=0, then reboot) or enable GPU splitting "
+                "with a minimum GPU count below the full node in the Miner Portal, "
+                "or rent it out to earn."
+            ),
+            extra_fields={
+                "ncu_profiling_access": (result.spec or {}).get("ncu_profiling_access"),
+                "supports_gpu_splitting": result.supports_gpu_splitting,
+                "gpu_splitting_min_count": result.gpu_splitting_min_count,
+            },
         )
 
     # ── Calculation reports: the per-cycle lines every scored node gets ───────

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -43,6 +43,14 @@ SOFT_LIMIT_PRICE_RATE = 1.1
 # incentive but stays active.
 MIN_DISK_TO_VRAM_RATE = 1.5
 
+# DAH-2546 — flagship capability gate. An unrented 8x machine of these base models must
+# have NCU profiling counters open on the host or real GPU splitting enabled to earn the
+# unrented incentive; with neither it forfeits the incentive but stays active.
+FLAGSHIP_CAPABILITY_BASE_MODELS = frozenset({"H200", "B200", "B300"})
+FLAGSHIP_CAPABILITY_GPU_COUNT = 8
+# Value the machine scrape reports when RmProfilingAdminOnly is 0 on the host (DAH-2182).
+NCU_PROFILING_UNRESTRICTED = "unrestricted"
+
 
 # ── Spec measurements ────────────────────────────────────────────────────────
 
@@ -289,6 +297,47 @@ class RentalPriceIncentive(DefaultIncentive):
                     "min_disk_to_vram_rate": measured.rate,
                     "enforced": enforced,
                     "reason": ZeroIncentiveReason.INSUFFICIENT_DISK_FOR_VRAM,
+                    "pool": "rental_excluded" if enforced else "rental_kept_shadow",
+                },
+            )
+        )
+
+    def _lacks_flagship_capability(self, result: JobResult, base_model: str) -> bool:
+        # unrented 8x flagship machine offering neither open NCU counters nor real splitting
+        if result.gpu_count != FLAGSHIP_CAPABILITY_GPU_COUNT:
+            return False
+        if base_model not in FLAGSHIP_CAPABILITY_BASE_MODELS:
+            return False
+        if result.spec is None:
+            # no scrape at all: a synthetic or estimated job result, nothing to measure
+            return False
+        ncu_access = result.spec.get("ncu_profiling_access")
+        has_open_ncu_counters = ncu_access == NCU_PROFILING_UNRESTRICTED
+        # min_gpu_count equal to the node size is whole-host-only in practice (rent_executor
+        # rejects smaller requests), so it does not count as splitting
+        has_real_splitting = bool(
+            result.supports_gpu_splitting
+            and result.gpu_splitting_min_count
+            and result.gpu_splitting_min_count < result.gpu_count
+        )
+        return not (has_open_ncu_counters or has_real_splitting)
+
+    def _log_flagship_capability_limit(self, result: JobResult) -> None:
+        # structured log for every rental-eligible 8x flagship executor lacking both capabilities
+        enforced = settings.ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT
+        logger.info(
+            _m(
+                "Unrented flagship executor has neither NCU profiling nor GPU splitting"
+                + ("" if enforced else " (shadow only - flag off)"),
+                extra={
+                    "executor_id": str(result.executor_info.uuid),
+                    "gpu_model": result.gpu_model,
+                    "gpu_count": result.gpu_count,
+                    "ncu_profiling_access": (result.spec or {}).get("ncu_profiling_access"),
+                    "supports_gpu_splitting": result.supports_gpu_splitting,
+                    "gpu_splitting_min_count": result.gpu_splitting_min_count,
+                    "enforced": enforced,
+                    "reason": ZeroIncentiveReason.FLAGSHIP_WITHOUT_NCU_OR_SPLIT,
                     "pool": "rental_excluded" if enforced else "rental_kept_shadow",
                 },
             )
@@ -577,6 +626,18 @@ class RentalPriceIncentive(DefaultIncentive):
                 eligible_for_rental_share = False
                 reason: MinerLogLine = MinerLogLine.no_payout_because_insufficient_disk_for_vram(
                     job_result, insufficient_disk
+                )
+                job_result.record_incentive_log(reason)
+
+        # DAH-2546 flagship capability gate: an idle 8x H200/B200/B300 must offer NCU profiling
+        # (open counters) or real GPU splitting to earn the unrented incentive (node stays
+        # active). While the flag is off we only log the would-be exclusion (shadow).
+        if eligible_for_rental_share and self._lacks_flagship_capability(job_result, base_model):
+            self._log_flagship_capability_limit(job_result)
+            if settings.ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT:
+                eligible_for_rental_share = False
+                reason: MinerLogLine = MinerLogLine.no_payout_because_flagship_without_ncu_or_split(
+                    job_result
                 )
                 job_result.record_incentive_log(reason)
 

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -324,7 +324,7 @@ class RentalPriceIncentive(DefaultIncentive):
         ncu_profiling_access = result.spec.get("ncu_profiling_access")
         # min_gpu_count equal to the node size is whole-host-only in practice (rent_executor
         # rejects smaller requests), so it does not count as splitting
-        has_real_splitting = (
+        has_real_splitting: bool = bool(
             result.supports_gpu_splitting
             and result.gpu_splitting_min_count
             and result.gpu_splitting_min_count < result.gpu_count

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -62,6 +62,14 @@ class InsufficientDisk(BaseModel):
     rate: float  # required disk-to-VRAM margin the machine failed to clear
 
 
+class MissingFlagshipCapability(BaseModel):
+    """What the scrape reported about NCU profiling on a flagship machine that offers neither
+    open profiling counters nor real GPU splitting. Sole owner of these scrape keys."""
+
+    ncu_profiling_access: str | None  # None = the scrape carries no observation at all
+    ncu_profiling_scrape_error: str | None  # set when the probe could not read the driver params
+
+
 # ── Snapshot models ──────────────────────────────────────────────────────────
 
 class GpuBucketRentalState(BaseModel):
@@ -302,27 +310,35 @@ class RentalPriceIncentive(DefaultIncentive):
             )
         )
 
-    def _lacks_flagship_capability(self, result: JobResult, base_model: str) -> bool:
-        # unrented 8x flagship machine offering neither open NCU counters nor real splitting
+    def _missing_flagship_capability(
+        self, result: JobResult, base_model: str
+    ) -> MissingFlagshipCapability | None:
+        # None also when the machine is out of the gate's scope: not an 8x flagship, or unscraped
         if result.gpu_count != FLAGSHIP_CAPABILITY_GPU_COUNT:
-            return False
+            return None
         if base_model not in FLAGSHIP_CAPABILITY_BASE_MODELS:
-            return False
+            return None
         if result.spec is None:
             # no scrape at all: a synthetic or estimated job result, nothing to measure
-            return False
-        ncu_access = result.spec.get("ncu_profiling_access")
-        has_open_ncu_counters = ncu_access == NCU_PROFILING_UNRESTRICTED
+            return None
+        ncu_profiling_access = result.spec.get("ncu_profiling_access")
         # min_gpu_count equal to the node size is whole-host-only in practice (rent_executor
         # rejects smaller requests), so it does not count as splitting
-        has_real_splitting = bool(
+        has_real_splitting = (
             result.supports_gpu_splitting
             and result.gpu_splitting_min_count
             and result.gpu_splitting_min_count < result.gpu_count
         )
-        return not (has_open_ncu_counters or has_real_splitting)
+        if ncu_profiling_access == NCU_PROFILING_UNRESTRICTED or has_real_splitting:
+            return None
+        return MissingFlagshipCapability(
+            ncu_profiling_access=ncu_profiling_access,
+            ncu_profiling_scrape_error=result.spec.get("ncu_profiling_scrape_error"),
+        )
 
-    def _log_flagship_capability_limit(self, result: JobResult) -> None:
+    def _log_flagship_capability_limit(
+        self, result: JobResult, missing: MissingFlagshipCapability
+    ) -> None:
         # structured log for every rental-eligible 8x flagship executor lacking both capabilities
         enforced = settings.ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT
         logger.info(
@@ -333,7 +349,9 @@ class RentalPriceIncentive(DefaultIncentive):
                     "executor_id": str(result.executor_info.uuid),
                     "gpu_model": result.gpu_model,
                     "gpu_count": result.gpu_count,
-                    "ncu_profiling_access": (result.spec or {}).get("ncu_profiling_access"),
+                    "ncu_profiling_access": missing.ncu_profiling_access,
+                    # tells a shadow report apart: probe failed vs provider left counters closed
+                    "ncu_profiling_scrape_error": missing.ncu_profiling_scrape_error,
                     "supports_gpu_splitting": result.supports_gpu_splitting,
                     "gpu_splitting_min_count": result.gpu_splitting_min_count,
                     "enforced": enforced,
@@ -629,15 +647,18 @@ class RentalPriceIncentive(DefaultIncentive):
                 )
                 job_result.record_incentive_log(reason)
 
-        # DAH-2546 flagship capability gate: an idle 8x H200/B200/B300 must offer NCU profiling
-        # (open counters) or real GPU splitting to earn the unrented incentive (node stays
-        # active). While the flag is off we only log the would-be exclusion (shadow).
-        if eligible_for_rental_share and self._lacks_flagship_capability(job_result, base_model):
-            self._log_flagship_capability_limit(job_result)
+        # DAH-2546 flagship capability gate; shadow-only while the flag is off
+        missing_capability = (
+            self._missing_flagship_capability(job_result, base_model)
+            if eligible_for_rental_share
+            else None
+        )
+        if missing_capability is not None:
+            self._log_flagship_capability_limit(job_result, missing_capability)
             if settings.ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT:
                 eligible_for_rental_share = False
                 reason: MinerLogLine = MinerLogLine.no_payout_because_flagship_without_ncu_or_split(
-                    job_result
+                    job_result, missing_capability
                 )
                 job_result.record_incentive_log(reason)
 

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -27,6 +27,7 @@ def test_reason_enum_pins_the_stable_code_contract():
         "nvidia_driver_below_minimum",
         "sysbox_not_enabled",
         "insufficient_disk_for_vram",
+        "flagship_without_ncu_or_split",
     }
 
 
@@ -111,6 +112,11 @@ def _job(**overrides) -> JobResult:
             lambda job: MinerLogLine.no_payout_because_sysbox_not_enabled(job),
             "sysbox_not_enabled",
             "sysbox",
+        ),
+        (
+            lambda job: MinerLogLine.no_payout_because_flagship_without_ncu_or_split(job),
+            "flagship_without_ncu_or_split",
+            "NCU profiling",
         ),
     ],
 )

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -7,7 +7,7 @@ fields, and that a line actually lands in JobResult.incentive_logs.
 import pytest
 from datura.requests.miner_requests import ExecutorSSHInfo
 from incentive.miner_incentive_log import MinerLogLine, ZeroIncentiveReason
-from incentive.rental_price import InsufficientDisk
+from incentive.rental_price import InsufficientDisk, MissingFlagshipCapability
 from services.task_service import JobResult
 
 H200 = "NVIDIA H200"
@@ -114,7 +114,12 @@ def _job(**overrides) -> JobResult:
             "sysbox",
         ),
         (
-            lambda job: MinerLogLine.no_payout_because_flagship_without_ncu_or_split(job),
+            lambda job: MinerLogLine.no_payout_because_flagship_without_ncu_or_split(
+                job,
+                MissingFlagshipCapability(
+                    ncu_profiling_access="restricted", ncu_profiling_scrape_error=None
+                ),
+            ),
             "flagship_without_ncu_or_split",
             "NCU profiling",
         ),

--- a/neurons/validators/tests/test_unrented_flagship_capability_limit.py
+++ b/neurons/validators/tests/test_unrented_flagship_capability_limit.py
@@ -1,0 +1,196 @@
+"""DAH-2546 — unrented incentive flagship capability gate.
+
+An unrented 8x H200/B200/B300 executor that neither has NCU profiling counters
+open on the host (ncu_profiling_access == "unrestricted") nor real GPU
+splitting enabled (min_gpu_count below the full node size) forfeits the
+unrented rental incentive while staying active. Enforcement is gated by
+ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT; while the flag is off the breach is
+only logged (shadow mode) and the payout is unchanged.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from datura.requests.miner_requests import ExecutorSSHInfo
+from incentive.config import IncentiveConfig
+from incentive.rental_price import RentalPriceIncentive
+
+from core.config import settings
+from services.task_service import JobResult
+
+H200 = "NVIDIA H200"
+B200 = "NVIDIA B200"
+B300 = "NVIDIA B300 SXM6 AC"
+H100 = "NVIDIA H100 80GB HBM3"
+
+
+def _build_incentive() -> RentalPriceIncentive:
+    return RentalPriceIncentive(IncentiveConfig(), AsyncMock(), {}, {})
+
+
+def _make_job(
+    *,
+    gpu_model: str = H200,
+    gpu_count: int = 8,
+    ncu_profiling_access: str | None = None,
+    supports_gpu_splitting: bool = False,
+    gpu_splitting_min_count: int | None = None,
+    is_rented: bool = False,
+    no_scrape: bool = False,
+) -> JobResult:
+    # ncu_profiling_access=None models a scrape without the key (machine not re-scraped yet);
+    # no_scrape=True models the spec-less synthetic JobResult the estimate path builds
+    if no_scrape:
+        spec = None
+    elif ncu_profiling_access is None:
+        spec = {}
+    else:
+        spec = {"ncu_profiling_access": ncu_profiling_access}
+    return JobResult(
+        executor_info=ExecutorSSHInfo(
+            uuid="exec-1",
+            address="10.0.0.1",
+            port=8080,
+            ssh_username="root",
+            ssh_port=22,
+            python_path="/usr/bin/python3",
+            root_dir="/tmp",
+            price_per_gpu=1.0,
+        ),
+        spec=spec,
+        score=1.0,
+        job_score=1.0,
+        job_batch_id="batch",
+        log_status="success",
+        log_text="ok",
+        gpu_model=gpu_model,
+        gpu_count=gpu_count,
+        is_rented=is_rented,
+        supports_gpu_splitting=supports_gpu_splitting,
+        gpu_splitting_min_count=gpu_splitting_min_count,
+        collateral_deposited=True,
+        sysbox_runtime=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "job_kwargs, lacks",
+    [
+        ({}, True),  # neither capability
+        ({"no_scrape": True}, False),  # spec-less synthetic/estimate result: fail open
+        ({"ncu_profiling_access": "unrestricted"}, False),
+        ({"ncu_profiling_access": "restricted"}, True),
+        ({"ncu_profiling_access": "unknown"}, True),
+        ({"supports_gpu_splitting": True, "gpu_splitting_min_count": 1}, False),
+        # min equal to the node size is whole-host-only in practice, not real splitting
+        ({"supports_gpu_splitting": True, "gpu_splitting_min_count": 8}, True),
+        # a configured min without hardware support does not count either
+        ({"gpu_splitting_min_count": 1}, True),
+        ({"gpu_model": B200}, True),
+        ({"gpu_model": B300}, True),
+        ({"gpu_model": B300, "supports_gpu_splitting": True, "gpu_splitting_min_count": 1}, False),
+        ({"gpu_model": H100}, False),  # not a flagship model
+        ({"gpu_count": 4}, False),  # only full 8x nodes are gated
+    ],
+)
+def test_lacks_flagship_capability(job_kwargs, lacks):
+    # Arrange
+    incentive = _build_incentive()
+    job = _make_job(**job_kwargs)
+    base_model = incentive.get_base_model_for_gpu(job.gpu_model)
+
+    # Act
+    result = incentive._lacks_flagship_capability(job, base_model)
+
+    # Assert
+    assert result is lacks
+
+
+def test_enforcement_defaults_to_shadow_mode():
+    # Arrange / Act — rollout contract: first deploy must be shadow-only, so the
+    # flag default (not the env-resolved value) must stay False.
+    default = type(settings).model_fields["ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT"].default
+
+    # Assert
+    assert default is False
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_keeps_rental_eligibility(monkeypatch):
+    # Arrange — neither capability but flag off → shadow only
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT", False)
+    incentive = _build_incentive()
+
+    # Act
+    result = await incentive.calculate_executor_score(_make_job())
+
+    # Assert — still eligible for the unrented rental pool, nothing told to the miner
+    assert result.eligible_for_rental_share is True
+    assert "flagship_without_ncu_or_split" not in "\n".join(result.incentive_logs)
+
+
+@pytest.mark.asyncio
+async def test_enforced_drops_rental_eligibility(monkeypatch):
+    # Arrange — neither capability and flag on
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT", True)
+    incentive = _build_incentive()
+
+    # Act
+    result = await incentive.calculate_executor_score(_make_job())
+
+    # Assert — excluded from the rental pool, no mining either (active but no incentive)
+    assert result.eligible_for_rental_share is False
+    assert result.mining_score == 0
+
+
+@pytest.mark.asyncio
+async def test_enforced_appends_customer_facing_incentive_log(monkeypatch):
+    # The zero-incentive reason must reach the miner-facing incentive log with
+    # both remediation paths spelled out.
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT", True)
+    incentive = _build_incentive()
+
+    result = await incentive.calculate_executor_score(_make_job())
+
+    log = "\n".join(result.incentive_logs)
+    assert "flagship_without_ncu_or_split" in log
+    assert "NCU profiling" in log
+    assert "GPU splitting" in log
+
+
+@pytest.mark.parametrize(
+    "job_kwargs, expect_eligible",
+    [
+        ({"ncu_profiling_access": "unrestricted"}, True),
+        ({"supports_gpu_splitting": True, "gpu_splitting_min_count": 1}, True),
+        # min equal to the node size (a live prod case: a B200 at min=8) is whole-host-only
+        ({"supports_gpu_splitting": True, "gpu_splitting_min_count": 8}, False),
+        ({"gpu_model": H100}, True),  # not a flagship model
+        # estimate_executor feeds spec-less synthetic results through the same scoring
+        # path every cycle; the gate must fail open on those (DAH-2520 precedent)
+        ({"no_scrape": True}, True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_enforced_eligibility_by_capability(monkeypatch, job_kwargs, expect_eligible):
+    # Arrange
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT", True)
+    incentive = _build_incentive()
+
+    # Act
+    result = await incentive.calculate_executor_score(_make_job(**job_kwargs))
+
+    # Assert
+    assert result.eligible_for_rental_share is expect_eligible
+
+
+@pytest.mark.asyncio
+async def test_rented_flagship_without_capabilities_untouched(monkeypatch):
+    # The gate governs only the unrented pool: a rented machine keeps normal scoring
+    # and is never told about the missing capabilities.
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT", True)
+    incentive = _build_incentive()
+
+    result = await incentive.calculate_executor_score(_make_job(is_rented=True))
+
+    assert "flagship_without_ncu_or_split" not in "\n".join(result.incentive_logs)

--- a/neurons/validators/tests/test_unrented_flagship_capability_limit.py
+++ b/neurons/validators/tests/test_unrented_flagship_capability_limit.py
@@ -8,6 +8,7 @@ ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT; while the flag is off the breach is
 only logged (shadow mode) and the payout is unchanged.
 """
 
+import logging
 from unittest.mock import AsyncMock
 
 import pytest
@@ -23,6 +24,9 @@ B200 = "NVIDIA B200"
 B300 = "NVIDIA B300 SXM6 AC"
 H100 = "NVIDIA H100 80GB HBM3"
 
+# a scrape carrying no NCU observation at all: a machine not re-scraped since DAH-2182 shipped
+SCRAPE_WITHOUT_NCU: dict[str, str] = {}
+
 
 def _build_incentive() -> RentalPriceIncentive:
     return RentalPriceIncentive(IncentiveConfig(), AsyncMock(), {}, {})
@@ -32,20 +36,12 @@ def _make_job(
     *,
     gpu_model: str = H200,
     gpu_count: int = 8,
-    ncu_profiling_access: str | None = None,
+    # spec=None models the spec-less synthetic JobResult the estimate path builds
+    spec: dict[str, str] | None = SCRAPE_WITHOUT_NCU,
     supports_gpu_splitting: bool = False,
     gpu_splitting_min_count: int | None = None,
     is_rented: bool = False,
-    no_scrape: bool = False,
 ) -> JobResult:
-    # ncu_profiling_access=None models a scrape without the key (machine not re-scraped yet);
-    # no_scrape=True models the spec-less synthetic JobResult the estimate path builds
-    if no_scrape:
-        spec = None
-    elif ncu_profiling_access is None:
-        spec = {}
-    else:
-        spec = {"ncu_profiling_access": ncu_profiling_access}
     return JobResult(
         executor_info=ExecutorSSHInfo(
             uuid="exec-1",
@@ -74,13 +70,13 @@ def _make_job(
 
 
 @pytest.mark.parametrize(
-    "job_kwargs, lacks",
+    "job_kwargs, is_missing",
     [
         ({}, True),  # neither capability
-        ({"no_scrape": True}, False),  # spec-less synthetic/estimate result: fail open
-        ({"ncu_profiling_access": "unrestricted"}, False),
-        ({"ncu_profiling_access": "restricted"}, True),
-        ({"ncu_profiling_access": "unknown"}, True),
+        ({"spec": None}, False),  # spec-less synthetic/estimate result: fail open
+        ({"spec": {"ncu_profiling_access": "unrestricted"}}, False),
+        ({"spec": {"ncu_profiling_access": "restricted"}}, True),
+        ({"spec": {"ncu_profiling_access": "unknown"}}, True),
         ({"supports_gpu_splitting": True, "gpu_splitting_min_count": 1}, False),
         # min equal to the node size is whole-host-only in practice, not real splitting
         ({"supports_gpu_splitting": True, "gpu_splitting_min_count": 8}, True),
@@ -93,17 +89,17 @@ def _make_job(
         ({"gpu_count": 4}, False),  # only full 8x nodes are gated
     ],
 )
-def test_lacks_flagship_capability(job_kwargs, lacks):
+def test_missing_flagship_capability(job_kwargs, is_missing):
     # Arrange
     incentive = _build_incentive()
     job = _make_job(**job_kwargs)
     base_model = incentive.get_base_model_for_gpu(job.gpu_model)
 
     # Act
-    result = incentive._lacks_flagship_capability(job, base_model)
+    missing = incentive._missing_flagship_capability(job, base_model)
 
     # Assert
-    assert result is lacks
+    assert (missing is not None) is is_missing
 
 
 def test_enforcement_defaults_to_shadow_mode():
@@ -127,6 +123,36 @@ async def test_shadow_mode_keeps_rental_eligibility(monkeypatch):
     # Assert — still eligible for the unrented rental pool, nothing told to the miner
     assert result.eligible_for_rental_share is True
     assert "flagship_without_ncu_or_split" not in "\n".join(result.incentive_logs)
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_emits_the_capability_log(monkeypatch, caplog):
+    # The shadow log is the whole deliverable of the first deploy: the rollout decision is
+    # made from these fields, and the scrape error is what separates a failed probe from a
+    # provider who deliberately left the counters closed.
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT", False)
+    incentive = _build_incentive()
+
+    with caplog.at_level(logging.INFO):
+        await incentive.calculate_executor_score(
+            _make_job(
+                spec={
+                    "ncu_profiling_access": "unknown",
+                    "ncu_profiling_scrape_error": "Cannot read /proc/driver/nvidia/params",
+                }
+            )
+        )
+
+    breach = next(
+        record.msg
+        for record in caplog.records
+        if record.msg.extra.get("reason") == "flagship_without_ncu_or_split"
+    )
+    assert "shadow only - flag off" in breach.message
+    assert breach.extra["ncu_profiling_access"] == "unknown"
+    assert breach.extra["ncu_profiling_scrape_error"] == "Cannot read /proc/driver/nvidia/params"
+    assert breach.extra["enforced"] is False
+    assert breach.extra["pool"] == "rental_kept_shadow"
 
 
 @pytest.mark.asyncio
@@ -156,19 +182,20 @@ async def test_enforced_appends_customer_facing_incentive_log(monkeypatch):
     assert "flagship_without_ncu_or_split" in log
     assert "NCU profiling" in log
     assert "GPU splitting" in log
+    assert [reason.reason for reason in result.zero_incentive_reasons] == [
+        "flagship_without_ncu_or_split"
+    ]
 
 
 @pytest.mark.parametrize(
     "job_kwargs, expect_eligible",
     [
-        ({"ncu_profiling_access": "unrestricted"}, True),
-        ({"supports_gpu_splitting": True, "gpu_splitting_min_count": 1}, True),
+        ({"spec": {"ncu_profiling_access": "unrestricted"}}, True),
         # min equal to the node size (a live prod case: a B200 at min=8) is whole-host-only
         ({"supports_gpu_splitting": True, "gpu_splitting_min_count": 8}, False),
-        ({"gpu_model": H100}, True),  # not a flagship model
         # estimate_executor feeds spec-less synthetic results through the same scoring
         # path every cycle; the gate must fail open on those (DAH-2520 precedent)
-        ({"no_scrape": True}, True),
+        ({"spec": None}, True),
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2546](https://app.notion.com/p/8x-H200-B200-B300-gate-unrented-incentive-on-NCU-profiling-or-real-GPU-split-3b2b8bfdbde981be89caceb36db7a5fc)

---

## Problem

Renters ask for NCU-capable flagship nodes and there are none where it matters most: 0/11 active 8x B300 have profiling counters open, 4/27 H200, 5/8 B200 (prod snapshot 2026-08-04; demand: ticket-0157). NCU and GPU splitting cannot coexist on one host — DAH-2182's taint makes an open-counters host whole-host-only — so a flagship node should offer at least one of the two. 26 of 46 active 8x flagship machines offer neither, and nothing in the incentive pushes providers to change that.

## Solution

A third unrented-incentive gate in `RentalPriceIncentive.calculate_executor_score`, shaped exactly like the DAH-2250 soft price limit and the DAH-2520 VRAM/disk gate: an idle 8x H200/B200/B300 with neither NCU profiling counters open (`spec.ncu_profiling_access == "unrestricted"`, DAH-2182 scrape, fail-closed) nor real GPU splitting (`supports_gpu_splitting` and `gpu_splitting_min_count < gpu_count`; min equal to the node size is whole-host-only in practice and does not count) forfeits the unrented incentive while staying active and rentable.

Rollout is shadow-first: `ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT` defaults to False — every breach is logged (`enforced=false`, `pool=rental_kept_shadow`) but the payout is unchanged. Flipping the env var enforces.

`spec is None` fails open: `precompute_all_estimates` feeds spec-less synthetic JobResults through the same scoring path every cycle; gating those would poison public GPU estimates and drown the shadow measurement (same guard as the DAH-2520 gate).

## Changes

- `incentive/rental_price.py` — flagship constants, `MissingFlagshipCapability` scrape-observation model, `_missing_flagship_capability` / `_log_flagship_capability_limit`, gate wiring after the DAH-2520 gate; shadow logs carry `ncu_profiling_scrape_error` so a failed probe is distinguishable from counters a provider left closed
- `core/config.py` — `ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT` (default False = shadow)
- `incentive/miner_incentive_log.py` — `ZeroIncentiveReason.FLAGSHIP_WITHOUT_NCU_OR_SPLIT` (appended, wire contract preserved), miner-facing constructor with both remediation paths, catalog docstring updated
- tests — new `tests/test_unrented_flagship_capability_limit.py`, enum contract test extended

## Deployment Steps

Use GitHub Action. Ships inert (flag off = shadow logging only). Enforce later by setting `ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT=true` in the validator env (lium-io-deployment `Pulumi.prod.yaml`), after provider docs and the announcement.

## Review Request

- [x] Just code review

## Other PRs

None to merge together. Reads fields shipped by Datura-ai/lium-io#1186 and Datura-ai/lium-io-backend#848 (DAH-2182, merged 2026-08-03). Provider docs (merge gpu-profiling.md, fix the "splitting does not change payouts" claim in gpu-splitting.md) go to lium-docs separately before enforcement.

## Risks

- Default is shadow: zero payout change until the env flag is flipped. Monotonic once enforced — the gate can only remove `eligible_for_rental_share`, never grant it.
- Enforcement impact (prod snapshot 2026-08-04): 26/46 active 8x flagship machines are non-compliant; the 8 currently-idle H200 (64 GPUs) lose the idle payout immediately, compliant idle machines gain (H200 8x bucket cap multiplier rises 0.8 → 1.0).
- Estimate path (`estimate_executor` / `precompute_all_estimates`) verified fail-open via the `spec is None` guard, so published GPU estimates are unaffected in both modes.
- Rented machines are untouched: the gate only runs for executors already eligible for the unrented pool.

## Test Cases

### Test Case 1

**Actions**

`pdm run pytest tests/test_unrented_flagship_capability_limit.py tests/test_miner_incentive_log.py`

**Expected Output**

50 passed: predicate truth table (incl. min=8 fake split and spec-less estimate fail-open), shadow keeps eligibility while emitting the structured log, enforced drops eligibility and the miner log carries both remediation paths, rented / non-flagship / 4x untouched, flag defaults to False, `ZeroIncentiveReason` append-only contract.

### Test Case 2

**Actions**

`pdm run pytest` (full validator suite)

**Expected Output**

1419 passed. The 3 failures in `test_sshd_bootstrap_script.py` are pre-existing on `origin/main` (macOS/BSD-sed environment; verified identical on a clean checkout) and unrelated to this change.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
