### PR TITLE
DAH-2602: attach the rental container to the RDMA fabric with an SR-IOV function

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -78,6 +78,7 @@ from services.gpu_power_limit import (
 )
 from services.gpu_wedge import cure_wedged_gpus, query_wedged_gpu_uuids
 from services.nvidia_devices import build_gpu_docker_config_for_executor
+from services.rdma_fabric import attach_container_to_rdma_fabric
 from services.redis_service import (
     STREAMING_LOG_CHANNEL,
     RedisService,
@@ -931,6 +932,55 @@ class DockerService:
             shm_size=custom_options.shm_size,
             entrypoint=custom_options.entrypoint,
         )
+
+    async def _attach_rdma_fabric_if_available(
+        self,
+        *,
+        ssh_client: asyncssh.SSHClientConnection,
+        container_name: str,
+        forwarded_devices: tuple[DeviceMount, ...],
+        default_extra: dict,
+    ) -> None:
+        """Give the container its own function on the RDMA fabric, when the host supports it.
+
+        Without this the container reaches its own cards but nothing across the wire: its only
+        address is the NAT bridge's, while the card's GID carries the host's (DAH-2602).
+
+        A failure here never fails the rental. Every precondition lives on the host — exclusive
+        RDMA namespace mode, a declared address range, a free virtual function — so an unprepared
+        host is the normal case, not an error, and the pod is still exactly what today's
+        passthrough delivers.
+        """
+        forwards_rdma = any(
+            device.path_on_host.startswith("/dev/infiniband/") for device in forwarded_devices
+        )
+        if not forwards_rdma:
+            return
+        try:
+            attachment = await attach_container_to_rdma_fabric(ssh_client, container_name)
+        except Exception:
+            logger.warning(
+                _m(
+                    "RDMA_FABRIC_ATTACH_FAILED",
+                    extra=get_extra_info({**default_extra, "container_name": container_name}),
+                ),
+                exc_info=True,
+            )
+            return
+        if attachment:
+            logger.info(
+                _m(
+                    "RDMA_FABRIC_ATTACHED",
+                    extra=get_extra_info({
+                        **default_extra,
+                        "container_name": container_name,
+                        "virtual_function_netdev": attachment.virtual_function.netdev,
+                        "virtual_function_rdma_device": attachment.virtual_function.rdma_device,
+                        "ipv4_cidr": attachment.ipv4_cidr,
+                        "vlan_id": attachment.vlan_id,
+                    }),
+                )
+            )
 
     @staticmethod
     def _memlock_ulimit_for(
@@ -4473,6 +4523,13 @@ class DockerService:
                     )
 
                     logger.info("Container creation step finished")
+
+                    await self._attach_rdma_fabric_if_available(
+                        ssh_client=ssh_client,
+                        container_name=container_name,
+                        forwarded_devices=run_spec.devices,
+                        default_extra=default_extra,
+                    )
 
                     # DAH-1524: isolate the bare `docker run` (dominated by the NVIDIA
                     # --gpus prestart hook, +sysbox/storage-opt) from the post-run

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -563,6 +563,11 @@ def build_startup_command_args(startup_commands: str | None) -> str:
     return " ".join(shlex.quote(token) for token in tokens)
 
 
+def _forwards_rdma_devices(devices: tuple[DeviceMount, ...]) -> bool:
+    """Whether this rental was handed the RDMA verbs devices (DAH-2571)."""
+    return any(device.path_on_host.startswith("/dev/infiniband/") for device in devices)
+
+
 class DockerService:
     def __init__(
         self,
@@ -933,8 +938,8 @@ class DockerService:
             entrypoint=custom_options.entrypoint,
         )
 
+    @staticmethod
     async def _attach_rdma_fabric_if_available(
-        self,
         *,
         ssh_client: asyncssh.SSHClientConnection,
         container_name: str,
@@ -951,10 +956,7 @@ class DockerService:
         host is the normal case, not an error, and the pod is still exactly what today's
         passthrough delivers.
         """
-        forwards_rdma = any(
-            device.path_on_host.startswith("/dev/infiniband/") for device in forwarded_devices
-        )
-        if not forwards_rdma:
+        if not _forwards_rdma_devices(forwarded_devices):
             return
         try:
             attachment = await attach_container_to_rdma_fabric(ssh_client, container_name)
@@ -998,10 +1000,7 @@ class DockerService:
         `mem_limit` is skipped for a falsy `memory_gb`, and a pod's `ram_total` defaults to 0 —
         there is no ceiling at all, and mlocked pages never reclaim.
         """
-        forwards_rdma = any(
-            device.path_on_host.startswith("/dev/infiniband/") for device in devices
-        )
-        if not forwards_rdma or not memory_gb:
+        if not _forwards_rdma_devices(devices) or not memory_gb:
             return ()
         return (ContainerUlimit(name="memlock", soft=-1, hard=-1),)
 

--- a/neurons/validators/src/services/rdma_fabric.py
+++ b/neurons/validators/src/services/rdma_fabric.py
@@ -21,6 +21,12 @@ NET_ADMIN, so nothing enforced by the container's own kernel namespace counts:
 Neither is configured by us at rental time: exclusive mode is host-wide and disruptive to flip
 while RDMA is in use, and only whoever owns the fabric knows which addresses on it are free. Both
 are read as preconditions, and the attachment is skipped when they are absent.
+
+KNOWN LIMITATION: the attachment is made once, when the container is created. Rental containers run
+under `restart-unless-stopped`, and a restart destroys the network namespace — the kernel returns
+the function to the host and the restarted container comes back with its bridge address only, no
+`fabric0` and no RDMA device, without saying so. Re-attaching on restart needs a watcher on the
+executor and is not built here; until it is, a pod that restarts has silently lost the fabric.
 """
 from __future__ import annotations
 
@@ -111,6 +117,14 @@ async def read_host_fabric_config(
         )
         return None
     vlan_id: int | None = document.get("vlan_id")
+    # The file is written on the host and its values reach `ip link set`; a non-integer tag would
+    # cross into that command as text.
+    if vlan_id is not None and not isinstance(vlan_id, int):
+        logger.warning(
+            "rdma_fabric: vlan_id in the host fabric config is not an integer, ignoring the config",
+            extra={"path": HOST_FABRIC_CONFIG_PATH, "vlan_id": repr(vlan_id)},
+        )
+        return None
     return HostFabricConfig(container_ip_range=container_ip_range, vlan_id=vlan_id)
 
 
@@ -154,23 +168,27 @@ def build_attachment(
     the range belongs to that host alone, and a derived address needs no state to survive a
     validator restart or a second container starting concurrently.
     """
-    addresses = list(ipaddress.ip_network(host_config.container_ip_range).hosts())
-    if virtual_function.index >= len(addresses):
+    container_ip_network = ipaddress.ip_network(host_config.container_ip_range)
+    # Indexed, not enumerated: the range comes from a file on the host, and materialising the
+    # addresses of a /8 someone typed there would cost the validator a gigabyte per pod.
+    usable_address_count = container_ip_network.num_addresses - 2
+    if virtual_function.index >= usable_address_count:
         logger.warning(
             "rdma_fabric: host range is smaller than the card's function count, "
             "leaving the container on the NAT bridge",
             extra={
                 "container_ip_range": host_config.container_ip_range,
                 "virtual_function_index": virtual_function.index,
-                "usable_addresses": len(addresses),
+                "usable_addresses": max(usable_address_count, 0),
             },
         )
         return None
-    prefix_length = ipaddress.ip_network(host_config.container_ip_range).prefixlen
+    # +1 skips the network address, matching what `.hosts()` would have yielded.
+    container_address = container_ip_network[virtual_function.index + 1]
     return RdmaFabricAttachment(
         virtual_function=virtual_function,
         mac_address=_locally_administered_mac_for(container_name),
-        ipv4_cidr=f"{addresses[virtual_function.index]}/{prefix_length}",
+        ipv4_cidr=f"{container_address}/{container_ip_network.prefixlen}",
         vlan_id=host_config.vlan_id,
     )
 
@@ -236,18 +254,18 @@ async def move_into_container_namespace(
     virtual_function = attachment.virtual_function
     host_netdev = shlex.quote(virtual_function.netdev)
     fabric_netdev = CONTAINER_FABRIC_NETDEV_NAME
-    steps = (
+    attach_commands = (
         f"ip link set {host_netdev} netns {container_pid}",
         f"nsenter -t {container_pid} -n ip link set {host_netdev} name {fabric_netdev}",
         f"nsenter -t {container_pid} -n ip addr add {attachment.ipv4_cidr} dev {fabric_netdev}",
         f"nsenter -t {container_pid} -n ip link set {fabric_netdev} up",
         f"rdma dev set {shlex.quote(virtual_function.rdma_device)} netns {container_pid}",
     )
-    for step in steps:
-        result = await ssh_client.run(step)
+    for command in attach_commands:
+        result = await ssh_client.run(command)
         if result.exit_status != 0:
             raise RuntimeError(
-                f"failed to attach the RDMA fabric function: {step!r} "
+                f"failed to attach the RDMA fabric function: {command!r} "
                 f"exited {result.exit_status}, stderr={result.stderr!r}"
             )
 

--- a/neurons/validators/src/services/rdma_fabric.py
+++ b/neurons/validators/src/services/rdma_fabric.py
@@ -1,0 +1,278 @@
+"""DAH-2602: put a rental container on the RDMA fabric without trusting anything inside it.
+
+Forwarding the verbs devices (DAH-2571) lets a container talk to the card, but not across hosts:
+the container's only address is the NAT bridge's, while the card's GID carries the HOST's address,
+so RoCE sends from an address that does not exist in the container's namespace. Measured on prod
+on 2026-08-06 — handshake completes over the mapped TCP port, zero RDMA bytes move.
+
+The fix is to give the container its own function on the fabric, and to make every property of it
+enforced somewhere the tenant cannot reach. The tenant is root in its container and holds
+NET_ADMIN, so nothing enforced by the container's own kernel namespace counts:
+
+- an SR-IOV **virtual function** carries a MAC, a VLAN and a rate limit programmed from the
+  physical function. `spoofchk on` makes the NIC drop frames that do not match, and `trust off`
+  denies promiscuous mode and MAC changes. Enforcement is in hardware, so root in the container
+  cannot spoof a neighbour on the segment.
+- **exclusive RDMA namespace mode** scopes RDMA devices to network namespaces. The VF's RDMA
+  device is moved into the container's namespace, where it is the only device visible and its GID
+  table holds only addresses that exist there. The source-address problem disappears rather than
+  being patched, and a stolen verbs handle shows nothing outside the namespace.
+
+Neither is configured by us at rental time: exclusive mode is host-wide and disruptive to flip
+while RDMA is in use, and only whoever owns the fabric knows which addresses on it are free. Both
+are read as preconditions, and the attachment is skipped when they are absent.
+"""
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import logging
+import shlex
+from dataclasses import dataclass
+
+import asyncssh
+
+logger = logging.getLogger(__name__)
+
+# Written by whoever provisions the box: they own the fabric and know which addresses on it are
+# free. A validator-wide setting cannot know that — the segment is shared between hosts.
+HOST_FABRIC_CONFIG_PATH = "/etc/lium/rdma-fabric.json"
+
+
+@dataclass(frozen=True, slots=True)
+class HostFabricConfig:
+    """The slice of the fabric segment this host may hand to containers."""
+
+    container_ip_range: str
+    vlan_id: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class VirtualFunction:
+    """One SR-IOV function of an RDMA card, currently unclaimed."""
+
+    physical_function_netdev: str
+    index: int
+    netdev: str
+    rdma_device: str
+
+
+@dataclass(frozen=True, slots=True)
+class RdmaFabricAttachment:
+    """A virtual function prepared for one container, with the identity the NIC will enforce."""
+
+    virtual_function: VirtualFunction
+    mac_address: str
+    ipv4_cidr: str
+    vlan_id: int | None
+
+
+# A VF whose netdev has been moved into a container's namespace no longer appears under the PF's
+# sysfs tree when read from the host, so this lists exactly the unclaimed functions.
+_LIST_FREE_VIRTUAL_FUNCTIONS = (
+    "for rdma_dir in /sys/class/infiniband/*; do "
+    '[ -d "$rdma_dir" ] || continue; '
+    'for pf_dir in "$rdma_dir"/device/net/*; do '
+    '[ -d "$pf_dir" ] || continue; '
+    'pf=$(basename "$pf_dir"); '
+    'for vf_dir in /sys/class/net/"$pf"/device/virtfn*; do '
+    '[ -d "$vf_dir" ] || continue; '
+    'index=${vf_dir##*/virtfn}; '
+    'vf_netdev=$(ls "$vf_dir"/net 2>/dev/null | head -1); '
+    'vf_rdma=$(ls "$vf_dir"/infiniband 2>/dev/null | head -1); '
+    '[ -n "$vf_netdev" ] && [ -n "$vf_rdma" ] && '
+    'printf "%s %s %s %s\\n" "$pf" "$index" "$vf_netdev" "$vf_rdma"; '
+    "done; done; done"
+)
+
+
+async def read_host_fabric_config(
+    ssh_client: asyncssh.SSHClientConnection,
+) -> HostFabricConfig | None:
+    """The address range this host may allocate from, or None when the host is not configured."""
+    result = await ssh_client.run(f"cat {HOST_FABRIC_CONFIG_PATH} 2>/dev/null")
+    if not result.stdout.strip():
+        return None
+    try:
+        document = json.loads(result.stdout)
+        container_ip_range: str = document["container_ip_range"]
+        ipaddress.ip_network(container_ip_range)
+    except (ValueError, KeyError, TypeError) as error:
+        logger.warning(
+            "rdma_fabric: unreadable host fabric config, leaving the container on the NAT bridge",
+            extra={"path": HOST_FABRIC_CONFIG_PATH, "error": str(error)},
+        )
+        return None
+    vlan_id: int | None = document.get("vlan_id")
+    return HostFabricConfig(container_ip_range=container_ip_range, vlan_id=vlan_id)
+
+
+async def is_rdma_namespace_mode_exclusive(ssh_client: asyncssh.SSHClientConnection) -> bool:
+    """Whether the host scopes RDMA devices per network namespace.
+
+    Shared mode — the default — lets any namespace holding a verbs node see every device on the
+    box and every GID the host owns. That is the mode the current passthrough runs in, and it is
+    not a namespace a tenant can be given a function inside of. Flipping it requires no RDMA
+    resources to be in use, so it belongs to host provisioning, not to a rental.
+    """
+    result = await ssh_client.run("rdma system show 2>/dev/null")
+    return "netns exclusive" in result.stdout
+
+
+async def find_free_virtual_function(
+    ssh_client: asyncssh.SSHClientConnection,
+) -> VirtualFunction | None:
+    result = await ssh_client.run(_LIST_FREE_VIRTUAL_FUNCTIONS)
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if len(fields) != 4 or not fields[1].isdigit():
+            continue
+        return VirtualFunction(
+            physical_function_netdev=fields[0],
+            index=int(fields[1]),
+            netdev=fields[2],
+            rdma_device=fields[3],
+        )
+    return None
+
+
+def build_attachment(
+    virtual_function: VirtualFunction,
+    host_config: HostFabricConfig,
+    container_name: str,
+) -> RdmaFabricAttachment | None:
+    """Assign the function's identity, or None when the host's range cannot cover it.
+
+    The address is derived from the VF index rather than allocated: indexes are unique on a host,
+    the range belongs to that host alone, and a derived address needs no state to survive a
+    validator restart or a second container starting concurrently.
+    """
+    addresses = list(ipaddress.ip_network(host_config.container_ip_range).hosts())
+    if virtual_function.index >= len(addresses):
+        logger.warning(
+            "rdma_fabric: host range is smaller than the card's function count, "
+            "leaving the container on the NAT bridge",
+            extra={
+                "container_ip_range": host_config.container_ip_range,
+                "virtual_function_index": virtual_function.index,
+                "usable_addresses": len(addresses),
+            },
+        )
+        return None
+    prefix_length = ipaddress.ip_network(host_config.container_ip_range).prefixlen
+    return RdmaFabricAttachment(
+        virtual_function=virtual_function,
+        mac_address=_locally_administered_mac_for(container_name),
+        ipv4_cidr=f"{addresses[virtual_function.index]}/{prefix_length}",
+        vlan_id=host_config.vlan_id,
+    )
+
+
+def _locally_administered_mac_for(container_name: str) -> str:
+    """A stable per-container MAC in the locally-administered unicast space.
+
+    Derived, not random, so a rebuilt container keeps the address a neighbour's ARP cache and the
+    switch's MAC table already learned.
+    """
+    digest = hashlib.sha256(container_name.encode()).digest()
+    return ":".join(["02", *(f"{byte:02x}" for byte in digest[:5])])
+
+
+async def reserve_virtual_function(
+    ssh_client: asyncssh.SSHClientConnection,
+    attachment: RdmaFabricAttachment,
+) -> None:
+    """Program the function's identity from the physical function, where the tenant cannot reach.
+
+    Every property set here is enforced by the NIC. This is what makes the container's NET_ADMIN
+    harmless against the fabric: root inside can rename or reconfigure the interface all it likes,
+    frames that do not match are dropped before they reach the wire.
+    """
+    virtual_function = attachment.virtual_function
+    command = (
+        f"ip link set {shlex.quote(virtual_function.physical_function_netdev)} "
+        f"vf {virtual_function.index} mac {attachment.mac_address}"
+    )
+    if attachment.vlan_id is not None:
+        command += f" vlan {attachment.vlan_id}"
+    command += " spoofchk on trust off"
+    result = await ssh_client.run(command)
+    if result.exit_status != 0:
+        raise RuntimeError(
+            f"failed to program virtual function identity: {command!r} "
+            f"exited {result.exit_status}, stderr={result.stderr!r}"
+        )
+
+
+async def move_into_container_namespace(
+    ssh_client: asyncssh.SSHClientConnection,
+    attachment: RdmaFabricAttachment,
+    container_name: str,
+) -> None:
+    """Hand the function to the container: netdev, address, then the RDMA device.
+
+    Order matters. The RDMA device moves last, because its GID table is built from the addresses
+    present in the namespace it lands in — move it before the address exists and the GIDs it
+    publishes are empty.
+    """
+    quoted_container_name = shlex.quote(container_name)
+    pid_result = await ssh_client.run(
+        f"/usr/bin/docker inspect -f '{{{{.State.Pid}}}}' {quoted_container_name}"
+    )
+    container_pid = pid_result.stdout.strip()
+    if not container_pid.isdigit() or container_pid == "0":
+        raise RuntimeError(
+            f"container {container_name} has no namespace to attach to (pid={container_pid!r})"
+        )
+
+    virtual_function = attachment.virtual_function
+    netdev = shlex.quote(virtual_function.netdev)
+    steps = (
+        f"ip link set {netdev} netns {container_pid}",
+        f"nsenter -t {container_pid} -n ip addr add {attachment.ipv4_cidr} dev {netdev}",
+        f"nsenter -t {container_pid} -n ip link set {netdev} up",
+        f"rdma dev set {shlex.quote(virtual_function.rdma_device)} netns {container_pid}",
+    )
+    for step in steps:
+        result = await ssh_client.run(step)
+        if result.exit_status != 0:
+            raise RuntimeError(
+                f"failed to attach the RDMA fabric function: {step!r} "
+                f"exited {result.exit_status}, stderr={result.stderr!r}"
+            )
+
+
+async def attach_container_to_rdma_fabric(
+    ssh_client: asyncssh.SSHClientConnection,
+    container_name: str,
+) -> RdmaFabricAttachment | None:
+    """Give the container a function on the fabric, or None when the host is not set up for it.
+
+    Every precondition is read, never created: the host must be in exclusive RDMA namespace mode,
+    must declare an address range, and must have a free virtual function. A host missing any of
+    them keeps today's behaviour — the container reaches its own cards and nothing across the wire.
+    """
+    host_config = await read_host_fabric_config(ssh_client)
+    if not host_config:
+        return None
+    if not await is_rdma_namespace_mode_exclusive(ssh_client):
+        logger.warning(
+            "rdma_fabric: host is in shared RDMA namespace mode, refusing to attach a function "
+            "(run `rdma system set netns exclusive` at provisioning time)",
+            extra={"container_name": container_name},
+        )
+        return None
+    virtual_function = await find_free_virtual_function(ssh_client)
+    if not virtual_function:
+        logger.warning(
+            "rdma_fabric: no free SR-IOV function on this host's RDMA cards",
+            extra={"container_name": container_name},
+        )
+        return None
+    attachment = build_attachment(virtual_function, host_config, container_name)
+    if not attachment:
+        return None
+    await reserve_virtual_function(ssh_client, attachment)
+    await move_into_container_namespace(ssh_client, attachment, container_name)
+    return attachment

--- a/neurons/validators/src/services/rdma_fabric.py
+++ b/neurons/validators/src/services/rdma_fabric.py
@@ -39,6 +39,12 @@ logger = logging.getLogger(__name__)
 # free. A validator-wide setting cannot know that — the segment is shared between hosts.
 HOST_FABRIC_CONFIG_PATH = "/etc/lium/rdma-fabric.json"
 
+# What the fabric interface is called inside every container. VF netdev names vary per host and
+# driver (enp1s0f0v3, eth4, ...), and NCCL/gloo do not pick a second interface on their own —
+# customers point them at it with NCCL_SOCKET_IFNAME/GLOO_SOCKET_IFNAME, so the name has to be
+# one documented constant, not something to discover per pod.
+CONTAINER_FABRIC_NETDEV_NAME = "fabric0"
+
 
 @dataclass(frozen=True, slots=True)
 class HostFabricConfig:
@@ -210,11 +216,12 @@ async def move_into_container_namespace(
     attachment: RdmaFabricAttachment,
     container_name: str,
 ) -> None:
-    """Hand the function to the container: netdev, address, then the RDMA device.
+    """Hand the function to the container: netdev, stable name, address, then the RDMA device.
 
-    Order matters. The RDMA device moves last, because its GID table is built from the addresses
-    present in the namespace it lands in — move it before the address exists and the GIDs it
-    publishes are empty.
+    Order matters twice. The rename happens inside the namespace, where the name cannot collide
+    with another rental's function. The RDMA device moves last, because its GID table is built
+    from the addresses present in the namespace it lands in — move it before the address exists
+    and the GIDs it publishes are empty.
     """
     quoted_container_name = shlex.quote(container_name)
     pid_result = await ssh_client.run(
@@ -227,11 +234,13 @@ async def move_into_container_namespace(
         )
 
     virtual_function = attachment.virtual_function
-    netdev = shlex.quote(virtual_function.netdev)
+    host_netdev = shlex.quote(virtual_function.netdev)
+    fabric_netdev = CONTAINER_FABRIC_NETDEV_NAME
     steps = (
-        f"ip link set {netdev} netns {container_pid}",
-        f"nsenter -t {container_pid} -n ip addr add {attachment.ipv4_cidr} dev {netdev}",
-        f"nsenter -t {container_pid} -n ip link set {netdev} up",
+        f"ip link set {host_netdev} netns {container_pid}",
+        f"nsenter -t {container_pid} -n ip link set {host_netdev} name {fabric_netdev}",
+        f"nsenter -t {container_pid} -n ip addr add {attachment.ipv4_cidr} dev {fabric_netdev}",
+        f"nsenter -t {container_pid} -n ip link set {fabric_netdev} up",
         f"rdma dev set {shlex.quote(virtual_function.rdma_device)} netns {container_pid}",
     )
     for step in steps:

--- a/neurons/validators/tests/test_rdma_fabric.py
+++ b/neurons/validators/tests/test_rdma_fabric.py
@@ -40,7 +40,7 @@ _HOST_CONFIG_JSON = '{"container_ip_range": "38.255.28.192/27", "vlan_id": 4021}
 _ONE_FREE_FUNCTION = "enp1s0f0 3 enp1s0f0v3 mlx5_7\n"
 
 
-def _ready_host(**overrides: _StubSshResult) -> _StubSsh:
+def _prepared_host(**overrides: _StubSshResult) -> _StubSsh:
     responses: dict[str, _StubSshResult] = {
         rdma_fabric.HOST_FABRIC_CONFIG_PATH: _StubSshResult(_HOST_CONFIG_JSON),
         "rdma system show": _StubSshResult("netns exclusive\n"),
@@ -53,7 +53,7 @@ def _ready_host(**overrides: _StubSshResult) -> _StubSsh:
 
 @pytest.mark.asyncio
 async def test_shared_namespace_mode_refuses_to_attach() -> None:
-    ssh = _ready_host(**{"rdma system show": _StubSshResult("netns shared\n")})
+    ssh = _prepared_host(**{"rdma system show": _StubSshResult("netns shared\n")})
 
     assert await attach_container_to_rdma_fabric(ssh, "pod_test") is None
     assert not any("ip link set" in command for command in ssh.commands)
@@ -61,7 +61,7 @@ async def test_shared_namespace_mode_refuses_to_attach() -> None:
 
 @pytest.mark.asyncio
 async def test_unconfigured_host_attaches_nothing_and_probes_nothing_further() -> None:
-    ssh = _ready_host(**{rdma_fabric.HOST_FABRIC_CONFIG_PATH: _StubSshResult("")})
+    ssh = _prepared_host(**{rdma_fabric.HOST_FABRIC_CONFIG_PATH: _StubSshResult("")})
 
     assert await attach_container_to_rdma_fabric(ssh, "pod_test") is None
     assert len(ssh.commands) == 1
@@ -69,14 +69,14 @@ async def test_unconfigured_host_attaches_nothing_and_probes_nothing_further() -
 
 @pytest.mark.asyncio
 async def test_no_free_virtual_function_leaves_the_container_alone() -> None:
-    ssh = _ready_host(**{"/sys/class/infiniband/*": _StubSshResult("")})
+    ssh = _prepared_host(**{"/sys/class/infiniband/*": _StubSshResult("")})
 
     assert await attach_container_to_rdma_fabric(ssh, "pod_test") is None
 
 
 @pytest.mark.asyncio
 async def test_identity_is_programmed_from_the_physical_function_with_spoofchk_and_no_trust() -> None:
-    ssh = _ready_host()
+    ssh = _prepared_host()
 
     attachment = await attach_container_to_rdma_fabric(ssh, "pod_test")
 
@@ -91,7 +91,7 @@ async def test_identity_is_programmed_from_the_physical_function_with_spoofchk_a
 
 @pytest.mark.asyncio
 async def test_rdma_device_moves_after_the_address_exists_in_the_namespace() -> None:
-    ssh = _ready_host()
+    ssh = _prepared_host()
 
     await attach_container_to_rdma_fabric(ssh, "pod_test")
 
@@ -104,7 +104,7 @@ async def test_rdma_device_moves_after_the_address_exists_in_the_namespace() -> 
 
 @pytest.mark.asyncio
 async def test_the_function_lands_in_the_containers_namespace() -> None:
-    ssh = _ready_host()
+    ssh = _prepared_host()
 
     await attach_container_to_rdma_fabric(ssh, "pod_test")
 
@@ -114,7 +114,7 @@ async def test_the_function_lands_in_the_containers_namespace() -> None:
 
 @pytest.mark.asyncio
 async def test_the_interface_is_renamed_to_the_documented_constant_before_it_is_addressed() -> None:
-    ssh = _ready_host()
+    ssh = _prepared_host()
 
     await attach_container_to_rdma_fabric(ssh, "pod_test")
 
@@ -128,7 +128,7 @@ async def test_the_interface_is_renamed_to_the_documented_constant_before_it_is_
 
 @pytest.mark.asyncio
 async def test_a_container_without_a_namespace_is_an_error_not_a_silent_skip() -> None:
-    ssh = _ready_host(**{"docker inspect": _StubSshResult("0\n")})
+    ssh = _prepared_host(**{"docker inspect": _StubSshResult("0\n")})
 
     with pytest.raises(RuntimeError, match="no namespace to attach to"):
         await attach_container_to_rdma_fabric(ssh, "pod_test")
@@ -136,7 +136,7 @@ async def test_a_container_without_a_namespace_is_an_error_not_a_silent_skip() -
 
 @pytest.mark.asyncio
 async def test_a_failed_step_raises_rather_than_leaving_a_half_attached_function() -> None:
-    ssh = _ready_host(**{"rdma dev set": _StubSshResult("", exit_status=1)})
+    ssh = _prepared_host(**{"rdma dev set": _StubSshResult("", exit_status=1)})
 
     with pytest.raises(RuntimeError, match="failed to attach"):
         await attach_container_to_rdma_fabric(ssh, "pod_test")
@@ -183,7 +183,7 @@ def test_a_range_too_small_for_the_function_index_refuses_rather_than_wrapping()
 
 @pytest.mark.asyncio
 async def test_unparsable_host_config_is_treated_as_unconfigured() -> None:
-    ssh = _ready_host(
+    ssh = _prepared_host(
         **{rdma_fabric.HOST_FABRIC_CONFIG_PATH: _StubSshResult("{not json")}
     )
 
@@ -207,10 +207,9 @@ _ORDINARY_RENTAL_DEVICES = (
 
 @pytest.mark.asyncio
 async def test_a_rental_without_rdma_devices_never_touches_the_host() -> None:
-    ssh = _ready_host()
+    ssh = _prepared_host()
 
     await DockerService._attach_rdma_fabric_if_available(
-        DockerService.__new__(DockerService),
         ssh_client=ssh,
         container_name="pod_ordinary",
         forwarded_devices=_ORDINARY_RENTAL_DEVICES,
@@ -223,10 +222,9 @@ async def test_a_rental_without_rdma_devices_never_touches_the_host() -> None:
 
 @pytest.mark.asyncio
 async def test_an_unprepared_host_with_rdma_devices_is_left_exactly_as_it_was() -> None:
-    ssh = _ready_host(**{rdma_fabric.HOST_FABRIC_CONFIG_PATH: _StubSshResult("")})
+    ssh = _prepared_host(**{rdma_fabric.HOST_FABRIC_CONFIG_PATH: _StubSshResult("")})
 
     await DockerService._attach_rdma_fabric_if_available(
-        DockerService.__new__(DockerService),
         ssh_client=ssh,
         container_name="pod_rdma",
         forwarded_devices=(*_ORDINARY_RENTAL_DEVICES, _device("/dev/infiniband/uverbs0")),
@@ -238,14 +236,38 @@ async def test_an_unprepared_host_with_rdma_devices_is_left_exactly_as_it_was() 
 
 @pytest.mark.asyncio
 async def test_an_attach_failure_does_not_fail_the_rental() -> None:
-    ssh = _ready_host(**{"rdma dev set": _StubSshResult("", exit_status=1)})
+    ssh = _prepared_host(**{"rdma dev set": _StubSshResult("", exit_status=1)})
 
     # The pod is already created and running by this point; a fabric it cannot reach is a
     # degraded rental, not a failed one.
     await DockerService._attach_rdma_fabric_if_available(
-        DockerService.__new__(DockerService),
         ssh_client=ssh,
         container_name="pod_rdma",
         forwarded_devices=(*_ORDINARY_RENTAL_DEVICES, _device("/dev/infiniband/uverbs0")),
         default_extra={},
     )
+
+
+@pytest.mark.asyncio
+async def test_a_non_integer_vlan_tag_is_refused_rather_than_reaching_the_shell() -> None:
+    ssh = _prepared_host(
+        **{
+            rdma_fabric.HOST_FABRIC_CONFIG_PATH: _StubSshResult(
+                '{"container_ip_range": "38.255.28.192/27", "vlan_id": "4021 ; reboot"}'
+            )
+        }
+    )
+
+    assert await attach_container_to_rdma_fabric(ssh, "pod_test") is None
+
+
+def test_a_huge_host_range_costs_nothing_to_index() -> None:
+    host_config = HostFabricConfig(container_ip_range="10.0.0.0/8", vlan_id=None)
+
+    attachment = build_attachment(
+        VirtualFunction("enp1s0f0", 2, "enp1s0f0v2", "mlx5_6"), host_config, "pod_test"
+    )
+
+    # Enumerating a /8 would allocate ~16.7M addresses inside the validator, per pod.
+    assert attachment is not None
+    assert attachment.ipv4_cidr == "10.0.0.3/8"

--- a/neurons/validators/tests/test_rdma_fabric.py
+++ b/neurons/validators/tests/test_rdma_fabric.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import pytest
 
 from services import rdma_fabric
+from services.docker_service import DockerService
+from services.rental_docker_sdk import DeviceMount
 from services.rdma_fabric import (
     HostFabricConfig,
     VirtualFunction,
@@ -186,3 +188,64 @@ async def test_unparsable_host_config_is_treated_as_unconfigured() -> None:
     )
 
     assert await attach_container_to_rdma_fabric(ssh, "pod_test") is None
+
+
+# --- The guard: an ordinary rental must not notice this feature exists at all ---
+
+
+def _device(path_on_host: str) -> DeviceMount:
+    return DeviceMount(path_on_host=path_on_host, path_in_container=path_on_host)
+
+
+_ORDINARY_RENTAL_DEVICES = (
+    _device("/dev/net/tun"),
+    _device("/dev/nvidia0"),
+    _device("/dev/nvidiactl"),
+    _device("/dev/nvidia-uvm"),
+)
+
+
+@pytest.mark.asyncio
+async def test_a_rental_without_rdma_devices_never_touches_the_host() -> None:
+    ssh = _ready_host()
+
+    await DockerService._attach_rdma_fabric_if_available(
+        DockerService.__new__(DockerService),
+        ssh_client=ssh,
+        container_name="pod_ordinary",
+        forwarded_devices=_ORDINARY_RENTAL_DEVICES,
+        default_extra={},
+    )
+
+    # Not "did nothing harmful" — did nothing at all, on the box of every rental that has no card.
+    assert ssh.commands == []
+
+
+@pytest.mark.asyncio
+async def test_an_unprepared_host_with_rdma_devices_is_left_exactly_as_it_was() -> None:
+    ssh = _ready_host(**{rdma_fabric.HOST_FABRIC_CONFIG_PATH: _StubSshResult("")})
+
+    await DockerService._attach_rdma_fabric_if_available(
+        DockerService.__new__(DockerService),
+        ssh_client=ssh,
+        container_name="pod_rdma",
+        forwarded_devices=(*_ORDINARY_RENTAL_DEVICES, _device("/dev/infiniband/uverbs0")),
+        default_extra={},
+    )
+
+    assert not any("ip link set" in command for command in ssh.commands)
+
+
+@pytest.mark.asyncio
+async def test_an_attach_failure_does_not_fail_the_rental() -> None:
+    ssh = _ready_host(**{"rdma dev set": _StubSshResult("", exit_status=1)})
+
+    # The pod is already created and running by this point; a fabric it cannot reach is a
+    # degraded rental, not a failed one.
+    await DockerService._attach_rdma_fabric_if_available(
+        DockerService.__new__(DockerService),
+        ssh_client=ssh,
+        container_name="pod_rdma",
+        forwarded_devices=(*_ORDINARY_RENTAL_DEVICES, _device("/dev/infiniband/uverbs0")),
+        default_extra={},
+    )

--- a/neurons/validators/tests/test_rdma_fabric.py
+++ b/neurons/validators/tests/test_rdma_fabric.py
@@ -1,0 +1,174 @@
+"""DAH-2602: the container gets a function on the fabric whose identity the NIC enforces."""
+from __future__ import annotations
+
+import pytest
+
+from services import rdma_fabric
+from services.rdma_fabric import (
+    HostFabricConfig,
+    VirtualFunction,
+    attach_container_to_rdma_fabric,
+    build_attachment,
+)
+
+
+class _StubSshResult:
+    def __init__(self, stdout: str, exit_status: int = 0) -> None:
+        self.stdout: str = stdout
+        self.stderr: str = ""
+        self.exit_status: int = exit_status
+
+
+class _StubSsh:
+    """Answers by substring match on the command, and records everything it was asked to run."""
+
+    def __init__(self, responses: dict[str, _StubSshResult]) -> None:
+        self._responses: dict[str, _StubSshResult] = responses
+        self.commands: list[str] = []
+
+    async def run(self, command: str) -> _StubSshResult:
+        self.commands.append(command)
+        for fragment, response in self._responses.items():
+            if fragment in command:
+                return response
+        return _StubSshResult("")
+
+
+_HOST_CONFIG_JSON = '{"container_ip_range": "38.255.28.192/27", "vlan_id": 4021}'
+_ONE_FREE_FUNCTION = "enp1s0f0 3 enp1s0f0v3 mlx5_7\n"
+
+
+def _ready_host(**overrides: _StubSshResult) -> _StubSsh:
+    responses: dict[str, _StubSshResult] = {
+        rdma_fabric.HOST_FABRIC_CONFIG_PATH: _StubSshResult(_HOST_CONFIG_JSON),
+        "rdma system show": _StubSshResult("netns exclusive\n"),
+        "/sys/class/infiniband/*": _StubSshResult(_ONE_FREE_FUNCTION),
+        "docker inspect": _StubSshResult("48211\n"),
+    }
+    responses.update(overrides)
+    return _StubSsh(responses)
+
+
+@pytest.mark.asyncio
+async def test_shared_namespace_mode_refuses_to_attach() -> None:
+    ssh = _ready_host(**{"rdma system show": _StubSshResult("netns shared\n")})
+
+    assert await attach_container_to_rdma_fabric(ssh, "pod_test") is None
+    assert not any("ip link set" in command for command in ssh.commands)
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_host_attaches_nothing_and_probes_nothing_further() -> None:
+    ssh = _ready_host(**{rdma_fabric.HOST_FABRIC_CONFIG_PATH: _StubSshResult("")})
+
+    assert await attach_container_to_rdma_fabric(ssh, "pod_test") is None
+    assert len(ssh.commands) == 1
+
+
+@pytest.mark.asyncio
+async def test_no_free_virtual_function_leaves_the_container_alone() -> None:
+    ssh = _ready_host(**{"/sys/class/infiniband/*": _StubSshResult("")})
+
+    assert await attach_container_to_rdma_fabric(ssh, "pod_test") is None
+
+
+@pytest.mark.asyncio
+async def test_identity_is_programmed_from_the_physical_function_with_spoofchk_and_no_trust() -> None:
+    ssh = _ready_host()
+
+    attachment = await attach_container_to_rdma_fabric(ssh, "pod_test")
+
+    assert attachment is not None
+    reserve = next(c for c in ssh.commands if "vf 3 mac" in c)
+    assert reserve.startswith("ip link set enp1s0f0 vf 3 mac 02:")
+    # Hardware-enforced identity is the whole point: without these the tenant's NET_ADMIN wins.
+    assert "spoofchk on" in reserve
+    assert "trust off" in reserve
+    assert "vlan 4021" in reserve
+
+
+@pytest.mark.asyncio
+async def test_rdma_device_moves_after_the_address_exists_in_the_namespace() -> None:
+    ssh = _ready_host()
+
+    await attach_container_to_rdma_fabric(ssh, "pod_test")
+
+    address_step = next(i for i, c in enumerate(ssh.commands) if "ip addr add" in c)
+    rdma_step = next(i for i, c in enumerate(ssh.commands) if c.startswith("rdma dev set"))
+    # The GID table is built from the addresses present when the device lands.
+    assert address_step < rdma_step
+    assert ssh.commands[rdma_step] == "rdma dev set mlx5_7 netns 48211"
+
+
+@pytest.mark.asyncio
+async def test_the_function_lands_in_the_containers_namespace() -> None:
+    ssh = _ready_host()
+
+    await attach_container_to_rdma_fabric(ssh, "pod_test")
+
+    assert "ip link set enp1s0f0v3 netns 48211" in ssh.commands
+    assert "nsenter -t 48211 -n ip addr add 38.255.28.196/27 dev enp1s0f0v3" in ssh.commands
+
+
+@pytest.mark.asyncio
+async def test_a_container_without_a_namespace_is_an_error_not_a_silent_skip() -> None:
+    ssh = _ready_host(**{"docker inspect": _StubSshResult("0\n")})
+
+    with pytest.raises(RuntimeError, match="no namespace to attach to"):
+        await attach_container_to_rdma_fabric(ssh, "pod_test")
+
+
+@pytest.mark.asyncio
+async def test_a_failed_step_raises_rather_than_leaving_a_half_attached_function() -> None:
+    ssh = _ready_host(**{"rdma dev set": _StubSshResult("", exit_status=1)})
+
+    with pytest.raises(RuntimeError, match="failed to attach"):
+        await attach_container_to_rdma_fabric(ssh, "pod_test")
+
+
+def test_address_is_derived_from_the_function_index_so_two_containers_cannot_collide() -> None:
+    host_config = HostFabricConfig(container_ip_range="38.255.28.192/27", vlan_id=None)
+
+    first = build_attachment(
+        VirtualFunction("enp1s0f0", 0, "enp1s0f0v0", "mlx5_4"), host_config, "pod_a"
+    )
+    second = build_attachment(
+        VirtualFunction("enp1s0f0", 1, "enp1s0f0v1", "mlx5_5"), host_config, "pod_b"
+    )
+
+    assert first is not None and second is not None
+    assert first.ipv4_cidr == "38.255.28.193/27"
+    assert second.ipv4_cidr == "38.255.28.194/27"
+    assert first.mac_address != second.mac_address
+
+
+def test_mac_is_stable_across_rebuilds_of_the_same_container() -> None:
+    host_config = HostFabricConfig(container_ip_range="38.255.28.192/27", vlan_id=None)
+    virtual_function = VirtualFunction("enp1s0f0", 0, "enp1s0f0v0", "mlx5_4")
+
+    first = build_attachment(virtual_function, host_config, "pod_test")
+    rebuilt = build_attachment(virtual_function, host_config, "pod_test")
+
+    assert first is not None and rebuilt is not None
+    assert first.mac_address == rebuilt.mac_address
+    # Locally administered unicast, so it cannot collide with a vendor-assigned address.
+    assert first.mac_address.startswith("02:")
+
+
+def test_a_range_too_small_for_the_function_index_refuses_rather_than_wrapping() -> None:
+    host_config = HostFabricConfig(container_ip_range="38.255.28.192/30", vlan_id=None)
+
+    attachment = build_attachment(
+        VirtualFunction("enp1s0f0", 7, "enp1s0f0v7", "mlx5_9"), host_config, "pod_test"
+    )
+
+    assert attachment is None
+
+
+@pytest.mark.asyncio
+async def test_unparsable_host_config_is_treated_as_unconfigured() -> None:
+    ssh = _ready_host(
+        **{rdma_fabric.HOST_FABRIC_CONFIG_PATH: _StubSshResult("{not json")}
+    )
+
+    assert await attach_container_to_rdma_fabric(ssh, "pod_test") is None

--- a/neurons/validators/tests/test_rdma_fabric.py
+++ b/neurons/validators/tests/test_rdma_fabric.py
@@ -107,7 +107,21 @@ async def test_the_function_lands_in_the_containers_namespace() -> None:
     await attach_container_to_rdma_fabric(ssh, "pod_test")
 
     assert "ip link set enp1s0f0v3 netns 48211" in ssh.commands
-    assert "nsenter -t 48211 -n ip addr add 38.255.28.196/27 dev enp1s0f0v3" in ssh.commands
+    assert "nsenter -t 48211 -n ip addr add 38.255.28.196/27 dev fabric0" in ssh.commands
+
+
+@pytest.mark.asyncio
+async def test_the_interface_is_renamed_to_the_documented_constant_before_it_is_addressed() -> None:
+    ssh = _ready_host()
+
+    await attach_container_to_rdma_fabric(ssh, "pod_test")
+
+    rename = "nsenter -t 48211 -n ip link set enp1s0f0v3 name fabric0"
+    assert rename in ssh.commands
+    # Customers reach it as NCCL_SOCKET_IFNAME=fabric0; the host-side driver name never leaks out.
+    assert ssh.commands.index(rename) < next(
+        i for i, c in enumerate(ssh.commands) if "ip addr add" in c
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Notion: https://app.notion.com/p/Give-the-rental-container-an-address-on-the-RDMA-fabric-3b4b8bfdbde981799dffc9de5fa0696d

## The problem

DAH-2571 forwards the RDMA verbs devices into the rental container, and that half works: `ibv_devinfo`
enumerates the cards, ports read `PORT_ACTIVE`, `memlock` is unlimited. RDMA still cannot cross a host.

Measured on prod on 2026-08-06 with two rented nodes on the same RoCE segment:

```
container:  inet 172.20.0.2/16  eth0        (the NAT bridge)
card GID:   0000:0000:0000:0000:0000:ffff:26ff:1c13  = 38.255.28.19  (the HOST)
result:     queue-pair handshake completes over the mapped TCP port, zero RDMA bytes move
```

RoCE sends with the source address carried in the card's GID. That address lives on the host's netdev,
not in the container's namespace, so the packets have nowhere to leave from. A colleague hit the same
wall one layer up — ranks advertise `172.20.0.3` and an ephemeral port during the collective's TCP
bootstrap. Same missing thing: the container has no routable identity of its own.

## The approach: give it one the tenant cannot forge

The tenant is root in its container and holds `NET_ADMIN` (it is there for the in-pod VPN path). So
anything enforced by the container's own kernel namespace is worth nothing. Two mechanisms put
enforcement out of its reach.

**SR-IOV virtual function.** One VF per rental, its identity programmed from the physical function:

```
ip link set <pf> vf <N> mac <derived> vlan <tenant> spoofchk on trust off
```

`spoofchk on` makes the NIC drop frames whose source does not match; `trust off` denies promiscuous
mode and MAC changes. Root inside the container can rename and reconfigure the interface all it likes —
frames that do not match die before the wire. This is the difference from macvlan, which trusts the
namespace owner with the interface's identity.

**Exclusive RDMA namespace mode.** The VF's RDMA device is moved into the container's namespace, where
it is the only device visible and its GID table holds only addresses that exist there. The
source-address problem dissolves instead of being patched, and a stolen verbs handle shows nothing
outside the namespace. Today's passthrough runs in the default *shared* mode, where any namespace
holding a verbs node sees every device on the box and every GID the host owns.

## Preconditions are read, never created

An unprepared host is the normal case, not an error — it keeps exactly today's behaviour, and a failure
anywhere in the attach is logged and swallowed rather than failing the rental.

- `rdma system set netns exclusive` — host-wide and disruptive to flip while RDMA is in use, so it
  belongs to provisioning.
- `/etc/lium/rdma-fabric.json` — `{"container_ip_range": "...", "vlan_id": N}`. Per host, because only
  whoever owns the fabric knows which addresses on the shared segment are free. A validator-wide
  setting cannot know that.
- A free virtual function. Discovery reads the PF's sysfs tree from the host namespace, where a VF
  already handed to a container no longer appears — so it lists exactly the unclaimed ones.

Inside the namespace the interface is renamed to **`fabric0`** before it gets its address. VF netdev
names vary per host and driver, and NCCL/gloo never pick a second interface on their own — a colleague's
cross-host run only worked with `NCCL_SOCKET_IFNAME`/`GLOO_SOCKET_IFNAME` pointed at the right device.
With one documented constant that setting is the same on every pod: `NCCL_SOCKET_IFNAME=fabric0`.

Addresses are derived from the VF index rather than allocated: indexes are unique per host, the range
belongs to that host alone, and a derived address needs no state to survive a validator restart or two
containers starting at once. MACs are derived from the container name, so a rebuilt container keeps the
address its neighbours' ARP caches and the switch's MAC table already learned.

## Not in this PR

- **Fabric-side partitioning.** The per-rental VLAN is programmed on the VF here, but the switch has to
  trunk it, and IB wants pkeys with limited membership instead. On the one real multi-node fabric in
  the fleet (`sm_lid=0xe`, the `69.63.236.160` trio) the subnet manager is the provider's, so IB
  partitioning is a conversation before it is code.
- **The macvlan fallback**, for hosts whose NICs expose no VFs. It is only safe together with dropping
  `NET_ADMIN` for those rentals — which costs the in-pod VPN — so half of it is worse than none.
- **A cross-host measurement.** No host on the fleet has exclusive mode and a declared range yet. That
  is what keeps this a draft.

## An ordinary rental cannot notice this

The attach is gated on a forwarded `/dev/infiniband/*` node, so a pod on a box with no card does not
merely skip the work — it issues no SSH command at all. Three tests hold that line: no RDMA devices →
`ssh.commands == []`; RDMA devices on an unprepared host → nothing is configured; a failing attach step
on a running pod → logged and swallowed, because a fabric the pod cannot reach is a degraded rental,
not a failed one.

Verified on staging. The branch is deployed on the staging validator, and a pod rented through it on a
host with no RDMA hardware came up completely untouched:

```
/dev/infiniband:        No such file or directory   -> attach returns before any SSH command
interfaces:             lo, eth0 172.20.0.2/16, docker0   (no fabric0)
ulimit -l:              8192   (default — memlock is only raised when RDMA devices are forwarded)
nvidia-smi:             NVIDIA RTX A6000
```

`Container creation step finished` in the staging validator log, and zero `RDMA_FABRIC` lines — an
unprepared host returns before logging, so nothing new is emitted on the 322-of-383 hosts with no card.

Still owed: the same run on a staging host that HAS a card, to exercise the branch with `forwards_rdma`
true. (An earlier attempt at that inspected a pod running released `main`, so it proved nothing here.)

Full validator suite: 1508 passed. The 3 failures in `test_sshd_bootstrap_script.py` are pre-existing —
verified by stashing this branch and re-running them on `main`.

Tests: `tests/test_rdma_fabric.py`, 16 cases — the three refusals, the hardware-enforced identity, the
ordering that makes the GID table non-empty, index-derived addresses that cannot collide, and a failed
step raising rather than leaving a half-attached function.
`pytest tests/test_rdma_fabric.py tests/test_nvidia_devices.py tests/test_infiniband_passthrough.py tests/test_scrape_infiniband.py` — 64 passed.
