### PR TITLE
Fix A10 GPU model normalization in validator

### DIFF
--- a/neurons/validators/src/services/task/checks/machine_spec_scrape.py
+++ b/neurons/validators/src/services/task/checks/machine_spec_scrape.py
@@ -8,6 +8,7 @@ from ..messages import MachineSpecMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
 from ..runner import SSHCommandRunner
 from services.file_encrypt_service import ORIGINAL_KEYS
+from services.gpu_spec_table import normalize_gpu_model
 from .network_ema import compute_ema
 
 
@@ -98,7 +99,19 @@ class MachineSpecScrapeCheck:
 
             gpu_info = specs.get("gpu", {}) or {}
             gpu_count = gpu_info.get("count", 0) or 0
-            gpu_details = gpu_info.get("details", []) or []
+            raw_gpu_details = gpu_info.get("details", []) or []
+            gpu_details = [
+                {
+                    **detail,
+                    "name": normalize_gpu_model(detail.get("name")),
+                }
+                if detail.get("name")
+                else detail
+                for detail in raw_gpu_details
+            ]
+            if gpu_details != raw_gpu_details:
+                gpu_info = {**gpu_info, "details": gpu_details}
+                specs = {**specs, "gpu": gpu_info}
             gpu_model = None
             if gpu_count > 0 and gpu_details:
                 gpu_model = gpu_details[0].get("name")

--- a/neurons/validators/src/services/task/checks/machine_spec_scrape.py
+++ b/neurons/validators/src/services/task/checks/machine_spec_scrape.py
@@ -32,6 +32,18 @@ def _deobfuscate(spec: dict[str, Any], obfuscation_keys: dict[str, str] | None) 
     return _update_keys(first_pass, ORIGINAL_KEYS)
 
 
+def _normalize_gpu_details(gpu_details: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            **detail,
+            "name": normalize_gpu_model(detail.get("name")),
+        }
+        if detail.get("name")
+        else detail
+        for detail in gpu_details
+    ]
+
+
 class MachineSpecScrapeCheck:
     """Run the obfuscated scrape script and unpack the executor's hardware profile.
 
@@ -100,15 +112,7 @@ class MachineSpecScrapeCheck:
             gpu_info = specs.get("gpu", {}) or {}
             gpu_count = gpu_info.get("count", 0) or 0
             raw_gpu_details = gpu_info.get("details", []) or []
-            gpu_details = [
-                {
-                    **detail,
-                    "name": normalize_gpu_model(detail.get("name")),
-                }
-                if detail.get("name")
-                else detail
-                for detail in raw_gpu_details
-            ]
+            gpu_details = _normalize_gpu_details(raw_gpu_details)
             if gpu_details != raw_gpu_details:
                 gpu_info = {**gpu_info, "details": gpu_details}
                 specs = {**specs, "gpu": gpu_info}

--- a/neurons/validators/src/services/task/checks/machine_spec_scrape.py
+++ b/neurons/validators/src/services/task/checks/machine_spec_scrape.py
@@ -112,10 +112,9 @@ class MachineSpecScrapeCheck:
             gpu_info = specs.get("gpu", {}) or {}
             gpu_count = gpu_info.get("count", 0) or 0
             raw_gpu_details = gpu_info.get("details", []) or []
+            # The native capability challenge derives its key from the raw NVML name in
+            # specs. Policy and scoring use the canonicalized state fields below.
             gpu_details = _normalize_gpu_details(raw_gpu_details)
-            if gpu_details != raw_gpu_details:
-                gpu_info = {**gpu_info, "details": gpu_details}
-                specs = {**specs, "gpu": gpu_info}
             gpu_model = None
             if gpu_count > 0 and gpu_details:
                 gpu_model = gpu_details[0].get("name")

--- a/neurons/validators/src/services/task/result_handler.py
+++ b/neurons/validators/src/services/task/result_handler.py
@@ -12,12 +12,34 @@ from core.utils import _m, get_extra_info
 from payload_models.payloads import MinerJobRequestPayload
 from protocol.vc_protocol.validator_requests import ResetVerifiedJobReason
 from datura.requests.miner_requests import ExecutorSSHInfo
+from services.gpu_spec_table import normalize_gpu_model
 from services.redis_service import INSPECTOR_EVENT_CHANNEL, RedisService
 
 from .models import JobResult
 from .pipeline import Context
 
 logger = logging.getLogger(__name__)
+
+
+def _canonicalize_published_gpu_names(specs: dict) -> dict:
+    gpu = specs.get("gpu")
+    if not isinstance(gpu, dict):
+        return specs
+
+    details = gpu.get("details")
+    if not isinstance(details, list):
+        return specs
+
+    canonical_details = [
+        {**detail, "name": normalize_gpu_model(detail.get("name"))}
+        if isinstance(detail, dict) and detail.get("name")
+        else detail
+        for detail in details
+    ]
+    if canonical_details == details:
+        return specs
+
+    return {**specs, "gpu": {**gpu, "details": canonical_details}}
 
 
 class ResultHandler:
@@ -122,11 +144,13 @@ class ResultHandler:
 
         # add TDX attestation and spot tier to specs (propagated to compute-app
         # via MACHINE_SPEC_CHANNEL → executor.specs)
-        specs = {
-            **(context.state.specs or {}),
-            "tdx_attestation_passed": context.tdx_attestation_passed,
-            "is_spot": is_spot,
-        }
+        specs = _canonicalize_published_gpu_names(
+            {
+                **(context.state.specs or {}),
+                "tdx_attestation_passed": context.tdx_attestation_passed,
+                "is_spot": is_spot,
+            }
+        )
         # G1 — NVIDIA CC GPU attestation outcome. Only added when a verification
         # was actually performed (None → key omitted), mirroring gpu_metrics.
         # Rides executor.specs to the backend like tdx_attestation_passed.

--- a/neurons/validators/tests/test_machine_spec_scrape_check.py
+++ b/neurons/validators/tests/test_machine_spec_scrape_check.py
@@ -83,6 +83,43 @@ def test_normalize_gpu_details_canonicalizes_a10_alias():
     ]
 
 
+@pytest.mark.asyncio
+async def test_machine_spec_scrape_preserves_raw_a10_name_for_native_challenge(
+    context_factory,
+):
+    raw_specs = {
+        "gpu": {
+            "count": 1,
+            "details": [{"name": "NVIDIA A10", "uuid": "GPU-abc123"}],
+        },
+    }
+    runner = DummySSHCommandRunner(
+        result=make_command_result(success=True, stdout="encrypted_payload_here")
+    )
+    services = build_services(ssh=DummySSHService(decrypted_data=raw_specs))
+    config = build_context_config(
+        machine_scrape_filename="scrape.sh",
+        machine_scrape_timeout=300,
+        obfuscation_keys={},
+    )
+    ctx = context_factory(
+        services=services,
+        config=config,
+        state=build_state(remote_dir="/remote/path"),
+        runner=runner,
+        encrypt_key="test-encrypt-key",
+    )
+
+    result = await MachineSpecScrapeCheck().run(ctx)
+
+    assert result.passed is True
+    updated_state = result.updates["state"]
+    assert updated_state.specs["gpu"]["details"][0]["name"] == "NVIDIA A10"
+    assert updated_state.gpu_details[0]["name"] == "NVIDIA A10 Tensor Core GPU"
+    assert updated_state.gpu_model == "NVIDIA A10 Tensor Core GPU"
+    assert updated_state.gpu_model_count == "NVIDIA A10 Tensor Core GPU:1"
+
+
 @pytest.mark.parametrize(
     "has_remote_dir,has_script_filename,scrape_success,stdout,has_encrypt_key,expected_pass,expected_reason",
     [

--- a/neurons/validators/tests/test_machine_spec_scrape_check.py
+++ b/neurons/validators/tests/test_machine_spec_scrape_check.py
@@ -105,8 +105,8 @@ async def test_machine_spec_scrape_check(
         "gpu": {
             "count": 2,
             "details": [
-                {"name": "NVIDIA RTX 3090", "uuid": "GPU-abc123"},
-                {"name": "NVIDIA RTX 3090", "uuid": "GPU-def456"},
+                {"name": "NVIDIA A10", "uuid": "GPU-abc123"},
+                {"name": "NVIDIA A10", "uuid": "GPU-def456"},
             ],
         },
         "cpu": {"cores": 8},
@@ -171,7 +171,13 @@ async def test_machine_spec_scrape_check(
         assert "state" in result.updates
         updated_state = result.updates["state"]
         # Check that specs were parsed and stored correctly
-        assert updated_state.specs.get("gpu") == mock_specs["gpu"]
+        assert updated_state.specs.get("gpu") == {
+            "count": 2,
+            "details": [
+                {"name": "NVIDIA A10 Tensor Core GPU", "uuid": "GPU-abc123"},
+                {"name": "NVIDIA A10 Tensor Core GPU", "uuid": "GPU-def456"},
+            ],
+        }
         assert updated_state.specs.get("cpu") == mock_specs["cpu"]
         assert updated_state.specs.get("gpu_processes") == mock_specs["gpu_processes"]
         assert updated_state.specs.get("sysbox_runtime") == mock_specs["sysbox_runtime"]
@@ -179,8 +185,8 @@ async def test_machine_spec_scrape_check(
         assert updated_state.specs.get("network", {}).get("ema_download_speed") is None
         assert updated_state.specs.get("network", {}).get("ema_upload_speed") is None
         assert updated_state.gpu_count == 2
-        assert updated_state.gpu_model == "NVIDIA RTX 3090"
-        assert updated_state.gpu_model_count == "NVIDIA RTX 3090:2"
+        assert updated_state.gpu_model == "NVIDIA A10 Tensor Core GPU"
+        assert updated_state.gpu_model_count == "NVIDIA A10 Tensor Core GPU:2"
         assert updated_state.gpu_uuids == "GPU-abc123,GPU-def456"
         assert updated_state.sysbox_runtime is True
         assert len(updated_state.gpu_details) == 2

--- a/neurons/validators/tests/test_machine_spec_scrape_check.py
+++ b/neurons/validators/tests/test_machine_spec_scrape_check.py
@@ -2,7 +2,10 @@ import json
 from datetime import datetime, UTC
 import pytest
 
-from neurons.validators.src.services.task.checks.machine_spec_scrape import MachineSpecScrapeCheck
+from neurons.validators.src.services.task.checks.machine_spec_scrape import (
+    MachineSpecScrapeCheck,
+    _normalize_gpu_details,
+)
 from neurons.validators.src.services.task.messages import MachineSpecMessages as Msg
 from neurons.validators.src.services.task.runner import SSHCommandResult
 
@@ -72,6 +75,14 @@ class DummySSHService:
         return json.dumps(self.decrypted_data)
 
 
+def test_normalize_gpu_details_canonicalizes_a10_alias():
+    assert _normalize_gpu_details(
+        [{"name": "NVIDIA A10", "uuid": "GPU-abc123"}]
+    ) == [
+        {"name": "NVIDIA A10 Tensor Core GPU", "uuid": "GPU-abc123"}
+    ]
+
+
 @pytest.mark.parametrize(
     "has_remote_dir,has_script_filename,scrape_success,stdout,has_encrypt_key,expected_pass,expected_reason",
     [
@@ -105,8 +116,8 @@ async def test_machine_spec_scrape_check(
         "gpu": {
             "count": 2,
             "details": [
-                {"name": "NVIDIA A10", "uuid": "GPU-abc123"},
-                {"name": "NVIDIA A10", "uuid": "GPU-def456"},
+                {"name": "NVIDIA RTX 3090", "uuid": "GPU-abc123"},
+                {"name": "NVIDIA RTX 3090", "uuid": "GPU-def456"},
             ],
         },
         "cpu": {"cores": 8},
@@ -171,13 +182,7 @@ async def test_machine_spec_scrape_check(
         assert "state" in result.updates
         updated_state = result.updates["state"]
         # Check that specs were parsed and stored correctly
-        assert updated_state.specs.get("gpu") == {
-            "count": 2,
-            "details": [
-                {"name": "NVIDIA A10 Tensor Core GPU", "uuid": "GPU-abc123"},
-                {"name": "NVIDIA A10 Tensor Core GPU", "uuid": "GPU-def456"},
-            ],
-        }
+        assert updated_state.specs.get("gpu") == mock_specs["gpu"]
         assert updated_state.specs.get("cpu") == mock_specs["cpu"]
         assert updated_state.specs.get("gpu_processes") == mock_specs["gpu_processes"]
         assert updated_state.specs.get("sysbox_runtime") == mock_specs["sysbox_runtime"]
@@ -185,8 +190,8 @@ async def test_machine_spec_scrape_check(
         assert updated_state.specs.get("network", {}).get("ema_download_speed") is None
         assert updated_state.specs.get("network", {}).get("ema_upload_speed") is None
         assert updated_state.gpu_count == 2
-        assert updated_state.gpu_model == "NVIDIA A10 Tensor Core GPU"
-        assert updated_state.gpu_model_count == "NVIDIA A10 Tensor Core GPU:2"
+        assert updated_state.gpu_model == "NVIDIA RTX 3090"
+        assert updated_state.gpu_model_count == "NVIDIA RTX 3090:2"
         assert updated_state.gpu_uuids == "GPU-abc123,GPU-def456"
         assert updated_state.sysbox_runtime is True
         assert len(updated_state.gpu_details) == 2

--- a/neurons/validators/tests/test_result_handler_gpu_metrics.py
+++ b/neurons/validators/tests/test_result_handler_gpu_metrics.py
@@ -66,6 +66,40 @@ async def test_handle_result_omits_gpu_metrics_when_absent(context_factory):
 
 
 @pytest.mark.asyncio
+async def test_handle_result_publishes_canonical_gpu_name_without_mutating_challenge_specs(
+    context_factory,
+):
+    raw_gpu_detail = {"name": "NVIDIA A10", "uuid": "GPU-abc123"}
+    state = build_state(
+        specs={"gpu": {"count": 1, "details": [raw_gpu_detail]}},
+        gpu_model_count="NVIDIA A10 Tensor Core GPU:1",
+    )
+    ctx = context_factory(
+        state=state,
+        tdx_attestation_passed=False,
+        score=1.0,
+        job_score=1.0,
+        collateral_deposited=False,
+        ssh_pub_keys=[],
+        rented=False,
+    )
+
+    result = await ResultHandler(redis_service=None, dry_run=True).handle_result(
+        context=ctx,
+        miner_info=_miner_info(),
+        executor_info=ctx.executor,
+        verified_job_info={},
+        log_text="ok",
+        success=True,
+    )
+
+    assert ctx.state.specs["gpu"]["details"] == [raw_gpu_detail]
+    assert result.spec["gpu"]["details"] == [
+        {"name": "NVIDIA A10 Tensor Core GPU", "uuid": "GPU-abc123"}
+    ]
+
+
+@pytest.mark.asyncio
 async def test_handle_result_defaults_inspector_outcome_to_skipped(context_factory):
     ctx = context_factory(
         score=1.0,


### PR DESCRIPTION
## Summary

- Normalize the raw `NVIDIA A10` NVML alias to the canonical `NVIDIA A10 Tensor Core GPU` model for validator policy and scoring.
- Preserve the raw GPU name while the native capability challenge runs because its challenge key is derived from the executor's raw machine information.
- Canonicalize GPU names only when publishing the completed machine spec to the backend, allowing the machine catalog to populate `machine_name` and `gpu_count` correctly.
- Keep the existing RTX 3090 scrape coverage and add A10 regression coverage for both validation and result publication.

## Root cause

The executor reports `NVIDIA A10`, while the validator and backend machine catalog use `NVIDIA A10 Tensor Core GPU`. Normalizing the stored scrape spec fixed the validator allowlist but changed the native capability challenge input and caused GPU verification to fail. Keeping the raw spec fixed that challenge, but publishing the raw name left the backend unable to match its machine catalog, producing `machine_name: null` and a blank GPU title in the webapp.

This change keeps the raw name only for the challenge and publishes the canonical name after validation completes.

## Impact

A10 executors validate successfully, retain native capability verification, and appear in the API and webapp with the correct GPU model and count.

## Validation

```text
101 passed, 69 warnings
```

Covered suites:

- machine-spec scrape and GPU alias normalization
- GPU model and VRAM prechecks
- native capability and matrix validation
- result publication canonicalization

Staging verification completed with A10 score `1.0`, three successful provider executors, and API output `machine_name: "NVIDIA A10 Tensor Core GPU"`.
