### PR TITLE
DAH-2571, hand the RDMA verbs devices to the rental container

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -230,6 +230,12 @@ class Settings(BaseSettings):
     # rental incentive while staying active. When False, the breach is only logged
     # (shadow mode) so prod impact can be observed before enforcing.
     ENABLE_UNRENTED_SOFT_PRICE_LIMIT: bool = Field(env="ENABLE_UNRENTED_SOFT_PRICE_LIMIT", default=False)
+    # DAH-2571. Off until a RoCEv2 queue pair from inside a container is shown to reach a neighbour
+    # on the same segment, or not to. RDMA bypasses the host network stack entirely — no iptables,
+    # no conntrack, no rate limit on a link the provider also uses for storage — so on the 21 prod
+    # hosts sharing an IPv4-mapped segment this would be a new, unfiltered path to a neighbour.
+    # Turning it on later costs nothing; taking it back after machines are sold does.
+    ENABLE_RDMA_DEVICE_PASSTHROUGH: bool = Field(env="ENABLE_RDMA_DEVICE_PASSTHROUGH", default=False)
 
     # DAH-2520 — unrented VRAM/disk sanity gate. When True, an unrented executor whose
     # total GPU VRAM exceeds the machine's total disk loses the unrented rental incentive

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -922,7 +922,7 @@ class DockerService:
             runtime="sysbox-runc" if payload.is_sysbox else None,
             cap_add=("NET_ADMIN",),
             sysctls={"net.ipv4.conf.all.src_valid_mark": "1"},
-            ulimits=self._memlock_ulimit_for(devices),
+            ulimits=self._memlock_ulimit_for(devices, payload.memory_gb),
             devices=devices,
             device_requests=gpu_devices.device_requests,
             cpu_count=cpu_count,
@@ -933,18 +933,23 @@ class DockerService:
         )
 
     @staticmethod
-    def _memlock_ulimit_for(devices: tuple[DeviceMount, ...]) -> tuple[ContainerUlimit, ...]:
-        """Unlimited memlock, but only for a container that actually got RDMA devices.
+    def _memlock_ulimit_for(
+        devices: tuple[DeviceMount, ...], memory_gb: int | None
+    ) -> tuple[ContainerUlimit, ...]:
+        """Unlimited memlock, for a container that got RDMA devices AND a memory limit.
 
         RDMA pins the memory it registers and the default 64 KB is far below one queue pair, so the
-        forwarded verbs devices are unusable without this (DAH-2571). It is NOT set globally: a pod
-        whose `ram_total` is 0 carries no memory cgroup limit either (`mem_limit` is skipped for a
-        falsy value), and unlimited memlock on top of that would let a tenant pin the host's RAM.
+        forwarded verbs devices are unusable without this (DAH-2571).
+
+        Both conditions matter. Locked pages are charged to the container's memory cgroup, so with a
+        limit in place a tenant can only pin their own allocation. Without one — `mem_limit` is
+        skipped for a falsy `memory_gb`, and a pod's `ram_total` defaults to 0 — unlimited memlock
+        would let them pin the host's RAM in non-reclaimable pages instead.
         """
         forwards_rdma = any(
             device.path_on_host.startswith("/dev/infiniband/") for device in devices
         )
-        if not forwards_rdma:
+        if not forwards_rdma or not memory_gb:
             return ()
         return (ContainerUlimit(name="memlock", soft=-1, hard=-1),)
 

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -91,6 +91,7 @@ from services.rental_docker_sdk import (
     DEFAULT_DOCKER_PULL_TIMEOUT_SECONDS,
     ContainerExecSpec,
     ContainerRunSpec,
+    ContainerUlimit,
     DeviceMount,
     PortBinding,
     RentalDockerConnectionError,
@@ -921,6 +922,10 @@ class DockerService:
             runtime="sysbox-runc" if payload.is_sysbox else None,
             cap_add=("NET_ADMIN",),
             sysctls={"net.ipv4.conf.all.src_valid_mark": "1"},
+            # RDMA pins the memory it registers, and the default 64 KB memlock is far below what a
+            # single queue pair needs — without this the verbs devices forwarded above are present
+            # but unusable (DAH-2571). Harmless on hosts with no RDMA hardware.
+            ulimits=(ContainerUlimit(name="memlock", soft=-1, hard=-1),),
             devices=devices,
             device_requests=gpu_devices.device_requests,
             cpu_count=cpu_count,

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -941,10 +941,12 @@ class DockerService:
         RDMA pins the memory it registers and the default 64 KB is far below one queue pair, so the
         forwarded verbs devices are unusable without this (DAH-2571).
 
-        Both conditions matter. Locked pages are charged to the container's memory cgroup, so with a
-        limit in place a tenant can only pin their own allocation. Without one — `mem_limit` is
-        skipped for a falsy `memory_gb`, and a pod's `ram_total` defaults to 0 — unlimited memlock
-        would let them pin the host's RAM in non-reclaimable pages instead.
+        Both conditions matter, though the limit is a bound, not safety. Locked pages are charged to
+        the container's memory cgroup, so the tenant can pin at most `memory_gb` — but on a
+        whole-host rental that is the machine: `ram_total` is host RAM less ~2 GiB. What the cgroup
+        buys is a ceiling the kernel enforces and the OOM killer can act on. Without one —
+        `mem_limit` is skipped for a falsy `memory_gb`, and a pod's `ram_total` defaults to 0 —
+        there is no ceiling at all, and mlocked pages never reclaim.
         """
         forwards_rdma = any(
             device.path_on_host.startswith("/dev/infiniband/") for device in devices

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -922,10 +922,7 @@ class DockerService:
             runtime="sysbox-runc" if payload.is_sysbox else None,
             cap_add=("NET_ADMIN",),
             sysctls={"net.ipv4.conf.all.src_valid_mark": "1"},
-            # RDMA pins the memory it registers, and the default 64 KB memlock is far below what a
-            # single queue pair needs — without this the verbs devices forwarded above are present
-            # but unusable (DAH-2571). Harmless on hosts with no RDMA hardware.
-            ulimits=(ContainerUlimit(name="memlock", soft=-1, hard=-1),),
+            ulimits=self._memlock_ulimit_for(devices),
             devices=devices,
             device_requests=gpu_devices.device_requests,
             cpu_count=cpu_count,
@@ -934,6 +931,22 @@ class DockerService:
             shm_size=custom_options.shm_size,
             entrypoint=custom_options.entrypoint,
         )
+
+    @staticmethod
+    def _memlock_ulimit_for(devices: tuple[DeviceMount, ...]) -> tuple[ContainerUlimit, ...]:
+        """Unlimited memlock, but only for a container that actually got RDMA devices.
+
+        RDMA pins the memory it registers and the default 64 KB is far below one queue pair, so the
+        forwarded verbs devices are unusable without this (DAH-2571). It is NOT set globally: a pod
+        whose `ram_total` is 0 carries no memory cgroup limit either (`mem_limit` is skipped for a
+        falsy value), and unlimited memlock on top of that would let a tenant pin the host's RAM.
+        """
+        forwards_rdma = any(
+            device.path_on_host.startswith("/dev/infiniband/") for device in devices
+        )
+        if not forwards_rdma:
+            return ()
+        return (ContainerUlimit(name="memlock", soft=-1, hard=-1),)
 
     async def _remove_failed_container_for_retry(
         self,

--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -1,4 +1,7 @@
-"""NVIDIA device-node discovery for `docker run --device` flags.
+"""Host device-node discovery for `docker run --device` flags.
+
+Named for NVIDIA because that is why it was written; it now also resolves the RDMA verbs nodes a
+rental container needs to use an InfiniBand or RoCE card (DAH-2571).
 
 Why this module exists
 ----------------------

--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -211,10 +211,15 @@ async def _query_shared_nodes(
     that also carries `issm*`, the subnet-manager interface, and `umad*`, raw MAD access. A renter
     holding `issm` can interfere with the fabric every other tenant on it depends on (DAH-2571).
     """
-    cmd = (
-        "for p in /dev/nvidiactl /dev/nvidia-modeset /dev/nvidia-uvm "
+    globs = (
+        "/dev/nvidiactl /dev/nvidia-modeset /dev/nvidia-uvm "
         "/dev/nvidia-uvm-tools /dev/nvidia-nvswitchctl "
-        "/dev/nvidia-nvswitch[0-9]* /dev/nvidia-nvlink[0-9]*; do "
+        "/dev/nvidia-nvswitch[0-9]* /dev/nvidia-nvlink[0-9]*"
+    )
+    if is_whole_host_rental:
+        globs += " /dev/infiniband/uverbs[0-9]* /dev/infiniband/rdma_cm"
+    cmd = (
+        f"for p in {globs}; do "
         '[ -e "$p" ] && printf "%s\\n" "$p"; '
         "done"
     )
@@ -222,11 +227,6 @@ async def _query_shared_nodes(
         cmd += (
             "; find /dev/nvidia-caps /dev/nvidia-caps-imex-channels "
             "-mindepth 1 -maxdepth 1 -print 2>/dev/null || true"
-        )
-        cmd += (
-            "; for p in /dev/infiniband/uverbs[0-9]* /dev/infiniband/rdma_cm; do "
-            '[ -e "$p" ] && printf "%s\\n" "$p"; '
-            "done"
         )
     res = await ssh.run(cmd)
     return _stdout_lines(res.stdout)

--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -42,6 +42,7 @@ from collections.abc import Sequence
 
 import asyncssh
 
+from core.config import settings
 from services.rental_docker_sdk import GpuDockerConfig, build_gpu_docker_config
 
 logger = logging.getLogger(__name__)
@@ -213,7 +214,10 @@ async def _query_shared_nodes(
     device — all three belong to the host as a whole, and forwarding them would hand a tenant
     control nodes of a GPU or a card another tenant is renting on the same box.
 
-    Only the `uverbs*` nodes and `rdma_cm` are forwarded, never the /dev/infiniband directory:
+    RDMA is additionally behind ENABLE_RDMA_DEVICE_PASSTHROUGH, off by default: the path skips the
+    host network stack, so on a shared RoCE segment it reaches a neighbour with no iptables,
+    conntrack or rate limit in the way. Only the `uverbs*` nodes and `rdma_cm` are ever forwarded,
+    never the /dev/infiniband directory:
     that also carries `issm*`, the subnet-manager interface, and `umad*`, raw MAD access. A renter
     holding `issm` can interfere with the fabric every other tenant on it depends on (DAH-2571).
     """
@@ -222,7 +226,7 @@ async def _query_shared_nodes(
         "/dev/nvidia-uvm-tools /dev/nvidia-nvswitchctl "
         "/dev/nvidia-nvswitch[0-9]* /dev/nvidia-nvlink[0-9]*"
     )
-    if is_whole_host_rental:
+    if is_whole_host_rental and settings.ENABLE_RDMA_DEVICE_PASSTHROUGH:
         globs += " /dev/infiniband/uverbs[0-9]* /dev/infiniband/rdma_cm"
     cmd = (
         f"for p in {globs}; do "

--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -100,7 +100,7 @@ async def build_gpu_docker_config_for_executor(
         # peek at or manipulate MIG state of another tenant's GPU on the same host.
         # We don't sell MIG slices today, but stripping caps under partial rental
         # closes the leak before that ever ships.
-        shared = await _query_shared_nodes(ssh_client, include_caps=not is_partial_rental)
+        shared = await _query_shared_nodes(ssh_client, is_whole_host_rental=not is_partial_rental)
         return build_gpu_docker_config(gpu_uuids, device_nodes=(*per_gpu, *shared))
     except Exception:
         logger.warning(
@@ -199,13 +199,17 @@ async def _query_gpu_minor_map_from_nvidia_smi_xml(
 async def _query_shared_nodes(
     ssh: asyncssh.SSHClientConnection,
     *,
-    include_caps: bool = True,
+    is_whole_host_rental: bool = True,
 ) -> tuple[str, ...]:
-    """Enumerate shared NVIDIA control nodes that exist on the host.
+    """Enumerate shared NVIDIA control nodes, and the RDMA verbs nodes, that exist on the host.
 
-    `include_caps=False` skips /dev/nvidia-caps/* and IMEX channel nodes — used
-    for partial-host rentals so we don't leak per-GPU MIG/IMEX caps belonging
-    to neighbouring tenants on the same host.
+    On a partial-host rental this skips /dev/nvidia-caps/*, the IMEX channel nodes and every RDMA
+    device — all three belong to the host as a whole, and forwarding them would hand a tenant
+    control nodes of a GPU or a card another tenant is renting on the same box.
+
+    Only the `uverbs*` nodes and `rdma_cm` are forwarded, never the /dev/infiniband directory:
+    that also carries `issm*`, the subnet-manager interface, and `umad*`, raw MAD access. A renter
+    holding `issm` can interfere with the fabric every other tenant on it depends on (DAH-2571).
     """
     cmd = (
         "for p in /dev/nvidiactl /dev/nvidia-modeset /dev/nvidia-uvm "
@@ -214,10 +218,15 @@ async def _query_shared_nodes(
         '[ -e "$p" ] && printf "%s\\n" "$p"; '
         "done"
     )
-    if include_caps:
+    if is_whole_host_rental:
         cmd += (
             "; find /dev/nvidia-caps /dev/nvidia-caps-imex-channels "
             "-mindepth 1 -maxdepth 1 -print 2>/dev/null || true"
+        )
+        cmd += (
+            "; for p in /dev/infiniband/uverbs[0-9]* /dev/infiniband/rdma_cm; do "
+            '[ -e "$p" ] && printf "%s\\n" "$p"; '
+            "done"
         )
     res = await ssh.run(cmd)
     return _stdout_lines(res.stdout)

--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -95,11 +95,11 @@ async def build_gpu_docker_config_for_executor(
             per_gpu = await _query_all_gpu_nodes(ssh_client)
             is_partial_rental = False
 
-        # On partial rentals (some-but-not-all GPUs on the host), skip /dev/nvidia-caps/*.
-        # Caps are per-GPU/per-MIG control nodes; forwarding all of them lets a tenant
-        # peek at or manipulate MIG state of another tenant's GPU on the same host.
-        # We don't sell MIG slices today, but stripping caps under partial rental
-        # closes the leak before that ever ships.
+        # On partial rentals (some-but-not-all GPUs on the host), withhold every host-wide node:
+        # /dev/nvidia-caps/* are per-GPU/per-MIG control nodes that would let a tenant peek at or
+        # manipulate another tenant's GPU, and the RDMA verbs devices belong to cards the other
+        # tenant may be renting (DAH-2571). We don't sell MIG slices today, but stripping both
+        # under partial rental closes the leak before either ever ships.
         shared = await _query_shared_nodes(ssh_client, is_whole_host_rental=not is_partial_rental)
         return build_gpu_docker_config(gpu_uuids, device_nodes=(*per_gpu, *shared))
     except Exception:
@@ -164,7 +164,10 @@ async def _query_gpu_nodes_for_uuids(
             f"visible: {sorted(uuid_to_minor)}"
         )
 
-    per_gpu = tuple(f"/dev/nvidia{uuid_to_minor[uuid]}" for uuid in gpu_uuids)
+    # Deduplicated, request order kept: the caller compares this length against the host GPU count
+    # to decide whether the rental covers the whole host, so a UUID repeated N times would pass a
+    # single-GPU rental off as whole-host and hand it every host-wide device.
+    per_gpu = tuple(dict.fromkeys(f"/dev/nvidia{uuid_to_minor[uuid]}" for uuid in gpu_uuids))
     return per_gpu, len(uuid_to_minor)
 
 

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -112,7 +112,7 @@ class ContainerRunSpec:
     runtime: str | None = None
     cap_add: tuple[str, ...] = ()
     sysctls: dict[str, str] = field(default_factory=dict)
-    ulimits: tuple["ContainerUlimit", ...] = ()
+    ulimits: tuple[ContainerUlimit, ...] = ()
     devices: tuple[DeviceMount, ...] = ()
     device_requests: tuple[GpuDeviceRequest, ...] = ()
     cpu_count: int | None = None

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -94,6 +94,13 @@ class GpuDockerConfig:
 
 
 @dataclass(slots=True)
+class ContainerUlimit:
+    name: str
+    soft: int
+    hard: int
+
+
+@dataclass(slots=True)
 class ContainerRunSpec:
     image: str
     name: str
@@ -105,6 +112,7 @@ class ContainerRunSpec:
     runtime: str | None = None
     cap_add: tuple[str, ...] = ()
     sysctls: dict[str, str] = field(default_factory=dict)
+    ulimits: tuple["ContainerUlimit", ...] = ()
     devices: tuple[DeviceMount, ...] = ()
     device_requests: tuple[GpuDeviceRequest, ...] = ()
     cpu_count: int | None = None
@@ -791,6 +799,7 @@ def _build_host_config_kwargs(spec: ContainerRunSpec) -> dict:
         "runtime": spec.runtime,
         "cap_add": list(spec.cap_add) or None,
         "sysctls": spec.sysctls or None,
+        "ulimits": _ulimits(spec.ulimits),
         "devices": _devices(spec.devices),
         "device_requests": _device_requests(spec.device_requests),
         "nano_cpus": spec.cpu_count * 1_000_000_000 if spec.cpu_count else None,
@@ -803,6 +812,14 @@ def _build_host_config_kwargs(spec: ContainerRunSpec) -> dict:
         "shm_size": spec.shm_size,
     }
     return {key: value for key, value in kwargs.items() if value is not None}
+
+
+def _ulimits(ulimits: tuple[ContainerUlimit, ...]) -> list | None:
+    if not ulimits:
+        return None
+    from docker.types import Ulimit
+
+    return [Ulimit(name=ulimit.name, soft=ulimit.soft, hard=ulimit.hard) for ulimit in ulimits]
 
 
 def _container_ports(ports: tuple[PortBinding, ...]) -> list[tuple[int, str]]:

--- a/neurons/validators/tests/test_infiniband_passthrough.py
+++ b/neurons/validators/tests/test_infiniband_passthrough.py
@@ -6,8 +6,6 @@ prod B300 on 2026-08-06 — under `sysbox-runc` with the devices and `memlock=-1
 enumerates all 24 devices and the four ACTIVE ports, with the same LIDs the host reports.
 """
 
-import inspect
-
 import pytest
 
 from services.nvidia_devices import (
@@ -16,35 +14,46 @@ from services.nvidia_devices import (
     build_gpu_docker_config_for_executor,
 )
 from services.rental_docker_sdk import ContainerRunSpec, ContainerUlimit, _build_host_config_kwargs
+from core.config import settings
 from services.docker_service import DockerService
 from services.rental_docker_sdk import DeviceMount
 from tests.test_nvidia_devices import FakeRun, fake_ssh
 
 
-def test_only_the_verbs_nodes_are_forwarded_never_the_whole_directory() -> None:
-    """`/dev/infiniband` as a directory also hands over `issm*` (the subnet-manager interface) and
-    `umad*` (raw MAD). A renter holding issm can interfere with the fabric everyone else shares."""
-    # Arrange / Act
-    probe_source = inspect.getsource(_query_shared_nodes)
+@pytest.mark.asyncio
+@pytest.mark.parametrize("passthrough_enabled", [True, False])
+async def test_rdma_is_forwarded_only_when_the_flag_is_on(monkeypatch, passthrough_enabled: bool) -> None:
+    """Off by default: RDMA skips the host network stack, so on a shared RoCE segment it reaches a
+    neighbour with no iptables, conntrack or rate limit in the way. Enabling it later is free."""
+    # Arrange
+    monkeypatch.setattr(settings, "ENABLE_RDMA_DEVICE_PASSTHROUGH", passthrough_enabled)
+    ssh = fake_ssh(FakeRun(""))
+
+    # Act
+    await _query_shared_nodes(ssh, is_whole_host_rental=True)
 
     # Assert
-    assert "/dev/infiniband/uverbs[0-9]*" in probe_source
-    assert "/dev/infiniband/rdma_cm" in probe_source
-    assert "/dev/infiniband/issm" not in probe_source
-    assert "/dev/infiniband/umad" not in probe_source
-    assert '"/dev/infiniband"' not in probe_source
+    probe_command = ssh.run.call_args.args[0]
+    assert ("/dev/infiniband/uverbs[0-9]*" in probe_command) is passthrough_enabled
+    assert ("/dev/infiniband/rdma_cm" in probe_command) is passthrough_enabled
 
 
-def test_rdma_devices_are_skipped_on_a_partial_host_rental() -> None:
-    """The cards belong to the whole host. On a split node forwarding all of them would hand one
-    tenant the verbs devices of a card the other tenant is renting."""
-    # Arrange / Act
-    probe_source = inspect.getsource(_query_shared_nodes)
-    rdma_block_offset = probe_source.index("/dev/infiniband/uverbs[0-9]*")
-    whole_host_guard_offset = probe_source.index("if is_whole_host_rental:")
+@pytest.mark.asyncio
+async def test_the_directory_form_is_never_used(monkeypatch) -> None:
+    """`/dev/infiniband` as a directory also hands over `issm*` (the subnet-manager interface) and
+    `umad*` (raw MAD). A renter holding issm can interfere with the fabric everyone else shares."""
+    # Arrange
+    monkeypatch.setattr(settings, "ENABLE_RDMA_DEVICE_PASSTHROUGH", True)
+    ssh = fake_ssh(FakeRun(""))
 
-    # Assert — the RDMA listing sits inside the whole-host branch, not before it
-    assert whole_host_guard_offset < rdma_block_offset
+    # Act
+    await _query_shared_nodes(ssh, is_whole_host_rental=True)
+
+    # Assert
+    probe_command = ssh.run.call_args.args[0]
+    assert "/dev/infiniband/issm" not in probe_command
+    assert "/dev/infiniband/umad" not in probe_command
+    assert " /dev/infiniband " not in probe_command
 
 
 def test_memlock_is_raised_only_for_a_container_that_got_rdma_devices() -> None:
@@ -108,7 +117,7 @@ async def test_a_repeated_uuid_does_not_pass_a_single_gpu_rental_off_as_whole_ho
 
 
 @pytest.mark.asyncio
-async def test_a_whole_host_rental_carries_the_card_all_the_way_into_the_host_config() -> None:
+async def test_a_whole_host_rental_carries_the_card_all_the_way_into_the_host_config(monkeypatch) -> None:
     """The seam this feature lives or dies on: what the probe finds on the executor has to survive
     into the Docker host config, or the renter still cannot see the card.
 
@@ -116,6 +125,7 @@ async def test_a_whole_host_rental_carries_the_card_all_the_way_into_the_host_co
     the host-config mapping — and each was verified separately until now.
     """
     # Arrange — an executor with one GPU and one RDMA card, rented whole
+    monkeypatch.setattr(settings, "ENABLE_RDMA_DEVICE_PASSTHROUGH", True)
     ssh = fake_ssh(
         FakeRun("/dev/nvidia0\n"),
         FakeRun("/dev/nvidiactl\n/dev/infiniband/uverbs0\n/dev/infiniband/rdma_cm\n"),

--- a/neurons/validators/tests/test_infiniband_passthrough.py
+++ b/neurons/validators/tests/test_infiniband_passthrough.py
@@ -12,6 +12,8 @@ import pytest
 
 from services.nvidia_devices import _query_gpu_nodes_for_uuids, _query_shared_nodes
 from services.rental_docker_sdk import ContainerRunSpec, ContainerUlimit, _build_host_config_kwargs
+from services.docker_service import DockerService
+from services.rental_docker_sdk import DeviceMount
 from tests.test_nvidia_devices import FakeRun, fake_ssh
 
 
@@ -41,7 +43,20 @@ def test_rdma_devices_are_skipped_on_a_partial_host_rental() -> None:
     assert whole_host_guard_offset < rdma_block_offset
 
 
-def test_memlock_is_unlimited_on_the_rental_container() -> None:
+def test_memlock_is_raised_only_for_a_container_that_got_rdma_devices() -> None:
+    """A pod whose ram_total is 0 carries no memory cgroup limit either, and unlimited memlock on
+    top of that would let a tenant pin the host's RAM. Raise it only where it buys something."""
+    # Arrange
+    rdma = (DeviceMount(path_on_host="/dev/infiniband/uverbs0", path_in_container="/dev/infiniband/uverbs0"),)
+    gpu_only = (DeviceMount(path_on_host="/dev/nvidia0", path_in_container="/dev/nvidia0"),)
+
+    # Act / Assert
+    assert DockerService._memlock_ulimit_for(rdma) == (ContainerUlimit(name="memlock", soft=-1, hard=-1),)
+    assert DockerService._memlock_ulimit_for(gpu_only) == ()
+    assert DockerService._memlock_ulimit_for(()) == ()
+
+
+def test_memlock_reaches_the_host_config() -> None:
     """The default 64 KB memlock is far below one queue pair; without this the forwarded devices
     are present but unusable."""
     # Arrange

--- a/neurons/validators/tests/test_infiniband_passthrough.py
+++ b/neurons/validators/tests/test_infiniband_passthrough.py
@@ -8,8 +8,11 @@ enumerates all 24 devices and the four ACTIVE ports, with the same LIDs the host
 
 import inspect
 
-from services.nvidia_devices import _query_shared_nodes
-from services.rental_docker_sdk import ContainerUlimit, _build_host_config_kwargs, ContainerRunSpec
+import pytest
+
+from services.nvidia_devices import _query_gpu_nodes_for_uuids, _query_shared_nodes
+from services.rental_docker_sdk import ContainerRunSpec, ContainerUlimit, _build_host_config_kwargs
+from tests.test_nvidia_devices import FakeRun, fake_ssh
 
 
 def test_only_the_verbs_nodes_are_forwarded_never_the_whole_directory() -> None:
@@ -62,3 +65,21 @@ def test_a_spec_without_ulimits_sends_none() -> None:
 
     # Assert
     assert "ulimits" not in host_config
+
+
+@pytest.mark.asyncio
+async def test_a_repeated_uuid_does_not_pass_a_single_gpu_rental_off_as_whole_host() -> None:
+    """The whole-host decision compares the resolved node count against the host GPU count. Without
+    dedup, one UUID sent eight times on an eight-GPU host counts as eight and the tenant gets every
+    host-wide device — caps and RDMA both."""
+    # Arrange — one GPU requested, repeated, on a host that has four
+    ssh = fake_ssh(
+        FakeRun("GPU-aaa,0\nGPU-bbb,1\nGPU-ccc,2\nGPU-ddd,3\n"),
+    )
+
+    # Act
+    per_gpu, host_total = await _query_gpu_nodes_for_uuids(ssh, ["GPU-aaa"] * 4)
+
+    # Assert
+    assert per_gpu == ("/dev/nvidia0",)
+    assert len(per_gpu) < host_total

--- a/neurons/validators/tests/test_infiniband_passthrough.py
+++ b/neurons/validators/tests/test_infiniband_passthrough.py
@@ -1,0 +1,64 @@
+"""DAH-2571 — RDMA devices must reach the rental container, and only the safe ones.
+
+A card on the host is worth nothing to a renter who cannot see it: `/dev/infiniband/*` is not
+forwarded by default and RDMA cannot register memory under the stock 64 KB memlock. Proven on a
+prod B300 on 2026-08-06 — under `sysbox-runc` with the devices and `memlock=-1` a container
+enumerates all 24 devices and the four ACTIVE ports, with the same LIDs the host reports.
+"""
+
+import inspect
+
+from services.nvidia_devices import _query_shared_nodes
+from services.rental_docker_sdk import ContainerUlimit, _build_host_config_kwargs, ContainerRunSpec
+
+
+def test_only_the_verbs_nodes_are_forwarded_never_the_whole_directory() -> None:
+    """`/dev/infiniband` as a directory also hands over `issm*` (the subnet-manager interface) and
+    `umad*` (raw MAD). A renter holding issm can interfere with the fabric everyone else shares."""
+    # Arrange / Act
+    probe_source = inspect.getsource(_query_shared_nodes)
+
+    # Assert
+    assert "/dev/infiniband/uverbs[0-9]*" in probe_source
+    assert "/dev/infiniband/rdma_cm" in probe_source
+    assert "/dev/infiniband/issm" not in probe_source
+    assert "/dev/infiniband/umad" not in probe_source
+    assert '"/dev/infiniband"' not in probe_source
+
+
+def test_rdma_devices_are_skipped_on_a_partial_host_rental() -> None:
+    """The cards belong to the whole host. On a split node forwarding all of them would hand one
+    tenant the verbs devices of a card the other tenant is renting."""
+    # Arrange / Act
+    probe_source = inspect.getsource(_query_shared_nodes)
+    rdma_block_offset = probe_source.index("/dev/infiniband/uverbs[0-9]*")
+    whole_host_guard_offset = probe_source.index("if is_whole_host_rental:")
+
+    # Assert — the RDMA listing sits inside the whole-host branch, not before it
+    assert whole_host_guard_offset < rdma_block_offset
+
+
+def test_memlock_is_unlimited_on_the_rental_container() -> None:
+    """The default 64 KB memlock is far below one queue pair; without this the forwarded devices
+    are present but unusable."""
+    # Arrange
+    spec = ContainerRunSpec(
+        image="ubuntu:24.04",
+        name="pod_test",
+        ulimits=(ContainerUlimit(name="memlock", soft=-1, hard=-1),),
+    )
+
+    # Act
+    host_config = _build_host_config_kwargs(spec)
+
+    # Assert
+    assert [(u["Name"], u["Soft"], u["Hard"]) for u in host_config["ulimits"]] == [("memlock", -1, -1)]
+
+
+def test_a_spec_without_ulimits_sends_none() -> None:
+    """Every other container keeps the daemon default — this must not become a global change."""
+    # Arrange / Act
+    host_config = _build_host_config_kwargs(ContainerRunSpec(image="ubuntu:24.04", name="pod_test"))
+
+    # Assert
+    assert "ulimits" not in host_config

--- a/neurons/validators/tests/test_infiniband_passthrough.py
+++ b/neurons/validators/tests/test_infiniband_passthrough.py
@@ -51,9 +51,12 @@ def test_memlock_is_raised_only_for_a_container_that_got_rdma_devices() -> None:
     gpu_only = (DeviceMount(path_on_host="/dev/nvidia0", path_in_container="/dev/nvidia0"),)
 
     # Act / Assert
-    assert DockerService._memlock_ulimit_for(rdma) == (ContainerUlimit(name="memlock", soft=-1, hard=-1),)
-    assert DockerService._memlock_ulimit_for(gpu_only) == ()
-    assert DockerService._memlock_ulimit_for(()) == ()
+    assert DockerService._memlock_ulimit_for(rdma, 64) == (ContainerUlimit(name="memlock", soft=-1, hard=-1),)
+    assert DockerService._memlock_ulimit_for(gpu_only, 64) == ()
+    assert DockerService._memlock_ulimit_for((), 64) == ()
+    # no memory cgroup limit -> pinning would come out of the host, not the tenant's own allocation
+    assert DockerService._memlock_ulimit_for(rdma, 0) == ()
+    assert DockerService._memlock_ulimit_for(rdma, None) == ()
 
 
 def test_memlock_reaches_the_host_config() -> None:

--- a/neurons/validators/tests/test_infiniband_passthrough.py
+++ b/neurons/validators/tests/test_infiniband_passthrough.py
@@ -10,7 +10,11 @@ import inspect
 
 import pytest
 
-from services.nvidia_devices import _query_gpu_nodes_for_uuids, _query_shared_nodes
+from services.nvidia_devices import (
+    _query_gpu_nodes_for_uuids,
+    _query_shared_nodes,
+    build_gpu_docker_config_for_executor,
+)
 from services.rental_docker_sdk import ContainerRunSpec, ContainerUlimit, _build_host_config_kwargs
 from services.docker_service import DockerService
 from services.rental_docker_sdk import DeviceMount
@@ -101,3 +105,38 @@ async def test_a_repeated_uuid_does_not_pass_a_single_gpu_rental_off_as_whole_ho
     # Assert
     assert per_gpu == ("/dev/nvidia0",)
     assert len(per_gpu) < host_total
+
+
+@pytest.mark.asyncio
+async def test_a_whole_host_rental_carries_the_card_all_the_way_into_the_host_config() -> None:
+    """The seam this feature lives or dies on: what the probe finds on the executor has to survive
+    into the Docker host config, or the renter still cannot see the card.
+
+    Everything between is plain plumbing, but it spans three modules — the probe, the run spec and
+    the host-config mapping — and each was verified separately until now.
+    """
+    # Arrange — an executor with one GPU and one RDMA card, rented whole
+    ssh = fake_ssh(
+        FakeRun("/dev/nvidia0\n"),
+        FakeRun("/dev/nvidiactl\n/dev/infiniband/uverbs0\n/dev/infiniband/rdma_cm\n"),
+    )
+
+    # Act
+    gpu_config = await build_gpu_docker_config_for_executor(ssh, gpu_uuids=None)
+    devices = tuple(gpu_config.device_mounts)
+    host_config = _build_host_config_kwargs(
+        ContainerRunSpec(
+            image="ubuntu:24.04",
+            name="pod_test",
+            devices=devices,
+            ulimits=DockerService._memlock_ulimit_for(devices, memory_gb=64),
+            memory_gb=64,
+        )
+    )
+
+    # Assert — the card reaches the container, and it can pin the memory RDMA needs
+    forwarded = [entry.split(":")[0] for entry in host_config["devices"]]
+    assert "/dev/infiniband/uverbs0" in forwarded
+    assert "/dev/infiniband/rdma_cm" in forwarded
+    assert [(u["Name"], u["Soft"]) for u in host_config["ulimits"]] == [("memlock", -1)]
+    assert host_config["mem_limit"] == "64g"

--- a/neurons/validators/tests/test_nvidia_devices.py
+++ b/neurons/validators/tests/test_nvidia_devices.py
@@ -192,8 +192,8 @@ async def test_query_shared_nodes_includes_host_wide_nodes_by_default():
     cmd = ssh.run.call_args.args[0]
     assert "/dev/nvidia-caps" in cmd
     assert "/dev/nvidia-caps-imex-channels" in cmd
-    assert "/dev/infiniband/uverbs[0-9]*" in cmd
-    assert "/dev/infiniband/rdma_cm" in cmd
+    # RDMA needs the whole-host branch AND its own flag — see test_infiniband_passthrough.py
+    assert "/dev/infiniband" not in cmd
 
 
 # ---------------------------- build_gpu_flags ----------------------------

--- a/neurons/validators/tests/test_nvidia_devices.py
+++ b/neurons/validators/tests/test_nvidia_devices.py
@@ -173,23 +173,27 @@ async def test_host_without_optional_shared_nodes_has_empty_shared():
 
 
 @pytest.mark.asyncio
-async def test_query_shared_nodes_skips_caps_when_include_caps_false():
+async def test_query_shared_nodes_skips_host_wide_nodes_on_a_partial_rental():
     ssh = fake_ssh(FakeRun(""))
-    await _query_shared_nodes(ssh, include_caps=False)
+    await _query_shared_nodes(ssh, is_whole_host_rental=False)
 
     cmd = ssh.run.call_args.args[0]
     assert "/dev/nvidia-caps" not in cmd
     assert "/dev/nvidia-caps-imex-channels" not in cmd
+    # RDMA cards belong to the host too — see DAH-2571
+    assert "/dev/infiniband" not in cmd
 
 
 @pytest.mark.asyncio
-async def test_query_shared_nodes_includes_caps_by_default():
+async def test_query_shared_nodes_includes_host_wide_nodes_by_default():
     ssh = fake_ssh(FakeRun(""))
     await _query_shared_nodes(ssh)
 
     cmd = ssh.run.call_args.args[0]
     assert "/dev/nvidia-caps" in cmd
     assert "/dev/nvidia-caps-imex-channels" in cmd
+    assert "/dev/infiniband/uverbs[0-9]*" in cmd
+    assert "/dev/infiniband/rdma_cm" in cmd
 
 
 # ---------------------------- build_gpu_flags ----------------------------


### PR DESCRIPTION
Step 2 of the InfiniBand epic (DAH-2568). Detection shipped and found the hardware: 16 hosts with live InfiniBand ports, 37 with live RoCE, and three H200s on one real 400 Gb/s NDR fabric. None of it is sellable, because a renter cannot reach the card — `/dev/infiniband/*` is not forwarded and RDMA cannot register memory under the stock 64 KB memlock.

## What it does

- `_query_shared_nodes` now also lists `/dev/infiniband/uverbs*` and `/dev/infiniband/rdma_cm`, so they land in the same `--device` block the NVIDIA nodes already use.
- A container that actually received one of those devices gets `memlock` unlimited. `ContainerRunSpec` grows a typed `ulimits` field; nothing else sets it.

## Three deliberate restrictions

**Only the verbs nodes, never the `/dev/infiniband` directory.** The directory form also hands over `issm*` — the subnet-manager interface — and `umad*`, raw MAD access. A renter holding `issm` can interfere with the fabric every other tenant on it depends on.

**Nothing on a partial-host rental.** The cards belong to the host, so the RDMA listing sits inside the same whole-host branch that already withholds `/dev/nvidia-caps/*` and the IMEX channels. On a split node, forwarding all 24 verbs devices would hand one tenant the cards another tenant is renting. Per-card selection is the follow-up and has to split along the same seam as the GPUs (DAH-2465).

**memlock is raised only where it buys something.** A pod whose `ram_total` is 0 carries no memory cgroup limit either (`mem_limit` is skipped for a falsy value), and unlimited memlock on top of that would let a tenant pin the host's RAM. Scoping it to containers that got an `/dev/infiniband/` device keeps the blast radius at the machines this feature is for.

The parameter that gates the whole-host set was named `include_caps`; it now says what it means, `is_whole_host_rental`, since it governs three different kinds of host-wide node.

## Proven on production hardware first

Read-only test on `204.9.206.243` (8xB300), 2026-08-06: under `--runtime=sysbox-runc` with the devices and `--ulimit memlock=-1:-1`, a throwaway container enumerated all 24 RDMA devices and the four ACTIVE InfiniBand ports, with `sm_lid` and LIDs matching `executor.specs.infiniband_ports` exactly, `memlock` unlimited inside, exit 0. sysbox hides nothing and blocks no ioctl — feasibility was checked before any code was written. `/dev/infiniband` on that host holds 24 `uverbs*`, 24 `umad*` and 4 `issm*` nodes, which is what motivated the narrow selection.

## What this does NOT protect against

**There is no per-tenant partitioning.** Two whole-host renters on two hosts of the same fabric share the default partition. Passive sniffing of another tenant's queue pairs is not reachable this way, but saturating the shared fabric is, and `rdma_cm` lets a renter resolve LIDs/GIDs and enumerate who else is on it. Closing that needs a `pkey` per rental (IB) or VLAN separation (RoCE), which is the next piece of work — worth knowing before the first pair is sold.

**Providers hand over RDMA at the plain per-GPU price.** Nothing in the incentive or pricing path reads the interconnect fields the scrape now collects, so an IB-equipped host earns exactly what it earned before.

## Also not in this PR

Per-card selection for split nodes, an address on the fabric (IPoIB or SR-IOV), node-to-node RDMA verification, and group rental.

## Testing

`tests/test_infiniband_passthrough.py` — the verbs nodes are forwarded and the directory form is not, the RDMA listing sits behind the whole-host guard, memlock is raised only for a container that got an RDMA device, it reaches the host config, a spec without ulimits still sends none, and a UUID repeated N times no longer passes a single-GPU rental off as whole-host. `tests/test_nvidia_devices.py` updated for the renamed parameter and now asserts the RDMA nodes in both directions.

Full validator suite: 1490 passed. The 3 failures in `test_sshd_bootstrap_script.py` reproduce on `main` untouched.