### PR TITLE
DAH-2588: poll for DinD SSH readiness instead of a fixed 5s wait

### DIFF
--- a/neurons/validators/src/services/executor_connectivity/dind_probe.py
+++ b/neurons/validators/src/services/executor_connectivity/dind_probe.py
@@ -1,8 +1,9 @@
 import asyncio
 import logging
+from typing import Any
 
 import asyncssh
-from asyncssh import SSHClientConnection
+from asyncssh import SSHClientConnection, SSHKey
 
 from core.docker_utils import DockerCommand
 from core.utils import _m, get_extra_info
@@ -17,12 +18,13 @@ logger = logging.getLogger(__name__)
 # "no sysbox", which delists an unrented executor for the whole cycle. Polling is also cheaper
 # than a longer sleep: a ready container is caught at ~3s instead of always waiting.
 #
-# The per-attempt timeout stays at 12s and is deliberately not tightened to the poll interval:
-# asyncssh counts TCP connect, key exchange AND authentication against it, none of which carry
-# over to the next attempt, so a host slow enough to need 6s would fail every single try.
-DIND_SSH_READY_TIMEOUT = 30
-DIND_SSH_CONNECT_TIMEOUT = 12
-DIND_SSH_POLL_INTERVAL = 1.5
+# The per-attempt timeout is deliberately not tightened to the poll interval: asyncssh counts TCP
+# connect, key exchange AND authentication against it, none of which carry over to the next
+# attempt, so a host slow enough to need 6s would fail every single try. An attempt is shortened
+# only when less than 12s of the deadline is left, which is time it could not have used anyway.
+DIND_SSH_READY_TIMEOUT_SECONDS = 30
+DIND_SSH_CONNECT_TIMEOUT_SECONDS = 12
+DIND_SSH_POLL_INTERVAL_SECONDS = 1.5
 
 
 class DindVerifier:
@@ -68,7 +70,9 @@ class DindVerifier:
 
             # Test SSH
             pkey = asyncssh.import_private_key(private_key)
-            async with await self._wait_for_ssh(host, port, pkey, log_ctx) as ssh:
+            async with await self._connect_retrying_until_sshd_answers(
+                host, port, pkey, log_ctx
+            ) as ssh:
                 # Test sysbox
                 if sysbox:
                     # daturaai/dind:0.0.1 bundles the hello-world image into the inner dockerd
@@ -121,39 +125,44 @@ class DindVerifier:
                 port=port,
             )
 
-    async def _wait_for_ssh(
+    async def _connect_retrying_until_sshd_answers(
         self,
         host: str,
         port: PortPair,
-        pkey,
-        log_ctx: dict,
+        pkey: SSHKey,
+        log_ctx: dict[str, Any],
     ) -> SSHClientConnection:
         """Connect to the freshly started DinD container, retrying until sshd answers.
 
-        Bounded twice over: each attempt carries its own connect/login timeout, and no attempt
-        starts once the deadline is within one poll interval. The last failure is re-raised
-        rather than wrapped, so the caller still logs the underlying error (a refused
-        connection and an unreachable host are different diagnoses).
+        The deadline caps the whole wait, not just the moment an attempt starts: a hanging
+        attempt gets whatever is left of the budget rather than a fresh 12s on top of it, so a
+        blackholed port cannot stretch the probe past DIND_SSH_READY_TIMEOUT_SECONDS (DAH-2272
+        exists because one such hang stalled the pipeline). The last failure is re-raised rather
+        than wrapped, so the caller still logs the underlying error (a refused connection and an
+        unreachable host are different diagnoses).
         """
         loop = asyncio.get_running_loop()
         started_at = loop.time()
-        deadline = started_at + DIND_SSH_READY_TIMEOUT
+        deadline = started_at + DIND_SSH_READY_TIMEOUT_SECONDS
         attempts = 0
 
         while True:
             attempts += 1
+            attempt_timeout_seconds = min(
+                DIND_SSH_CONNECT_TIMEOUT_SECONDS, deadline - loop.time()
+            )
             try:
-                ssh = await asyncssh.connect(
+                connection = await asyncssh.connect(
                     host=host,
                     port=port.external,
                     username="root",
                     client_keys=[pkey],
                     known_hosts=None,
-                    connect_timeout=DIND_SSH_CONNECT_TIMEOUT,
-                    login_timeout=DIND_SSH_CONNECT_TIMEOUT,
+                    connect_timeout=attempt_timeout_seconds,
+                    login_timeout=attempt_timeout_seconds,
                 )
             except Exception:
-                if loop.time() + DIND_SSH_POLL_INTERVAL >= deadline:
+                if loop.time() + DIND_SSH_POLL_INTERVAL_SECONDS >= deadline:
                     logger.warning(
                         _m(
                             "DinD SSH not ready before deadline",
@@ -167,7 +176,7 @@ class DindVerifier:
                         )
                     )
                     raise
-                await asyncio.sleep(DIND_SSH_POLL_INTERVAL)
+                await asyncio.sleep(DIND_SSH_POLL_INTERVAL_SECONDS)
                 continue
 
             logger.info(
@@ -182,7 +191,7 @@ class DindVerifier:
                     ),
                 )
             )
-            return ssh
+            return connection
 
 
 class DindProbe:

--- a/neurons/validators/src/services/executor_connectivity/dind_probe.py
+++ b/neurons/validators/src/services/executor_connectivity/dind_probe.py
@@ -137,16 +137,19 @@ class DindVerifier:
         The deadline caps the whole wait, not just the moment an attempt starts: a hanging
         attempt gets whatever is left of the budget rather than a fresh 12s on top of it, so a
         blackholed port cannot stretch the probe past DIND_SSH_READY_TIMEOUT_SECONDS (DAH-2272
-        exists because one such hang stalled the pipeline). The last failure is re-raised rather
-        than wrapped, so the caller still logs the underlying error (a refused connection and an
-        unreachable host are different diagnoses).
+        exists because one such hang stalled the pipeline). No attempt starts once the deadline
+        has passed either — a poll that resumes late would otherwise get a negative budget and
+        report a timeout in place of the real connection error. The last failure is raised as is,
+        so the caller still logs that error (a refused connection and an unreachable host are
+        different diagnoses).
         """
         loop = asyncio.get_running_loop()
         started_at = loop.time()
         deadline = started_at + DIND_SSH_READY_TIMEOUT_SECONDS
         attempts = 0
+        last_error: Exception | None = None
 
-        while True:
+        while loop.time() < deadline:
             attempts += 1
             attempt_timeout_seconds = min(
                 DIND_SSH_CONNECT_TIMEOUT_SECONDS, deadline - loop.time()
@@ -161,21 +164,10 @@ class DindVerifier:
                     connect_timeout=attempt_timeout_seconds,
                     login_timeout=attempt_timeout_seconds,
                 )
-            except Exception:
+            except Exception as error:
+                last_error = error
                 if loop.time() + DIND_SSH_POLL_INTERVAL_SECONDS >= deadline:
-                    logger.warning(
-                        _m(
-                            "DinD SSH not ready before deadline",
-                            extra=get_extra_info(
-                                {
-                                    **log_ctx,
-                                    "ssh_waited_sec": round(loop.time() - started_at, 2),
-                                    "ssh_attempts": attempts,
-                                }
-                            ),
-                        )
-                    )
-                    raise
+                    break
                 await asyncio.sleep(DIND_SSH_POLL_INTERVAL_SECONDS)
                 continue
 
@@ -192,6 +184,20 @@ class DindVerifier:
                 )
             )
             return connection
+
+        logger.warning(
+            _m(
+                "DinD SSH not ready before deadline",
+                extra=get_extra_info(
+                    {
+                        **log_ctx,
+                        "ssh_waited_sec": round(loop.time() - started_at, 2),
+                        "ssh_attempts": attempts,
+                    }
+                ),
+            )
+        )
+        raise last_error
 
 
 class DindProbe:

--- a/neurons/validators/src/services/executor_connectivity/dind_probe.py
+++ b/neurons/validators/src/services/executor_connectivity/dind_probe.py
@@ -11,6 +11,19 @@ from services.ssh_service import SSHService
 
 logger = logging.getLogger(__name__)
 
+# DAH-2588: how long sshd inside the DinD container may take to accept a login. Measured in
+# prod the container is ready in ~3s (p99 ~7s, max ~10s), so the fixed 5s wait this replaced
+# sat right on the median and refused roughly one probe in 130 — and a refused probe reads as
+# "no sysbox", which delists an unrented executor for the whole cycle. Polling is also cheaper
+# than a longer sleep: a ready container is caught at ~3s instead of always waiting.
+#
+# The per-attempt timeout stays at 12s and is deliberately not tightened to the poll interval:
+# asyncssh counts TCP connect, key exchange AND authentication against it, none of which carry
+# over to the next attempt, so a host slow enough to need 6s would fail every single try.
+DIND_SSH_READY_TIMEOUT = 30
+DIND_SSH_CONNECT_TIMEOUT = 12
+DIND_SSH_POLL_INTERVAL = 1.5
+
 
 class DindVerifier:
     """Verifies Docker-in-Docker capability."""
@@ -52,21 +65,10 @@ class DindVerifier:
                 )
 
             logger.info(_m("DinD container created", extra=get_extra_info(log_ctx)))
-            await asyncio.sleep(5)
 
             # Test SSH
             pkey = asyncssh.import_private_key(private_key)
-            async with asyncssh.connect(
-                host=host,
-                port=port.external,
-                username="root",
-                client_keys=[pkey],
-                known_hosts=None,
-                connect_timeout=12,
-                login_timeout=12,
-            ) as ssh:
-                logger.info(_m("DinD SSH connected", extra=get_extra_info(log_ctx)))
-
+            async with await self._wait_for_ssh(host, port, pkey, log_ctx) as ssh:
                 # Test sysbox
                 if sysbox:
                     # daturaai/dind:0.0.1 bundles the hello-world image into the inner dockerd
@@ -118,6 +120,69 @@ class DindVerifier:
                 sysbox_runtime=sysbox,
                 port=port,
             )
+
+    async def _wait_for_ssh(
+        self,
+        host: str,
+        port: PortPair,
+        pkey,
+        log_ctx: dict,
+    ) -> SSHClientConnection:
+        """Connect to the freshly started DinD container, retrying until sshd answers.
+
+        Bounded twice over: each attempt carries its own connect/login timeout, and no attempt
+        starts once the deadline is within one poll interval. The last failure is re-raised
+        rather than wrapped, so the caller still logs the underlying error (a refused
+        connection and an unreachable host are different diagnoses).
+        """
+        loop = asyncio.get_running_loop()
+        started_at = loop.time()
+        deadline = started_at + DIND_SSH_READY_TIMEOUT
+        attempts = 0
+
+        while True:
+            attempts += 1
+            try:
+                ssh = await asyncssh.connect(
+                    host=host,
+                    port=port.external,
+                    username="root",
+                    client_keys=[pkey],
+                    known_hosts=None,
+                    connect_timeout=DIND_SSH_CONNECT_TIMEOUT,
+                    login_timeout=DIND_SSH_CONNECT_TIMEOUT,
+                )
+            except Exception:
+                if loop.time() + DIND_SSH_POLL_INTERVAL >= deadline:
+                    logger.warning(
+                        _m(
+                            "DinD SSH not ready before deadline",
+                            extra=get_extra_info(
+                                {
+                                    **log_ctx,
+                                    "ssh_waited_sec": round(loop.time() - started_at, 2),
+                                    "ssh_attempts": attempts,
+                                }
+                            ),
+                        )
+                    )
+                    raise
+                await asyncio.sleep(DIND_SSH_POLL_INTERVAL)
+                continue
+
+            logger.info(
+                _m(
+                    "DinD SSH connected",
+                    extra=get_extra_info(
+                        {
+                            **log_ctx,
+                            "ssh_ready_sec": round(loop.time() - started_at, 2),
+                            "ssh_attempts": attempts,
+                        }
+                    ),
+                )
+            )
+            return ssh
 
 
 class DindProbe:

--- a/neurons/validators/tests/executor_connectivity/test_dind_verifier.py
+++ b/neurons/validators/tests/executor_connectivity/test_dind_verifier.py
@@ -29,7 +29,6 @@ async def test_dind_verifier_sysbox_failure_sets_false(mocker):
         ]
     )
 
-    mocker.patch("services.executor_connectivity.dind_probe.asyncio.sleep", new=mocker.AsyncMock())
     mocker.patch(
         "services.executor_connectivity.dind_probe.asyncssh.import_private_key",
         return_value=mocker.Mock(),
@@ -38,9 +37,10 @@ async def test_dind_verifier_sysbox_failure_sets_false(mocker):
     ssh_session = mocker.AsyncMock()
     ssh_session.run = mocker.AsyncMock(return_value=_run_result(mocker, exit_status=1, stderr="fail"))
 
-    connect = mocker.patch("services.executor_connectivity.dind_probe.asyncssh.connect")
+    connect = mocker.patch(
+        "services.executor_connectivity.dind_probe.asyncssh.connect", new=mocker.AsyncMock()
+    )
     connect.return_value.__aenter__.return_value = ssh_session
-    connect.return_value.__aexit__.return_value = mocker.AsyncMock()
 
     verifier = DindVerifier(ssh_service)
 
@@ -73,7 +73,9 @@ async def test_dind_verifier_docker_run_fails(mocker):
         ]
     )
 
-    connect = mocker.patch("services.executor_connectivity.dind_probe.asyncssh.connect")
+    connect = mocker.patch(
+        "services.executor_connectivity.dind_probe.asyncssh.connect", new=mocker.AsyncMock()
+    )
 
     verifier = DindVerifier(ssh_service)
 
@@ -88,6 +90,63 @@ async def test_dind_verifier_docker_run_fails(mocker):
     assert result.success is False
     assert "check failed" in (result.log_text or "")
     connect.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dind_verifier_retries_connect_until_sshd_is_up(mocker):
+    """DAH-2588: sshd inside a fresh container is not listening immediately, so a refused
+    connection must be retried under the readiness deadline instead of failing the probe."""
+    port = PortPair(9000, 9000)
+
+    ssh_service = mocker.Mock()
+    ssh_service.generate_keypair.return_value = ("priv", "pub")
+
+    ssh_client = mocker.AsyncMock()
+    ssh_client.run = mocker.AsyncMock(
+        side_effect=[
+            _run_result(mocker, exit_status=0, stdout="container_id"),
+            _run_result(mocker, exit_status=0, stdout=""),
+        ]
+    )
+
+    mocker.patch(
+        "services.executor_connectivity.dind_probe.asyncssh.import_private_key",
+        return_value=mocker.Mock(),
+    )
+
+    ssh_session = mocker.AsyncMock()
+    ssh_session.run = mocker.AsyncMock(return_value=_run_result(mocker, exit_status=0))
+    connection = mocker.MagicMock()
+    connection.__aenter__.return_value = ssh_session
+
+    connect = mocker.patch(
+        "services.executor_connectivity.dind_probe.asyncssh.connect",
+        new=mocker.AsyncMock(
+            side_effect=[
+                ConnectionRefusedError("[Errno 111] Connect call failed"),
+                ConnectionRefusedError("[Errno 111] Connect call failed"),
+                connection,
+            ]
+        ),
+    )
+    sleep = mocker.patch(
+        "services.executor_connectivity.dind_probe.asyncio.sleep", new=mocker.AsyncMock()
+    )
+
+    verifier = DindVerifier(ssh_service)
+
+    result = await verifier.verify(
+        port,
+        ssh_client=ssh_client,
+        host="127.0.0.1",
+        container_name_prefix="container_miner",
+        sysbox=True,
+    )
+
+    assert result.success is True
+    assert result.sysbox_runtime is True
+    assert connect.await_count == 3
+    assert sleep.await_args_list == [mocker.call(1.5), mocker.call(1.5)]
 
 
 @pytest.mark.asyncio
@@ -107,7 +166,6 @@ async def test_dind_verifier_hung_connect_fails_within_timeout(mocker):
         ]
     )
 
-    mocker.patch("services.executor_connectivity.dind_probe.asyncio.sleep", new=mocker.AsyncMock())
     mocker.patch(
         "services.executor_connectivity.dind_probe.asyncssh.import_private_key",
         return_value=mocker.Mock(),
@@ -118,8 +176,10 @@ async def test_dind_verifier_hung_connect_fails_within_timeout(mocker):
     # login_timeout, which asyncssh surfaces as a TimeoutError).
     connect = mocker.patch(
         "services.executor_connectivity.dind_probe.asyncssh.connect",
-        side_effect=TimeoutError("connect timed out"),
+        new=mocker.AsyncMock(side_effect=TimeoutError("connect timed out")),
     )
+    # Deadline already spent, so the probe gives up on the first attempt instead of polling.
+    mocker.patch("services.executor_connectivity.dind_probe.DIND_SSH_READY_TIMEOUT", 0)
 
     verifier = DindVerifier(ssh_service)
 
@@ -142,6 +202,51 @@ async def test_dind_verifier_hung_connect_fails_within_timeout(mocker):
 
 
 @pytest.mark.asyncio
+async def test_dind_verifier_gives_up_after_deadline(mocker):
+    """DAH-2588: a container that never comes up must still fail, and fail with the underlying
+    connection error rather than a generic timeout — the two have different diagnoses."""
+    port = PortPair(9000, 9000)
+
+    ssh_service = mocker.Mock()
+    ssh_service.generate_keypair.return_value = ("priv", "pub")
+
+    ssh_client = mocker.AsyncMock()
+    ssh_client.run = mocker.AsyncMock(
+        side_effect=[
+            _run_result(mocker, exit_status=0, stdout="container_id"),
+            _run_result(mocker, exit_status=0, stdout=""),
+        ]
+    )
+
+    mocker.patch(
+        "services.executor_connectivity.dind_probe.asyncssh.import_private_key",
+        return_value=mocker.Mock(),
+    )
+
+    # Real (tiny) sleeps, so the loop's own clock advances and the deadline is what stops it.
+    mocker.patch("services.executor_connectivity.dind_probe.DIND_SSH_READY_TIMEOUT", 0.05)
+    mocker.patch("services.executor_connectivity.dind_probe.DIND_SSH_POLL_INTERVAL", 0.01)
+    connect = mocker.patch(
+        "services.executor_connectivity.dind_probe.asyncssh.connect",
+        new=mocker.AsyncMock(side_effect=ConnectionRefusedError("[Errno 111] Connect call failed")),
+    )
+
+    verifier = DindVerifier(ssh_service)
+
+    result = await verifier.verify(
+        port,
+        ssh_client=ssh_client,
+        host="127.0.0.1",
+        container_name_prefix="container_miner",
+        sysbox=True,
+    )
+
+    assert result.success is False
+    assert "check failed" in (result.log_text or "")
+    assert connect.await_count >= 2
+
+
+@pytest.mark.asyncio
 async def test_dind_verifier_hung_inner_docker_run_degrades_sysbox(mocker):
     """DAH-2272: a hung inner `docker run --rm hello-world` must degrade to
     sysbox_ok=False via asyncio.wait_for(timeout=30) instead of hanging the
@@ -159,7 +264,6 @@ async def test_dind_verifier_hung_inner_docker_run_degrades_sysbox(mocker):
         ]
     )
 
-    mocker.patch("services.executor_connectivity.dind_probe.asyncio.sleep", new=mocker.AsyncMock())
     mocker.patch(
         "services.executor_connectivity.dind_probe.asyncssh.import_private_key",
         return_value=mocker.Mock(),
@@ -176,9 +280,10 @@ async def test_dind_verifier_hung_inner_docker_run_degrades_sysbox(mocker):
     ssh_session = mocker.AsyncMock()
     ssh_session.run = mocker.Mock(return_value=_hangs_forever())
 
-    connect = mocker.patch("services.executor_connectivity.dind_probe.asyncssh.connect")
+    connect = mocker.patch(
+        "services.executor_connectivity.dind_probe.asyncssh.connect", new=mocker.AsyncMock()
+    )
     connect.return_value.__aenter__.return_value = ssh_session
-    connect.return_value.__aexit__.return_value = mocker.AsyncMock()
 
     seen_timeouts = []
 

--- a/neurons/validators/tests/executor_connectivity/test_dind_verifier.py
+++ b/neurons/validators/tests/executor_connectivity/test_dind_verifier.py
@@ -285,6 +285,52 @@ async def test_dind_verifier_hanging_attempts_stay_inside_the_deadline(mocker):
 
 
 @pytest.mark.asyncio
+async def test_dind_verifier_late_poll_wakeup_starts_no_further_attempt(mocker):
+    """DAH-2588: when the loop resumes the poll past the deadline there is no budget left, and an
+    attempt started anyway could only time out — reporting a timeout instead of the connection
+    error that actually kept sshd unreachable."""
+    port = PortPair(9000, 9000)
+    verifier, ssh_client = _build_started_dind(mocker)
+
+    mocker.patch("services.executor_connectivity.dind_probe.DIND_SSH_READY_TIMEOUT_SECONDS", 0.05)
+    mocker.patch("services.executor_connectivity.dind_probe.DIND_SSH_POLL_INTERVAL_SECONDS", 0.01)
+
+    granted_timeouts = []
+
+    async def refuse_immediately(**kwargs):
+        granted_timeouts.append(kwargs["connect_timeout"])
+        raise ConnectionRefusedError("[Errno 111] Connect call failed")
+
+    connect = mocker.patch(
+        "services.executor_connectivity.dind_probe.asyncssh.connect",
+        new=mocker.AsyncMock(side_effect=refuse_immediately),
+    )
+
+    # A poll that oversleeps its interval by more than the deadline had left.
+    real_sleep = asyncio.sleep
+
+    async def oversleep(_):
+        await real_sleep(0.2)
+
+    mocker.patch(
+        "services.executor_connectivity.dind_probe.asyncio.sleep",
+        new=mocker.AsyncMock(side_effect=oversleep),
+    )
+
+    result = await verifier.verify(
+        port,
+        ssh_client=ssh_client,
+        host="127.0.0.1",
+        container_name_prefix="container_miner",
+        sysbox=True,
+    )
+
+    assert result.success is False
+    assert connect.await_count == 1
+    assert all(timeout > 0 for timeout in granted_timeouts)
+
+
+@pytest.mark.asyncio
 async def test_dind_verifier_hung_inner_docker_run_degrades_sysbox(mocker):
     """DAH-2272: a hung inner `docker run --rm hello-world` must degrade to
     sysbox_ok=False via asyncio.wait_for(timeout=30) instead of hanging the

--- a/neurons/validators/tests/executor_connectivity/test_dind_verifier.py
+++ b/neurons/validators/tests/executor_connectivity/test_dind_verifier.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Any, NamedTuple
 
 import pytest
 
@@ -12,6 +13,31 @@ def _run_result(mocker, exit_status=0, stdout="", stderr=""):
     result.stdout = stdout
     result.stderr = stderr
     return result
+
+
+class StartedDind(NamedTuple):
+    verifier: DindVerifier
+    ssh_client: Any
+
+
+def _build_started_dind(mocker) -> StartedDind:
+    # a probe whose `docker run` already succeeded, so the test starts at the SSH step
+    ssh_service = mocker.Mock()
+    ssh_service.generate_keypair.return_value = ("priv", "pub")
+
+    ssh_client = mocker.AsyncMock()
+    ssh_client.run = mocker.AsyncMock(
+        side_effect=[
+            _run_result(mocker, exit_status=0, stdout="container_id"),
+            _run_result(mocker, exit_status=0, stdout=""),
+        ]
+    )
+
+    mocker.patch(
+        "services.executor_connectivity.dind_probe.asyncssh.import_private_key",
+        return_value=mocker.Mock(),
+    )
+    return StartedDind(DindVerifier(ssh_service), ssh_client)
 
 
 @pytest.mark.asyncio
@@ -97,22 +123,7 @@ async def test_dind_verifier_retries_connect_until_sshd_is_up(mocker):
     """DAH-2588: sshd inside a fresh container is not listening immediately, so a refused
     connection must be retried under the readiness deadline instead of failing the probe."""
     port = PortPair(9000, 9000)
-
-    ssh_service = mocker.Mock()
-    ssh_service.generate_keypair.return_value = ("priv", "pub")
-
-    ssh_client = mocker.AsyncMock()
-    ssh_client.run = mocker.AsyncMock(
-        side_effect=[
-            _run_result(mocker, exit_status=0, stdout="container_id"),
-            _run_result(mocker, exit_status=0, stdout=""),
-        ]
-    )
-
-    mocker.patch(
-        "services.executor_connectivity.dind_probe.asyncssh.import_private_key",
-        return_value=mocker.Mock(),
-    )
+    verifier, ssh_client = _build_started_dind(mocker)
 
     ssh_session = mocker.AsyncMock()
     ssh_session.run = mocker.AsyncMock(return_value=_run_result(mocker, exit_status=0))
@@ -132,8 +143,6 @@ async def test_dind_verifier_retries_connect_until_sshd_is_up(mocker):
     sleep = mocker.patch(
         "services.executor_connectivity.dind_probe.asyncio.sleep", new=mocker.AsyncMock()
     )
-
-    verifier = DindVerifier(ssh_service)
 
     result = await verifier.verify(
         port,
@@ -178,8 +187,9 @@ async def test_dind_verifier_hung_connect_fails_within_timeout(mocker):
         "services.executor_connectivity.dind_probe.asyncssh.connect",
         new=mocker.AsyncMock(side_effect=TimeoutError("connect timed out")),
     )
-    # Deadline already spent, so the probe gives up on the first attempt instead of polling.
-    mocker.patch("services.executor_connectivity.dind_probe.DIND_SSH_READY_TIMEOUT", 0)
+    # One poll interval outlasts the whole deadline, so the probe gives up on the first attempt
+    # while that attempt still gets the full connect budget the assertions below pin.
+    mocker.patch("services.executor_connectivity.dind_probe.DIND_SSH_POLL_INTERVAL_SECONDS", 60)
 
     verifier = DindVerifier(ssh_service)
 
@@ -206,32 +216,15 @@ async def test_dind_verifier_gives_up_after_deadline(mocker):
     """DAH-2588: a container that never comes up must still fail, and fail with the underlying
     connection error rather than a generic timeout — the two have different diagnoses."""
     port = PortPair(9000, 9000)
-
-    ssh_service = mocker.Mock()
-    ssh_service.generate_keypair.return_value = ("priv", "pub")
-
-    ssh_client = mocker.AsyncMock()
-    ssh_client.run = mocker.AsyncMock(
-        side_effect=[
-            _run_result(mocker, exit_status=0, stdout="container_id"),
-            _run_result(mocker, exit_status=0, stdout=""),
-        ]
-    )
-
-    mocker.patch(
-        "services.executor_connectivity.dind_probe.asyncssh.import_private_key",
-        return_value=mocker.Mock(),
-    )
+    verifier, ssh_client = _build_started_dind(mocker)
 
     # Real (tiny) sleeps, so the loop's own clock advances and the deadline is what stops it.
-    mocker.patch("services.executor_connectivity.dind_probe.DIND_SSH_READY_TIMEOUT", 0.05)
-    mocker.patch("services.executor_connectivity.dind_probe.DIND_SSH_POLL_INTERVAL", 0.01)
+    mocker.patch("services.executor_connectivity.dind_probe.DIND_SSH_READY_TIMEOUT_SECONDS", 0.05)
+    mocker.patch("services.executor_connectivity.dind_probe.DIND_SSH_POLL_INTERVAL_SECONDS", 0.01)
     connect = mocker.patch(
         "services.executor_connectivity.dind_probe.asyncssh.connect",
         new=mocker.AsyncMock(side_effect=ConnectionRefusedError("[Errno 111] Connect call failed")),
     )
-
-    verifier = DindVerifier(ssh_service)
 
     result = await verifier.verify(
         port,
@@ -244,6 +237,51 @@ async def test_dind_verifier_gives_up_after_deadline(mocker):
     assert result.success is False
     assert "check failed" in (result.log_text or "")
     assert connect.await_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_dind_verifier_hanging_attempts_stay_inside_the_deadline(mocker):
+    """DAH-2588: attempts that hang for their whole budget must not push the probe past the
+    readiness deadline — the last attempt gets what is left of it, not a fresh full budget."""
+    port = PortPair(9000, 9000)
+    verifier, ssh_client = _build_started_dind(mocker)
+
+    # Same 30/12/1.5 ratio as production, scaled down 100x so the test runs in real time.
+    ready_timeout_seconds = 0.3
+    mocker.patch(
+        "services.executor_connectivity.dind_probe.DIND_SSH_READY_TIMEOUT_SECONDS",
+        ready_timeout_seconds,
+    )
+    mocker.patch("services.executor_connectivity.dind_probe.DIND_SSH_CONNECT_TIMEOUT_SECONDS", 0.12)
+    mocker.patch("services.executor_connectivity.dind_probe.DIND_SSH_POLL_INTERVAL_SECONDS", 0.015)
+
+    granted_timeouts = []
+
+    async def hang_for_the_whole_budget(**kwargs):
+        granted_timeouts.append(kwargs["connect_timeout"])
+        await asyncio.sleep(kwargs["connect_timeout"])
+        raise TimeoutError("connect timed out")
+
+    mocker.patch(
+        "services.executor_connectivity.dind_probe.asyncssh.connect",
+        new=mocker.AsyncMock(side_effect=hang_for_the_whole_budget),
+    )
+
+    started_at = asyncio.get_running_loop().time()
+
+    result = await verifier.verify(
+        port,
+        ssh_client=ssh_client,
+        host="127.0.0.1",
+        container_name_prefix="container_miner",
+        sysbox=True,
+    )
+
+    elapsed = asyncio.get_running_loop().time() - started_at
+
+    assert result.success is False
+    assert elapsed <= ready_timeout_seconds * 1.2
+    assert granted_timeouts[-1] < granted_timeouts[0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
[DAH-2588](https://app.notion.com/p/Stop-single-cycle-DinD-probe-failures-from-delisting-healthy-executors-3b3b8bfdbde981ebb922c29ac55e8866)

## What was broken

`DindVerifier.verify` waited a fixed 5s after `docker run`, then made a **single**
`asyncssh.connect` attempt. Across ~1000 prod probes the DinD container needs ~3s to accept a
login (p99 ~7s, max ~10s), so that wait sat on the median: when it lost, the probe returned
`success=False`, `ConnectivityOrchestrator` turned that into `sysbox_runtime = False`, and the
fatal `SysboxRequiredCheck` zeroed the executor's score, cleared its accumulated verification
and delisted it for the cycle.

Reference incident — executor `5f2cc740-3946-4663-9cc6-68a87d3ffa13`, wave `2026-08-05 05:23:48`,
unrented, 300/300 ports verified, scrape reported sysbox present:

```
05:30:04.925  DinD container created
05:30:11.251  DinD check failed  error "[Errno 111] Connect call failed ('192.222.55.74', 20000)"
05:31:50      SYSBOX_REQUIRED_MISSING  score 0, verification cleared
05:38:48      next wave: sysbox_runtime = TRUE, score 1.0, back on the market
```

Host uptime rose straight through the failing wave — the machine never went anywhere. The
provider saw a "machine went offline" notification and came to Discord.

## How it's fixed

`DindVerifier._connect_retrying_until_sshd_answers` polls `asyncssh.connect` every 1.5s under a
single 30s deadline. On success it logs `ssh_ready_sec` and `ssh_attempts`; on giving up it logs
`DinD SSH not ready before deadline` with the same fields, so the two cases stop looking
identical in Loki.

The deadline bounds the **whole** wait, not just the moment an attempt starts. Two guards do
that together: no attempt starts once the deadline is within one poll interval, and an attempt
that would outlive the deadline gets only the budget that is left
(`min(DIND_SSH_CONNECT_TIMEOUT_SECONDS, deadline - now)`). Without the second guard a blackholed
port stretches the probe to ~39s rather than 30s — an attempt greenlit at 27s still claimed a
fresh 12s — which is the DAH-2272 failure mode (a hung connect stalling the pipeline) coming
back stacked, and nothing upstream bounds it: `ConnectivityOrchestrator` awaits the probe with
no `asyncio.wait_for` around it.

The per-attempt `connect_timeout` / `login_timeout` otherwise stay at **12s** and are
deliberately not tightened toward the poll interval. asyncssh counts TCP connect, key exchange
*and* authentication against that budget and none of it carries over to the next attempt, so
tightening it would fail every attempt on a host that simply needs 6s to handshake — a new class
of false negative in place of the old one. The clamp above only shortens an attempt when less
than 12s of the deadline remains, which is time that attempt could not have used anyway.

This is the first of the three parts in the spec; the random probe port and the cross-wave
debounce are not in this PR.

Net effect on the probe budget is negative, not positive: a container ready at 3s is now caught
at ~3s instead of always waiting 5s.

## Test plan

- [x] `pdm run pytest tests/` in `neurons/validators` — 1470 passed, 9 skipped. (Three failures in
      `tests/test_sshd_bootstrap_script.py` are pre-existing on `main` — verified by running that
      file against a clean `origin/main` checkout — and excluded.)
- [x] Mutation check: forcing the retry loop to give up on the first attempt fails exactly
      `test_dind_verifier_retries_connect_until_sshd_is_up` and `test_dind_verifier_gives_up_after_deadline`.
      Removing the remaining-budget clamp fails exactly
      `test_dind_verifier_hanging_attempts_stay_inside_the_deadline`, which runs the production
      30/12/1.5 ratio scaled down 100x and asserts the probe still finishes inside the deadline.
- [x] `ruff check` on both changed files — 2 findings (`UP041`), both pre-existing on `main`.

### Pre-deploy verification

Run the probe ~20x against a staging executor and read `ssh_ready_sec` from
`DinD SSH connected`: a p99 above 5s confirms the race the fixed wait was losing. Then block the
DinD port on a healthy executor and confirm the probe now spends the full deadline and logs
`DinD SSH not ready before deadline` before failing — and that `ssh_waited_sec` lands at ~30s,
not ~39s.

### Post-deploy verification

- +1 d: `DinD check failed` rate falls below today's ~2.6%; no executor shows a single isolated
  `Sysbox required for unrented executor` wave with `ssh_ready_sec` absent.
- +7 d: one-to-three-wave `Sysbox required for unrented executor` hits collapse toward zero,
  while the ~17 persistently sysbox-less machines stay banned.
