### PR TITLE
DAH-2594: count a passed TDX attestation as a flagship capability

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -238,8 +238,8 @@ class Settings(BaseSettings):
     ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT: bool = Field(env="ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT", default=False)
 
     # DAH-2546 — flagship capability gate. When True, an unrented 8x H200/B200/B300 executor
-    # with no NCU profiling counters open, no real GPU splitting enabled and no passed TDX
-    # attestation (DAH-2594) loses the unrented rental incentive while staying active.
+    # with no NCU profiling counters open, no real GPU splitting enabled and no verified TDX
+    # quote (DAH-2594) loses the unrented rental incentive while staying active.
     # When False, the breach is only logged
     # (shadow mode) so prod impact can be observed before enforcing.
     ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT: bool = Field(env="ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT", default=False)

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -238,8 +238,9 @@ class Settings(BaseSettings):
     ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT: bool = Field(env="ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT", default=False)
 
     # DAH-2546 — flagship capability gate. When True, an unrented 8x H200/B200/B300 executor
-    # with neither NCU profiling counters open nor real GPU splitting enabled loses the
-    # unrented rental incentive while staying active. When False, the breach is only logged
+    # with no NCU profiling counters open, no real GPU splitting enabled and no passed TDX
+    # attestation (DAH-2594) loses the unrented rental incentive while staying active.
+    # When False, the breach is only logged
     # (shadow mode) so prod impact can be observed before enforcing.
     ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT: bool = Field(env="ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT", default=False)
 

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -9,7 +9,7 @@ WHERE A NODE EARNS (two "pools" of subnet emission; the rest is burned):
 HOW A NODE PICKS A POOL:
   rented?                                              -> mining pool (always earns)
   idle AND model in program AND price ok AND disk >= 1.5x VRAM
-       AND (not flagship-8x OR NCU/split offered)
+       AND (not flagship-8x OR NCU/split/attested-CVM offered)
                                AND capacity?            -> unrented pool (earns)
   otherwise                                            -> 0 incentive (reason below)
 
@@ -24,7 +24,8 @@ WHAT THIS CATALOG HOLDS — every `MinerLogLine` the miner-facing log block
      GPU model not in the unrented program (earns only when rented),
      price above the market soft limit (lower the price to earn),
      total disk below 1.5x total GPU VRAM (add disk to earn),
-     8x H200/B200/B300 with neither NCU profiling nor GPU splitting (offer either to earn),
+     8x H200/B200/B300 with no NCU profiling, GPU splitting or passed TDX
+       attestation (offer any of the three to earn),
      no unrented capacity for that GPU-count tier this cycle,
      NVIDIA driver below the minimum, sysbox runtime not enabled
 

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -346,11 +346,12 @@ class MinerLogLine(BaseModel):
             reason=ZeroIncentiveReason.FLAGSHIP_WITHOUT_NCU_OR_SPLIT,
             message=(
                 f"No unrented incentive: an idle {result.gpu_count}x {result.gpu_model} must offer "
-                "NCU profiling or GPU splitting. Either open the host profiling counters "
-                "(NVreg_RestrictProfilingToAdminUsers=0, then reboot), which also makes the node "
-                "rentable only as a whole host, or set a minimum GPU count below the full node in "
-                "the Miner Portal on a host that supports docker storage limits, "
-                "or rent it out to earn."
+                "NCU profiling, GPU splitting or confidential computing. Either open the host "
+                "profiling counters (NVreg_RestrictProfilingToAdminUsers=0, then reboot), which "
+                "also makes the node rentable only as a whole host, or set a minimum GPU count "
+                "below the full node in the Miner Portal on a host that supports docker storage "
+                "limits, or run the executor inside a confidential VM whose TDX attestation "
+                "passes, or rent it out to earn."
             ),
             extra_fields={
                 "ncu_profiling_access": missing.ncu_profiling_access,

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -44,8 +44,8 @@ SOFT_LIMIT_PRICE_RATE = 1.1
 MIN_DISK_TO_VRAM_RATE = 1.5
 
 # DAH-2546 — flagship capability gate. An unrented 8x machine of these base models must
-# have NCU profiling counters open on the host, real GPU splitting enabled, or a passed TDX
-# attestation (DAH-2594) to earn the unrented incentive; with none of the three it forfeits
+# have NCU profiling counters open on the host, real GPU splitting enabled, or a verified TDX
+# quote (DAH-2594) to earn the unrented incentive; with none of the three it forfeits
 # the incentive but stays active.
 FLAGSHIP_CAPABILITY_BASE_MODELS = frozenset({"H200", "B200", "B300"})
 FLAGSHIP_CAPABILITY_GPU_COUNT = 8
@@ -336,11 +336,16 @@ class RentalPriceIncentive(DefaultIncentive):
             and result.gpu_splitting_min_count < result.gpu_count
         )
         # DAH-2594 — a CVM provider has no access to the host GPU drivers, so NCU counters are
-        # unreachable by construction; a passed attestation is that machine's capability path
+        # unreachable by construction; a verified TDX quote is that machine's capability path.
+        # The quote alone, not JobResult.tdx_attestation_passed: that flag also drops on a failed
+        # GPU-CC verdict, which is observe-only today, so a CVM submitting failing GPU evidence
+        # would earn less than one submitting none. Bad GPU evidence is the GPU-attestation
+        # enforcement flag's job; once it is on, evidence is mandatory and no digest reaches here.
+        attested_cvm: bool = result.attestation_digest is not None
         if (
             ncu_profiling_access == NCU_PROFILING_UNRESTRICTED
             or has_real_splitting
-            or result.tdx_attestation_passed
+            or attested_cvm
         ):
             return None
         return MissingFlagshipCapability(
@@ -367,8 +372,8 @@ class RentalPriceIncentive(DefaultIncentive):
                     "ncu_profiling_scrape_error": missing.ncu_profiling_scrape_error,
                     "supports_gpu_splitting": result.supports_gpu_splitting,
                     "gpu_splitting_min_count": result.gpu_splitting_min_count,
-                    # separates a self-declared CVM whose attestation did not pass from an
-                    # ordinary host; tdx_attestation_passed is False on every line emitted here
+                    # separates a self-declared CVM whose TDX quote did not verify from an
+                    # ordinary host; attestation_digest is None on every line emitted here
                     "tdx_quote_present": bool(result.executor_info.tdx_quote),
                     "enforced": enforced,
                     "reason": ZeroIncentiveReason.FLAGSHIP_WITHOUT_NCU_OR_SPLIT,

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -44,8 +44,9 @@ SOFT_LIMIT_PRICE_RATE = 1.1
 MIN_DISK_TO_VRAM_RATE = 1.5
 
 # DAH-2546 — flagship capability gate. An unrented 8x machine of these base models must
-# have NCU profiling counters open on the host or real GPU splitting enabled to earn the
-# unrented incentive; with neither it forfeits the incentive but stays active.
+# have NCU profiling counters open on the host, real GPU splitting enabled, or a passed TDX
+# attestation (DAH-2594) to earn the unrented incentive; with none of the three it forfeits
+# the incentive but stays active.
 FLAGSHIP_CAPABILITY_BASE_MODELS = frozenset({"H200", "B200", "B300"})
 FLAGSHIP_CAPABILITY_GPU_COUNT = 8
 # Value the machine scrape reports when RmProfilingAdminOnly is 0 on the host (DAH-2182).
@@ -63,8 +64,8 @@ class InsufficientDisk(BaseModel):
 
 
 class MissingFlagshipCapability(BaseModel):
-    """What the scrape reported about NCU profiling on a flagship machine that offers neither
-    open profiling counters nor real GPU splitting. Sole owner of these scrape keys."""
+    """What the scrape reported about NCU profiling on a flagship machine that offers no open
+    profiling counters, real GPU splitting or attested CVM. Sole owner of these scrape keys."""
 
     ncu_profiling_access: str | None  # None = the scrape carries no observation at all
     ncu_profiling_scrape_error: str | None  # set when the probe could not read the driver params
@@ -334,7 +335,13 @@ class RentalPriceIncentive(DefaultIncentive):
             and result.gpu_splitting_min_count
             and result.gpu_splitting_min_count < result.gpu_count
         )
-        if ncu_profiling_access == NCU_PROFILING_UNRESTRICTED or has_real_splitting:
+        # DAH-2594 — a CVM provider has no access to the host GPU drivers, so NCU counters are
+        # unreachable by construction; a passed attestation is that machine's capability path
+        if (
+            ncu_profiling_access == NCU_PROFILING_UNRESTRICTED
+            or has_real_splitting
+            or result.tdx_attestation_passed
+        ):
             return None
         return MissingFlagshipCapability(
             ncu_profiling_access=ncu_profiling_access,
@@ -344,11 +351,12 @@ class RentalPriceIncentive(DefaultIncentive):
     def _log_flagship_capability_limit(
         self, result: JobResult, missing: MissingFlagshipCapability
     ) -> None:
-        # structured log for every rental-eligible 8x flagship executor lacking both capabilities
+        # structured log for every rental-eligible 8x flagship executor lacking all capabilities
         enforced = settings.ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT
         logger.info(
             _m(
-                "Unrented flagship executor has neither NCU profiling nor GPU splitting"
+                "Unrented flagship executor has no NCU profiling, GPU splitting "
+                "or confidential computing"
                 + ("" if enforced else " (shadow only - flag off)"),
                 extra={
                     "executor_id": str(result.executor_info.uuid),
@@ -359,6 +367,9 @@ class RentalPriceIncentive(DefaultIncentive):
                     "ncu_profiling_scrape_error": missing.ncu_profiling_scrape_error,
                     "supports_gpu_splitting": result.supports_gpu_splitting,
                     "gpu_splitting_min_count": result.gpu_splitting_min_count,
+                    # separates a self-declared CVM whose attestation did not pass from an
+                    # ordinary host; tdx_attestation_passed is False on every line emitted here
+                    "tdx_quote_present": bool(result.executor_info.tdx_quote),
                     "enforced": enforced,
                     "reason": ZeroIncentiveReason.FLAGSHIP_WITHOUT_NCU_OR_SPLIT,
                     "pool": "rental_excluded" if enforced else "rental_kept_shadow",

--- a/neurons/validators/tests/test_unrented_flagship_capability_limit.py
+++ b/neurons/validators/tests/test_unrented_flagship_capability_limit.py
@@ -2,7 +2,7 @@
 
 An unrented 8x H200/B200/B300 executor that has none of NCU profiling counters
 open on the host (ncu_profiling_access == "unrestricted"), real GPU splitting
-enabled (min_gpu_count below the full node size), or a passed TDX attestation
+enabled (min_gpu_count below the full node size), or a verified TDX quote
 forfeits the unrented rental incentive while staying active. Enforcement is gated by
 ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT; while the flag is off the breach is
 only logged (shadow mode) and the payout is unchanged.
@@ -27,6 +27,9 @@ H100 = "NVIDIA H100 80GB HBM3"
 # a scrape carrying no NCU observation at all: a machine not re-scraped since DAH-2182 shipped
 SCRAPE_WITHOUT_NCU: dict[str, str] = {}
 
+# what prepare_host_policy returns for a verified TDX quote: os_image_hash + compose_hash
+ATTESTATION_DIGEST = "0f1e2d:9a8b7c"
+
 
 def _build_incentive() -> RentalPriceIncentive:
     return RentalPriceIncentive(IncentiveConfig(), AsyncMock(), {}, {})
@@ -41,7 +44,8 @@ def _make_job(
     supports_gpu_splitting: bool = False,
     gpu_splitting_min_count: int | None = None,
     is_rented: bool = False,
-    tdx_attestation_passed: bool = False,
+    attestation_digest: str | None = None,
+    gpu_attestation_passed: bool | None = None,
     tdx_quote: str | None = None,
 ) -> JobResult:
     return JobResult(
@@ -66,7 +70,8 @@ def _make_job(
         gpu_count=gpu_count,
         is_rented=is_rented,
         supports_gpu_splitting=supports_gpu_splitting,
-        tdx_attestation_passed=tdx_attestation_passed,
+        attestation_digest=attestation_digest,
+        gpu_attestation_passed=gpu_attestation_passed,
         gpu_splitting_min_count=gpu_splitting_min_count,
         collateral_deposited=True,
         sysbox_runtime=True,
@@ -91,8 +96,11 @@ def _make_job(
         ({"gpu_model": B300, "supports_gpu_splitting": True, "gpu_splitting_min_count": 1}, False),
         ({"gpu_model": H100}, False),  # not a flagship model
         ({"gpu_count": 4}, False),  # only full 8x nodes are gated
-        ({"tdx_attestation_passed": True}, False),
-        ({"gpu_model": B200, "tdx_attestation_passed": True}, False),
+        ({"attestation_digest": ATTESTATION_DIGEST}, False),
+        ({"gpu_model": B200, "attestation_digest": ATTESTATION_DIGEST}, False),
+        # a CVM whose GPU-CC evidence verified bad still counts: GPU attestation is a separate
+        # (observe-only) lever, and withholding evidence must never pay more than submitting it
+        ({"attestation_digest": ATTESTATION_DIGEST, "gpu_attestation_passed": False}, False),
     ],
 )
 def test_missing_flagship_capability(job_kwargs, is_missing):
@@ -164,15 +172,15 @@ async def test_shadow_mode_emits_the_capability_log(monkeypatch, caplog):
 
 @pytest.mark.asyncio
 async def test_self_declared_cvm_is_still_excluded(monkeypatch, caplog):
-    # A machine that submitted a quote but whose attestation did not pass still fails the
-    # gate; the log has to separate it from an ordinary host, since tdx_attestation_passed
-    # is False on every line this gate emits.
+    # A machine that submitted a quote the validator did not verify still fails the gate; the
+    # log has to separate it from an ordinary host, since attestation_digest is None on every
+    # line this gate emits.
     monkeypatch.setattr(settings, "ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT", True)
     incentive = _build_incentive()
 
     with caplog.at_level(logging.INFO):
         result = await incentive.calculate_executor_score(
-            _make_job(tdx_quote='{"quote": "..."}', tdx_attestation_passed=False)
+            _make_job(tdx_quote='{"quote": "..."}', attestation_digest=None)
         )
 
     breach = next(
@@ -227,7 +235,7 @@ async def test_enforced_appends_customer_facing_incentive_log(monkeypatch):
         # path every cycle; the gate must fail open on those (DAH-2520 precedent)
         ({"spec": None}, True),
         # DAH-2594 — an attested CVM cannot open host NCU counters, attestation is its path
-        ({"tdx_attestation_passed": True}, True),
+        ({"attestation_digest": ATTESTATION_DIGEST}, True),
     ],
 )
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_unrented_flagship_capability_limit.py
+++ b/neurons/validators/tests/test_unrented_flagship_capability_limit.py
@@ -41,6 +41,8 @@ def _make_job(
     supports_gpu_splitting: bool = False,
     gpu_splitting_min_count: int | None = None,
     is_rented: bool = False,
+    tdx_attestation_passed: bool = False,
+    tdx_quote: str | None = None,
 ) -> JobResult:
     return JobResult(
         executor_info=ExecutorSSHInfo(
@@ -52,6 +54,7 @@ def _make_job(
             python_path="/usr/bin/python3",
             root_dir="/tmp",
             price_per_gpu=1.0,
+            tdx_quote=tdx_quote,
         ),
         spec=spec,
         score=1.0,
@@ -63,6 +66,7 @@ def _make_job(
         gpu_count=gpu_count,
         is_rented=is_rented,
         supports_gpu_splitting=supports_gpu_splitting,
+        tdx_attestation_passed=tdx_attestation_passed,
         gpu_splitting_min_count=gpu_splitting_min_count,
         collateral_deposited=True,
         sysbox_runtime=True,
@@ -87,6 +91,8 @@ def _make_job(
         ({"gpu_model": B300, "supports_gpu_splitting": True, "gpu_splitting_min_count": 1}, False),
         ({"gpu_model": H100}, False),  # not a flagship model
         ({"gpu_count": 4}, False),  # only full 8x nodes are gated
+        ({"tdx_attestation_passed": True}, False),
+        ({"gpu_model": B200, "tdx_attestation_passed": True}, False),
     ],
 )
 def test_missing_flagship_capability(job_kwargs, is_missing):
@@ -153,6 +159,29 @@ async def test_shadow_mode_emits_the_capability_log(monkeypatch, caplog):
     assert breach.extra["ncu_profiling_scrape_error"] == "Cannot read /proc/driver/nvidia/params"
     assert breach.extra["enforced"] is False
     assert breach.extra["pool"] == "rental_kept_shadow"
+    assert breach.extra["tdx_quote_present"] is False
+
+
+@pytest.mark.asyncio
+async def test_self_declared_cvm_is_still_excluded(monkeypatch, caplog):
+    # A machine that submitted a quote but whose attestation did not pass still fails the
+    # gate; the log has to separate it from an ordinary host, since tdx_attestation_passed
+    # is False on every line this gate emits.
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT", True)
+    incentive = _build_incentive()
+
+    with caplog.at_level(logging.INFO):
+        result = await incentive.calculate_executor_score(
+            _make_job(tdx_quote='{"quote": "..."}', tdx_attestation_passed=False)
+        )
+
+    breach = next(
+        record.msg
+        for record in caplog.records
+        if record.msg.extra.get("reason") == "flagship_without_ncu_or_split"
+    )
+    assert result.eligible_for_rental_share is False
+    assert breach.extra["tdx_quote_present"] is True
 
 
 @pytest.mark.asyncio
@@ -182,6 +211,7 @@ async def test_enforced_appends_customer_facing_incentive_log(monkeypatch):
     assert "flagship_without_ncu_or_split" in log
     assert "NCU profiling" in log
     assert "GPU splitting" in log
+    assert "confidential computing" in log
     assert [reason.reason for reason in result.zero_incentive_reasons] == [
         "flagship_without_ncu_or_split"
     ]
@@ -196,6 +226,8 @@ async def test_enforced_appends_customer_facing_incentive_log(monkeypatch):
         # estimate_executor feeds spec-less synthetic results through the same scoring
         # path every cycle; the gate must fail open on those (DAH-2520 precedent)
         ({"spec": None}, True),
+        # DAH-2594 — an attested CVM cannot open host NCU counters, attestation is its path
+        ({"tdx_attestation_passed": True}, True),
     ],
 )
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_unrented_flagship_capability_limit.py
+++ b/neurons/validators/tests/test_unrented_flagship_capability_limit.py
@@ -1,9 +1,9 @@
-"""DAH-2546 — unrented incentive flagship capability gate.
+"""DAH-2546 / DAH-2594 — unrented incentive flagship capability gate.
 
-An unrented 8x H200/B200/B300 executor that neither has NCU profiling counters
-open on the host (ncu_profiling_access == "unrestricted") nor real GPU
-splitting enabled (min_gpu_count below the full node size) forfeits the
-unrented rental incentive while staying active. Enforcement is gated by
+An unrented 8x H200/B200/B300 executor that has none of NCU profiling counters
+open on the host (ncu_profiling_access == "unrestricted"), real GPU splitting
+enabled (min_gpu_count below the full node size), or a passed TDX attestation
+forfeits the unrented rental incentive while staying active. Enforcement is gated by
 ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT; while the flag is off the breach is
 only logged (shadow mode) and the payout is unchanged.
 """


### PR DESCRIPTION
## Problem

DAH-2546 gates the unrented (idle) incentive for 8x H200/B200/B300: the machine must have NCU
profiling counters open on the host, or real GPU splitting. Enforced in production since
2026-08-04.

A confidential-computing node can satisfy neither. NCU counters are opened on the host, and a CVM
provider has no access to the host GPU drivers — there is nothing for them to configure. Splitting
is likewise unavailable. So an attested CVM sits at zero idle incentive with no action available to
its owner.

The stated policy is broader than the code: idle incentive should require **CC or profiling or GPU
splitting**. `_missing_flagship_capability` only ever looked at the last two.

Live case: an 8x H200 CVM with `tdx_attestation_passed=true`, `ncu_profiling_access="restricted"`
and no splitting, excluded from the rental pool since 2026-08-05 16:47:05 UTC.

## Change

A third clause in the existing gate condition:

```python
if (
    ncu_profiling_access == NCU_PROFILING_UNRESTRICTED
    or has_real_splitting
    or result.tdx_attestation_passed
):
    return None
```

`JobResult.tdx_attestation_passed` is set by the validator itself from
`host_policy.attestation_passed` — `attestation_digest is not None AND gpu_attestation_passed is not
False`. A machine that submits no `tdx_quote` is never verified, so it can never reach `True`; the
signal is not miner-forgeable. The clause sits after the existing `spec is None` guard, so the
spec-less synthetic results from `precompute_all_estimates` keep failing open exactly as before.

The miner-facing message and the internal log now name all three paths.

`_log_flagship_capability_limit` gains one field, `tdx_quote_present`. It separates a self-declared
CVM whose attestation did not pass from an ordinary host — a distinction `tdx_attestation_passed`
cannot make, since it is `False` on every line this gate emits. Internal Loki log only; the wire
payload and the TimescaleDB column are untouched.

## Deliberately not changed

- **`ZeroIncentiveReason.FLAGSHIP_WITHOUT_NCU_OR_SPLIT` keeps its string value.** The enum is
  append-only — Loki dashboards and the DAH-2340 backend payload key off exact strings. The name is
  now a slight misnomer; that is the cheaper cost.
- **No `settings.ENABLE_TDX_ATTESTATION` in the condition.** With attestation off the field is
  already `False`.
- **No enforcement-flag change.** `ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT` stays as deployed.
- **Not extended to unattested CVMs.** A machine that presents a quote but fails attestation is
  already zeroed upstream by the Minimal-G5 gate in `score_calculator.py` and never reaches this
  code; where it would reach it, attestation is disabled and the quote is an unverified string.

## Verification

- `pdm run pytest tests/test_unrented_flagship_capability_limit.py tests/test_miner_incentive_log.py
  tests/test_rental_price_incentive_flow.py tests/test_rental_price_estimate.py
  tests/test_rental_price_helpers.py tests/prod_snapshot/ -q` → 136 passed, 4 skipped.
- Full package: `pdm run pytest tests/ -q` → 1483 passed, 9 skipped, 3 failed. The 3 are
  `tests/test_sshd_bootstrap_script.py`, pre-existing and macOS-only (BSD `sed`) — they fail
  identically with this diff stashed.
- RED confirmed before the fix: reverting only the two `src/incentive/` files leaves 6 failures —
  the two new parametrize rows, the enforced-CC row, the message assert and the two
  `tdx_quote_present` asserts.

## Effect once deployed

The gated CVM returns to the rental pool on the first scoring cycle after the validator rollout.
Nothing loses incentive: the change can only move an executor from excluded to included.

Provider documentation is a separate follow-up — `emission.mdx` does not describe this gate at all
today, and `gpu-splitting.md` still claims splitting unlocks no incentive.
