### PR TITLE
DAH-2572: take verifyx download speed from the speedtest

### DIFF
--- a/neurons/validators/src/services/task/checks/network_ema.py
+++ b/neurons/validators/src/services/task/checks/network_ema.py
@@ -14,3 +14,27 @@ def compute_ema(prev: float | None, current: float | None, alpha: float = NETWOR
     if prev is None:
         return current
     return alpha * current + (1 - alpha) * prev
+
+
+def resolve_display_speeds(network: dict) -> tuple[float | None, float | None]:
+    """Pick the (upload, download) speeds that renters and providers are shown.
+
+    Most trusted first: the verifyx EMA, then the scrape EMA, then the raw measurements.
+    ``0`` counts as missing, so a zeroed EMA does not mask a real measurement. Resolved here,
+    once, so that no consumer has to repeat the priority order and drift from it.
+    """
+    upload = (
+        network.get("ema_verifyx_upload_speed")
+        or network.get("ema_upload_speed")
+        or network.get("verifyx_upload_speed")
+        or network.get("upload_speed")
+        or None
+    )
+    download = (
+        network.get("ema_verifyx_download_speed")
+        or network.get("ema_download_speed")
+        or network.get("verifyx_download_speed")
+        or network.get("download_speed")
+        or None
+    )
+    return upload, download

--- a/neurons/validators/src/services/task/result_handler.py
+++ b/neurons/validators/src/services/task/result_handler.py
@@ -14,6 +14,7 @@ from protocol.vc_protocol.validator_requests import ResetVerifiedJobReason
 from datura.requests.miner_requests import ExecutorSSHInfo
 from services.redis_service import INSPECTOR_EVENT_CHANNEL, RedisService
 
+from .checks.network_ema import resolve_display_speeds
 from .models import JobResult
 from .pipeline import Context
 
@@ -126,6 +127,17 @@ class ResultHandler:
             **(context.state.specs or {}),
             "tdx_attestation_passed": context.tdx_attestation_passed,
             "is_spot": is_spot,
+        }
+
+        # DAH-2572: the speeds every UI shows. Resolved here, at the only point where specs
+        # leave the validator, so the marketplace and the provider portal cannot disagree
+        # about which of the four measured numbers is the current one.
+        network: dict = specs.get("network") or {}
+        display_upload_speed, display_download_speed = resolve_display_speeds(network)
+        specs["network"] = {
+            **network,
+            "display_upload_speed": display_upload_speed,
+            "display_download_speed": display_download_speed,
         }
         # G1 — NVIDIA CC GPU attestation outcome. Only added when a verification
         # was actually performed (None → key omitted), mirroring gpu_metrics.

--- a/neurons/validators/src/services/verifyx_validation_service.py
+++ b/neurons/validators/src/services/verifyx_validation_service.py
@@ -366,8 +366,12 @@ def _verify_network_test(challenge_data: dict, response_data: dict) -> Tuple[dic
         errors.append(f"Integrity check failed for {download_result['pkg']}")
         success = False
 
-    download_speed = network_execution["download"]["speed_mbps"]
-    upload_speed = network_execution.get("speedtest", {}).get("upload_mbps")
+    speedtest: dict = network_execution.get("speedtest", {})
+    # The package download exists to check integrity and runs on one connection; the speedtest
+    # goes parallel above a gigabit, so it is the honest number for a fast link. Keep the
+    # package speed as the fallback for executors still on an older verifyx.
+    download_speed: float = speedtest.get("download_mbps") or network_execution["download"]["speed_mbps"]
+    upload_speed: float | None = speedtest.get("upload_mbps")
 
     if download_speed < settings.verifyx.NETWORK_MIN_DOWNLOAD_SPEED_MBPS:
         errors.append(

--- a/neurons/validators/src/services/verifyx_validation_service.py
+++ b/neurons/validators/src/services/verifyx_validation_service.py
@@ -366,12 +366,12 @@ def _verify_network_test(challenge_data: dict, response_data: dict) -> Tuple[dic
         errors.append(f"Integrity check failed for {download_result['pkg']}")
         success = False
 
-    speedtest: dict = network_execution.get("speedtest", {})
-    # The package download exists to check integrity and runs on one connection; the speedtest
-    # goes parallel above a gigabit, so it is the honest number for a fast link. Keep the
-    # package speed as the fallback for executors still on an older verifyx.
-    download_speed: float = speedtest.get("download_mbps") or network_execution["download"]["speed_mbps"]
-    upload_speed: float | None = speedtest.get("upload_mbps")
+    # The package download runs on one connection and exists to check integrity; the speedtest
+    # goes parallel above a gigabit, so it is the honest number for a fast link. No fallback:
+    # the checksum gate above rejects executors on an older verifyx before the challenge runs.
+    speedtest: dict[str, float] = network_execution["speedtest"]
+    download_speed: float = speedtest["download_mbps"]
+    upload_speed: float = speedtest["upload_mbps"]
 
     if download_speed < settings.verifyx.NETWORK_MIN_DOWNLOAD_SPEED_MBPS:
         errors.append(

--- a/neurons/validators/tests/test_network_ema.py
+++ b/neurons/validators/tests/test_network_ema.py
@@ -1,0 +1,33 @@
+"""Tests for the display-speed resolution published to every UI (DAH-2572)."""
+
+from __future__ import annotations
+
+from neurons.validators.src.services.task.checks.network_ema import resolve_display_speeds
+
+
+def test_verifyx_ema_wins_over_every_other_measurement() -> None:
+    network = {
+        "upload_speed": 100.0,
+        "download_speed": 200.0,
+        "ema_upload_speed": 110.0,
+        "ema_download_speed": 210.0,
+        "ema_verifyx_upload_speed": 900.0,
+        "ema_verifyx_download_speed": 9100.0,
+    }
+
+    assert resolve_display_speeds(network) == (900.0, 9100.0)
+
+
+def test_zeroed_ema_does_not_mask_a_real_measurement() -> None:
+    network = {
+        "upload_speed": 100.0,
+        "download_speed": 200.0,
+        "ema_verifyx_upload_speed": 0.0,
+        "ema_verifyx_download_speed": 0.0,
+    }
+
+    assert resolve_display_speeds(network) == (100.0, 200.0)
+
+
+def test_a_node_with_no_measurement_at_all_resolves_to_none() -> None:
+    assert resolve_display_speeds({}) == (None, None)

--- a/neurons/validators/tests/test_verifyx_validation_service.py
+++ b/neurons/validators/tests/test_verifyx_validation_service.py
@@ -121,36 +121,19 @@ async def test_run_ssh_command_is_bounded_by_the_hard_timeout():
     )
 
 
-def _network_payloads(package_speed: float, speedtest: dict[str, float] | None) -> tuple[dict, dict]:
-    download = {"pkg": "pkg", "size": 10, "hash": "abc", "speed_mbps": package_speed}
+def test_network_speeds_come_from_the_speedtest_not_the_package_download() -> None:
     challenge_data = {"network_challenge": {"download": {"pkg": "pkg", "size": 10, "hash": "abc"}}}
-    network_execution = {
-        "success": True,
-        "download": download,
-        "execution_time_ms": 1000,
+    response_data = {
+        "network_execution": {
+            "success": True,
+            "download": {"pkg": "pkg", "size": 10, "hash": "abc", "speed_mbps": 420.0},
+            "speedtest": {"download_mbps": 8100.0, "upload_mbps": 7400.0},
+            "execution_time_ms": 1000,
+        }
     }
-    if speedtest is not None:
-        network_execution["speedtest"] = speedtest
-    return challenge_data, {"network_execution": network_execution}
-
-
-def test_network_download_speed_comes_from_the_speedtest() -> None:
-    challenge_data, response_data = _network_payloads(
-        package_speed=420.0, speedtest={"download_mbps": 8100.0, "upload_mbps": 7400.0}
-    )
 
     stats, errors = _verify_network_test(challenge_data, response_data)
 
     assert errors == []
     assert stats["download_speed"] == 8100.0
     assert stats["upload_speed"] == 7400.0
-
-
-def test_network_download_speed_falls_back_to_the_package_download() -> None:
-    challenge_data, response_data = _network_payloads(package_speed=420.0, speedtest=None)
-
-    stats, errors = _verify_network_test(challenge_data, response_data)
-
-    assert errors == []
-    assert stats["download_speed"] == 420.0
-    assert stats["upload_speed"] is None

--- a/neurons/validators/tests/test_verifyx_validation_service.py
+++ b/neurons/validators/tests/test_verifyx_validation_service.py
@@ -17,6 +17,7 @@ import pytest
 
 from neurons.validators.src.services.verifyx_validation_service import (
     MIN_CIPHER_LEN,
+    _verify_network_test,
     VerifyXFailureClass,
     VerifyXValidationService,
 )
@@ -118,3 +119,38 @@ async def test_run_ssh_command_is_bounded_by_the_hard_timeout():
     run.assert_awaited_once_with(
         "python verifyx_executor.py", timeout=vvs.VERIFYX_COMMAND_TIMEOUT_SECONDS
     )
+
+
+def _network_payloads(package_speed: float, speedtest: dict[str, float] | None) -> tuple[dict, dict]:
+    download = {"pkg": "pkg", "size": 10, "hash": "abc", "speed_mbps": package_speed}
+    challenge_data = {"network_challenge": {"download": {"pkg": "pkg", "size": 10, "hash": "abc"}}}
+    network_execution = {
+        "success": True,
+        "download": download,
+        "execution_time_ms": 1000,
+    }
+    if speedtest is not None:
+        network_execution["speedtest"] = speedtest
+    return challenge_data, {"network_execution": network_execution}
+
+
+def test_network_download_speed_comes_from_the_speedtest() -> None:
+    challenge_data, response_data = _network_payloads(
+        package_speed=420.0, speedtest={"download_mbps": 8100.0, "upload_mbps": 7400.0}
+    )
+
+    stats, errors = _verify_network_test(challenge_data, response_data)
+
+    assert errors == []
+    assert stats["download_speed"] == 8100.0
+    assert stats["upload_speed"] == 7400.0
+
+
+def test_network_download_speed_falls_back_to_the_package_download() -> None:
+    challenge_data, response_data = _network_payloads(package_speed=420.0, speedtest=None)
+
+    stats, errors = _verify_network_test(challenge_data, response_data)
+
+    assert errors == []
+    assert stats["download_speed"] == 420.0
+    assert stats["upload_speed"] is None


### PR DESCRIPTION
Two changes on the same path, both from the provider report that a 10 Gbps node is advertised like a 1 Gbps one.

**Speed source.** The stored download speed came from the package download inside the verifyx challenge. That download exists to check integrity and runs on a single connection, so on a fast link it measured the connection, not the link. The speedtest result was already in the response and we threw its download away, keeping only the upload. Now both come from the speedtest, which goes parallel above 800 Mbps (Datura-ai/celium-gpu-verifier#12).

**One resolved speed for every UI.** The marketplace picked which of the four measured numbers to show by walking a priority chain in the backend; the provider portal did not know that chain and showed the raw measurement, so the two screens disagreed. The choice now happens once here, at the only point where specs leave the validator, and is published as `display_upload_speed` / `display_download_speed`. Consumers read that field: Datura-ai/lium-io-backend#864, Datura-ai/lium-miner-portal-frontend#160.

No backfill: specs are rewritten on every validation cycle, so nodes pick the field up within roughly ten minutes; ones that never revalidate are not listed anyway. Deploy this before the two consumers.

`pytest` — 1463 passed; the 3 sshd-bootstrap failures also fail on clean main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)