### PR TITLE
DAH-2576 - Launch and stop the validation CVM from cvmd, with dstack.py as a library

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -242,6 +242,7 @@ jobs:
           ansible-playbook -i inventory/localhost.yml tests/test_sgx_registration.yml
           ansible-playbook -i inventory/localhost.yml tests/test_stubs.yml
           ansible-playbook -i inventory/localhost.yml tests/test_cvmd.yml
+          ansible-playbook -i inventory/localhost.yml tests/test_cvmd_launch.yml
           ansible-playbook -i inventory/localhost.yml tests/test_repo_app_pristine.yml
           ansible-playbook -i inventory/localhost.yml tests/test_reboot_teardown_gate.yml
 

--- a/neurons/executor/ansible/group_vars/all/main.yml
+++ b/neurons/executor/ansible/group_vars/all/main.yml
@@ -306,6 +306,13 @@ lium_cvmd_key_provider_port: 3443
 # the VM.
 lium_cvmd_launch_timeout_seconds: 900
 
+# How long a graceful poweroff is given before cvmd signals the process group.
+# A large-memory TDX guest returns its RAM to the host as it exits, and that is
+# slow — 43 minutes was measured for a 1.13 TB guest on this fleet. Too low and
+# a legitimate slow exit is cut short by a SIGKILL. Per-hardware-class budgets
+# are DAH-2577's open item.
+lium_cvmd_teardown_timeout_seconds: 600
+
 # --- CVM sizing: PROVIDER configuration, never an API field ------------------
 #
 # A cvmd request names which software stack to run; the host decides how big it

--- a/neurons/executor/ansible/group_vars/all/main.yml
+++ b/neurons/executor/ansible/group_vars/all/main.yml
@@ -253,6 +253,97 @@ lium_cvmd_skew_seconds: 60
 # `kind` plus three hashes — hundreds of bytes.
 lium_cvmd_max_body_bytes: 65536
 
+# --- the launch path (DAH-2576) ---------------------------------------------
+#
+# All of the below is optional. cvmd starts and serves /health and /v1/state
+# without it; a launch request on a host that lacks a setting is refused naming
+# that setting. That split is deliberate — a mistyped size should not take the
+# node's state reporting down with it.
+
+# Where dstack.py and host_api.py live on this host. cvmd imports dstack.py as a
+# library rather than shelling out, so this is a directory, not an executable.
+# Typically <repo>/neurons/executor/dstacktee/scripts.
+lium_cvmd_dstack_scripts_dir: ""
+
+# Where cvmd keeps the VM directories it creates. Deliberately NOT dstacktee's
+# own run/vms: a legacy CVM launched by lium-cvm.sh must stay untouched by cvmd
+# during the rollout, and separate directories are what guarantee that.
+lium_cvmd_run_dir: /var/lib/cvmd/vms
+
+# The approved artifact catalog: which software stacks this host may launch.
+# Each entry pins a triple (QEMU build + OS image hash + compose hash) and the
+# local paths that produce it. A request naming a triple that is not here is
+# refused, which is what lets a validator detect a host serving a stack other
+# than the one it expects to attest.
+#
+#   lium_cvmd_catalog:
+#     - id: validation-v3
+#       kind: validation
+#       qemu: "10.1.0"
+#       os_image_hash: a6eafc5f007f642d8ea90c7fa8881f1e6715720ccb531941a28218f4f26d7b02
+#       compose_hash: ab4d14336f0762c0d8ec7631a69148246661de84ceead7a215f8a33b74fd43e6
+#       os_image_path: /opt/lium-io/neurons/executor/dstacktee/run/images/dstack-nvidia-0.5.11
+#       compose_path: /etc/cvmd/composes/validation-v3.yml
+#       init_script: /opt/lium-io/neurons/executor/dstacktee/app/init_script.sh
+#       pre_launch_script: /opt/lium-io/neurons/executor/dstacktee/app/pre_launch_script.sh
+#
+# Hashes must be 64 lowercase hex digits — no `sha256:` prefix, no uppercase.
+# cvmd compares them against values it computes itself, so any other spelling
+# would never match and the launch would fail as "not approved", which sends an
+# operator looking at the wrong thing.
+#
+# This is the DAH-2576 stub. DAH-2578 replaces it with the backend's signed
+# manifest, at which point this list stops being the source of truth.
+lium_cvmd_catalog: []
+
+# dstack's key-provider port, which the guest reaches for its sealing key. The
+# same default lium-cvm.sh relies on.
+lium_cvmd_key_provider_port: 3443
+
+# How long a launch waits for the guest to answer before giving up and failing
+# the node. Generous because a TDX guest with a large memory backing boots
+# slowly; the CVM is left running on timeout, so this bounds the request, not
+# the VM.
+lium_cvmd_launch_timeout_seconds: 900
+
+# --- CVM sizing: PROVIDER configuration, never an API field ------------------
+#
+# A cvmd request names which software stack to run; the host decides how big it
+# is. Settled while reviewing DAH-2575. Everything here is the CVM's shape, so
+# these are the CVM_* values from dstacktee/.env, moved to where the daemon can
+# read them.
+lium_cvm_vcpus: 0
+lium_cvm_memory: ""
+lium_cvm_disk: ""
+
+# PCI slots to pass through, e.g. ["19:00.0", "3b:00.0"], or the single entry
+# ["all"]. An empty list is a legal CVM with no passthrough — so it does not
+# block a launch the way a missing size does.
+lium_cvm_gpus: []
+
+# Forwarded ports as "protocol[:address]:host_port:guest_port". Every one must
+# be bindable before QEMU starts, so a mapping that collides with a CVM already
+# on this host refuses the launch instead of producing two guests fighting over
+# an address.
+lium_cvm_ports: []
+
+# Passed to dstack as --env-file. It lands in the guest's .user-config, which is
+# OUTSIDE app-compose.json — so its contents do not change the compose hash, and
+# two hosts with different env still measure identically.
+lium_cvm_env_file: ""
+
+# The guest-side port carrying SSH. When set, cvmd reads the guest's host key
+# through the matching forward and reports its fingerprint; that read is also
+# what proves the CVM is up, since a TCP accept only proves QEMU is listening.
+# Unset => readiness falls back to a TCP accept and the fingerprint is null.
+lium_cvm_ssh_guest_port: 0
+
+# Both left at what lium-cvm.sh leaves them at: it passes neither flag, so
+# argparse defaults them to false. They change the QEMU command line and
+# therefore the measurements — do not enable one on a single host.
+lium_cvm_pin_numa: false
+lium_cvm_hugepages: false
+
 # catalog variable interface. Unset => the stub says what it is waiting on.
 # Set => the stub asserts its companion then fails "not implemented".
 lium_catalog_manifest_url: ""

--- a/neurons/executor/ansible/roles/cvmd/README.md
+++ b/neurons/executor/ansible/roles/cvmd/README.md
@@ -36,6 +36,7 @@ request.
 | `lium_cvmd_catalog` | The approved artifacts — see below. |
 | `lium_cvmd_key_provider_port` | dstack's key-provider port. `3443`. |
 | `lium_cvmd_launch_timeout_seconds` | How long a launch waits for the guest before failing the node. |
+| `lium_cvmd_teardown_timeout_seconds` | The graceful-poweroff window before cvmd signals the process group. |
 | `lium_cvm_vcpus`, `lium_cvm_memory`, `lium_cvm_disk` | CVM sizing. |
 | `lium_cvm_gpus` | PCI slots to pass through, `["all"]`, or `[]` for none. |
 | `lium_cvm_ports` | Forwarded ports, `protocol[:address]:host:guest`. |

--- a/neurons/executor/ansible/roles/cvmd/README.md
+++ b/neurons/executor/ansible/roles/cvmd/README.md
@@ -41,7 +41,7 @@ request.
 | `lium_cvm_gpus` | PCI slots to pass through, `["all"]`, or `[]` for none. |
 | `lium_cvm_ports` | Forwarded ports, `protocol[:address]:host:guest`. |
 | `lium_cvm_env_file` | Passed as `--env-file`. Lands outside `app-compose.json`, so it does not change the compose hash. |
-| `lium_cvm_ssh_guest_port` | The guest-side SSH port. Set ⇒ cvmd reports the host-key fingerprint and uses reading it as proof the CVM is up. |
+| `lium_cvm_ssh_guest_port` | The guest-side SSH port. Set ⇒ cvmd reports the host-key fingerprint and uses reading it as proof the CVM is up. Must be the guest side (the last field) of one `lium_cvm_ports` entry — the role refuses a value nothing forwards, since there would be nothing to read it through. |
 | `lium_cvm_pin_numa`, `lium_cvm_hugepages` | Both change the QEMU command line and therefore the measurements. `lium-cvm.sh` passes neither. |
 
 **Sizing is provider configuration, never an API field.** A cvmd request names

--- a/neurons/executor/ansible/roles/cvmd/README.md
+++ b/neurons/executor/ansible/roles/cvmd/README.md
@@ -21,6 +21,67 @@ Produce the tarball and its checksum with
 [`cvmd/packaging/build.sh`](../../cvmd/packaging/build.sh), which prints exactly
 the sha256 this role expects.
 
+### The launch path (DAH-2576)
+
+Optional as a whole — cvmd serves `/health` and `/v1/state` without any of it and
+refuses a launch naming the setting it lacks. `lium_cvmd_dstack_scripts_dir` is
+the switch: set it and the role requires the rest, because a host with HALF a
+launch configuration looks configured and refuses every launch at the first
+request.
+
+| Variable | Meaning |
+|---|---|
+| `lium_cvmd_dstack_scripts_dir` | The dstacktee `scripts` directory. cvmd **imports** `dstack.py` from it as a library, so a path to the repo root will not do. |
+| `lium_cvmd_run_dir` | Where cvmd keeps the VM directories it creates. Deliberately not dstacktee's own `run/vms`. |
+| `lium_cvmd_catalog` | The approved artifacts — see below. |
+| `lium_cvmd_key_provider_port` | dstack's key-provider port. `3443`. |
+| `lium_cvmd_launch_timeout_seconds` | How long a launch waits for the guest before failing the node. |
+| `lium_cvm_vcpus`, `lium_cvm_memory`, `lium_cvm_disk` | CVM sizing. |
+| `lium_cvm_gpus` | PCI slots to pass through, `["all"]`, or `[]` for none. |
+| `lium_cvm_ports` | Forwarded ports, `protocol[:address]:host:guest`. |
+| `lium_cvm_env_file` | Passed as `--env-file`. Lands outside `app-compose.json`, so it does not change the compose hash. |
+| `lium_cvm_ssh_guest_port` | The guest-side SSH port. Set ⇒ cvmd reports the host-key fingerprint and uses reading it as proof the CVM is up. |
+| `lium_cvm_pin_numa`, `lium_cvm_hugepages` | Both change the QEMU command line and therefore the measurements. `lium-cvm.sh` passes neither. |
+
+**Sizing is provider configuration, never an API field.** A cvmd request names
+which software stack to run; the host decides how big it is. So there is nothing
+a caller could send to fill a gap here — a host missing a size refuses every
+launch, which is why the role refuses first.
+
+### The catalog pins a triple
+
+`lium_cvmd_catalog` is a list of approved artifacts, rendered to
+`/etc/cvmd/catalog.json`. Each entry pins the **triple** — QEMU build, OS image
+hash, compose hash — that this host is allowed to produce, plus the local paths
+that produce it:
+
+```yaml
+lium_cvmd_catalog:
+  - id: validation-v3
+    kind: validation
+    qemu: "10.1.0"
+    os_image_hash: a6eafc5f007f642d8ea90c7fa8881f1e6715720ccb531941a28218f4f26d7b02
+    compose_hash: ab4d14336f0762c0d8ec7631a69148246661de84ceead7a215f8a33b74fd43e6
+    os_image_path: /opt/lium-io/neurons/executor/dstacktee/run/images/dstack-nvidia-0.5.11
+    compose_path: /etc/cvmd/composes/validation-v3.yml
+    init_script: /opt/lium-io/neurons/executor/dstacktee/app/init_script.sh
+    pre_launch_script: /opt/lium-io/neurons/executor/dstacktee/app/pre_launch_script.sh
+```
+
+Hashes must be 64 lowercase hex digits — no `sha256:` prefix, no uppercase. cvmd
+compares them against values it computes itself, so any other spelling would
+never match and the launch would fail as "not approved", sending an operator
+looking at the wrong thing. `load_catalog` refuses those spellings outright, and
+the role runs it against the rendered file before it replaces the working one.
+
+`compose_path` must point at an **already-resolved** compose. `lium-cvm.sh`
+substitutes `${EXECUTOR_RUNNER_IMAGE_DIGEST}` before dstack measures the file;
+under cvmd the catalog carries the resolved copy, and the compose-hash gate is
+what catches it if that ever stops being true.
+
+This is the DAH-2576 stub. DAH-2578 replaces it with the backend's signed
+manifest, at which point this list stops being the source of truth.
+
 ### Authorised clients are hotkeys, not SSH keys
 
 cvmd authenticates a **signed request** against a bittensor hotkey, so the only

--- a/neurons/executor/ansible/roles/cvmd/defaults/main.yml
+++ b/neurons/executor/ansible/roles/cvmd/defaults/main.yml
@@ -10,6 +10,7 @@ cvmd_prefix: /opt/cvmd
 cvmd_config_dir: /etc/cvmd
 cvmd_config_path: /etc/cvmd/config.toml
 cvmd_authorized_clients_path: /etc/cvmd/authorized_clients.json
+cvmd_catalog_path: /etc/cvmd/catalog.json
 cvmd_tls_dir: /etc/cvmd/tls
 cvmd_state_dir: /var/lib/cvmd
 cvmd_unit_path: /etc/systemd/system/cvmd.service

--- a/neurons/executor/ansible/roles/cvmd/tasks/configure.yml
+++ b/neurons/executor/ansible/roles/cvmd/tasks/configure.yml
@@ -21,10 +21,16 @@
     owner: root
     group: root
     mode: "0640"
-    # Parsed by the same library cvmd parses it with. A TOML error caught here
-    # leaves the previous config in place; caught at startup it leaves no
-    # working daemon.
-    validate: python3 -c 'import sys, tomllib; tomllib.load(open(sys.argv[1], "rb"))' %s
+    # Loaded by cvmd's OWN loader, not merely parsed as TOML. load_config is
+    # what refuses at startup — the TOML syntax, the required keys, the paired
+    # TLS settings, the port mappings dstack has to turn into hostfwd rules — so
+    # running it against the candidate file makes an unstartable daemon
+    # impossible to install. Caught here it leaves the previous config in place;
+    # caught at startup it leaves no working daemon.
+    validate: >-
+      {{ cvmd_prefix }}/venv/bin/python -c
+      'import sys, pathlib; from cvmd.config import load_config;
+      load_config(pathlib.Path(sys.argv[1]))' %s
   notify: Restart cvmd
 
 # Validated by cvmd's OWN loader, not by a JSON parse. load_authorized_clients

--- a/neurons/executor/ansible/roles/cvmd/tasks/configure.yml
+++ b/neurons/executor/ansible/roles/cvmd/tasks/configure.yml
@@ -45,6 +45,33 @@
       load_authorized_clients(pathlib.Path(sys.argv[1]))' %s
   notify: Restart cvmd
 
+# Validated by cvmd's own loader too, for the same reason as the clients file:
+# load_catalog is what refuses at launch time, and it does the hex-digit check,
+# the duplicate-triple check and the version check. A catalog that would make
+# every launch fail never replaces a working one.
+- name: Render the artifact catalog
+  ansible.builtin.template:
+    src: catalog.json.j2
+    dest: "{{ cvmd_catalog_path }}"
+    owner: root
+    group: root
+    mode: "0640"
+    validate: >-
+      {{ cvmd_prefix }}/venv/bin/python -c
+      'import sys, pathlib; from cvmd.catalog import load_catalog;
+      load_catalog(pathlib.Path(sys.argv[1]))' %s
+  when: lium_cvmd_dstack_scripts_dir | length > 0
+  notify: Restart cvmd
+
+- name: Ensure the CVM run directory exists
+  ansible.builtin.file:
+    path: "{{ lium_cvmd_run_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+  when: lium_cvmd_dstack_scripts_dir | length > 0
+
 - name: Enable cvmd and start it
   ansible.builtin.systemd_service:
     name: cvmd.service

--- a/neurons/executor/ansible/roles/cvmd/tasks/main.yml
+++ b/neurons/executor/ansible/roles/cvmd/tasks/main.yml
@@ -98,6 +98,69 @@
   loop_control:
     label: "{{ item.hotkey | truncate(16, true, '…') }}"
 
+# --- the launch path (DAH-2576) ---------------------------------------------
+#
+# Optional as a whole: cvmd serves /health and /v1/state without any of it, and
+# refuses a launch naming the setting it lacks. But a host that has been given
+# HALF a launch configuration is a different thing — it looks configured and
+# refuses every launch at the first request, which is the worst moment to find
+# out. So the scripts directory is what switches these checks on.
+
+- name: A host configured to launch CVMs has what a launch needs
+  ansible.builtin.assert:
+    that:
+      - lium_cvmd_run_dir | length > 0
+      - lium_cvm_vcpus | int > 0
+      - lium_cvm_memory | length > 0
+      - lium_cvm_disk | length > 0
+      - lium_cvm_ports | length > 0
+      - lium_cvmd_catalog | length > 0
+    fail_msg: >-
+      lium_cvmd_dstack_scripts_dir is set, so this host is meant to launch CVMs,
+      but it is missing one of lium_cvmd_run_dir, lium_cvm_vcpus,
+      lium_cvm_memory, lium_cvm_disk, lium_cvm_ports or lium_cvmd_catalog. cvmd
+      would start and then refuse every launch. Sizing is deliberately provider
+      configuration and never part of a request, so there is nothing a caller
+      could supply to fill the gap.
+    quiet: true
+  when: lium_cvmd_dstack_scripts_dir | length > 0
+
+- name: The dstack launcher is where the host says it is
+  ansible.builtin.stat:
+    path: "{{ lium_cvmd_dstack_scripts_dir }}/dstack.py"
+  register: cvmd_dstack_script
+  when: lium_cvmd_dstack_scripts_dir | length > 0
+
+# cvmd imports dstack.py rather than shelling out to it, and that import also
+# needs host_api.py beside it. Checking here names the wrong directory; checking
+# at launch time reports it as "this host cannot run the dstack launcher".
+- name: The dstack launcher is importable as a library
+  ansible.builtin.assert:
+    that:
+      - cvmd_dstack_script.stat.exists
+    fail_msg: >-
+      lium_cvmd_dstack_scripts_dir is {{ lium_cvmd_dstack_scripts_dir }}, and
+      there is no dstack.py in it. This must be the dstacktee `scripts`
+      directory — cvmd imports dstack.py from it as a library, so a path to the
+      repository root or to lium-cvm.sh will not do.
+    quiet: true
+  when: lium_cvmd_dstack_scripts_dir | length > 0
+
+# Every mapping must be bindable at launch time; a duplicate host port is the
+# one collision that is knowable now, and cvmd refuses the whole config for it.
+- name: Each forwarded port is protocol[:address]:host:guest
+  ansible.builtin.assert:
+    that:
+      - item is match('^(tcp|udp):([^:]+:)?[0-9]{1,5}:[0-9]{1,5}$')
+    fail_msg: >-
+      lium_cvm_ports[{{ index }}] is {{ item | to_json }}, which is not
+      'protocol[:address]:host_port:guest_port'. dstack parses these into QEMU
+      hostfwd rules, so a malformed one becomes a CVM with no way in.
+    quiet: true
+  loop: "{{ lium_cvm_ports }}"
+  loop_control:
+    index_var: index
+
 - name: Read the host Python version
   ansible.builtin.command: python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])'
   register: cvmd_python_version

--- a/neurons/executor/ansible/roles/cvmd/tasks/main.yml
+++ b/neurons/executor/ansible/roles/cvmd/tasks/main.yml
@@ -146,20 +146,48 @@
     quiet: true
   when: lium_cvmd_dstack_scripts_dir | length > 0
 
-# Every mapping must be bindable at launch time; a duplicate host port is the
-# one collision that is knowable now, and cvmd refuses the whole config for it.
-- name: Each forwarded port is protocol[:address]:host:guest
+# A cheap first pass that names the offending variable and index. The
+# authoritative check is cvmd's own parser, run against the rendered config by
+# configure.yml — but that needs the venv, which install.yml has not created
+# yet, and failing before a download beats failing after one.
+#
+# The range half is not decoration: `[0-9]{1,5}` alone accepts 0 and 70000, both
+# of which cvm/ports.py rejects, so without it this passes a host the daemon
+# then refuses to start on.
+- name: Each forwarded port is protocol[:address]:host:guest, with ports in 1-65535
   ansible.builtin.assert:
     that:
       - item is match('^(tcp|udp):([^:]+:)?[0-9]{1,5}:[0-9]{1,5}$')
+      - item.split(':')[-2:] | map('int') | select('lt', 1) | list | length == 0
+      - item.split(':')[-2:] | map('int') | select('gt', 65535) | list | length == 0
     fail_msg: >-
       lium_cvm_ports[{{ index }}] is {{ item | to_json }}, which is not
-      'protocol[:address]:host_port:guest_port'. dstack parses these into QEMU
-      hostfwd rules, so a malformed one becomes a CVM with no way in.
+      'protocol[:address]:host_port:guest_port' with both ports in 1-65535.
+      dstack parses these into QEMU hostfwd rules, so a malformed one becomes a
+      CVM with no way in.
     quiet: true
   loop: "{{ lium_cvm_ports }}"
   loop_control:
     index_var: index
+
+# cvmd reads the guest's SSH host key through this forward, and that read is
+# also what proves the CVM is up. A guest port nothing forwards leaves the
+# launch with no readiness signal and no fingerprint, so cvmd refuses it — the
+# same refusal, named here instead of at the first request.
+- name: The SSH guest port is one of the forwarded ports
+  ansible.builtin.assert:
+    that:
+      - lium_cvm_ports | select('search', ':' ~ lium_cvm_ssh_guest_port ~ '$') | list | length > 0
+    fail_msg: >-
+      lium_cvm_ssh_guest_port is {{ lium_cvm_ssh_guest_port }}, and none of
+      lium_cvm_ports forwards it: {{ lium_cvm_ports | to_json }}. The guest port
+      is the LAST field of each mapping. cvmd reads the host key through that
+      forward, so with no match there is nothing to probe and the launch report
+      would carry no fingerprint.
+    quiet: true
+  when:
+    - lium_cvmd_dstack_scripts_dir | length > 0
+    - lium_cvm_ssh_guest_port | int > 0
 
 - name: Read the host Python version
   ansible.builtin.command: python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])'

--- a/neurons/executor/ansible/roles/cvmd/templates/catalog.json.j2
+++ b/neurons/executor/ansible/roles/cvmd/templates/catalog.json.j2
@@ -1,0 +1,8 @@
+{# The approved artifact catalog — DAH-2576's stub for the signed manifest that
+   DAH-2578 will fetch from the backend.
+
+   Rendered from `lium_cvmd_catalog` through `to_json`, so an operator's extra
+   keys are carried verbatim and cvmd's loader is what decides whether the file
+   is usable. The role validates the result with that same loader before it
+   replaces the working copy. #}
+{{ {"version": 1, "artifacts": lium_cvmd_catalog} | to_nice_json }}

--- a/neurons/executor/ansible/roles/cvmd/templates/config.toml.j2
+++ b/neurons/executor/ansible/roles/cvmd/templates/config.toml.j2
@@ -27,3 +27,37 @@ skew_seconds = {{ lium_cvmd_skew_seconds }}
 # Real bodies are a `kind` plus three hashes. The cap is enforced before the
 # body is buffered.
 max_body_bytes = {{ lium_cvmd_max_body_bytes }}
+
+# --- the launch path (DAH-2576) ---------------------------------------------
+#
+# Emitted only when the host has been given a scripts directory. An absent
+# setting is refused per-launch, naming itself; an empty string here would be a
+# path cvmd would try and fail to import.
+{% if lium_cvmd_dstack_scripts_dir %}
+dstack_scripts_dir = "{{ lium_cvmd_dstack_scripts_dir }}"
+catalog_path = "{{ cvmd_catalog_path }}"
+run_dir = "{{ lium_cvmd_run_dir }}"
+key_provider_port = {{ lium_cvmd_key_provider_port }}
+launch_timeout_seconds = {{ lium_cvmd_launch_timeout_seconds }}
+
+# CVM sizing — provider configuration, never sent in a request.
+{% if lium_cvm_vcpus %}
+cvm_vcpus = {{ lium_cvm_vcpus }}
+{% endif %}
+{% if lium_cvm_memory %}
+cvm_memory = "{{ lium_cvm_memory }}"
+{% endif %}
+{% if lium_cvm_disk %}
+cvm_disk = "{{ lium_cvm_disk }}"
+{% endif %}
+cvm_gpus = {{ lium_cvm_gpus | to_json }}
+cvm_ports = {{ lium_cvm_ports | to_json }}
+{% if lium_cvm_env_file %}
+cvm_env_file = "{{ lium_cvm_env_file }}"
+{% endif %}
+{% if lium_cvm_ssh_guest_port %}
+cvm_ssh_guest_port = {{ lium_cvm_ssh_guest_port }}
+{% endif %}
+cvm_pin_numa = {{ lium_cvm_pin_numa | lower }}
+cvm_hugepages = {{ lium_cvm_hugepages | lower }}
+{% endif %}

--- a/neurons/executor/ansible/roles/cvmd/templates/config.toml.j2
+++ b/neurons/executor/ansible/roles/cvmd/templates/config.toml.j2
@@ -39,6 +39,7 @@ catalog_path = "{{ cvmd_catalog_path }}"
 run_dir = "{{ lium_cvmd_run_dir }}"
 key_provider_port = {{ lium_cvmd_key_provider_port }}
 launch_timeout_seconds = {{ lium_cvmd_launch_timeout_seconds }}
+teardown_timeout_seconds = {{ lium_cvmd_teardown_timeout_seconds }}
 
 # CVM sizing — provider configuration, never sent in a request.
 {% if lium_cvm_vcpus %}

--- a/neurons/executor/ansible/tests/test_cvmd_launch.yml
+++ b/neurons/executor/ansible/tests/test_cvmd_launch.yml
@@ -166,6 +166,108 @@
           with no way in. refused={{ port_refused }} msg={{ port_msg }}
         quiet: true
 
+    # --- a port in range for the regex but not for cvmd -------------------
+    # The shape is right and every field is a number, so a shape-only check
+    # passes it — and then cvm/ports.py rejects it and the daemon will not
+    # start. The role's job is to name the variable before that happens.
+    - name: Run cvmd with a port number outside 1-65535
+      block:
+        - name: Include cvmd with an out-of-range host port
+          ansible.builtin.include_role:
+            name: cvmd
+          vars:
+            lium_cvm_ports: ["tcp:0.0.0.0:70000:2200"]
+
+        - name: Record that cvmd accepted an unbindable port
+          ansible.builtin.set_fact:
+            range_refused: false
+            range_msg: ""
+      rescue:
+        - name: Record the range refusal
+          ansible.builtin.set_fact:
+            range_refused: true
+            range_msg: >-
+              {{ ansible_failed_result.msg | default('') }}
+              {{ ansible_failed_result.results | default([]) | map(attribute='msg') | join(' ') }}
+
+    - name: A port outside 1-65535 is refused with the same rule cvmd applies
+      ansible.builtin.assert:
+        that:
+          - range_refused | bool
+          - "'1-65535' in range_msg"
+        fail_msg: >-
+          cvmd accepted a port number its own parser rejects, so the daemon
+          would refuse to start on a config this run reported as good.
+          refused={{ range_refused }} msg={{ range_msg }}
+        quiet: true
+
+    # --- an SSH guest port nothing forwards -------------------------------
+    # The guest port is the LAST field, so 2200:22 forwards 22 and not 2200.
+    # cvmd reads the host key through that forward and uses the read as its
+    # readiness signal, so with no match the launch has neither.
+    - name: Run cvmd with an SSH guest port that no mapping carries
+      block:
+        - name: Include cvmd with the guest side one field out
+          ansible.builtin.include_role:
+            name: cvmd
+          vars:
+            lium_cvm_ports: ["tcp:0.0.0.0:12200:22"]
+            lium_cvm_ssh_guest_port: 2200
+
+        - name: Record that cvmd accepted an unprobeable SSH port
+          ansible.builtin.set_fact:
+            ssh_refused: false
+            ssh_msg: ""
+      rescue:
+        - name: Record the SSH-port refusal
+          ansible.builtin.set_fact:
+            ssh_refused: true
+            ssh_msg: >-
+              {{ ansible_failed_result.msg | default('') }}
+              {{ ansible_failed_result.results | default([]) | map(attribute='msg') | join(' ') }}
+
+    - name: An SSH guest port nothing forwards is refused, and the variable is named
+      ansible.builtin.assert:
+        that:
+          - ssh_refused | bool
+          - "'lium_cvm_ssh_guest_port' in ssh_msg"
+        fail_msg: >-
+          cvmd accepted a host whose SSH guest port no forward carries. The
+          launch would have no readiness signal and report a null fingerprint.
+          refused={{ ssh_refused }} msg={{ ssh_msg }}
+        quiet: true
+
+    # The matching case, so the assert cannot pass by refusing everything.
+    - name: Run cvmd with an SSH guest port that is forwarded
+      block:
+        - name: Include cvmd with a matching guest port
+          ansible.builtin.include_role:
+            name: cvmd
+          vars:
+            lium_cvm_ports: ["tcp:0.0.0.0:12200:2200"]
+            lium_cvm_ssh_guest_port: 2200
+
+        - name: Record that the launch checks passed
+          ansible.builtin.set_fact:
+            ssh_match_refused: false
+            ssh_match_msg: ""
+      rescue:
+        - name: Record where the matching case stopped
+          ansible.builtin.set_fact:
+            ssh_match_refused: true
+            ssh_match_msg: >-
+              {{ ansible_failed_result.msg | default('') }}
+              {{ ansible_failed_result.results | default([]) | map(attribute='msg') | join(' ') }}
+
+    - name: A forwarded SSH guest port passes the launch checks
+      ansible.builtin.assert:
+        that:
+          - not (ssh_match_refused | bool) or 'lium_cvm_ssh_guest_port' not in ssh_match_msg
+        fail_msg: >-
+          cvmd refused an SSH guest port that IS forwarded, so the check rejects
+          valid configuration. msg={{ ssh_match_msg }}
+        quiet: true
+
 - name: The rendered catalog is what cvmd's loader reads
   hosts: localhost
   gather_facts: false

--- a/neurons/executor/ansible/tests/test_cvmd_launch.yml
+++ b/neurons/executor/ansible/tests/test_cvmd_launch.yml
@@ -1,0 +1,217 @@
+---
+# The cvmd role's launch-path checks — DAH-2576.
+#
+# The launch path as a whole is optional: cvmd serves /health and /v1/state
+# without it and refuses a launch naming the setting it lacks. What is NOT
+# acceptable is HALF of it, because that host looks configured and refuses every
+# launch at the first request. `lium_cvmd_dstack_scripts_dir` is what switches
+# these checks on, so each case below sets it and then leaves one thing out.
+#
+# Every case stops at an assert before install.yml, so this runs unprivileged
+# with nothing fetched and no service touched — same as tests/test_cvmd.yml.
+#
+# The shared settings are repeated per case rather than combined from a base
+# mapping: `include_role`'s `vars` must be a literal dictionary, and a templated
+# `{{ base | combine(...) }}` is rejected outright.
+
+- name: The cvmd role refuses a half-configured launch host
+  hosts: localhost
+  gather_facts: false
+  vars:
+    lium_test_mode: true
+    lium_cvmd_package_url: file:///nonexistent/cvmd.tar.gz
+    lium_cvmd_package_sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+    lium_cvmd_authorized_clients:
+      - hotkey: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        scope: validation
+    lium_cvmd_dstack_scripts_dir: "{{ playbook_dir }}/../../dstacktee/scripts"
+    lium_cvm_vcpus: 16
+    lium_cvm_memory: 64G
+    lium_cvm_disk: 200G
+    lium_cvm_ports: ["tcp:0.0.0.0:12200:2200"]
+    lium_cvmd_catalog:
+      - id: validation-v1
+        kind: validation
+        qemu: "10.1.0"
+        os_image_hash: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        compose_hash: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+        os_image_path: /opt/images/dstack-nvidia-0.5.11
+        compose_path: /etc/cvmd/composes/validation-v1.yml
+
+  tasks:
+    # --- sizing missing ---------------------------------------------------
+    - name: Run cvmd with a scripts directory but no memory size
+      block:
+        - name: Include cvmd with sizing half-filled
+          ansible.builtin.include_role:
+            name: cvmd
+          vars:
+            lium_cvm_memory: ""
+
+        - name: Record that cvmd accepted a host it cannot launch on
+          ansible.builtin.set_fact:
+            sizing_refused: false
+            sizing_msg: ""
+      rescue:
+        - name: Record the sizing refusal
+          ansible.builtin.set_fact:
+            sizing_refused: true
+            sizing_msg: >-
+              {{ ansible_failed_result.msg | default('') }}
+              {{ ansible_failed_result.results | default([]) | map(attribute='msg') | join(' ') }}
+
+    - name: A launch host missing a size is refused, and the variable is named
+      ansible.builtin.assert:
+        that:
+          - sizing_refused | bool
+          - "'lium_cvm_memory' in sizing_msg"
+        fail_msg: >-
+          cvmd accepted a host configured to launch CVMs with no memory size. It
+          would start and then refuse every launch, and sizing is provider
+          configuration so no caller could fill the gap.
+          refused={{ sizing_refused }} msg={{ sizing_msg }}
+        quiet: true
+
+    # --- catalog missing --------------------------------------------------
+    - name: Run cvmd with no catalog
+      block:
+        - name: Include cvmd with an empty catalog
+          ansible.builtin.include_role:
+            name: cvmd
+          vars:
+            lium_cvmd_catalog: []
+
+        - name: Record that cvmd accepted a host with nothing approved
+          ansible.builtin.set_fact:
+            catalog_refused: false
+            catalog_msg: ""
+      rescue:
+        - name: Record the catalog refusal
+          ansible.builtin.set_fact:
+            catalog_refused: true
+            catalog_msg: >-
+              {{ ansible_failed_result.msg | default('') }}
+              {{ ansible_failed_result.results | default([]) | map(attribute='msg') | join(' ') }}
+
+    - name: A launch host with an empty catalog is refused
+      ansible.builtin.assert:
+        that:
+          - catalog_refused | bool
+          - "'lium_cvmd_catalog' in catalog_msg"
+        fail_msg: >-
+          cvmd accepted a launch host whose catalog approves nothing.
+          refused={{ catalog_refused }} msg={{ catalog_msg }}
+        quiet: true
+
+    # --- the scripts directory is not the scripts directory ---------------
+    - name: Run cvmd pointed at a directory with no dstack.py
+      block:
+        - name: Include cvmd with the dstacktee root instead of scripts/
+          ansible.builtin.include_role:
+            name: cvmd
+          vars:
+            lium_cvmd_dstack_scripts_dir: "{{ playbook_dir }}/../../dstacktee"
+
+        - name: Record that cvmd accepted an unimportable launcher path
+          ansible.builtin.set_fact:
+            launcher_refused: false
+            launcher_msg: ""
+      rescue:
+        - name: Record the launcher refusal
+          ansible.builtin.set_fact:
+            launcher_refused: true
+            launcher_msg: >-
+              {{ ansible_failed_result.msg | default('') }}
+              {{ ansible_failed_result.results | default([]) | map(attribute='msg') | join(' ') }}
+
+    - name: A scripts directory with no dstack.py is refused, and says why
+      ansible.builtin.assert:
+        that:
+          - launcher_refused | bool
+          - "'dstack.py' in launcher_msg"
+        fail_msg: >-
+          cvmd accepted a launcher path it cannot import from. cvmd imports
+          dstack.py as a library, so the dstacktee root will not do.
+          refused={{ launcher_refused }} msg={{ launcher_msg }}
+        quiet: true
+
+    # --- a port mapping dstack cannot parse -------------------------------
+    - name: Run cvmd with a malformed port mapping
+      block:
+        - name: Include cvmd with a port missing its guest side
+          ansible.builtin.include_role:
+            name: cvmd
+          vars:
+            lium_cvm_ports: ["tcp:12200"]
+
+        - name: Record that cvmd accepted an unparseable mapping
+          ansible.builtin.set_fact:
+            port_refused: false
+            port_msg: ""
+      rescue:
+        - name: Record the port refusal
+          ansible.builtin.set_fact:
+            port_refused: true
+            port_msg: >-
+              {{ ansible_failed_result.msg | default('') }}
+              {{ ansible_failed_result.results | default([]) | map(attribute='msg') | join(' ') }}
+
+    - name: A malformed port mapping is refused before it becomes a hostfwd rule
+      ansible.builtin.assert:
+        that:
+          - port_refused | bool
+          - "'host_port' in port_msg"
+        fail_msg: >-
+          cvmd accepted a port mapping dstack cannot parse, which becomes a CVM
+          with no way in. refused={{ port_refused }} msg={{ port_msg }}
+        quiet: true
+
+- name: The rendered catalog is what cvmd's loader reads
+  hosts: localhost
+  gather_facts: false
+  vars:
+    lium_test_mode: true
+    cvmd_catalog_render_path: /tmp/lium-cvmd-catalog.json
+    lium_cvmd_catalog:
+      - id: validation-v1
+        kind: validation
+        qemu: "10.1.0"
+        os_image_hash: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        compose_hash: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+        os_image_path: /opt/images/dstack-nvidia-0.5.11
+        compose_path: /etc/cvmd/composes/validation-v1.yml
+
+  tasks:
+    - name: Render the catalog template directly
+      ansible.builtin.template:
+        src: ../roles/cvmd/templates/catalog.json.j2
+        dest: "{{ cvmd_catalog_render_path }}"
+        mode: "0600"
+
+    - name: Read it back
+      ansible.builtin.slurp:
+        src: "{{ cvmd_catalog_render_path }}"
+      register: rendered_catalog
+
+    - name: It carries the version cvmd's loader requires and the pinned triple
+      ansible.builtin.assert:
+        that:
+          - parsed.version == 1
+          - parsed.artifacts | length == 1
+          - parsed.artifacts[0].id == 'validation-v1'
+          - parsed.artifacts[0].compose_hash == 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+        fail_msg: >-
+          The rendered catalog is not the shape cvmd's loader accepts:
+          {{ rendered_catalog.content | b64decode }}
+        quiet: true
+      vars:
+        parsed: "{{ rendered_catalog.content | b64decode | from_json }}"
+
+    - name: Remove the rendered catalog
+      ansible.builtin.file:
+        path: "{{ cvmd_catalog_render_path }}"
+        state: absent
+
+    - name: PASS
+      ansible.builtin.debug:
+        msg: "PASS cvmd refuses a half-configured launch host, and renders a catalog its loader reads."

--- a/neurons/executor/cvmd/README.md
+++ b/neurons/executor/cvmd/README.md
@@ -1,24 +1,90 @@
 # cvmd — CVM host daemon
 
 The control-plane daemon that runs on a CVM host. It exposes a signed HTTPS API with two
-authorized clients holding disjoint scopes, and it holds the node's state machine.
-
-**DAH-2575 ships the skeleton only.** The mutating endpoints are registered with full auth and
-scope enforcement but return `501` — the CVM operations behind them land in DAH-2576. That split
-is deliberate: the scope matrix is testable end-to-end today, so 2576 fills in handlers rather
-than also wiring auth.
+authorized clients holding disjoint scopes, holds the node's state machine, and launches and
+stops the node's CVM.
 
 ## API
 
 | Route | Auth | Now |
 |---|---|---|
 | `GET /health` | none | `200 {"version": ...}` |
-| `GET /v1/state` | either key | the persisted state document |
-| `POST /v1/cvm` | validator key for `kind=validation`, platform key for `kind=renter` | `501` |
-| `DELETE /v1/cvm` | platform key | `501` |
+| `GET /v1/state` | either key | the state document plus the running CVM |
+| `POST /v1/cvm` `kind=validation` | validator key | launches the validation CVM (DAH-2576) |
+| `POST /v1/cvm` `kind=renter` | platform key | `501` — DAH-2580 |
+| `DELETE /v1/cvm` | platform key | tears the CVM down |
 
 A scope violation on an otherwise valid request is `403`. Everything else that fails auth is
 `401`. A validly signed body that is not usable is `422`, never a scope bypass.
+
+`DELETE` is platform-scoped even for a validation CVM. It carries no `kind`, so a validator
+holding that right could destroy a *renter's* CVM — the platform owns the node's lifecycle and
+the validator only asks for a validation CVM.
+
+## Launching a CVM
+
+```
+POST /v1/cvm
+{"kind": "validation",
+ "qemu": "10.1.0",
+ "os_image_hash": "<64 lowercase hex>",
+ "compose_hash":  "<64 lowercase hex>"}
+```
+
+The body names **which software stack to run** and nothing else. Sizing — vCPUs, memory, disk,
+GPUs, forwarded ports — is provider configuration read from `/etc/cvmd/config.toml`: the caller
+says what to run, the host says how big it is.
+
+The three hashes are a *pinned triple*, and they are the entire input to the CVM's measurements.
+cvmd resolves them against the local catalog (`/etc/cvmd/catalog.json`), and a triple the
+catalog does not carry is refused naming the component that was not approved. That is what lets
+a validator detect a host serving a stack other than the one it expects to attest.
+
+The request returns when the CVM is up, with the launch report — instance id, forwarded ports,
+and the guest's SSH host-key fingerprint. Meanwhile `/v1/state` moves
+`RECONCILING → LAUNCHING → VALIDATION_RUNNING`.
+
+### The measurement gate
+
+cvmd imports `dstacktee/scripts/dstack.py` **as a library** and calls the same functions its CLI
+calls, so the bytes it measures are produced by the same code `lium-cvm.sh` produces them with.
+`tests/test_dstack_library.py` prepares one CVM both ways and compares every file.
+
+Calling the same code makes identical measurements likely; the gate makes them checked. Between
+`setup_instance` writing the VM directory and QEMU starting, cvmd measures what it just built:
+
+| Component | Read from |
+|---|---|
+| `compose_hash` | `sha256(<vm_dir>/shared/app-compose.json)` — the same digest dstack's own `app_compose_hash()` takes |
+| `os_image_hash` | `<image_path>/digest.txt` |
+| `qemu` | `get_qemu_version_string()`, which is what lands in the attested `vm_config` |
+
+Any difference from the requested triple and the launch does not happen — the VM directory is
+removed and the node is left exactly where it was. Configuration says what was *intended*; only
+the files say what was *built*.
+
+### One CVM per node
+
+GPU passthrough is exclusive, so a node holds one CVM. The check reads `/proc` for a running TDX
+guest rather than cvmd's own records — during the CVM v2 rollout the CVM already on a host is
+most likely one `lium-cvm.sh` started, and cvmd's records cannot see those. A stopped CVM's
+directory blocks a launch too: it still owns the node until `DELETE` removes it.
+
+### The supervisor
+
+`run_instance` blocks for the VM's whole life and the host API server has to stay up beside it,
+so cvmd spawns `python -m cvmd.dstack.child` in its own session. The CVM therefore survives a
+cvmd restart, and `RECONCILING` is how the daemon comes back under a guest it did not start.
+
+`console.log` in the VM directory is the guest's serial console plus the full QEMU command line
+`run_instance` prints before exec — the primary evidence for what was launched and how it booted.
+
+Teardown asks the guest to power off through dstack's own path, then signals the supervisor's
+**process group**. dstack's own `--force` kills the pid in `runtime.json`, which is the
+supervisor's — QEMU is its child, so killing that pid alone leaves a running VM holding the
+guest's RAM and the GPUs while every layer above reports success. Confirming the group is gone
+is the floor; the four-condition predicate (VFIO descriptors closed, RAM returned, ports
+bindable) is DAH-2577.
 
 ## Signing a request
 

--- a/neurons/executor/cvmd/README.md
+++ b/neurons/executor/cvmd/README.md
@@ -44,6 +44,13 @@ The request returns when the CVM is up, with the launch report — instance id, 
 and the guest's SSH host-key fingerprint. Meanwhile `/v1/state` moves
 `RECONCILING → LAUNCHING → VALIDATION_RUNNING`.
 
+Readiness is that fingerprint read: a host key can only be collected once sshd inside the guest
+answers through the forward, which is far later and far more meaningful than QEMU accepting a
+connection. So `cvm_ssh_guest_port` must name the guest side of one `cvm_ports` entry — a value
+nothing forwards is refused up front, because it would leave the launch with no readiness check
+at all. On a host with no `ssh-keyscan` installed, readiness degrades to a TCP accept and the
+report's fingerprint is null; the note in the report says which happened.
+
 ### The measurement gate
 
 cvmd imports `dstacktee/scripts/dstack.py` **as a library** and calls the same functions its CLI

--- a/neurons/executor/cvmd/README.md
+++ b/neurons/executor/cvmd/README.md
@@ -73,18 +73,32 @@ directory blocks a launch too: it still owns the node until `DELETE` removes it.
 ### The supervisor
 
 `run_instance` blocks for the VM's whole life and the host API server has to stay up beside it,
-so cvmd spawns `python -m cvmd.dstack.child` in its own session. The CVM therefore survives a
-cvmd restart, and `RECONCILING` is how the daemon comes back under a guest it did not start.
+so cvmd spawns `python -u -m cvmd.dstack.child`. That process **double-forks**: the survivor has
+init as its parent and leads its own session and process group.
+
+Three separate things have to hold for the CVM to outlive cvmd, and each was learned by
+restarting the daemon on a real host:
+
+| | |
+|---|---|
+| Its own session | so a signal aimed at cvmd's process group misses it |
+| init as its parent | so it is reaped the instant it exits. As cvmd's child it lingered as a **zombie**, and a zombie is still a process-group member — `killpg(pgid, 0)` kept succeeding, so every teardown ran the full signal ladder (260s) and then reported "still present after SIGKILL" about a guest that had powered off gracefully. `os.kill(pid, 0)` has the same blind spot, and that is what `shutdown_instance` waits on |
+| `KillMode=process` in the unit | because systemd kills by **cgroup**, and detaching does not leave one. With the default, `systemctl restart cvmd` logged `Killing process ... (qemu-system-x86) with signal SIGKILL` and the node came back FAILED holding a CVM directory and no CVM |
+
+`RECONCILING` is how the daemon comes back under a guest it did not start.
 
 `console.log` in the VM directory is the guest's serial console plus the full QEMU command line
 `run_instance` prints before exec — the primary evidence for what was launched and how it booted.
+The child runs with `-u` because Python block-buffers stdout to a file, and without it that one
+line stays in the buffer for the VM's whole life while QEMU writes past it.
 
 Teardown asks the guest to power off through dstack's own path, then signals the supervisor's
 **process group**. dstack's own `--force` kills the pid in `runtime.json`, which is the
 supervisor's — QEMU is its child, so killing that pid alone leaves a running VM holding the
 guest's RAM and the GPUs while every layer above reports success. Confirming the group is gone
 is the floor; the four-condition predicate (VFIO descriptors closed, RAM returned, ports
-bindable) is DAH-2577.
+bindable) is DAH-2577, as is the per-hardware-class value for `teardown_timeout_seconds` — a
+1.13 TB guest was measured taking 43 minutes to return its memory.
 
 ## Signing a request
 

--- a/neurons/executor/cvmd/packaging/config.toml
+++ b/neurons/executor/cvmd/packaging/config.toml
@@ -43,6 +43,11 @@ max_body_bytes = 65536
 # key_provider_port = 3443
 # launch_timeout_seconds = 900
 #
+# The graceful-poweroff window before cvmd signals the process group. A large-memory TDX guest
+# returns its RAM to the host as it exits and that is slow — 43 minutes was measured for a
+# 1.13 TB guest. Per-hardware-class budgets are DAH-2577's open item.
+# teardown_timeout_seconds = 600
+#
 # CVM sizing is PROVIDER configuration and is never sent in a request: a caller names which
 # software stack to run, and the host decides how big it is.
 # cvm_vcpus = 16

--- a/neurons/executor/cvmd/packaging/config.toml
+++ b/neurons/executor/cvmd/packaging/config.toml
@@ -21,3 +21,42 @@ skew_seconds = 60
 
 # Real bodies are a `kind` plus three hashes. The cap is enforced before the body is buffered.
 max_body_bytes = 65536
+
+# --- the launch path (DAH-2576) ----------------------------------------------
+#
+# Commented out because none of it has a safe default: every value names a path or a size that
+# only this host knows. cvmd runs without them and refuses a launch naming the one it lacks, so
+# an unconfigured host is observable rather than broken. On an Ansible-managed host the cvmd
+# role writes these; the values below are the shape, not a recommendation.
+#
+# Where dstack.py and host_api.py are. cvmd imports dstack.py as a library, so this is the
+# dstacktee `scripts` directory, not an executable.
+# dstack_scripts_dir = "/opt/lium-io/neurons/executor/dstacktee/scripts"
+#
+# The approved artifact catalog. DAH-2578 replaces this file with the backend's signed manifest.
+# catalog_path = "/etc/cvmd/catalog.json"
+#
+# Where cvmd keeps the VM directories it creates. Deliberately not dstacktee's own run/vms — a
+# CVM launched by lium-cvm.sh must stay untouched by cvmd while both paths exist.
+# run_dir = "/var/lib/cvmd/vms"
+#
+# key_provider_port = 3443
+# launch_timeout_seconds = 900
+#
+# CVM sizing is PROVIDER configuration and is never sent in a request: a caller names which
+# software stack to run, and the host decides how big it is.
+# cvm_vcpus = 16
+# cvm_memory = "64G"
+# cvm_disk = "200G"
+# cvm_gpus = ["19:00.0", "3b:00.0"]        # or ["all"], or [] for no passthrough
+# cvm_ports = ["tcp:0.0.0.0:2200:2200", "tcp:0.0.0.0:8001:8001"]
+# cvm_env_file = "/etc/cvmd/cvm.env"
+#
+# The guest-side port carrying SSH. Set it and cvmd reports the guest's host-key fingerprint
+# and uses reading it as proof the CVM is up; leave it unset and readiness is a TCP accept,
+# which only proves QEMU is listening.
+# cvm_ssh_guest_port = 2200
+#
+# Both change the QEMU command line and therefore the measurements. lium-cvm.sh passes neither.
+# cvm_pin_numa = false
+# cvm_hugepages = false

--- a/neurons/executor/cvmd/packaging/cvmd.service
+++ b/neurons/executor/cvmd/packaging/cvmd.service
@@ -13,6 +13,25 @@ Environment=CVMD_CONFIG_PATH=/etc/cvmd/config.toml
 # directory resets the startup floor, so it is state, not cache.
 StateDirectory=cvmd
 
+# The CVM must outlive cvmd. A daemon upgrade that took the node's guest with it would be worse
+# than the outage it was fixing, which is why the supervisor detaches into its own session and
+# why RECONCILING exists at all.
+#
+# The default, control-group, kills EVERY process in the unit's cgroup on stop. A session is
+# not a cgroup, so detaching is not enough on its own: measured on au11, `systemctl restart
+# cvmd` logged
+#
+#     cvmd.service: Killing process 218807 (qemu-system-x86) with signal SIGKILL
+#
+# and the node came back FAILED with a CVM directory and no CVM. `process` stops the main
+# process only and leaves the supervisor — and the guest under it — running, for cvmd to adopt
+# on its next start.
+#
+# The consequence is deliberate: `systemctl stop cvmd` stops the control plane, not the CVM.
+# `systemctl kill cvmd` still reaches everything, which is the escape hatch for an operator who
+# means it.
+KillMode=process
+
 Restart=on-failure
 RestartSec=5
 

--- a/neurons/executor/cvmd/src/cvmd/app.py
+++ b/neurons/executor/cvmd/src/cvmd/app.py
@@ -6,6 +6,7 @@ startup failure, not a daemon that authorizes a subset of what the operator wrot
 """
 
 import logging
+import threading
 
 from fastapi import FastAPI
 
@@ -13,6 +14,8 @@ from cvmd.auth.clients import load_authorized_clients
 from cvmd.auth.middleware import AuthMiddleware
 from cvmd.auth.replay import ReplayStore
 from cvmd.config import Config
+from cvmd.cvm.instance import InstanceStore
+from cvmd.cvm.manager import CvmManager
 from cvmd.routes.cvm import router
 from cvmd.state.store import StateStore
 
@@ -25,12 +28,19 @@ def create_app(config: Config) -> FastAPI:
 
     store = StateStore(config.state_dir)
     replay = ReplayStore(config.state_dir, skew_seconds=config.skew_seconds)
+    instances = InstanceStore(config.state_dir)
+    manager = CvmManager(config=config.launch, store=store, instances=instances)
 
     app = FastAPI(title="cvmd", docs_url=None, redoc_url=None, openapi_url=None)
     app.state.config = config
     app.state.store = store
     app.state.replay = replay
     app.state.clients = clients
+    app.state.instances = instances
+    app.state.cvm = manager
+    # One CVM operation at a time. Held by the route rather than inside the manager so a second
+    # request is refused immediately instead of blocking a worker thread for the whole launch.
+    app.state.cvm_lock = threading.Lock()
 
     app.add_middleware(
         AuthMiddleware,
@@ -40,10 +50,15 @@ def create_app(config: Config) -> FastAPI:
     )
     app.include_router(router)
 
+    # Before the first request, not on the first request: a node that came back under a running
+    # CVM must report the truth to whoever asks first, including a health check.
+    state = manager.reconcile()
+
     logger.info(
-        "cvmd ready: %d authorized keys, state=%s, startup floor=%d",
+        "cvmd ready: %d authorized keys, state=%s, startup floor=%d, cvm=%s",
         len(clients),
-        store.state,
+        state,
         replay.startup_floor_ns,
+        instances.current.instance_id if instances.current else "none",
     )
     return app

--- a/neurons/executor/cvmd/src/cvmd/catalog.py
+++ b/neurons/executor/cvmd/src/cvmd/catalog.py
@@ -16,10 +16,16 @@ verifies a signature, so the file's integrity rests on its filesystem permission
 """
 
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
 SCHEMA_VERSION = 1
+
+# What a hash looks like on both sides of the gate: the catalog's pinned values and the request
+# body's. Owned here, where the values are compared against digests cvmd computes itself, and
+# imported by the request model so the two cannot drift into accepting different spellings.
+HEX64 = r"^[0-9a-f]{64}$"
 
 
 class CatalogError(Exception):
@@ -99,7 +105,7 @@ def _decode_artifact(raw, index: int) -> Artifact:
     # would read as "this stack is not approved" — refuse it here, where the cause is legible.
     for field in ("os_image_hash", "compose_hash"):
         value = getattr(artifact, field)
-        if len(value) != 64 or any(c not in "0123456789abcdef" for c in value):
+        if not re.fullmatch(HEX64, value):
             raise CatalogError(f"{where}: `{field}` must be 64 lowercase hex digits, got {value!r}")
     return artifact
 

--- a/neurons/executor/cvmd/src/cvmd/catalog.py
+++ b/neurons/executor/cvmd/src/cvmd/catalog.py
@@ -1,0 +1,171 @@
+"""The local artifact catalog — which software stacks this host is allowed to launch.
+
+A catalog entry pins a **triple**: the QEMU build, the OS image hash, and the compose hash.
+Those three values are the entire input to the CVM's measurements, so an entry is a statement
+that "this host may produce exactly these MRTD/RTMR values". Everything else in the entry is
+the local path needed to actually produce them.
+
+The caller names a triple; cvmd refuses anything the catalog does not carry. That is the whole
+point: a validator can only attest a stack it asked for, so a host quietly serving a different
+one has to fail the request rather than the attestation.
+
+**This is DAH-2576's stub.** DAH-2578 replaces the loader with a client for the backend's
+signed manifest — fetch, verify the signature, cache, refuse unsigned/tampered/stale. The
+*shape* below is what that client will produce, so only `load_catalog` changes. Nothing here
+verifies a signature, so the file's integrity rests on its filesystem permissions today.
+"""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+
+
+class CatalogError(Exception):
+    """The catalog is missing, unreadable, or malformed. Always refuses a launch."""
+
+
+class TripleNotFound(Exception):
+    """No catalog entry matches the requested triple. The message names which part failed."""
+
+
+@dataclass(frozen=True)
+class Artifact:
+    """One approved stack: the triple it produces, and the local inputs that produce it."""
+
+    id: str
+    kind: str
+    qemu: str
+    os_image_hash: str
+    compose_hash: str
+    os_image_path: Path
+    compose_path: Path
+    init_script: Path | None = None
+    pre_launch_script: Path | None = None
+    local_key_provider: bool = True
+    enable_logs: bool = False
+    enable_sysinfo: bool = False
+
+    @property
+    def triple(self) -> tuple[str, str, str]:
+        return (self.qemu, self.os_image_hash, self.compose_hash)
+
+
+def _require_str(raw: dict, key: str, where: str) -> str:
+    value = raw.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise CatalogError(f"{where}: `{key}` must be a non-empty string")
+    return value.strip()
+
+
+def _optional_path(raw: dict, key: str, where: str) -> Path | None:
+    value = raw.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise CatalogError(f"{where}: `{key}` must be a non-empty string when present")
+    return Path(value.strip())
+
+
+def _bool(raw: dict, key: str, default: bool, where: str) -> bool:
+    value = raw.get(key, default)
+    if not isinstance(value, bool):
+        raise CatalogError(f"{where}: `{key}` must be a boolean, got {value!r}")
+    return value
+
+
+def _decode_artifact(raw, index: int) -> Artifact:
+    where = f"artifacts[{index}]"
+    if not isinstance(raw, dict):
+        raise CatalogError(f"{where} must be an object")
+
+    artifact = Artifact(
+        id=_require_str(raw, "id", where),
+        kind=_require_str(raw, "kind", where),
+        qemu=_require_str(raw, "qemu", where),
+        os_image_hash=_require_str(raw, "os_image_hash", where),
+        compose_hash=_require_str(raw, "compose_hash", where),
+        os_image_path=Path(_require_str(raw, "os_image_path", where)),
+        compose_path=Path(_require_str(raw, "compose_path", where)),
+        init_script=_optional_path(raw, "init_script", where),
+        pre_launch_script=_optional_path(raw, "pre_launch_script", where),
+        local_key_provider=_bool(raw, "local_key_provider", True, where),
+        enable_logs=_bool(raw, "enable_logs", False, where),
+        enable_sysinfo=_bool(raw, "enable_sysinfo", False, where),
+    )
+    # Hashes are compared against values cvmd computes itself, which are lowercase hex. A
+    # catalog written with uppercase or a `sha256:` prefix would never match and the failure
+    # would read as "this stack is not approved" — refuse it here, where the cause is legible.
+    for field in ("os_image_hash", "compose_hash"):
+        value = getattr(artifact, field)
+        if len(value) != 64 or any(c not in "0123456789abcdef" for c in value):
+            raise CatalogError(f"{where}: `{field}` must be 64 lowercase hex digits, got {value!r}")
+    return artifact
+
+
+def load_catalog(path: Path) -> list[Artifact]:
+    """Read and fully validate the catalog. Any problem refuses every launch, not some."""
+    try:
+        raw = json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise CatalogError(f"no catalog at {path}") from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CatalogError(f"cannot read catalog at {path}: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise CatalogError(f"{path}: catalog must be a JSON object")
+    if raw.get("version") != SCHEMA_VERSION:
+        raise CatalogError(
+            f"{path}: catalog version {raw.get('version')!r} is not the supported "
+            f"{SCHEMA_VERSION} — refusing rather than guessing at the shape"
+        )
+
+    entries = raw.get("artifacts")
+    if not isinstance(entries, list):
+        raise CatalogError(f"{path}: `artifacts` must be a list")
+
+    artifacts = [_decode_artifact(entry, index) for index, entry in enumerate(entries)]
+
+    seen: dict[tuple[str, str, str, str], str] = {}
+    for artifact in artifacts:
+        key = (artifact.kind, *artifact.triple)
+        if key in seen:
+            raise CatalogError(
+                f"{path}: {artifact.id} and {seen[key]} pin the same kind and triple, so a "
+                f"request could resolve to either"
+            )
+        seen[key] = artifact.id
+    return artifacts
+
+
+def resolve(
+    artifacts: list[Artifact], *, kind: str, qemu: str, os_image_hash: str, compose_hash: str
+) -> Artifact:
+    """Return the single entry matching the triple, or raise naming what did not match.
+
+    The message narrows one component at a time so an operator learns *which* part of their
+    triple is unapproved — "compose hash is not in the catalog" is actionable, "not found" is
+    not.
+    """
+    requested = {"qemu": qemu, "os_image_hash": os_image_hash, "compose_hash": compose_hash}
+
+    candidates = [a for a in artifacts if a.kind == kind]
+    if not candidates:
+        kinds = sorted({a.kind for a in artifacts}) or ["(none)"]
+        raise TripleNotFound(
+            f"the catalog carries no {kind!r} artifact (it has: {', '.join(kinds)})"
+        )
+
+    for field, value in requested.items():
+        narrowed = [a for a in candidates if getattr(a, field) == value]
+        if not narrowed:
+            approved = sorted({getattr(a, field) for a in candidates})
+            raise TripleNotFound(
+                f"{field}={value!r} is not approved for kind={kind!r}; the catalog allows: "
+                f"{', '.join(approved)}"
+            )
+        candidates = narrowed
+
+    # load_catalog already rejected duplicate (kind, triple) pairs, so exactly one survives.
+    return candidates[0]

--- a/neurons/executor/cvmd/src/cvmd/config.py
+++ b/neurons/executor/cvmd/src/cvmd/config.py
@@ -19,6 +19,15 @@ DEFAULT_SKEW_SECONDS = 60
 # held for the whole window (see LaunchConfig).
 DEFAULT_LAUNCH_TIMEOUT_SECONDS = 900
 
+# How long a graceful poweroff is given before cvmd signals the process group.
+#
+# A large-memory TDX guest returns its RAM to the host as it exits, and that is slow — 43
+# minutes was measured for a 1.13 TB guest on this fleet. So this is a floor for ordinary
+# sizes, not a budget for the largest ones; setting it too low turns a legitimate slow exit
+# into a SIGKILL partway through. Per-hardware-class budgets are DAH-2577's open item, which
+# is why this is a setting rather than a constant.
+DEFAULT_TEARDOWN_TIMEOUT_SECONDS = 600
+
 # dstack's default key-provider port. lium-cvm.sh relies on the same default.
 DEFAULT_KEY_PROVIDER_PORT = 3443
 
@@ -50,6 +59,7 @@ class LaunchConfig:
     run_dir: Path | None = None
     key_provider_port: int = DEFAULT_KEY_PROVIDER_PORT
     launch_timeout_seconds: int = DEFAULT_LAUNCH_TIMEOUT_SECONDS
+    teardown_timeout_seconds: int = DEFAULT_TEARDOWN_TIMEOUT_SECONDS
 
     vcpus: int | None = None
     memory: str | None = None
@@ -185,6 +195,10 @@ def _load_launch(table: dict) -> LaunchConfig:
             _get(table, "launch_timeout_seconds", DEFAULT_LAUNCH_TIMEOUT_SECONDS),
             "launch_timeout_seconds",
         ),
+        teardown_timeout_seconds=_as_int(
+            _get(table, "teardown_timeout_seconds", DEFAULT_TEARDOWN_TIMEOUT_SECONDS),
+            "teardown_timeout_seconds",
+        ),
         vcpus=_as_optional_int(_get(table, "cvm_vcpus"), "cvm_vcpus"),
         memory=_as_optional_str(_get(table, "cvm_memory")),
         disk=_as_optional_str(_get(table, "cvm_disk")),
@@ -201,6 +215,8 @@ def _load_launch(table: dict) -> LaunchConfig:
         raise ConfigError("`key_provider_port` must be positive")
     if launch.launch_timeout_seconds <= 0:
         raise ConfigError("`launch_timeout_seconds` must be positive")
+    if launch.teardown_timeout_seconds <= 0:
+        raise ConfigError("`teardown_timeout_seconds` must be positive")
     return launch
 
 

--- a/neurons/executor/cvmd/src/cvmd/config.py
+++ b/neurons/executor/cvmd/src/cvmd/config.py
@@ -14,12 +14,73 @@ DEFAULT_MAX_BODY_BYTES = 64 * 1024
 # The freshness window the request timestamp must fall inside, in seconds.
 DEFAULT_SKEW_SECONDS = 60
 
+# How long a launch waits for the guest to become reachable before giving up. A TDX guest with
+# a large memory backing takes minutes to boot, so this is generous by design; the request is
+# held for the whole window (see LaunchConfig).
+DEFAULT_LAUNCH_TIMEOUT_SECONDS = 900
+
+# dstack's default key-provider port. lium-cvm.sh relies on the same default.
+DEFAULT_KEY_PROVIDER_PORT = 3443
+
 
 class ConfigError(Exception):
     """Raised when the config file is missing, malformed, or internally inconsistent.
 
     Always fatal: cvmd refuses to start rather than run on a half-understood config.
     """
+
+
+@dataclass(frozen=True)
+class LaunchConfig:
+    """Everything the launch path needs that is not in the request.
+
+    Sizing is **provider configuration**, never an API field: a cvmd request names which
+    software stack to run, and the host decides how big it is. That was settled while
+    reviewing DAH-2575 and is why `CreateCvmRequest` carries no vcpu/memory/disk/gpu.
+
+    Every field is optional because a node can legitimately be installed before it has a
+    catalog — refusing to start would take `/v1/state` down with it. `missing()` names what a
+    launch would need, so an incomplete config fails at the point of use with a specific
+    reason rather than at import with a stack trace. A *malformed* value is still fatal at
+    startup: absent and wrong are different problems.
+    """
+
+    dstack_scripts_dir: Path | None = None
+    catalog_path: Path | None = None
+    run_dir: Path | None = None
+    key_provider_port: int = DEFAULT_KEY_PROVIDER_PORT
+    launch_timeout_seconds: int = DEFAULT_LAUNCH_TIMEOUT_SECONDS
+
+    vcpus: int | None = None
+    memory: str | None = None
+    disk: str | None = None
+    gpus: tuple[str, ...] = ()
+    ports: tuple[str, ...] = ()
+    env_file: Path | None = None
+    # The guest-side port carrying SSH. When set, cvmd reads the guest's host key off the
+    # forwarded port and treats that as proof the CVM is up. When unset, readiness falls back
+    # to a plain TCP accept and the launch report's fingerprint is null — honest degradation
+    # rather than a guessed port.
+    ssh_guest_port: int | None = None
+    pin_numa: bool = False
+    hugepages: bool = False
+
+    # Required for a launch. `gpus` is deliberately absent: a CVM with no GPUs is a legal
+    # configuration, so an empty list cannot be distinguished from an unset one and must not
+    # block a launch.
+    _REQUIRED = (
+        "dstack_scripts_dir",
+        "catalog_path",
+        "run_dir",
+        "vcpus",
+        "memory",
+        "disk",
+        "ports",
+    )
+
+    def missing(self) -> list[str]:
+        """Names of the settings a launch needs and does not have."""
+        return [name for name in self._REQUIRED if not getattr(self, name)]
 
 
 @dataclass(frozen=True)
@@ -32,6 +93,7 @@ class Config:
     tls_key: Path | None = None
     skew_seconds: int = DEFAULT_SKEW_SECONDS
     max_body_bytes: int = DEFAULT_MAX_BODY_BYTES
+    launch: LaunchConfig = LaunchConfig()
 
     @property
     def tls_enabled(self) -> bool:
@@ -61,6 +123,85 @@ def _as_int(value, key: str) -> int:
         return int(value)
     except (TypeError, ValueError) as exc:
         raise ConfigError(f"{key} must be an integer, got {value!r}") from exc
+
+
+def _as_optional_int(value, key: str) -> int | None:
+    if value is None or value == "":
+        return None
+    return _as_int(value, key)
+
+
+def _as_optional_str(value) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _as_tuple(value, key: str) -> tuple[str, ...]:
+    """A list in TOML, or a comma-separated string from an env override.
+
+    Both spellings exist because config.toml is written by Ansible while the env vars are how
+    tests and operators poke one setting without editing the file.
+    """
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return tuple(item.strip() for item in value.split(",") if item.strip())
+    if isinstance(value, (list, tuple)):
+        items = []
+        for item in value:
+            if not isinstance(item, str):
+                raise ConfigError(f"{key} must be a list of strings, got {item!r}")
+            if item.strip():
+                items.append(item.strip())
+        return tuple(items)
+    raise ConfigError(f"{key} must be a list of strings or a comma-separated string")
+
+
+def _as_bool(value, key: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    text = str(value).strip().lower()
+    if text in ("true", "1", "yes", "on"):
+        return True
+    if text in ("false", "0", "no", "off", ""):
+        return False
+    raise ConfigError(f"{key} must be a boolean, got {value!r}")
+
+
+def _load_launch(table: dict) -> LaunchConfig:
+    """Read the DAH-2576 launch settings. Absent is fine; malformed is fatal."""
+    launch = LaunchConfig(
+        dstack_scripts_dir=_as_path(_get(table, "dstack_scripts_dir")),
+        catalog_path=_as_path(_get(table, "catalog_path")),
+        run_dir=_as_path(_get(table, "run_dir")),
+        key_provider_port=_as_int(
+            _get(table, "key_provider_port", DEFAULT_KEY_PROVIDER_PORT), "key_provider_port"
+        ),
+        launch_timeout_seconds=_as_int(
+            _get(table, "launch_timeout_seconds", DEFAULT_LAUNCH_TIMEOUT_SECONDS),
+            "launch_timeout_seconds",
+        ),
+        vcpus=_as_optional_int(_get(table, "cvm_vcpus"), "cvm_vcpus"),
+        memory=_as_optional_str(_get(table, "cvm_memory")),
+        disk=_as_optional_str(_get(table, "cvm_disk")),
+        gpus=_as_tuple(_get(table, "cvm_gpus"), "cvm_gpus"),
+        ports=_as_tuple(_get(table, "cvm_ports"), "cvm_ports"),
+        env_file=_as_path(_get(table, "cvm_env_file")),
+        ssh_guest_port=_as_optional_int(_get(table, "cvm_ssh_guest_port"), "cvm_ssh_guest_port"),
+        pin_numa=_as_bool(_get(table, "cvm_pin_numa"), "cvm_pin_numa"),
+        hugepages=_as_bool(_get(table, "cvm_hugepages"), "cvm_hugepages"),
+    )
+    if launch.vcpus is not None and launch.vcpus <= 0:
+        raise ConfigError("`cvm_vcpus` must be positive")
+    if launch.key_provider_port <= 0:
+        raise ConfigError("`key_provider_port` must be positive")
+    if launch.launch_timeout_seconds <= 0:
+        raise ConfigError("`launch_timeout_seconds` must be positive")
+    return launch
 
 
 def load_config(path: Path | None = None) -> Config:
@@ -105,4 +246,5 @@ def load_config(path: Path | None = None) -> Config:
         tls_key=tls_key,
         skew_seconds=skew_seconds,
         max_body_bytes=max_body_bytes,
+        launch=_load_launch(table),
     )

--- a/neurons/executor/cvmd/src/cvmd/config.py
+++ b/neurons/executor/cvmd/src/cvmd/config.py
@@ -5,6 +5,8 @@ import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
+from cvmd.cvm import ports
+
 DEFAULT_CONFIG_PATH = Path("/etc/cvmd/config.toml")
 
 # Real request bodies are a `kind` plus three hashes — hundreds of bytes. The cap exists so an
@@ -209,6 +211,16 @@ def _load_launch(table: dict) -> LaunchConfig:
         pin_numa=_as_bool(_get(table, "cvm_pin_numa"), "cvm_pin_numa"),
         hugepages=_as_bool(_get(table, "cvm_hugepages"), "cvm_hugepages"),
     )
+    # Parsed with the launch path's own parser, not re-described here. Without this a mapping
+    # like "tcp:0.0.0.0:0:22" is well-formed TOML, so the daemon starts looking configured and
+    # refuses every launch at the first request — the failure mode the whole fail-at-startup
+    # rule exists to avoid. It is also what lets Ansible check the rendered file by running
+    # `load_config` against it, the same way it checks the catalog with `load_catalog`.
+    try:
+        ports.parse_all(launch.ports)
+    except ports.PortError as exc:
+        raise ConfigError(f"`cvm_ports`: {exc}") from exc
+
     if launch.vcpus is not None and launch.vcpus <= 0:
         raise ConfigError("`cvm_vcpus` must be positive")
     if launch.key_provider_port <= 0:

--- a/neurons/executor/cvmd/src/cvmd/cvm/__init__.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/__init__.py
@@ -1,0 +1,6 @@
+"""The CVM launch path — DAH-2576.
+
+`manager.py` is the entry point; everything else is one step of it. The order in `manager` is
+the safety argument: guard, resolve, prepare, **measure**, then launch. Nothing reaches QEMU
+until the artifacts on disk hash to the triple the caller asked for.
+"""

--- a/neurons/executor/cvmd/src/cvmd/cvm/instance.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/instance.py
@@ -1,0 +1,130 @@
+"""What CVM this node is running, persisted beside the state document.
+
+Kept out of `state.json` on purpose. The state document is a small, fully-pinned contract that
+DAH-2575 shipped and its tests assert byte for byte; the instance record is a bag of facts that
+will keep growing as DAH-2577 adds teardown timings and DAH-2580 adds renter metadata. Two
+files with separate lifetimes cost one extra write and stop every future field from being a
+change to a contract other components read.
+
+The record is the node's answer to "what is running here". It is written before the supervisor
+is spawned — a record with no process is a recoverable inconsistency, while a process with no
+record is an orphan cvmd cannot find, stop, or report.
+"""
+
+from dataclasses import asdict, dataclass, field, replace
+from datetime import UTC, datetime
+from pathlib import Path
+
+from cvmd.atomic import read_json, write_json_durable
+
+INSTANCE_FILENAME = "instance.json"
+SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class PortReport:
+    protocol: str
+    address: str
+    host_port: int
+    guest_port: int
+
+
+@dataclass(frozen=True)
+class Instance:
+    """One CVM. `ssh_fingerprint` is None until the guest is up and has been probed."""
+
+    instance_id: str
+    kind: str
+    artifact_id: str
+    vm_dir: str
+    supervisor_pid: int
+    created_at: str
+    qemu: str
+    os_image_hash: str
+    compose_hash: str
+    ports: list[PortReport] = field(default_factory=list)
+    ssh_fingerprint: str | None = None
+
+    def to_json(self) -> dict:
+        return {"version": SCHEMA_VERSION, **asdict(self)}
+
+    def report(self) -> dict:
+        """The launch report the API returns: identity, reachability, and what it measures as."""
+        return {
+            "instance_id": self.instance_id,
+            "kind": self.kind,
+            "artifact_id": self.artifact_id,
+            "ports": [asdict(port) for port in self.ports],
+            "ssh_host_key_fingerprint": self.ssh_fingerprint,
+            "measurements": {
+                "qemu": self.qemu,
+                "os_image_hash": self.os_image_hash,
+                "compose_hash": self.compose_hash,
+            },
+        }
+
+
+def now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _decode(raw) -> Instance | None:
+    if not isinstance(raw, dict) or raw.get("version") != SCHEMA_VERSION:
+        return None
+    try:
+        ports = [PortReport(**port) for port in raw.get("ports", [])]
+        return Instance(
+            instance_id=str(raw["instance_id"]),
+            kind=str(raw["kind"]),
+            artifact_id=str(raw["artifact_id"]),
+            vm_dir=str(raw["vm_dir"]),
+            supervisor_pid=int(raw["supervisor_pid"]),
+            created_at=str(raw["created_at"]),
+            qemu=str(raw["qemu"]),
+            os_image_hash=str(raw["os_image_hash"]),
+            compose_hash=str(raw["compose_hash"]),
+            ports=ports,
+            ssh_fingerprint=raw.get("ssh_fingerprint"),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+class InstanceStore:
+    """Holds the current instance record, or None when the node is running no CVM.
+
+    A record that cannot be decoded is treated as **absent but noted**, never as a fresh node:
+    the caller gets None and `load_error` explains why, so an unreadable file surfaces as a
+    refusal to launch over the top of something rather than as a clean slate.
+    """
+
+    def __init__(self, state_dir: Path) -> None:
+        self._path = state_dir / INSTANCE_FILENAME
+        self._instance: Instance | None = None
+        self.load_error: str | None = None
+
+        if self._path.exists():
+            decoded = _decode(read_json(self._path))
+            if decoded is None:
+                self.load_error = f"{self._path} is unreadable or malformed"
+            self._instance = decoded
+
+    @property
+    def current(self) -> Instance | None:
+        return self._instance
+
+    def set(self, instance: Instance) -> Instance:
+        self._instance = instance
+        write_json_durable(self._path, instance.to_json())
+        self.load_error = None
+        return instance
+
+    def update(self, **changes) -> Instance:
+        if self._instance is None:
+            raise ValueError("no instance to update")
+        return self.set(replace(self._instance, **changes))
+
+    def clear(self) -> None:
+        self._instance = None
+        self.load_error = None
+        self._path.unlink(missing_ok=True)

--- a/neurons/executor/cvmd/src/cvmd/cvm/manager.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/manager.py
@@ -39,7 +39,6 @@ RUNNING_STATE = {
 }
 
 READINESS_POLL_SECONDS = 5
-DEFAULT_SHUTDOWN_TIMEOUT_SECONDS = 120
 
 # Probing localhost, not the mapping's bind address: 0.0.0.0 is not a destination, and a
 # forward bound to a public address is still reachable from the host it runs on.
@@ -496,14 +495,14 @@ class CvmManager:
                 # ours to signal — refusing to stop would be worse than stopping abruptly.
                 logger.warning("%s; falling back to signalling the process group", exc.reason)
                 detail = supervisor.shutdown_by_signal(
-                    instance.supervisor_pid, timeout=DEFAULT_SHUTDOWN_TIMEOUT_SECONDS
+                    instance.supervisor_pid, timeout=self._config.teardown_timeout_seconds
                 )
             else:
                 detail = supervisor.shutdown(
                     dstack,
                     vm_dir,
                     instance.supervisor_pid,
-                    timeout=DEFAULT_SHUTDOWN_TIMEOUT_SECONDS,
+                    timeout=self._config.teardown_timeout_seconds,
                 )
 
         still_there = supervisor.is_supervisor(instance.supervisor_pid, vm_dir)

--- a/neurons/executor/cvmd/src/cvmd/cvm/manager.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/manager.py
@@ -60,6 +60,11 @@ class LaunchFailure(Exception):
         self.reason = reason
 
 
+def _describe(running: list[tuple[int, str]]) -> str:
+    """How a refusal names the guests `supervisor.running_cvms()` found."""
+    return ", ".join(f"pid {pid} ({name})" for pid, name in running)
+
+
 @dataclass(frozen=True)
 class Triple:
     qemu: str
@@ -184,7 +189,13 @@ class CvmManager:
                     NodeState.FAILED,
                     last_error=f"reconciliation found {state} while the node was {current}",
                 )
+            # From the staging point the edge is legal, so ask again from there. Recursing
+            # rather than transitioning straight away is what keeps RECONCILING working as a
+            # destination as well as a waypoint: the equality branch above is then the one that
+            # answers, instead of this line requesting the RECONCILING -> RECONCILING self-edge
+            # the machine does not have.
             self._store.transition(NodeState.RECONCILING)
+            return self._settle(state)
         return self._store.transition(state).state
 
     def _fail(self, reason: str) -> NodeState:
@@ -208,6 +219,8 @@ class CvmManager:
         dstack = self._load_dstack()
         artifact = self._resolve(kind, triple)
         mappings = self._parse_ports()
+
+        self._assert_ssh_port_is_forwarded(mappings)
 
         self._assert_node_is_free()
         try:
@@ -267,6 +280,28 @@ class CvmManager:
         except ports.PortError as exc:
             raise LaunchFailure(503, f"this host's cvm_ports setting is unusable: {exc}") from exc
 
+    def _assert_ssh_port_is_forwarded(self, mappings: list[ports.PortMapping]) -> None:
+        """A configured SSH guest port that nothing forwards is a refusal, not a degradation.
+
+        Readiness and the report's fingerprint both come from reading the guest's host key
+        through that forward. With no mapping to read it through there is no readiness check
+        left at all, and answering 201 VALIDATION_RUNNING milliseconds after spawning QEMU
+        would tell the caller the CVM is up before the guest has booted. Refusing here names
+        the setting that is wrong, before anything is prepared or started.
+
+        Asked through `_readiness_port`, so this is the same lookup the readiness loop will
+        make rather than a second copy of the matching rule.
+        """
+        if self._config.ssh_guest_port is None or self._readiness_port(mappings) is not None:
+            return
+        forwarded = ", ".join(str(mapping) for mapping in mappings) or "(none)"
+        raise LaunchFailure(
+            503,
+            f"this host's cvm_ssh_guest_port is {self._config.ssh_guest_port}, which none of "
+            f"its cvm_ports forwards ({forwarded}); readiness and the launch report's SSH "
+            f"fingerprint are both read through that forward, so there is nothing to probe",
+        )
+
     def _assert_node_is_free(self) -> None:
         """One CVM per node, checked against the host rather than against cvmd's own records.
 
@@ -276,11 +311,10 @@ class CvmManager:
         """
         running = supervisor.running_cvms()
         if running:
-            listed = ", ".join(f"pid {pid} ({name})" for pid, name in running)
             raise LaunchFailure(
                 409,
-                f"a confidential guest is already running on this host ({listed}); GPU "
-                f"passthrough is exclusive, so this node can hold only one",
+                f"a confidential guest is already running on this host ({_describe(running)}); "
+                f"GPU passthrough is exclusive, so this node can hold only one",
             )
 
         instance = self._instances.current
@@ -409,6 +443,19 @@ class CvmManager:
         probe = self._readiness_port(mappings)
         deadline = time.monotonic() + self._config.launch_timeout_seconds
         want_fingerprint = self._config.ssh_guest_port is not None and probe is not None
+        weak_note = "port accepts connections; no SSH probe configured"
+        if want_fingerprint and not sshkey.keyscan_available():
+            # Asked once, here, rather than discovered inside the loop. `read_host_key` returns
+            # None when ssh-keyscan is absent, which is indistinguishable from "the guest is not
+            # up yet" — so without this the loop would poll for the whole launch timeout, then
+            # fail a node whose CVM had booted fine.
+            logger.warning(
+                "ssh-keyscan is not installed, so no SSH host-key fingerprint can be reported "
+                "for this launch; readiness falls back to a TCP accept on port %d",
+                probe.host_port,
+            )
+            want_fingerprint = False
+            weak_note = "port accepts connections; ssh-keyscan is not installed on this host"
 
         while time.monotonic() < deadline:
             if not supervisor.is_supervisor(instance.supervisor_pid, vm_dir):
@@ -428,9 +475,7 @@ class CvmManager:
                     instance = self._instances.update(ssh_fingerprint=fingerprint)
                     return self._running(instance)
             elif sshkey.accepts_connection(PROBE_HOST, probe.host_port):
-                return self._running(
-                    instance, note="port accepts connections; no SSH probe configured"
-                )
+                return self._running(instance, note=weak_note)
 
             time.sleep(READINESS_POLL_SECONDS)
 
@@ -472,6 +517,23 @@ class CvmManager:
             stray = self._stray_directories()
             if not stray:
                 return {"torn_down": False, "reason": "this node is running no CVM"}
+
+            # A directory cvmd has no record of may still have a guest under it — that is what
+            # "no record" usually means. Removing the disk from a live QEMU would report a
+            # teardown that did not happen and leave the node's GPUs and forwarded ports held
+            # by a process nothing can find, since the record that named its pid is what went
+            # missing. The `/proc` scan is the only evidence available here, so it decides.
+            running = supervisor.running_cvms()
+            if running:
+                reason = (
+                    f"{', '.join(str(path) for path in stray)} holds a CVM cvmd has no record "
+                    f"of and a confidential guest is still running ({_describe(running)}); its "
+                    f"disk was left in place and it must be stopped by hand before this node "
+                    f"is free"
+                )
+                self._fail(reason)
+                raise LaunchFailure(409, reason)
+
             for path in stray:
                 self._discard(path)
             self._settle(NodeState.RECONCILING)

--- a/neurons/executor/cvmd/src/cvmd/cvm/manager.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/manager.py
@@ -1,0 +1,519 @@
+"""The launch path, in the order that makes it safe.
+
+    guard -> resolve -> prepare -> MEASURE -> launch -> confirm
+
+Nothing reaches QEMU until the artifacts written to disk hash to the triple the caller asked
+for. Every refusal below is a refusal *before* a VM exists, which is what keeps a rejected
+launch from leaving the node in a state someone has to clean up by hand.
+
+Every method here is blocking. `create` runs `setup_instance`, spawns a process and then waits
+minutes for a guest to boot — the routes call it on a worker thread so the daemon keeps
+answering `/v1/state` while a launch is in flight, which is the only way the state transitions
+are observable to anyone.
+"""
+
+import logging
+import shutil
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+from cvmd import catalog
+from cvmd.config import LaunchConfig
+from cvmd.cvm import measure, ports, sshkey, supervisor
+from cvmd.cvm.instance import Instance, InstanceStore, PortReport, now_iso
+from cvmd.dstack.loader import DStackUnavailable, load_dstack
+from cvmd.dstack.plan import setup_namespace
+from cvmd.state.machine import NodeState, is_legal
+from cvmd.state.store import StateStore
+
+logger = logging.getLogger(__name__)
+
+KIND_VALIDATION = "validation"
+KIND_RENTER = "renter"
+
+RUNNING_STATE = {
+    KIND_VALIDATION: NodeState.VALIDATION_RUNNING,
+    KIND_RENTER: NodeState.RENTER_RUNNING,
+}
+
+READINESS_POLL_SECONDS = 5
+DEFAULT_SHUTDOWN_TIMEOUT_SECONDS = 120
+
+# Probing localhost, not the mapping's bind address: 0.0.0.0 is not a destination, and a
+# forward bound to a public address is still reachable from the host it runs on.
+PROBE_HOST = "127.0.0.1"
+
+
+class LaunchFailure(Exception):
+    """A refusal, carrying the HTTP status that describes *why* it was refused.
+
+    Statuses are chosen so a caller can act on them without parsing prose: 503 means this host
+    is not equipped for the request, 409 means the host's current state forbids it, 422 means
+    the request named something this host will not run, 504 means the CVM was started but did
+    not come up in time.
+    """
+
+    def __init__(self, status: int, reason: str) -> None:
+        super().__init__(reason)
+        self.status = status
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class Triple:
+    qemu: str
+    os_image_hash: str
+    compose_hash: str
+
+    def as_tuple(self) -> tuple[str, str, str]:
+        return (self.qemu, self.os_image_hash, self.compose_hash)
+
+
+class CvmManager:
+    def __init__(
+        self, *, config: LaunchConfig, store: StateStore, instances: InstanceStore
+    ) -> None:
+        self._config = config
+        self._store = store
+        self._instances = instances
+
+    # ------------------------------------------------------------------ reporting
+
+    def describe(self) -> dict | None:
+        """What `/v1/state` reports about the CVM, if there is one."""
+        instance = self._instances.current
+        if instance is None:
+            return None
+        return {
+            **instance.report(),
+            "supervisor_pid": instance.supervisor_pid,
+            "supervisor_alive": supervisor.is_supervisor(
+                instance.supervisor_pid, Path(instance.vm_dir)
+            ),
+            "created_at": instance.created_at,
+        }
+
+    # ------------------------------------------------------------------ reconcile
+
+    @property
+    def manages_cvms(self) -> bool:
+        """Is this host configured to hold CVMs at all?
+
+        A cvmd installed before its catalog and run directory exist is a legitimate state, and
+        on such a host there is nothing to reconcile *against*. Re-deriving a state from facts
+        it cannot observe would be worse than leaving the persisted one alone.
+        """
+        return self._config.run_dir is not None
+
+    def reconcile(self) -> NodeState:
+        """Derive the node's state from what is actually on the host.
+
+        Runs at startup, which is the case that matters: a CVM outlives a cvmd restart by
+        design, so the daemon must be able to come back under a running guest and land on the
+        right state without pretending it launched it. `RECONCILING` doubles as the idle state
+        — the machine has no separate IDLE, and every edge out of `RECONCILING` says so.
+        """
+        if not self.manages_cvms:
+            return self._store.state
+
+        if self._instances.load_error:
+            return self._fail(
+                f"{self._instances.load_error}; refusing to assume this node is idle while a "
+                f"CVM it forgot may still be running"
+            )
+
+        instance = self._instances.current
+        if instance is not None:
+            vm_dir = Path(instance.vm_dir)
+            if supervisor.is_supervisor(instance.supervisor_pid, vm_dir):
+                logger.info("adopted the running %s CVM %s", instance.kind, instance.instance_id)
+                state = RUNNING_STATE.get(instance.kind)
+                if state is None:
+                    return self._fail(
+                        f"CVM {instance.instance_id} has unknown kind {instance.kind!r}"
+                    )
+                return self._settle(state)
+            return self._fail(
+                f"the supervisor for CVM {instance.instance_id} (pid {instance.supervisor_pid}) "
+                f"is gone but its directory {vm_dir} remains"
+            )
+
+        stray = self._stray_directories()
+        if stray:
+            return self._fail(
+                f"{', '.join(str(path) for path in stray)} holds a CVM disk that cvmd has no "
+                f"record of, so this node's resources may already be committed"
+            )
+
+        # No CVM here. If the persisted state claimed one was running, the node lost it while
+        # cvmd was not looking — that is a failure, not an idle node, and saying so is the
+        # difference between a node an operator investigates and one that silently drops work.
+        if self._store.state in (
+            NodeState.LAUNCHING,
+            NodeState.VALIDATION_RUNNING,
+            NodeState.RENTER_RUNNING,
+        ):
+            return self._fail(f"this node was {self._store.state} but no CVM is running on it")
+
+        logger.info("no CVM on this node")
+        return self._settle(NodeState.RECONCILING)
+
+    def _stray_directories(self) -> list[Path]:
+        run_dir = self._config.run_dir
+        return supervisor.vm_directories(run_dir) if run_dir else []
+
+    def _settle(self, state: NodeState) -> NodeState:
+        """Move to `state`, clearing any stale error, going the long way if the edge is illegal.
+
+        The machine's edges describe an orderly lifecycle; reconciliation runs exactly when the
+        node has not had one. `RECONCILING` reaches every state, so it is the universal
+        staging point — and reaching it from a running state means something discontinuous
+        happened, which is what `FAILED` is for. Coercing the edge instead would report a state
+        the host was never observed in.
+        """
+        current = self._store.state
+        if current == state:
+            if self._store.document.last_error is not None:
+                self._store.record_error(None)
+            return state
+
+        if not is_legal(current, state):
+            if not is_legal(current, NodeState.RECONCILING):
+                self._store.transition(
+                    NodeState.FAILED,
+                    last_error=f"reconciliation found {state} while the node was {current}",
+                )
+            self._store.transition(NodeState.RECONCILING)
+        return self._store.transition(state).state
+
+    def _fail(self, reason: str) -> NodeState:
+        logger.error("reconciliation failed: %s", reason)
+        if self._store.state == NodeState.FAILED:
+            self._store.record_error(reason)
+            return NodeState.FAILED
+        return self._store.transition(NodeState.FAILED, last_error=reason).state
+
+    # ------------------------------------------------------------------ create
+
+    def create(self, *, kind: str, triple: Triple) -> dict:
+        """Launch a CVM and return its launch report. Raises LaunchFailure on any refusal."""
+        config = self._config
+        missing = config.missing()
+        if missing:
+            raise LaunchFailure(
+                503, f"this host has no launch configuration for {', '.join(missing)}"
+            )
+
+        dstack = self._load_dstack()
+        artifact = self._resolve(kind, triple)
+        mappings = self._parse_ports()
+
+        self._assert_node_is_free()
+        try:
+            ports.assert_free(mappings)
+        except ports.PortError as exc:
+            raise LaunchFailure(409, str(exc)) from exc
+
+        self._enter_launching()
+
+        instance_id = str(uuid.uuid4())
+        vm_dir = config.run_dir / instance_id
+        try:
+            self._prepare(dstack, artifact=artifact, vm_dir=vm_dir)
+            measured = self._measure(dstack, artifact=artifact, vm_dir=vm_dir, triple=triple)
+        except LaunchFailure:
+            # The directory is the whole footprint of a launch that never started a process,
+            # so removing it returns the node to exactly where it was.
+            self._discard(vm_dir)
+            raise
+
+        instance = self._start(
+            dstack_scripts_dir=config.dstack_scripts_dir,
+            artifact=artifact,
+            instance_id=instance_id,
+            vm_dir=vm_dir,
+            mappings=mappings,
+            measured=measured,
+            kind=kind,
+        )
+        return self._await_ready(instance, mappings)
+
+    def _load_dstack(self):
+        try:
+            return load_dstack(self._config.dstack_scripts_dir)
+        except DStackUnavailable as exc:
+            raise LaunchFailure(503, f"this host cannot run the dstack launcher: {exc}") from exc
+
+    def _resolve(self, kind: str, triple: Triple) -> catalog.Artifact:
+        try:
+            artifacts = catalog.load_catalog(self._config.catalog_path)
+        except catalog.CatalogError as exc:
+            raise LaunchFailure(503, str(exc)) from exc
+        try:
+            return catalog.resolve(
+                artifacts,
+                kind=kind,
+                qemu=triple.qemu,
+                os_image_hash=triple.os_image_hash,
+                compose_hash=triple.compose_hash,
+            )
+        except catalog.TripleNotFound as exc:
+            raise LaunchFailure(422, str(exc)) from exc
+
+    def _parse_ports(self) -> list[ports.PortMapping]:
+        try:
+            return ports.parse_all(self._config.ports)
+        except ports.PortError as exc:
+            raise LaunchFailure(503, f"this host's cvm_ports setting is unusable: {exc}") from exc
+
+    def _assert_node_is_free(self) -> None:
+        """One CVM per node, checked against the host rather than against cvmd's own records.
+
+        The `/proc` scan comes first deliberately: it is the only check that also sees a CVM
+        started by `lium-cvm.sh`, and during the CVM v2 rollout that is the one most likely to
+        be there.
+        """
+        running = supervisor.running_cvms()
+        if running:
+            listed = ", ".join(f"pid {pid} ({name})" for pid, name in running)
+            raise LaunchFailure(
+                409,
+                f"a confidential guest is already running on this host ({listed}); GPU "
+                f"passthrough is exclusive, so this node can hold only one",
+            )
+
+        instance = self._instances.current
+        if instance is not None:
+            raise LaunchFailure(
+                409,
+                f"this node already has CVM {instance.instance_id} ({instance.kind}); destroy "
+                f"it before launching another",
+            )
+
+        stray = self._stray_directories()
+        if stray:
+            raise LaunchFailure(
+                409,
+                f"{', '.join(str(path) for path in stray)} still holds a CVM disk; destroy it "
+                f"before launching another",
+            )
+
+    def _enter_launching(self) -> None:
+        # FAILED reaches LAUNCHING only through RECONCILING — recovery is deliberate, so the
+        # daemon re-derives the host's real state instead of assuming the failure cleared.
+        if self._store.state == NodeState.FAILED:
+            self.reconcile()
+            if self._store.state == NodeState.FAILED:
+                raise LaunchFailure(
+                    409,
+                    f"this node is FAILED and reconciliation did not clear it: "
+                    f"{self._store.document.last_error}",
+                )
+        self._store.transition(NodeState.LAUNCHING)
+
+    def _prepare(self, dstack, *, artifact: catalog.Artifact, vm_dir: Path) -> None:
+        """Write the VM directory using dstack's own `setup_instance`. No CVM exists yet."""
+        namespace = setup_namespace(artifact=artifact, launch=self._config, vm_dir=vm_dir)
+        try:
+            self._config.run_dir.mkdir(parents=True, exist_ok=True)
+            dstack.DStackManager().setup_instance(namespace)
+        except Exception as exc:  # noqa: BLE001 - setup_instance raises whatever it hits
+            self._store.transition(NodeState.FAILED, last_error=f"preparing {vm_dir} failed: {exc}")
+            raise LaunchFailure(500, f"preparing the CVM failed: {exc}") from exc
+
+    def _measure(
+        self, dstack, *, artifact: catalog.Artifact, vm_dir: Path, triple: Triple
+    ) -> measure.Measurements:
+        try:
+            measured = measure.measure(
+                dstack=dstack, vm_dir=vm_dir, image_path=artifact.os_image_path
+            )
+            measure.assert_matches(measured, triple.as_tuple())
+        except measure.MeasurementError as exc:
+            self._store.transition(NodeState.FAILED, last_error=str(exc))
+            raise LaunchFailure(409, str(exc)) from exc
+        logger.info("%s measures as the requested triple", vm_dir)
+        return measured
+
+    def _discard(self, vm_dir: Path) -> None:
+        shutil.rmtree(vm_dir, ignore_errors=True)
+
+    def _start(
+        self,
+        *,
+        dstack_scripts_dir: Path,
+        artifact: catalog.Artifact,
+        instance_id: str,
+        vm_dir: Path,
+        mappings: list[ports.PortMapping],
+        measured: measure.Measurements,
+        kind: str,
+    ) -> Instance:
+        try:
+            pid = supervisor.spawn(
+                scripts_dir=dstack_scripts_dir,
+                vm_dir=vm_dir,
+                kp_port=self._config.key_provider_port,
+            )
+        except supervisor.SupervisorError as exc:
+            self._store.transition(NodeState.FAILED, last_error=str(exc))
+            self._discard(vm_dir)
+            raise LaunchFailure(500, str(exc)) from exc
+
+        # Recorded immediately: from here on a process exists, and a process cvmd has no record
+        # of is one it can neither report nor stop. The VM directory covers the gap between
+        # spawn and this write — `reconcile` finds it and fails the node loudly.
+        return self._instances.set(
+            Instance(
+                instance_id=instance_id,
+                kind=kind,
+                artifact_id=artifact.id,
+                vm_dir=str(vm_dir),
+                supervisor_pid=pid,
+                created_at=now_iso(),
+                qemu=measured.qemu,
+                os_image_hash=measured.os_image_hash,
+                compose_hash=measured.compose_hash,
+                ports=[
+                    PortReport(
+                        protocol=m.protocol,
+                        address=m.address,
+                        host_port=m.host_port,
+                        guest_port=m.guest_port,
+                    )
+                    for m in mappings
+                ],
+            )
+        )
+
+    # ------------------------------------------------------------------ readiness
+
+    def _readiness_port(self, mappings: list[ports.PortMapping]) -> ports.PortMapping | None:
+        guest_port = self._config.ssh_guest_port
+        if guest_port is None:
+            return mappings[0] if mappings else None
+        for mapping in mappings:
+            if mapping.guest_port == guest_port:
+                return mapping
+        return None
+
+    def _await_ready(self, instance: Instance, mappings: list[ports.PortMapping]) -> dict:
+        """Hold until the guest answers, then move to the running state.
+
+        The SSH host key is both the report's fingerprint field and the readiness signal: it
+        can only be read once sshd inside the guest is answering through the forward, which is
+        a much later — and much more meaningful — moment than QEMU accepting a connection.
+        """
+        vm_dir = Path(instance.vm_dir)
+        probe = self._readiness_port(mappings)
+        deadline = time.monotonic() + self._config.launch_timeout_seconds
+        want_fingerprint = self._config.ssh_guest_port is not None and probe is not None
+
+        while time.monotonic() < deadline:
+            if not supervisor.is_supervisor(instance.supervisor_pid, vm_dir):
+                reason = f"the CVM exited while booting; see {supervisor.console_log_path(vm_dir)}"
+                self._store.transition(NodeState.FAILED, last_error=reason)
+                raise LaunchFailure(500, reason)
+
+            if probe is None:
+                # Nothing is forwarded, so there is nothing to probe. The supervisor being
+                # alive is the only readiness evidence available, and saying so is better than
+                # inventing a check.
+                return self._running(instance, note="no forwarded port to probe")
+
+            if want_fingerprint:
+                fingerprint = sshkey.read_host_key(PROBE_HOST, probe.host_port)
+                if fingerprint:
+                    instance = self._instances.update(ssh_fingerprint=fingerprint)
+                    return self._running(instance)
+            elif sshkey.accepts_connection(PROBE_HOST, probe.host_port):
+                return self._running(
+                    instance, note="port accepts connections; no SSH probe configured"
+                )
+
+            time.sleep(READINESS_POLL_SECONDS)
+
+        reason = (
+            f"the CVM did not become reachable on port {probe.host_port} within "
+            f"{self._config.launch_timeout_seconds}s"
+        )
+        # Deliberately left running. A slow guest is the common cause, and killing it here
+        # would destroy the console log's only live counterpart while it may still come up.
+        self._store.transition(NodeState.FAILED, last_error=reason)
+        raise LaunchFailure(504, reason)
+
+    def _running(self, instance: Instance, *, note: str | None = None) -> dict:
+        state = RUNNING_STATE.get(instance.kind)
+        if state is None:
+            raise LaunchFailure(500, f"no running state is defined for kind {instance.kind!r}")
+        self._store.transition(state)
+        logger.info("CVM %s is %s", instance.instance_id, state)
+        report = {**instance.report(), "state": str(state)}
+        if note:
+            report["note"] = note
+        return report
+
+    # ------------------------------------------------------------------ destroy
+
+    def destroy(self) -> dict:
+        """Stop the CVM and free the node. Safe to call when nothing is running.
+
+        Idempotent on purpose: a platform that timed out mid-teardown has to be able to repeat
+        the call, and answering "there was nothing here" is more useful to it than an error it
+        has to special-case.
+
+        The VM directory is removed, disk included. A CVM's disk is not durable state — the
+        validation CVM must measure identically on every launch, and a renter's is gone with
+        the rental — and leaving it behind would block the next launch on this node.
+        """
+        instance = self._instances.current
+        if instance is None:
+            stray = self._stray_directories()
+            if not stray:
+                return {"torn_down": False, "reason": "this node is running no CVM"}
+            for path in stray:
+                self._discard(path)
+            self._settle(NodeState.RECONCILING)
+            return {
+                "torn_down": True,
+                "detail": f"removed {len(stray)} CVM director(y/ies) cvmd had no record of",
+            }
+
+        vm_dir = Path(instance.vm_dir)
+        if self._store.state == NodeState.FAILED:
+            self._store.transition(NodeState.RECONCILING)
+        if self._store.state != NodeState.TEARDOWN:
+            self._store.transition(NodeState.TEARDOWN)
+
+        detail = "the supervisor was already gone"
+        if supervisor.is_supervisor(instance.supervisor_pid, vm_dir):
+            try:
+                dstack = self._load_dstack()
+            except LaunchFailure as exc:
+                # Without dstack there is no graceful path, but the process group is still
+                # ours to signal — refusing to stop would be worse than stopping abruptly.
+                logger.warning("%s; falling back to signalling the process group", exc.reason)
+                detail = supervisor.shutdown_by_signal(
+                    instance.supervisor_pid, timeout=DEFAULT_SHUTDOWN_TIMEOUT_SECONDS
+                )
+            else:
+                detail = supervisor.shutdown(
+                    dstack,
+                    vm_dir,
+                    instance.supervisor_pid,
+                    timeout=DEFAULT_SHUTDOWN_TIMEOUT_SECONDS,
+                )
+
+        still_there = supervisor.is_supervisor(instance.supervisor_pid, vm_dir)
+        self._discard(vm_dir)
+        self._instances.clear()
+
+        if still_there:
+            reason = f"CVM {instance.instance_id} did not stop: {detail}"
+            self._store.transition(NodeState.FAILED, last_error=reason)
+            raise LaunchFailure(500, reason)
+
+        self._store.transition(NodeState.RECONCILING)
+        return {"torn_down": True, "instance_id": instance.instance_id, "detail": detail}

--- a/neurons/executor/cvmd/src/cvmd/cvm/measure.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/measure.py
@@ -1,0 +1,117 @@
+"""Measure what was prepared, and refuse to launch anything else.
+
+The task's requirement is that a cvmd launch and a `lium-cvm.sh` launch of the same triple
+produce identical MRTD and RTMR0-3. Calling the same launcher code makes that *likely*; this
+module makes it *checked*. Between `setup_instance` writing the VM directory and QEMU being
+started, cvmd hashes the artifacts it just produced and compares them with the triple the
+caller named. A mismatch means the host would have attested as something the caller did not
+ask for, so the launch does not happen.
+
+The three values are the whole input to the measurements:
+
+  compose_hash   sha256 of `<vm_dir>/shared/app-compose.json` — the same bytes and the same
+                 digest dstack's own `app_compose_hash()` takes (vmm/src/app/qemu.rs).
+                 Covers the compose file, the init and pre-launch scripts, and the
+                 local-key-provider / logs / sysinfo flags, because `setup_instance` folds all
+                 of them into that one file.
+  os_image_hash  `<image_path>/digest.txt`, which is the value `run_instance` itself stamps
+                 into the guest config as `os_image_hash`.
+  qemu           `get_qemu_version_string()`, which is what lands in `vm_config["qemu_version"]`
+                 and what the verifier reconstructs the expected measurements against.
+
+Reading them from the artifacts rather than from the configuration is the point: configuration
+says what was *intended*, and only the files say what was *built*.
+"""
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+
+APP_COMPOSE = Path("shared") / "app-compose.json"
+DIGEST_FILE = "digest.txt"
+
+_CHUNK = 1024 * 1024
+
+
+class MeasurementError(Exception):
+    """An artifact could not be measured, or measured to something other than the request."""
+
+
+@dataclass(frozen=True)
+class Measurements:
+    qemu: str
+    os_image_hash: str
+    compose_hash: str
+
+    def as_dict(self) -> dict:
+        return {
+            "qemu": self.qemu,
+            "os_image_hash": self.os_image_hash,
+            "compose_hash": self.compose_hash,
+        }
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(_CHUNK):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def compose_hash(vm_dir: Path) -> str:
+    """sha256 of the measured app-compose.json, as the guest will report it."""
+    path = vm_dir / APP_COMPOSE
+    if not path.is_file():
+        raise MeasurementError(f"{path} was not written — the VM directory is not prepared")
+    return _sha256(path)
+
+
+def os_image_hash(image_path: Path) -> str:
+    """The image's own digest, read from the file `run_instance` reads it from."""
+    path = image_path / DIGEST_FILE
+    try:
+        value = path.read_text().strip()
+    except OSError as exc:
+        raise MeasurementError(f"cannot read the OS image digest at {path}: {exc}") from exc
+    if not value:
+        raise MeasurementError(f"{path} is empty, so the OS image is unidentified")
+    return value
+
+
+def qemu_version(dstack: ModuleType) -> str:
+    """The QEMU build string that ends up in the attested vm_config."""
+    version = dstack.get_qemu_version_string()
+    if not version:
+        raise MeasurementError(
+            "the configured QEMU did not report a version, so the build cannot be pinned"
+        )
+    return str(version)
+
+
+def measure(*, dstack: ModuleType, vm_dir: Path, image_path: Path) -> Measurements:
+    return Measurements(
+        qemu=qemu_version(dstack),
+        os_image_hash=os_image_hash(image_path),
+        compose_hash=compose_hash(vm_dir),
+    )
+
+
+def assert_matches(actual: Measurements, expected: tuple[str, str, str]) -> None:
+    """Compare against the requested (qemu, os_image_hash, compose_hash).
+
+    Every difference is reported, not just the first: an operator who fixes one pin, relaunches
+    and hits the next one has built a CVM twice to learn something one message could have said.
+    """
+    wanted = Measurements(*expected)
+    differences = [
+        f"{field}: requested {getattr(wanted, field)}, prepared {getattr(actual, field)}"
+        for field in ("qemu", "os_image_hash", "compose_hash")
+        if getattr(wanted, field) != getattr(actual, field)
+    ]
+    if differences:
+        raise MeasurementError(
+            "the prepared CVM would not measure as the requested triple, so it was not "
+            "launched — " + "; ".join(differences)
+        )

--- a/neurons/executor/cvmd/src/cvmd/cvm/measure.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/measure.py
@@ -44,13 +44,6 @@ class Measurements:
     os_image_hash: str
     compose_hash: str
 
-    def as_dict(self) -> dict:
-        return {
-            "qemu": self.qemu,
-            "os_image_hash": self.os_image_hash,
-            "compose_hash": self.compose_hash,
-        }
-
 
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()

--- a/neurons/executor/cvmd/src/cvmd/cvm/ports.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/ports.py
@@ -1,0 +1,97 @@
+"""Forwarded ports: parse them the way dstack does, and refuse a launch that would collide.
+
+A forwarded port is the one piece of a CVM that reaches outside the host, so a collision is not
+a startup nuisance — it is one CVM answering on another's address. QEMU's own `hostfwd` failure
+arrives after the guest is already being built, inside a child process cvmd is not waiting on,
+so the check belongs here, before anything is started.
+"""
+
+import errno
+import socket
+from dataclasses import dataclass
+
+# Mirrors DStackManager._parse_port_mapping: "protocol[:address]:from:to", `from` being the
+# host-side port and `to` the guest-side one, with 127.0.0.1 as the implied address.
+DEFAULT_ADDRESS = "127.0.0.1"
+
+
+class PortError(Exception):
+    """A mapping cvmd cannot parse, or a host port it cannot claim."""
+
+
+@dataclass(frozen=True)
+class PortMapping:
+    protocol: str
+    address: str
+    host_port: int
+    guest_port: int
+
+    def __str__(self) -> str:
+        return f"{self.protocol}:{self.address}:{self.host_port}:{self.guest_port}"
+
+
+def parse(spec: str) -> PortMapping:
+    parts = spec.split(":")
+    if len(parts) == 3:
+        protocol, host_port, guest_port = parts
+        address = DEFAULT_ADDRESS
+    elif len(parts) == 4:
+        protocol, address, host_port, guest_port = parts
+    else:
+        raise PortError(f"{spec!r} is not 'protocol[:address]:from:to'")
+
+    try:
+        host, guest = int(host_port), int(guest_port)
+    except ValueError as exc:
+        raise PortError(f"{spec!r} has a non-numeric port") from exc
+    if not (0 < host < 65536 and 0 < guest < 65536):
+        raise PortError(f"{spec!r} has a port outside 1-65535")
+    return PortMapping(protocol=protocol.lower(), address=address, host_port=host, guest_port=guest)
+
+
+def parse_all(specs) -> list[PortMapping]:
+    mappings = [parse(spec) for spec in specs]
+
+    claimed: dict[tuple[str, int], str] = {}
+    for mapping in mappings:
+        key = (mapping.protocol, mapping.host_port)
+        if key in claimed:
+            raise PortError(
+                f"host port {mapping.host_port}/{mapping.protocol} is mapped twice "
+                f"({claimed[key]} and {mapping}) — only one of them could ever receive traffic"
+            )
+        claimed[key] = str(mapping)
+    return mappings
+
+
+def _is_free(mapping: PortMapping) -> bool:
+    """Can this host address and port be bound right now?
+
+    SO_REUSEADDR is deliberately **not** set. It would let the bind succeed against a socket in
+    TIME_WAIT, and against some sockets already bound to a more specific address — which is the
+    exact case this check exists to catch. A port held only by TIME_WAIT reads as busy here,
+    and refusing a launch a few seconds early is the safe direction to be wrong in.
+    """
+    family = socket.AF_INET6 if ":" in mapping.address else socket.AF_INET
+    kind = socket.SOCK_DGRAM if mapping.protocol == "udp" else socket.SOCK_STREAM
+    with socket.socket(family, kind) as probe:
+        try:
+            probe.bind((mapping.address, mapping.host_port))
+        except OSError as exc:
+            if exc.errno in (errno.EADDRINUSE, errno.EACCES, errno.EADDRNOTAVAIL):
+                return False
+            raise
+    return True
+
+
+def assert_free(mappings: list[PortMapping]) -> None:
+    """Raise naming every port already taken, not just the first.
+
+    All of them, because an operator fixing one port at a time across three launch attempts is
+    three chances to leave a CVM half-built.
+    """
+    taken = [str(mapping) for mapping in mappings if not _is_free(mapping)]
+    if taken:
+        raise PortError(
+            f"these forwarded ports are already in use on this host: {', '.join(taken)}"
+        )

--- a/neurons/executor/cvmd/src/cvmd/cvm/sshkey.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/sshkey.py
@@ -1,0 +1,88 @@
+"""Is the guest up, and what is its SSH host key?
+
+The launch report has to carry the guest's SSH host-key fingerprint, and reading it doubles as
+the readiness signal: a key can only be collected once sshd inside the CVM is answering on the
+forwarded port, which means the guest booted, the network device came up, and the port forward
+works. A plain TCP accept proves much less — QEMU's user-mode forward accepts before anything
+inside the guest is listening.
+
+`ssh-keyscan` does the protocol work. Writing an SSH transport here to avoid a subprocess would
+be a second implementation of a handshake whose only job is to produce a value openssh already
+prints, and cvmd's dependencies stay deliberately small.
+"""
+
+import base64
+import hashlib
+import logging
+import socket
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+KEYSCAN = "ssh-keyscan"
+KEYSCAN_TIMEOUT_SECONDS = 10
+
+
+def fingerprint_of(base64_key: str) -> str:
+    """The OpenSSH SHA256 fingerprint of a base64-encoded host key blob.
+
+    Same construction `ssh-keygen -l` prints: sha256 over the raw key blob, base64, no padding.
+    """
+    blob = base64.b64decode(base64_key, validate=True)
+    digest = base64.b64encode(hashlib.sha256(blob).digest()).decode().rstrip("=")
+    return f"SHA256:{digest}"
+
+
+def _parse_keyscan(output: str) -> str | None:
+    """Pull the first host key out of ssh-keyscan output.
+
+    Lines are `host keytype base64key`; comments start with '#'. Any single key identifies the
+    guest, so the first usable line wins rather than the run failing on an unexpected key type.
+    """
+    for line in output.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        try:
+            return fingerprint_of(parts[2])
+        except (ValueError, base64.binascii.Error):
+            continue
+    return None
+
+
+def read_host_key(host: str, port: int) -> str | None:
+    """Fingerprint of the guest's SSH host key, or None if it cannot be read yet.
+
+    None is "not ready or not readable", never an error: this runs in a poll loop where the
+    normal answer for the first several minutes is "not yet".
+    """
+    try:
+        result = subprocess.run(  # noqa: S603 - fixed argv, host and port are host config
+            [KEYSCAN, "-T", str(KEYSCAN_TIMEOUT_SECONDS), "-p", str(port), host],
+            capture_output=True,
+            text=True,
+            timeout=KEYSCAN_TIMEOUT_SECONDS + 5,
+            check=False,
+        )
+    except FileNotFoundError:
+        logger.warning(
+            "%s is not installed, so no SSH host-key fingerprint can be reported; readiness "
+            "falls back to a TCP accept",
+            KEYSCAN,
+        )
+        return None
+    except subprocess.TimeoutExpired:
+        return None
+    return _parse_keyscan(result.stdout)
+
+
+def accepts_connection(host: str, port: int, *, timeout: float = 5.0) -> bool:
+    """Does anything accept a TCP connection here? The weaker readiness signal."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False

--- a/neurons/executor/cvmd/src/cvmd/cvm/sshkey.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/sshkey.py
@@ -14,6 +14,7 @@ prints, and cvmd's dependencies stay deliberately small.
 import base64
 import hashlib
 import logging
+import shutil
 import socket
 import subprocess
 
@@ -21,6 +22,16 @@ logger = logging.getLogger(__name__)
 
 KEYSCAN = "ssh-keyscan"
 KEYSCAN_TIMEOUT_SECONDS = 10
+
+
+def keyscan_available() -> bool:
+    """Is `ssh-keyscan` on this host's PATH?
+
+    Asked once, before the readiness loop starts, because the answer decides which signal the
+    loop can use at all. Discovering it inside the loop would mean polling for a fingerprint
+    that can never arrive until the launch times out.
+    """
+    return shutil.which(KEYSCAN) is not None
 
 
 def fingerprint_of(base64_key: str) -> str:

--- a/neurons/executor/cvmd/src/cvmd/cvm/supervisor.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/supervisor.py
@@ -53,10 +53,6 @@ TERMINATION_GRACE_SECONDS = 10
 # it — which is the only way "one CVM per node" can hold while both launch paths exist.
 TDX_GUEST_MARKER = "tdx-guest"
 
-# `run_instance` writes this when the VM is about to start and removes it when QEMU exits, so
-# its presence is dstack's own liveness marker. cvmd reads it, but never trusts it alone.
-RUNTIME_FILE = "runtime.json"
-
 # The file dstack creates for the guest's disk. Its existence is the fail-closed "a CVM lives
 # in this directory" predicate: a stopped CVM still owns the node's GPUs and ports until its
 # directory is removed, so a launch must not step over one just because no process is running.
@@ -128,19 +124,6 @@ def vm_directories(run_dir: Path) -> list[Path]:
     if not run_dir.is_dir():
         return []
     return sorted(child for child in run_dir.iterdir() if (child / DISK_IMAGE).exists())
-
-
-def runtime_pid(vm_dir: Path) -> int | None:
-    """The pid dstack recorded for this VM, if it recorded one. A claim, not evidence."""
-    from cvmd.atomic import read_json
-
-    raw = read_json(vm_dir / RUNTIME_FILE)
-    if not isinstance(raw, dict):
-        return None
-    try:
-        return int(raw["pid"])
-    except (KeyError, TypeError, ValueError):
-        return None
 
 
 def _await_pid_file(vm_dir: Path, deadline: float) -> int:
@@ -257,7 +240,21 @@ def shutdown(dstack: ModuleType, vm_dir: Path, pid: int, *, timeout: int) -> str
     predicate — VFIO file descriptors closed, guest RAM returned, forwarded ports bindable —
     because a reaped QEMU is necessary for those and nowhere near sufficient.
     """
-    dstack.shutdown_instance(str(vm_dir), timeout=timeout, force=False)
+    try:
+        dstack.shutdown_instance(str(vm_dir), timeout=timeout, force=False)
+    except Exception as exc:  # noqa: BLE001 - the ladder below is what must not be skipped
+        # `shutdown_instance` reads `runtime.json` and indexes `cid` outside its own try block,
+        # and `run_instance` writes that file with a plain open() rather than atomically. A host
+        # that crashed mid-write therefore leaves a JSONDecodeError or a KeyError here. Letting
+        # it propagate would skip the signal ladder entirely — the guest would never be
+        # signalled at all, which is the one outcome this function exists to prevent.
+        logger.warning(
+            "dstack's graceful shutdown of %s raised %s; falling back to signalling the "
+            "process group",
+            vm_dir,
+            exc,
+        )
+        return shutdown_by_signal(pid, timeout=timeout)
 
     # `shutdown_instance` has already waited up to `timeout` for the supervisor to exit, and the
     # supervisor only exits once QEMU has. So this is a confirmation that the group drained, not

--- a/neurons/executor/cvmd/src/cvmd/cvm/supervisor.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/supervisor.py
@@ -1,0 +1,232 @@
+"""Start, recognise and stop the process that holds a CVM.
+
+The supervisor is `cvmd.dstack.child` in its own session. Everything here is about the two
+questions cvmd has to answer honestly about it: *is it still ours*, and *is it really gone*.
+
+Measured on au11 (2026-08-08): `run/vms/my-executor/runtime.json` still named pid 56920 hours
+after that process died, because `lium-cvm.sh stop` gave up waiting and left the file behind.
+So a recorded pid is a claim, never evidence. `is_supervisor` reads `/proc/<pid>/cmdline` and
+requires both the child module name and this CVM's directory, which also rules out a recycled
+pid — a real risk on a host that has been up for weeks.
+"""
+
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from types import ModuleType
+
+logger = logging.getLogger(__name__)
+
+CHILD_MODULE = "cvmd.dstack.child"
+CONSOLE_LOG = "console.log"
+
+# How long a signalled process group gets before the next signal. A TDX guest returns its
+# memory to the host as it exits and that is not instant, but this is the *post-signal* wait —
+# the graceful window is the caller's `timeout`.
+TERMINATION_GRACE_SECONDS = 10
+
+# What a running CVM's QEMU always carries on its command line. dstack builds every TDX guest
+# with `-object tdx-guest,id=tdx`, so this identifies one whether cvmd or `lium-cvm.sh` started
+# it — which is the only way "one CVM per node" can hold while both launch paths exist.
+TDX_GUEST_MARKER = "tdx-guest"
+
+# `run_instance` writes this when the VM is about to start and removes it when QEMU exits, so
+# its presence is dstack's own liveness marker. cvmd reads it, but never trusts it alone.
+RUNTIME_FILE = "runtime.json"
+
+# The file dstack creates for the guest's disk. Its existence is the fail-closed "a CVM lives
+# in this directory" predicate: a stopped CVM still owns the node's GPUs and ports until its
+# directory is removed, so a launch must not step over one just because no process is running.
+DISK_IMAGE = "hda.img"
+
+
+class SupervisorError(Exception):
+    """The supervisor could not be started."""
+
+
+def _cmdline(pid: int) -> list[str] | None:
+    try:
+        raw = Path(f"/proc/{pid}/cmdline").read_bytes()
+    except OSError:
+        return None
+    return [part for part in raw.decode(errors="replace").split("\0") if part]
+
+
+def is_supervisor(pid: int, vm_dir: Path) -> bool:
+    """Is `pid` alive *and* the supervisor for this VM directory?
+
+    Both halves matter. Liveness alone accepts a recycled pid; identity alone accepts a record
+    of something long dead.
+    """
+    argv = _cmdline(pid)
+    if argv is None:
+        return False
+    joined = " ".join(argv)
+    return CHILD_MODULE in joined and str(vm_dir) in joined
+
+
+def running_cvms() -> list[tuple[int, str]]:
+    """Every TDX guest running on this host right now, as (pid, argv0-ish description).
+
+    This is what makes "one CVM per node" true rather than "one cvmd-managed CVM per node".
+    GPU passthrough is exclusive and so is the host's TDX capacity, so a CVM started by
+    `lium-cvm.sh` blocks a cvmd launch exactly as much as one cvmd started — and during the
+    CVM v2 rollout both launch paths exist on the same hosts. Reading `/proc` finds both;
+    cvmd's own records find only its own.
+    """
+    found: list[tuple[int, str]] = []
+    proc = Path("/proc")
+    if not proc.is_dir():
+        return found
+
+    for entry in proc.iterdir():
+        if not entry.name.isdigit():
+            continue
+        argv = _cmdline(int(entry.name))
+        if not argv:
+            continue
+        # The marker has to appear in an argument, not merely somewhere in the joined string,
+        # so a path or a log filename containing it cannot be mistaken for a running guest.
+        if any(TDX_GUEST_MARKER in arg for arg in argv) and "qemu" in argv[0].lower():
+            found.append((int(entry.name), argv[0]))
+    return sorted(found)
+
+
+def console_log_path(vm_dir: Path) -> Path:
+    return vm_dir / CONSOLE_LOG
+
+
+def vm_directories(run_dir: Path) -> list[Path]:
+    """Every directory under `run_dir` that holds a CVM's disk.
+
+    Keyed on the disk image rather than on the directory existing, so a half-written directory
+    from a launch that failed before `qemu-img create` does not look like a live CVM.
+    """
+    if not run_dir.is_dir():
+        return []
+    return sorted(child for child in run_dir.iterdir() if (child / DISK_IMAGE).exists())
+
+
+def runtime_pid(vm_dir: Path) -> int | None:
+    """The pid dstack recorded for this VM, if it recorded one. A claim, not evidence."""
+    from cvmd.atomic import read_json
+
+    raw = read_json(vm_dir / RUNTIME_FILE)
+    if not isinstance(raw, dict):
+        return None
+    try:
+        return int(raw["pid"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def spawn(*, scripts_dir: Path, vm_dir: Path, kp_port: int) -> int:
+    """Start the supervisor detached from cvmd and return its pid.
+
+    `start_new_session=True` puts it in its own session and process group, so it survives a
+    cvmd restart and never receives a signal aimed at the daemon. Both streams go to
+    `console.log`: QEMU runs `-nographic` with its serial line on stdio, so that file is the
+    guest's boot console, and `run_instance` prints the full QEMU command line into it first.
+    A pipe would be worse than useless here — nothing would drain it, and the guest would block
+    on a full buffer partway through booting.
+    """
+    log_path = console_log_path(vm_dir)
+    try:
+        log_handle = log_path.open("ab", buffering=0)
+    except OSError as exc:
+        raise SupervisorError(f"cannot open the console log at {log_path}: {exc}") from exc
+
+    try:
+        with open(os.devnull, "rb") as devnull:
+            process = subprocess.Popen(  # noqa: S603 - argv is built here, never from a request
+                [sys.executable, "-m", CHILD_MODULE, str(scripts_dir), str(vm_dir), str(kp_port)],
+                stdin=devnull,
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                close_fds=True,
+            )
+    except OSError as exc:
+        raise SupervisorError(f"cannot start the supervisor: {exc}") from exc
+    finally:
+        # cvmd holds no handle on the console log; the child owns it now. Keeping one open would
+        # pin the file after a teardown removed it.
+        log_handle.close()
+
+    logger.info("supervisor for %s started as pid %d", vm_dir, process.pid)
+    return process.pid
+
+
+def _process_group_gone(pid: int) -> bool:
+    try:
+        os.killpg(pid, 0)
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        return False
+    return False
+
+
+def _wait_for_group(pid: int, seconds: int) -> bool:
+    for _ in range(max(seconds, 1)):
+        if _process_group_gone(pid):
+            return True
+        time.sleep(1)
+    return _process_group_gone(pid)
+
+
+def shutdown(dstack: ModuleType, vm_dir: Path, pid: int, *, timeout: int) -> str:
+    """Stop the CVM and return what it took. Raises nothing — it reports.
+
+    Three escalating steps, and the middle one is the reason this is not simply a call to
+    `shutdown_instance`:
+
+    1. `shutdown_instance` asks the guest to power off over vsock. This is dstack's own path
+       and the only graceful one.
+    2. If the process group is still there, SIGTERM the **group**. `shutdown_instance`'s own
+       `--force` kills the pid in `runtime.json`, which is the *supervisor's* pid — QEMU is its
+       child, so killing that pid alone orphans a running VM still holding the guest's RAM and
+       the GPUs. Signalling the group reaches both, and the group exists precisely because
+       `spawn` started a new session.
+    3. SIGKILL the group.
+
+    Confirming the process group is gone is the floor, not the ceiling. DAH-2577 adds the real
+    predicate — VFIO file descriptors closed, guest RAM returned, forwarded ports bindable —
+    because a reaped QEMU is necessary for those and nowhere near sufficient.
+    """
+    dstack.shutdown_instance(str(vm_dir), timeout=timeout, force=False)
+    if _wait_for_group(pid, timeout):
+        return "guest powered off on request"
+
+    logger.warning(
+        "CVM at %s did not power off in %ds; signalling process group %d", vm_dir, timeout, pid
+    )
+    return shutdown_by_signal(pid, timeout=timeout)
+
+
+def shutdown_by_signal(pid: int, *, timeout: int) -> str:
+    """SIGTERM then SIGKILL the supervisor's whole process group.
+
+    The **group**, not the pid. `shutdown_instance`'s own `--force` kills the pid recorded in
+    `runtime.json`, which is the supervisor's — QEMU is its child, so killing that pid alone
+    leaves a running VM still holding the guest's RAM and the GPUs while every layer above
+    reports a successful stop. `spawn` starts a new session precisely so this group exists.
+    """
+    if _process_group_gone(pid):
+        return "process group was already gone"
+
+    for signal_number, label in ((signal.SIGTERM, "SIGTERM"), (signal.SIGKILL, "SIGKILL")):
+        try:
+            os.killpg(pid, signal_number)
+        except ProcessLookupError:
+            return f"process group exited before {label}"
+        except PermissionError:
+            return f"no permission to send {label} to process group {pid}"
+        if _wait_for_group(pid, min(timeout, TERMINATION_GRACE_SECONDS)):
+            return f"process group stopped by {label}"
+
+    return f"process group {pid} is still present after SIGKILL"

--- a/neurons/executor/cvmd/src/cvmd/cvm/supervisor.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/supervisor.py
@@ -1,13 +1,22 @@
 """Start, recognise and stop the process that holds a CVM.
 
-The supervisor is `cvmd.dstack.child` in its own session. Everything here is about the two
-questions cvmd has to answer honestly about it: *is it still ours*, and *is it really gone*.
+The supervisor is `cvmd.dstack.child`, detached into its own session with init as its parent.
+Everything here is about the two questions cvmd has to answer honestly about it: *is it still
+ours*, and *is it really gone*.
 
 Measured on au11 (2026-08-08): `run/vms/my-executor/runtime.json` still named pid 56920 hours
 after that process died, because `lium-cvm.sh stop` gave up waiting and left the file behind.
 So a recorded pid is a claim, never evidence. `is_supervisor` reads `/proc/<pid>/cmdline` and
 requires both the child module name and this CVM's directory, which also rules out a recycled
 pid — a real risk on a host that has been up for weeks.
+
+Also measured on au11, and the reason the supervisor **double-forks**: when cvmd was the
+supervisor's parent, a stopped supervisor stayed a zombie until something else called `wait()`.
+A zombie is still a process-group member, so `killpg(pgid, 0)` kept succeeding and every
+teardown burned the full signal ladder — 260s, ending in a SIGKILL and the message "still
+present after SIGKILL", while the guest had in fact powered off gracefully. `os.kill(pid, 0)`
+has the same blind spot, and that is what `shutdown_instance` waits on. Orphaning the
+supervisor to init makes it reaped the moment it exits, so both checks tell the truth.
 """
 
 import logging
@@ -23,6 +32,16 @@ logger = logging.getLogger(__name__)
 
 CHILD_MODULE = "cvmd.dstack.child"
 CONSOLE_LOG = "console.log"
+
+# Written by the supervisor after it has detached, so its appearance means "fully independent
+# of cvmd", not merely "started". cvmd cannot learn the pid from Popen: Popen sees the
+# short-lived process that forks and exits, never the grandchild that holds the VM.
+PID_FILE = "supervisor.pid"
+
+# How long to wait for the fork-and-exit, and then for the pid file. Both are microseconds of
+# work; the budget is for a loaded host, not for anything that can legitimately take seconds.
+DETACH_TIMEOUT_SECONDS = 30
+PID_FILE_POLL_SECONDS = 0.05
 
 # How long a signalled process group gets before the next signal. A TDX guest returns its
 # memory to the host as it exits and that is not instant, but this is the *post-signal* wait —
@@ -124,15 +143,35 @@ def runtime_pid(vm_dir: Path) -> int | None:
         return None
 
 
-def spawn(*, scripts_dir: Path, vm_dir: Path, kp_port: int) -> int:
-    """Start the supervisor detached from cvmd and return its pid.
+def _await_pid_file(vm_dir: Path, deadline: float) -> int:
+    path = vm_dir / PID_FILE
+    while time.monotonic() < deadline:
+        try:
+            return int(path.read_text().strip())
+        except (OSError, ValueError):
+            time.sleep(PID_FILE_POLL_SECONDS)
+    raise SupervisorError(
+        f"the supervisor did not report its pid in {path}; see {console_log_path(vm_dir)}"
+    )
 
-    `start_new_session=True` puts it in its own session and process group, so it survives a
-    cvmd restart and never receives a signal aimed at the daemon. Both streams go to
-    `console.log`: QEMU runs `-nographic` with its serial line on stdio, so that file is the
-    guest's boot console, and `run_instance` prints the full QEMU command line into it first.
-    A pipe would be worse than useless here — nothing would drain it, and the guest would block
-    on a full buffer partway through booting.
+
+def spawn(*, scripts_dir: Path, vm_dir: Path, kp_port: int) -> int:
+    """Start the supervisor, detached from cvmd, and return the pid that holds the VM.
+
+    Both streams go to `console.log`: QEMU runs `-nographic` with its serial line on stdio, so
+    that file is the guest's boot console, and `run_instance` prints the full QEMU command line
+    into it first. A pipe would be worse than useless — nothing would drain it, and the guest
+    would block on a full buffer partway through booting.
+
+    `-u` because Python block-buffers stdout when it is a file. Without it the command line sits
+    in the child's buffer for the VM's entire life while QEMU writes past it through the same
+    descriptor, so the one line that says what was launched is missing from the log for exactly
+    as long as anyone would want to read it.
+
+    The process Popen starts is not the supervisor. It forks, exits, and the grandchild is the
+    one that holds the VM — see the module docstring for what being cvmd's child cost. `wait()`
+    reaps the intermediate; the real pid comes from the file the grandchild writes once it has
+    detached.
     """
     log_path = console_log_path(vm_dir)
     try:
@@ -143,7 +182,15 @@ def spawn(*, scripts_dir: Path, vm_dir: Path, kp_port: int) -> int:
     try:
         with open(os.devnull, "rb") as devnull:
             process = subprocess.Popen(  # noqa: S603 - argv is built here, never from a request
-                [sys.executable, "-m", CHILD_MODULE, str(scripts_dir), str(vm_dir), str(kp_port)],
+                [
+                    sys.executable,
+                    "-u",
+                    "-m",
+                    CHILD_MODULE,
+                    str(scripts_dir),
+                    str(vm_dir),
+                    str(kp_port),
+                ],
                 stdin=devnull,
                 stdout=log_handle,
                 stderr=subprocess.STDOUT,
@@ -157,8 +204,20 @@ def spawn(*, scripts_dir: Path, vm_dir: Path, kp_port: int) -> int:
         # pin the file after a teardown removed it.
         log_handle.close()
 
-    logger.info("supervisor for %s started as pid %d", vm_dir, process.pid)
-    return process.pid
+    deadline = time.monotonic() + DETACH_TIMEOUT_SECONDS
+    try:
+        exit_code = process.wait(timeout=DETACH_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired as exc:
+        process.kill()
+        raise SupervisorError(
+            f"the supervisor did not detach within {DETACH_TIMEOUT_SECONDS}s; see {log_path}"
+        ) from exc
+    if exit_code != 0:
+        raise SupervisorError(f"the supervisor exited {exit_code} before detaching; see {log_path}")
+
+    pid = _await_pid_file(vm_dir, deadline)
+    logger.info("supervisor for %s detached as pid %d", vm_dir, pid)
+    return pid
 
 
 def _process_group_gone(pid: int) -> bool:
@@ -199,7 +258,12 @@ def shutdown(dstack: ModuleType, vm_dir: Path, pid: int, *, timeout: int) -> str
     because a reaped QEMU is necessary for those and nowhere near sufficient.
     """
     dstack.shutdown_instance(str(vm_dir), timeout=timeout, force=False)
-    if _wait_for_group(pid, timeout):
+
+    # `shutdown_instance` has already waited up to `timeout` for the supervisor to exit, and the
+    # supervisor only exits once QEMU has. So this is a confirmation that the group drained, not
+    # a second full wait — repeating the long one here would double the worst case for no
+    # information.
+    if _wait_for_group(pid, TERMINATION_GRACE_SECONDS):
         return "guest powered off on request"
 
     logger.warning(

--- a/neurons/executor/cvmd/src/cvmd/dstack/__init__.py
+++ b/neurons/executor/cvmd/src/cvmd/dstack/__init__.py
@@ -1,0 +1,7 @@
+"""The seam onto `dstacktee/scripts/dstack.py`.
+
+cvmd does not reimplement any part of the launcher. dstack.py shapes what the CVM measures,
+so a second implementation would be a second set of measurements — the whole point of CVM v2
+is that the validator can predict them. This package imports the real file and calls the same
+functions its CLI calls.
+"""

--- a/neurons/executor/cvmd/src/cvmd/dstack/child.py
+++ b/neurons/executor/cvmd/src/cvmd/dstack/child.py
@@ -5,31 +5,57 @@ the VM is gone — and the host API server `start_server` opens has to stay up b
 guest to fetch its sealing key. Neither fits inside an HTTP handler, so cvmd spawns this module
 and the QEMU process lives under it.
 
-The process is deliberately in its own session (the parent passes `start_new_session=True`).
-A CVM must outlive a cvmd restart: a daemon upgrade that took the node's CVM with it would be
-worse than the outage it was fixing, and `RECONCILING` exists precisely so cvmd can rediscover
-a CVM it did not start.
+The process **double-forks**: the one cvmd starts forks, exits, and the grandchild holds the VM
+with init as its parent. A CVM must outlive a cvmd restart — a daemon upgrade that took the
+node's CVM with it would be worse than the outage it was fixing, and `RECONCILING` exists
+precisely so cvmd can rediscover a CVM it did not start. Orphaning to init also means the
+supervisor is reaped the instant it exits rather than lingering as a zombie in its own process
+group, which is what made every teardown on au11 burn its full signal ladder and then report a
+failure that had not happened.
 
-Run as: `python -m cvmd.dstack.child <scripts_dir> <vm_dir> <kp_port>`
+Run as: `python -u -m cvmd.dstack.child <scripts_dir> <vm_dir> <kp_port>`
 
 stdout carries the guest's serial console — QEMU is started with `-nographic -serial chardev:ser0`
 over stdio — plus the full QEMU command line that `run_instance` prints before exec. The parent
 points both streams at `<vm_dir>/console.log`, which makes that file the primary evidence for
-what was launched and how it booted.
+what was launched and how it booted. `-u` is not optional: block-buffered, that command line
+stays in this process's buffer for the VM's whole life.
 """
 
+import os
 import sys
 from pathlib import Path
 
 from cvmd.dstack.loader import DStackUnavailable, load_dstack
 
-USAGE = "usage: python -m cvmd.dstack.child <scripts_dir> <vm_dir> <kp_port>"
+USAGE = "usage: python -u -m cvmd.dstack.child <scripts_dir> <vm_dir> <kp_port>"
+
+PID_FILE = "supervisor.pid"
 
 # Distinct from any exit code QEMU itself can return, so the parent can tell "the launcher never
 # got started" apart from "the VM ran and exited".
 EXIT_BAD_USAGE = 64
 EXIT_NO_DSTACK = 65
 EXIT_LAUNCH_FAILED = 66
+EXIT_NO_DETACH = 67
+
+
+def _detach(vm_dir: Path) -> None:
+    """Fork, orphan this process to init, and record the pid that holds the VM.
+
+    The fork parent leaves through `os._exit`, which skips atexit handlers and — the part that
+    matters — skips flushing the stdio buffers it inherited. A normal exit would replay whatever
+    this process had already buffered into the console log a second time.
+
+    `setsid` after the fork makes the surviving process its own session and process-group
+    leader, so QEMU lands in a group whose id is this pid. That is what lets cvmd stop the VM by
+    signalling the group: dstack's own `--force` kills the pid in `runtime.json`, which is this
+    process, leaving QEMU orphaned and still holding the guest's RAM.
+    """
+    if os.fork() > 0:
+        os._exit(0)
+    os.setsid()
+    (vm_dir / PID_FILE).write_text(f"{os.getpid()}\n")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -45,11 +71,20 @@ def main(argv: list[str] | None = None) -> int:
         print(f"{USAGE}\nkp_port must be an integer, got {raw_port!r}", file=sys.stderr)
         return EXIT_BAD_USAGE
 
+    # Before the launcher import, so a host that cannot import dstack.py fails as cvmd's
+    # immediate child with a legible exit code rather than as a detached process cvmd has
+    # already recorded and has to discover the death of.
     try:
         dstack = load_dstack(Path(scripts_dir))
     except DStackUnavailable as exc:
         print(f"cvmd: cannot import the dstack launcher: {exc}", file=sys.stderr)
         return EXIT_NO_DSTACK
+
+    try:
+        _detach(Path(vm_dir))
+    except OSError as exc:
+        print(f"cvmd: the supervisor could not detach: {exc}", file=sys.stderr)
+        return EXIT_NO_DETACH
 
     # The same two calls dstack.py's own `run` subcommand makes, in the same order. The host
     # API server has to be listening before the guest boots, and `run_instance` needs the port

--- a/neurons/executor/cvmd/src/cvmd/dstack/child.py
+++ b/neurons/executor/cvmd/src/cvmd/dstack/child.py
@@ -1,0 +1,67 @@
+"""The supervisor process: one CVM, held for its whole life.
+
+`DStackManager.run_instance` calls `subprocess.run(qemu, check=True)` — it does not return until
+the VM is gone — and the host API server `start_server` opens has to stay up beside it for the
+guest to fetch its sealing key. Neither fits inside an HTTP handler, so cvmd spawns this module
+and the QEMU process lives under it.
+
+The process is deliberately in its own session (the parent passes `start_new_session=True`).
+A CVM must outlive a cvmd restart: a daemon upgrade that took the node's CVM with it would be
+worse than the outage it was fixing, and `RECONCILING` exists precisely so cvmd can rediscover
+a CVM it did not start.
+
+Run as: `python -m cvmd.dstack.child <scripts_dir> <vm_dir> <kp_port>`
+
+stdout carries the guest's serial console — QEMU is started with `-nographic -serial chardev:ser0`
+over stdio — plus the full QEMU command line that `run_instance` prints before exec. The parent
+points both streams at `<vm_dir>/console.log`, which makes that file the primary evidence for
+what was launched and how it booted.
+"""
+
+import sys
+from pathlib import Path
+
+from cvmd.dstack.loader import DStackUnavailable, load_dstack
+
+USAGE = "usage: python -m cvmd.dstack.child <scripts_dir> <vm_dir> <kp_port>"
+
+# Distinct from any exit code QEMU itself can return, so the parent can tell "the launcher never
+# got started" apart from "the VM ran and exited".
+EXIT_BAD_USAGE = 64
+EXIT_NO_DSTACK = 65
+EXIT_LAUNCH_FAILED = 66
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if len(argv) != 3:
+        print(USAGE, file=sys.stderr)
+        return EXIT_BAD_USAGE
+
+    scripts_dir, vm_dir, raw_port = argv
+    try:
+        kp_port = int(raw_port)
+    except ValueError:
+        print(f"{USAGE}\nkp_port must be an integer, got {raw_port!r}", file=sys.stderr)
+        return EXIT_BAD_USAGE
+
+    try:
+        dstack = load_dstack(Path(scripts_dir))
+    except DStackUnavailable as exc:
+        print(f"cvmd: cannot import the dstack launcher: {exc}", file=sys.stderr)
+        return EXIT_NO_DSTACK
+
+    # The same two calls dstack.py's own `run` subcommand makes, in the same order. The host
+    # API server has to be listening before the guest boots, and `run_instance` needs the port
+    # it landed on to write into the guest config.
+    try:
+        server = dstack.start_server(vm_dir, kp_port)
+        dstack.DStackManager().run_instance(vm_dir, server.host_port)
+    except Exception as exc:  # noqa: BLE001 - the child's job is to report, not to interpret
+        print(f"cvmd: the CVM exited abnormally: {exc}", file=sys.stderr)
+        return EXIT_LAUNCH_FAILED
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/neurons/executor/cvmd/src/cvmd/dstack/loader.py
+++ b/neurons/executor/cvmd/src/cvmd/dstack/loader.py
@@ -1,0 +1,101 @@
+"""Import `dstack.py` from the dstacktee checkout and hand back the module.
+
+dstack.py is a CLI script, not a package: it is not on cvmd's `sys.path`, it is not pip-installed,
+and it does `import host_api` — a sibling import that only resolves when its own directory is
+importable. So the loader adds that directory to `sys.path` and loads the file by path.
+
+Nothing here adapts, patches, or wraps the module. The value of importing rather than
+re-implementing is that the bytes cvmd measures are produced by the same code the shell path
+produces them with; any adaptation layer would be exactly the fork this task forbids.
+"""
+
+import importlib.util
+import sys
+import threading
+from pathlib import Path
+from types import ModuleType
+
+MODULE_NAME = "dstack"
+SIBLING_MODULE = "host_api"
+
+# The functions cvmd calls. Checked at import so a dstack.py that has moved on fails here, with
+# a legible message, instead of raising AttributeError partway through a launch.
+REQUIRED_ATTRIBUTES = (
+    "DStackManager",
+    "shutdown_instance",
+    "start_server",
+    "get_qemu_version_string",
+)
+
+_lock = threading.Lock()
+_cache: dict[Path, ModuleType] = {}
+
+
+class DStackUnavailable(Exception):
+    """dstack.py could not be imported, or is not the shape cvmd calls."""
+
+
+def _add_to_path(scripts_dir: str) -> None:
+    """Make `import host_api` resolve.
+
+    Appended, not prepended: this directory is not ours, and putting a third-party script
+    directory ahead of the stdlib would let a file dropped in beside dstack.py shadow a module
+    the daemon depends on.
+    """
+    if scripts_dir not in sys.path:
+        sys.path.append(scripts_dir)
+
+
+def load_dstack(scripts_dir: Path) -> ModuleType:
+    """Import dstack.py from `scripts_dir` and return it. Cached per directory.
+
+    Raises DStackUnavailable with the reason — the caller turns that into a refusal, because a
+    host that cannot import the launcher cannot launch anything.
+    """
+    scripts_dir = Path(scripts_dir).expanduser().resolve()
+    cached = _cache.get(scripts_dir)
+    if cached is not None:
+        return cached
+
+    source = scripts_dir / f"{MODULE_NAME}.py"
+    if not source.is_file():
+        raise DStackUnavailable(f"no {MODULE_NAME}.py at {source}")
+    if not (scripts_dir / f"{SIBLING_MODULE}.py").is_file():
+        raise DStackUnavailable(
+            f"{source} needs {SIBLING_MODULE}.py beside it and {scripts_dir} has none"
+        )
+
+    with _lock:
+        # Re-check inside the lock: two concurrent launches would otherwise both exec the
+        # module, and the second would replace a module object the first is already using.
+        cached = _cache.get(scripts_dir)
+        if cached is not None:
+            return cached
+
+        _add_to_path(str(scripts_dir))
+        spec = importlib.util.spec_from_file_location(MODULE_NAME, source)
+        if spec is None or spec.loader is None:
+            raise DStackUnavailable(f"cannot build an import spec for {source}")
+
+        module = importlib.util.module_from_spec(spec)
+        # Registered before exec so the module behaves exactly like a normal import — a module
+        # that is mid-exec and absent from sys.modules re-executes if anything imports it.
+        sys.modules[MODULE_NAME] = module
+        try:
+            # dstack.py calls logging.basicConfig() at import. Under the daemon that is a
+            # no-op, because uvicorn has already given the root logger a handler.
+            spec.loader.exec_module(module)
+        except Exception as exc:  # noqa: BLE001 - any import failure is the same refusal
+            sys.modules.pop(MODULE_NAME, None)
+            raise DStackUnavailable(f"importing {source} failed: {exc}") from exc
+
+        absent = [name for name in REQUIRED_ATTRIBUTES if not hasattr(module, name)]
+        if absent:
+            sys.modules.pop(MODULE_NAME, None)
+            raise DStackUnavailable(
+                f"{source} has no {', '.join(absent)} — cvmd calls it as a library and this "
+                f"build does not offer the entry points it calls"
+            )
+
+        _cache[scripts_dir] = module
+        return module

--- a/neurons/executor/cvmd/src/cvmd/dstack/plan.py
+++ b/neurons/executor/cvmd/src/cvmd/dstack/plan.py
@@ -1,0 +1,65 @@
+"""Build the argument object `DStackManager.setup_instance` expects.
+
+`setup_instance` takes an `argparse.Namespace` because its only caller today is dstack.py's own
+CLI. Handing it a Namespace is what makes cvmd a *library caller* rather than a fork: the
+alternative — refactoring dstack.py to take a dataclass — is a change to the file that shapes
+attestation, and this task forbids that.
+
+Every field below mirrors one flag in `lium-cvm.sh new`. The pairing is the contract: if the
+shell path grows a flag that changes what gets measured, this module has to grow with it, and
+the compose-hash gate in `cvm/measure.py` is what makes the omission fail loudly instead of
+silently producing a differently-measured CVM.
+
+    lium-cvm.sh new                       here
+    ----------------------------------    -----------------------------------------
+    <compose_file>                        artifact.compose_path
+    --dir "$VMS_DIR/$cvm_name"            vm_dir
+    --image "$IMAGE_DIR/$OS_IMAGE_NAME"   artifact.os_image_path
+    --init-script "$INIT_SCRIPT"          artifact.init_script
+    --pre-launch-script "$PRE..."         artifact.pre_launch_script
+    --vcpus / --memory / --disk           launch config (provider-set, never requested)
+    --gpu (repeated) / --port (repeated)  launch config
+    --env-file "$env_file"                launch config
+    --local-key-provider                  artifact.local_key_provider
+    --enable-logs / --enable-sysinfo      artifact.enable_logs / enable_sysinfo
+    (not passed)                          pin_numa / hugepages, both False by default —
+                                          argparse's store_true default, which is what the
+                                          shell path leaves them at
+"""
+
+import argparse
+from pathlib import Path
+
+from cvmd.catalog import Artifact
+from cvmd.config import LaunchConfig
+
+
+def _script_argument(path: Path | None) -> str | None:
+    """dstack.py opens the script when the value is truthy, so absent must be None, not ''."""
+    return str(path) if path is not None else None
+
+
+def setup_namespace(
+    *, artifact: Artifact, launch: LaunchConfig, vm_dir: Path
+) -> argparse.Namespace:
+    """The exact arguments `lium-cvm.sh new` would produce for this artifact and this host."""
+    return argparse.Namespace(
+        compose_file=str(artifact.compose_path),
+        dir=str(vm_dir),
+        image=str(artifact.os_image_path),
+        vcpus=launch.vcpus,
+        memory=launch.memory,
+        disk=launch.disk,
+        # dstack.py treats `--gpu all` as the string list ["all"]; anything else is a list of
+        # PCI slots. An empty list is a legal configuration — a CVM with no passthrough.
+        gpu=list(launch.gpus),
+        port=list(launch.ports),
+        local_key_provider=artifact.local_key_provider,
+        enable_logs=artifact.enable_logs,
+        enable_sysinfo=artifact.enable_sysinfo,
+        init_script=_script_argument(artifact.init_script),
+        pre_launch_script=_script_argument(artifact.pre_launch_script),
+        env_file=str(launch.env_file) if launch.env_file is not None else None,
+        pin_numa=launch.pin_numa,
+        hugepages=launch.hugepages,
+    )

--- a/neurons/executor/cvmd/src/cvmd/routes/cvm.py
+++ b/neurons/executor/cvmd/src/cvmd/routes/cvm.py
@@ -16,13 +16,13 @@ the period during which someone wants to read it.
 
 import asyncio
 import logging
-import threading
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, ValidationError
 
 from cvmd import __version__
+from cvmd.catalog import HEX64
 from cvmd.cvm.manager import KIND_RENTER, KIND_VALIDATION, CvmManager, LaunchFailure, Triple
 from cvmd.state.store import StateStore
 
@@ -31,8 +31,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 RENTER_NOT_IMPLEMENTED = "renter CVM provisioning lands in DAH-2580"
-
-HEX64 = r"^[0-9a-f]{64}$"
 
 
 class CreateCvmRequest(BaseModel):
@@ -60,12 +58,31 @@ def _manager(request: Request) -> CvmManager:
     return request.app.state.cvm
 
 
-def _lock(request: Request) -> threading.Lock:
-    return request.app.state.cvm_lock
-
-
 def _failure(exc: LaunchFailure) -> JSONResponse:
     return JSONResponse(status_code=exc.status, content={"detail": exc.reason})
+
+
+async def _exclusively(request: Request, operation, *, success: int) -> JSONResponse:
+    """Run one CVM operation on a worker thread, at most one at a time.
+
+    The lock is non-blocking on purpose: a second operation arriving mid-launch is refused, not
+    queued. Queueing would leave the caller waiting on a node that is already committed, and the
+    answer it needs — "not here, not now" — is available immediately.
+    """
+    lock = request.app.state.cvm_lock
+    if not lock.acquire(blocking=False):
+        return JSONResponse(
+            status_code=409,
+            content={"detail": "another CVM operation is already in progress on this node"},
+        )
+    try:
+        report = await asyncio.to_thread(operation)
+    except LaunchFailure as exc:
+        logger.warning("CVM operation refused (%d): %s", exc.status, exc.reason)
+        return _failure(exc)
+    finally:
+        lock.release()
+    return JSONResponse(status_code=success, content=report)
 
 
 @router.get("/health")
@@ -92,45 +109,19 @@ async def create_cvm(request: Request) -> JSONResponse:
     except ValidationError as exc:
         return JSONResponse(status_code=422, content={"detail": exc.errors(include_url=False)})
 
+    triple = Triple(
+        qemu=parsed.qemu,
+        os_image_hash=parsed.os_image_hash,
+        compose_hash=parsed.compose_hash,
+    )
     manager = _manager(request)
-    lock = _lock(request)
-    # Non-blocking on purpose: a second launch arriving mid-launch is refused, not queued.
-    # Queueing would leave the caller waiting on a node that is already committed, and the
-    # answer it needs — "not here, not now" — is available immediately.
-    if not lock.acquire(blocking=False):
-        return JSONResponse(
-            status_code=409,
-            content={"detail": "another CVM operation is already in progress on this node"},
-        )
-    try:
-        triple = Triple(
-            qemu=parsed.qemu,
-            os_image_hash=parsed.os_image_hash,
-            compose_hash=parsed.compose_hash,
-        )
-        report = await asyncio.to_thread(manager.create, kind=KIND_VALIDATION, triple=triple)
-    except LaunchFailure as exc:
-        logger.warning("launch refused (%d): %s", exc.status, exc.reason)
-        return _failure(exc)
-    finally:
-        lock.release()
-    return JSONResponse(status_code=201, content=report)
+    return await _exclusively(
+        request,
+        lambda: manager.create(kind=KIND_VALIDATION, triple=triple),
+        success=201,
+    )
 
 
 @router.delete("/v1/cvm")
 async def destroy_cvm(request: Request) -> JSONResponse:
-    manager = _manager(request)
-    lock = _lock(request)
-    if not lock.acquire(blocking=False):
-        return JSONResponse(
-            status_code=409,
-            content={"detail": "another CVM operation is already in progress on this node"},
-        )
-    try:
-        report = await asyncio.to_thread(manager.destroy)
-    except LaunchFailure as exc:
-        logger.error("teardown failed (%d): %s", exc.status, exc.reason)
-        return _failure(exc)
-    finally:
-        lock.release()
-    return JSONResponse(status_code=200, content=report)
+    return await _exclusively(request, _manager(request).destroy, success=200)

--- a/neurons/executor/cvmd/src/cvmd/routes/cvm.py
+++ b/neurons/executor/cvmd/src/cvmd/routes/cvm.py
@@ -5,33 +5,67 @@ parsed and the scope check already evaluated. They never re-read the raw bytes: 
 only has to disagree with the first once for the scope check and the handler to act on different
 values.
 
-The two mutating routes are registered with full auth and scope enforcement but return 501. That
-is deliberate: the scope matrix is testable end-to-end today, and DAH-2576 only fills in handlers
-rather than also wiring auth.
+`POST {kind: "validation"}` and `DELETE` do real work as of DAH-2576. `POST {kind: "renter"}`
+still answers 501: the renter body is DAH-2580's to define, and validating it against a
+validation-shaped model now would be inventing its contract.
+
+Both mutating handlers run the manager on a worker thread. A launch waits minutes for a guest
+to boot, and holding the event loop for that would make `/v1/state` unanswerable for exactly
+the period during which someone wants to read it.
 """
+
+import asyncio
+import logging
+import threading
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 from cvmd import __version__
+from cvmd.cvm.manager import KIND_RENTER, KIND_VALIDATION, CvmManager, LaunchFailure, Triple
 from cvmd.state.store import StateStore
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-NOT_IMPLEMENTED = "not implemented in DAH-2575 — CVM operations land in DAH-2576"
+RENTER_NOT_IMPLEMENTED = "renter CVM provisioning lands in DAH-2580"
+
+HEX64 = r"^[0-9a-f]{64}$"
 
 
 class CreateCvmRequest(BaseModel):
-    """The create body. `kind` is what the middleware resolved the scope from; the pinned triple
-    is carried through unvalidated here because DAH-2576 owns what a valid triple is.
+    """The create body: which stack to run, never how big to make it.
+
+    The pinned triple is required, not defaulted. A host that chose the stack itself would give
+    the validator no way to tell "the CVM I asked for" from "whatever this host felt like
+    running" — and detecting exactly that is why the triple is attested at all.
+
+    Sizing (vCPUs, memory, disk, GPUs) is absent by design: it is provider configuration read
+    from `/etc/cvmd/config.toml`, settled while reviewing DAH-2575.
     """
 
     kind: str
+    qemu: str = Field(min_length=1)
+    os_image_hash: str = Field(pattern=HEX64)
+    compose_hash: str = Field(pattern=HEX64)
 
 
 def _store(request: Request) -> StateStore:
     return request.app.state.store
+
+
+def _manager(request: Request) -> CvmManager:
+    return request.app.state.cvm
+
+
+def _lock(request: Request) -> threading.Lock:
+    return request.app.state.cvm_lock
+
+
+def _failure(exc: LaunchFailure) -> JSONResponse:
+    return JSONResponse(status_code=exc.status, content={"detail": exc.reason})
 
 
 @router.get("/health")
@@ -41,18 +75,62 @@ async def health() -> dict:
 
 @router.get("/v1/state")
 async def get_state(request: Request) -> dict:
-    return _store(request).document.to_json()
+    return {**_store(request).document.to_json(), "cvm": _manager(request).describe()}
 
 
 @router.post("/v1/cvm")
 async def create_cvm(request: Request) -> JSONResponse:
+    body = request.state.parsed_body
+
+    # Checked before the model so the renter path keeps answering 501 rather than 422 for a
+    # body whose required fields DAH-2580 has not defined yet.
+    if isinstance(body, dict) and body.get("kind") == KIND_RENTER:
+        return JSONResponse(status_code=501, content={"detail": RENTER_NOT_IMPLEMENTED})
+
     try:
-        CreateCvmRequest.model_validate(request.state.parsed_body)
+        parsed = CreateCvmRequest.model_validate(body)
     except ValidationError as exc:
         return JSONResponse(status_code=422, content={"detail": exc.errors(include_url=False)})
-    return JSONResponse(status_code=501, content={"detail": NOT_IMPLEMENTED})
+
+    manager = _manager(request)
+    lock = _lock(request)
+    # Non-blocking on purpose: a second launch arriving mid-launch is refused, not queued.
+    # Queueing would leave the caller waiting on a node that is already committed, and the
+    # answer it needs — "not here, not now" — is available immediately.
+    if not lock.acquire(blocking=False):
+        return JSONResponse(
+            status_code=409,
+            content={"detail": "another CVM operation is already in progress on this node"},
+        )
+    try:
+        triple = Triple(
+            qemu=parsed.qemu,
+            os_image_hash=parsed.os_image_hash,
+            compose_hash=parsed.compose_hash,
+        )
+        report = await asyncio.to_thread(manager.create, kind=KIND_VALIDATION, triple=triple)
+    except LaunchFailure as exc:
+        logger.warning("launch refused (%d): %s", exc.status, exc.reason)
+        return _failure(exc)
+    finally:
+        lock.release()
+    return JSONResponse(status_code=201, content=report)
 
 
 @router.delete("/v1/cvm")
 async def destroy_cvm(request: Request) -> JSONResponse:
-    return JSONResponse(status_code=501, content={"detail": NOT_IMPLEMENTED})
+    manager = _manager(request)
+    lock = _lock(request)
+    if not lock.acquire(blocking=False):
+        return JSONResponse(
+            status_code=409,
+            content={"detail": "another CVM operation is already in progress on this node"},
+        )
+    try:
+        report = await asyncio.to_thread(manager.destroy)
+    except LaunchFailure as exc:
+        logger.error("teardown failed (%d): %s", exc.status, exc.reason)
+        return _failure(exc)
+    finally:
+        lock.release()
+    return JSONResponse(status_code=200, content=report)

--- a/neurons/executor/cvmd/tests/conftest.py
+++ b/neurons/executor/cvmd/tests/conftest.py
@@ -72,6 +72,74 @@ def config(clients_file: Path, state_dir: Path) -> Config:
     return Config(authorized_clients=clients_file, state_dir=state_dir)
 
 
+# --------------------------------------------------------------------------- DAH-2576
+
+# The real launcher, in this repo. The launch tests import it rather than a stub: the whole
+# claim of DAH-2576 is that cvmd calls *this file*, and a stub would pass while the claim was
+# false. It needs nothing but the standard library, so importing it here costs nothing.
+DSTACK_SCRIPTS = Path(__file__).resolve().parents[2] / "dstacktee" / "scripts"
+
+
+@pytest.fixture
+def dstack_scripts() -> Path:
+    if not (DSTACK_SCRIPTS / "dstack.py").is_file():
+        pytest.skip(f"no dstack.py at {DSTACK_SCRIPTS}")
+    return DSTACK_SCRIPTS
+
+
+@pytest.fixture
+def dstack(dstack_scripts: Path):
+    from cvmd.dstack.loader import load_dstack
+
+    return load_dstack(dstack_scripts)
+
+
+@pytest.fixture
+def compose_file(tmp_path: Path) -> Path:
+    """A compose file with no unresolved placeholders.
+
+    `lium-cvm.sh` substitutes `${EXECUTOR_RUNNER_IMAGE_DIGEST}` *before* dstack measures the
+    file. Under cvmd the catalog points at an already-resolved compose, and the compose-hash
+    gate is what catches it if that ever stops being true.
+    """
+    path = tmp_path / "docker-compose.yml"
+    path.write_text(
+        "services:\n"
+        "  executor-runner:\n"
+        "    image: daturaai/compute-subnet-executor-runner@sha256:" + ("c" * 64) + "\n"
+    )
+    return path
+
+
+@pytest.fixture
+def guest_scripts(tmp_path: Path) -> tuple[Path, Path]:
+    init = tmp_path / "init_script.sh"
+    init.write_text("#!/bin/sh\necho init\n")
+    pre_launch = tmp_path / "pre_launch_script.sh"
+    pre_launch.write_text("#!/bin/sh\necho pre-launch\n")
+    return init, pre_launch
+
+
+@pytest.fixture
+def env_file(tmp_path: Path) -> Path:
+    path = tmp_path / "cvm.env"
+    path.write_text("EXTERNAL_PORT=8001\nSSH_PORT=2200\n")
+    return path
+
+
+@pytest.fixture
+def image_dir(tmp_path: Path) -> Path:
+    """An OS image directory with the one file cvmd measures.
+
+    `setup_instance` only records the image path; `digest.txt` is read at measurement time and
+    by `run_instance`, so this is enough for everything short of an actual boot.
+    """
+    path = tmp_path / "images" / "dstack-nvidia-0.5.11"
+    path.mkdir(parents=True)
+    (path / "digest.txt").write_text("d" * 64 + "\n")
+    return path
+
+
 @pytest.fixture
 def app(config: Config):
     return create_app(config)

--- a/neurons/executor/cvmd/tests/fixtures/sleepy_supervisor.py
+++ b/neurons/executor/cvmd/tests/fixtures/sleepy_supervisor.py
@@ -1,0 +1,29 @@
+"""A stand-in supervisor that detaches exactly as the real one does, then waits.
+
+Used by `test_supervisor.py` in place of `cvmd.dstack.child`. It calls the real `_detach`, so
+what the test asserts about sessions, parents and reaping is asserted about the shipping code —
+only the part that would start QEMU is replaced.
+
+Invoked with the same argv `spawn` builds: <scripts_dir> <vm_dir> <kp_port>.
+"""
+
+import sys
+import time
+from pathlib import Path
+
+from cvmd.dstack.child import _detach
+
+SLEEP_SECONDS = 120
+
+
+def main() -> int:
+    _detach(Path(sys.argv[2]))
+    # Deliberately NOT flushed, exactly as `run_instance` prints the QEMU command line. Whether
+    # this reaches the console log while the process is still running is entirely down to `-u`.
+    print("detached")
+    time.sleep(SLEEP_SECONDS)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/neurons/executor/cvmd/tests/test_catalog.py
+++ b/neurons/executor/cvmd/tests/test_catalog.py
@@ -1,0 +1,137 @@
+"""The catalog decides what this host may launch, so every way of misreading it is a refusal."""
+
+import json
+from pathlib import Path
+
+import pytest
+from cvmd.catalog import CatalogError, TripleNotFound, load_catalog, resolve
+
+QEMU = "10.1.0"
+OS_IMAGE = "a" * 64
+COMPOSE = "b" * 64
+
+
+def entry(**overrides) -> dict:
+    base = {
+        "id": "validation-v3",
+        "kind": "validation",
+        "qemu": QEMU,
+        "os_image_hash": OS_IMAGE,
+        "compose_hash": COMPOSE,
+        "os_image_path": "/opt/dstack/images/dstack-nvidia-0.5.11",
+        "compose_path": "/etc/cvmd/composes/validation-v3.yml",
+    }
+    base.update(overrides)
+    return base
+
+
+def write(path: Path, *entries, version: int = 1) -> Path:
+    path.write_text(json.dumps({"version": version, "artifacts": list(entries)}))
+    return path
+
+
+@pytest.fixture
+def catalog_path(tmp_path: Path) -> Path:
+    return tmp_path / "catalog.json"
+
+
+class TestLoading:
+    def test_a_well_formed_catalog_loads(self, catalog_path):
+        artifacts = load_catalog(write(catalog_path, entry()))
+        assert [a.id for a in artifacts] == ["validation-v3"]
+        assert artifacts[0].triple == (QEMU, OS_IMAGE, COMPOSE)
+
+    def test_defaults_match_lium_cvm_sh(self, catalog_path):
+        """An entry that says nothing about flags gets what the shell path uses by default."""
+        artifact = load_catalog(write(catalog_path, entry()))[0]
+        assert artifact.local_key_provider is True
+        assert artifact.enable_logs is False
+        assert artifact.enable_sysinfo is False
+
+    def test_a_missing_catalog_is_an_error_not_an_empty_list(self, catalog_path):
+        """An absent catalog must refuse every launch, never approve nothing quietly."""
+        with pytest.raises(CatalogError, match="no catalog at"):
+            load_catalog(catalog_path)
+
+    def test_unparseable_json_is_refused(self, catalog_path):
+        catalog_path.write_text("{not json")
+        with pytest.raises(CatalogError, match="cannot read catalog"):
+            load_catalog(catalog_path)
+
+    def test_an_unknown_version_is_refused_rather_than_guessed(self, catalog_path):
+        with pytest.raises(CatalogError, match="is not the supported"):
+            load_catalog(write(catalog_path, entry(), version=99))
+
+    def test_a_missing_field_is_refused(self, catalog_path):
+        broken = entry()
+        del broken["compose_path"]
+        with pytest.raises(CatalogError, match="compose_path"):
+            load_catalog(write(catalog_path, broken))
+
+    @pytest.mark.parametrize(
+        "value",
+        ["A" * 64, "sha256:" + "a" * 64, "a" * 63, "z" * 64],
+        ids=["uppercase", "prefixed", "too-short", "not-hex"],
+    )
+    def test_a_hash_that_could_never_match_is_refused_at_load(self, catalog_path, value):
+        """cvmd compares against lowercase hex it computes itself.
+
+        An entry written any other way would never match, and the launch would fail as "not
+        approved" — which sends an operator looking at the wrong thing entirely.
+        """
+        with pytest.raises(CatalogError, match="64 lowercase hex"):
+            load_catalog(write(catalog_path, entry(compose_hash=value)))
+
+    def test_two_entries_with_the_same_triple_are_refused(self, catalog_path):
+        """A request that could resolve to either entry has no single answer."""
+        with pytest.raises(CatalogError, match="pin the same kind and triple"):
+            load_catalog(write(catalog_path, entry(id="a"), entry(id="b")))
+
+
+class TestResolving:
+    @pytest.fixture
+    def artifacts(self, catalog_path):
+        return load_catalog(
+            write(
+                catalog_path,
+                entry(),
+                entry(id="renter-v1", kind="renter", compose_hash="c" * 64),
+            )
+        )
+
+    def test_the_matching_triple_resolves(self, artifacts):
+        found = resolve(
+            artifacts, kind="validation", qemu=QEMU, os_image_hash=OS_IMAGE, compose_hash=COMPOSE
+        )
+        assert found.id == "validation-v3"
+
+    def test_kind_is_part_of_the_match(self, artifacts):
+        """The renter entry shares a QEMU build and image; only its compose hash differs."""
+        found = resolve(
+            artifacts, kind="renter", qemu=QEMU, os_image_hash=OS_IMAGE, compose_hash="c" * 64
+        )
+        assert found.id == "renter-v1"
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [("qemu", "9.2.1"), ("os_image_hash", "f" * 64), ("compose_hash", "e" * 64)],
+    )
+    def test_an_unapproved_component_is_named_in_the_refusal(self, artifacts, field, value):
+        """ "Not found" is not actionable; "this compose hash is not approved" is."""
+        request = {"qemu": QEMU, "os_image_hash": OS_IMAGE, "compose_hash": COMPOSE}
+        request[field] = value
+
+        with pytest.raises(TripleNotFound) as raised:
+            resolve(artifacts, kind="validation", **request)
+
+        message = str(raised.value)
+        assert field in message
+        assert value in message
+        # The refusal also says what *is* approved, so the fix does not need a second round trip.
+        assert getattr(artifacts[0], field) in message
+
+    def test_an_unknown_kind_lists_the_kinds_there_are(self, artifacts):
+        with pytest.raises(TripleNotFound, match="validation, renter|renter, validation"):
+            resolve(
+                artifacts, kind="sandbox", qemu=QEMU, os_image_hash=OS_IMAGE, compose_hash=COMPOSE
+            )

--- a/neurons/executor/cvmd/tests/test_config.py
+++ b/neurons/executor/cvmd/tests/test_config.py
@@ -144,6 +144,37 @@ class TestConfig:
         with pytest.raises(ConfigError, match="positive"):
             load_config(path)
 
+    @pytest.mark.parametrize(
+        "mapping",
+        [
+            "tcp:12200",  # no guest side
+            "tcp:0.0.0.0:0:22",  # port 0 — well-formed TOML, refused by the parser
+            "tcp:0.0.0.0:70000:22",  # above 65535
+            "sftp:0.0.0.0:2200:2200:2200",  # too many fields
+        ],
+    )
+    def test_an_unusable_port_mapping_refuses(self, tmp_path, mapping):
+        """Malformed is fatal at startup — absent and wrong are different problems.
+
+        Left to the launch path, one of these makes a host that looks configured and refuses
+        every launch at the first request, which is the state nobody discovers until a
+        validator does.
+        """
+        path = tmp_path / "config.toml"
+        path.write_text(
+            f'authorized_clients = "/a.json"\nstate_dir = "/b"\ncvm_ports = ["{mapping}"]\n'
+        )
+        with pytest.raises(ConfigError, match="cvm_ports"):
+            load_config(path)
+
+    def test_a_usable_port_mapping_loads(self, tmp_path):
+        path = tmp_path / "config.toml"
+        path.write_text(
+            'authorized_clients = "/a.json"\nstate_dir = "/b"\n'
+            'cvm_ports = ["tcp:0.0.0.0:12200:2200", "udp:65535:1"]\n'
+        )
+        assert load_config(path).launch.ports == ("tcp:0.0.0.0:12200:2200", "udp:65535:1")
+
     def test_env_overrides_the_file(self, tmp_path, monkeypatch):
         path = tmp_path / "config.toml"
         path.write_text('authorized_clients = "/a.json"\nstate_dir = "/b"\nport = 9443\n')

--- a/neurons/executor/cvmd/tests/test_dstack_library.py
+++ b/neurons/executor/cvmd/tests/test_dstack_library.py
@@ -1,0 +1,216 @@
+"""cvmd calls the real dstack.py, and calling it produces the same bytes the CLI produces.
+
+This is the file that holds DAH-2576's central claim up: *import dstack.py as a library — no
+behavior fork, zero measured bytes changed*. Two halves:
+
+1. The import works against the file actually in this repo, with the entry points cvmd calls.
+2. Preparing a VM directory through cvmd's plan and through `dstack.py new` — the same command
+   line `lium-cvm.sh` builds — yields byte-identical results.
+
+The second is the one that would catch a fork. `app-compose.json` **is** the compose hash, so
+if these two paths ever diverge by a byte, the CVM measures as something the validator did not
+whitelist, and it would fail at attestation time on a host rather than here.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from cvmd.catalog import Artifact
+from cvmd.config import LaunchConfig
+from cvmd.cvm import measure
+from cvmd.dstack.loader import DStackUnavailable, load_dstack
+from cvmd.dstack.plan import setup_namespace
+
+VCPUS = 16
+MEMORY = "64G"
+DISK = "200G"
+GPUS = ("19:00.0", "3b:00.0")
+PORTS = ("tcp:0.0.0.0:12200:2200", "tcp:0.0.0.0:18001:8001")
+
+
+class TestTheImport:
+    def test_the_repo_s_dstack_imports_as_a_library(self, dstack):
+        """It is a CLI script with a sibling import, not a package. It still has to import."""
+        assert hasattr(dstack, "DStackManager")
+        assert hasattr(dstack, "shutdown_instance")
+        assert hasattr(dstack, "start_server")
+        assert hasattr(dstack, "get_qemu_version_string")
+
+    def test_the_sibling_module_resolves(self, dstack):
+        """dstack.py does `import host_api`, which only works if its directory is importable."""
+        assert dstack.host_api is not None
+
+    def test_loading_twice_returns_one_module(self, dstack_scripts):
+        """Two launches must not each re-execute the launcher into a separate module object."""
+        assert load_dstack(dstack_scripts) is load_dstack(dstack_scripts)
+
+    def test_a_directory_without_dstack_is_refused(self, tmp_path):
+        with pytest.raises(DStackUnavailable, match="no dstack.py"):
+            load_dstack(tmp_path)
+
+    def test_dstack_without_its_sibling_is_refused_before_import(self, tmp_path):
+        """Refused for the real reason, rather than as an opaque ImportError mid-launch."""
+        (tmp_path / "dstack.py").write_text("import host_api\n")
+        with pytest.raises(DStackUnavailable, match="host_api.py"):
+            load_dstack(tmp_path)
+
+
+def _artifact(compose: Path, image: Path, scripts: tuple[Path, Path]) -> Artifact:
+    init, pre_launch = scripts
+    return Artifact(
+        id="validation-test",
+        kind="validation",
+        qemu="10.1.0",
+        os_image_hash="d" * 64,
+        compose_hash="0" * 64,  # replaced by the measured value in the tests that need it
+        os_image_path=image,
+        compose_path=compose,
+        init_script=init,
+        pre_launch_script=pre_launch,
+        local_key_provider=True,
+        enable_logs=False,
+        enable_sysinfo=False,
+    )
+
+
+def _launch_config(env: Path) -> LaunchConfig:
+    return LaunchConfig(vcpus=VCPUS, memory=MEMORY, disk=DISK, gpus=GPUS, ports=PORTS, env_file=env)
+
+
+def _cli_arguments(artifact: Artifact, env_file: Path, vm_dir: Path) -> list[str]:
+    """Exactly the flags `lium-cvm.sh new` passes, in its order (lium-cvm.sh:461-474)."""
+    argv = [
+        "new",
+        str(artifact.compose_path),
+        "--init-script",
+        str(artifact.init_script),
+        "--pre-launch-script",
+        str(artifact.pre_launch_script),
+        "--dir",
+        str(vm_dir),
+        "--image",
+        str(artifact.os_image_path),
+        "--vcpus",
+        str(VCPUS),
+        "--memory",
+        MEMORY,
+        "--disk",
+        DISK,
+        "--env-file",
+        str(env_file),
+    ]
+    for gpu in GPUS:
+        argv += ["--gpu", gpu]
+    for port in PORTS:
+        argv += ["--port", port]
+    argv.append("--local-key-provider")
+    return argv
+
+
+class TestNoBehaviorFork:
+    """Prepare the same CVM both ways and compare every file."""
+
+    @pytest.fixture
+    def prepared(
+        self, dstack, dstack_scripts, tmp_path, compose_file, guest_scripts, env_file, image_dir
+    ):
+        artifact = _artifact(compose_file, image_dir, guest_scripts)
+
+        via_library = tmp_path / "run-library" / "instance"
+        via_library.parent.mkdir()
+        namespace = setup_namespace(
+            artifact=artifact, launch=_launch_config(env_file), vm_dir=via_library
+        )
+        dstack.DStackManager().setup_instance(namespace)
+
+        via_cli = tmp_path / "run-cli" / "instance"
+        via_cli.parent.mkdir()
+        result = subprocess.run(
+            [sys.executable, str(dstack_scripts / "dstack.py")]
+            + _cli_arguments(artifact, env_file, via_cli),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        return via_library, via_cli
+
+    def test_app_compose_is_byte_identical(self, prepared):
+        """The measured artifact. Equal bytes here is equal compose_hash, by definition."""
+        library, cli = prepared
+        assert (library / "shared" / "app-compose.json").read_bytes() == (
+            cli / "shared" / "app-compose.json"
+        ).read_bytes()
+
+    def test_the_compose_hash_is_the_same(self, prepared):
+        library, cli = prepared
+        assert measure.compose_hash(library) == measure.compose_hash(cli)
+
+    def test_every_prepared_file_matches(self, prepared):
+        """Not only the measured one — the whole directory, so a divergence anywhere shows up.
+
+        `vm-manifest.json` is exempt on one field only: it stamps `created_at_ms` from the
+        clock, and the two runs happen milliseconds apart. Every other key is compared.
+        """
+        library, cli = prepared
+
+        def relative(root):
+            return sorted(p.relative_to(root) for p in root.rglob("*") if p.is_file())
+
+        assert relative(library) == relative(cli)
+
+        for name in relative(library):
+            left, right = library / name, cli / name
+            if name.name == "vm-manifest.json":
+                left_manifest = json.loads(left.read_text())
+                right_manifest = json.loads(right.read_text())
+                assert left_manifest.pop("created_at_ms") > 0
+                assert right_manifest.pop("created_at_ms") > 0
+                # The instance id is the directory name, which differs by construction.
+                assert left_manifest.pop("id") == "instance"
+                assert right_manifest.pop("id") == "instance"
+                assert left_manifest == right_manifest
+            else:
+                assert left.read_bytes() == right.read_bytes(), f"{name} differs"
+
+    def test_the_flags_that_shape_the_measurement_are_present(self, prepared):
+        """Guards the pairing itself: a missing flag would make both sides equally wrong.
+
+        Each assertion below is a value that only arrives if the corresponding flag was passed,
+        so an omission in `plan.py` fails here rather than at attestation time on a host.
+        """
+        library, _ = prepared
+        app_compose = json.loads((library / "shared" / "app-compose.json").read_text())
+
+        assert app_compose["local_key_provider_enabled"] is True  # --local-key-provider
+        assert app_compose["init_script"].startswith("#!/bin/sh")  # --init-script
+        assert app_compose["pre_launch_script"].startswith("#!/bin/sh")  # --pre-launch-script
+        assert "executor-runner" in app_compose["docker_compose_file"]  # the compose itself
+        assert app_compose["public_logs"] is False  # --enable-logs absent
+        assert "public_sysinfo" not in app_compose  # --enable-sysinfo absent
+
+        manifest = json.loads((library / "vm-manifest.json").read_text())
+        assert manifest["vcpu"] == VCPUS
+        assert manifest["memory"] == 64 * 1024
+        assert manifest["disk_size"] == 200
+        assert [gpu["slot"] for gpu in manifest["gpus"]["gpus"]] == list(GPUS)
+        assert [(p["from"], p["to"]) for p in manifest["port_map"]] == [
+            (12200, 2200),
+            (18001, 8001),
+        ]
+
+    def test_the_env_file_reaches_the_guest_but_not_the_measurement(self, prepared):
+        """`--env-file` writes `.user-config`, which is outside app-compose.json.
+
+        Worth pinning: it means host env can differ between two CVMs that must still measure
+        identically, which is what lets sizing be provider configuration.
+        """
+        library, _ = prepared
+        user_config = json.loads((library / "shared" / ".user-config").read_text())
+        assert user_config["env_vars"]["SSH_PORT"] == "2200"
+
+        app_compose = (library / "shared" / "app-compose.json").read_text()
+        assert "SSH_PORT" not in app_compose

--- a/neurons/executor/cvmd/tests/test_launch.py
+++ b/neurons/executor/cvmd/tests/test_launch.py
@@ -1,0 +1,544 @@
+"""The launch path: what it refuses, in what order, and what it leaves behind when it does.
+
+The launches here stop at the point QEMU would start. `supervisor.spawn` is the seam — a test
+host has no TDX, no GPUs and no OS image, so starting a real guest is the hardware run's job
+(see the acceptance evidence on the PR). Everything up to and including the measurement gate
+is real: the real dstack.py writes the real VM directory and the real hashes are compared.
+
+That split is deliberate. Every refusal below happens *before* a process exists, so these are
+exactly the paths where a bug would leave a node in a state someone has to clean up by hand.
+"""
+
+import json
+import socket
+from pathlib import Path
+
+import pytest
+from cvmd.config import Config, LaunchConfig
+from cvmd.cvm import measure, supervisor
+from cvmd.cvm.instance import InstanceStore
+from cvmd.cvm.manager import CvmManager, LaunchFailure, Triple
+from cvmd.state.machine import NodeState
+from cvmd.state.store import StateStore
+
+QEMU_FALLBACK = "0.0.0-test"
+OS_IMAGE_HASH = "d" * 64
+
+
+@pytest.fixture
+def free_ports() -> tuple[int, int]:
+    with socket.socket() as a, socket.socket() as b:
+        a.bind(("127.0.0.1", 0))
+        b.bind(("127.0.0.1", 0))
+        return a.getsockname()[1], b.getsockname()[1]
+
+
+@pytest.fixture
+def catalog_file(tmp_path, compose_file, guest_scripts, image_dir, dstack, monkeypatch) -> Path:
+    """A catalog pinning the triple this host will actually produce.
+
+    The compose hash is computed by preparing the CVM once and measuring it — the same value
+    `setup_instance` will produce during the test. Hardcoding a hash would make the test assert
+    that two constants are equal; deriving it makes the test assert that the *gate* works.
+    """
+    from cvmd.catalog import Artifact
+    from cvmd.dstack.plan import setup_namespace
+
+    init, pre_launch = guest_scripts
+    probe_dir = tmp_path / "probe" / "instance"
+    probe_dir.parent.mkdir(parents=True, exist_ok=True)
+    artifact = Artifact(
+        id="validation-test",
+        kind="validation",
+        qemu="unused",
+        os_image_hash=OS_IMAGE_HASH,
+        compose_hash="0" * 64,
+        os_image_path=image_dir,
+        compose_path=compose_file,
+        init_script=init,
+        pre_launch_script=pre_launch,
+    )
+    dstack.DStackManager().setup_instance(
+        setup_namespace(
+            artifact=artifact,
+            launch=LaunchConfig(vcpus=2, memory="2G", disk="20G"),
+            vm_dir=probe_dir,
+        )
+    )
+    compose_hash = measure.compose_hash(probe_dir)
+
+    path = tmp_path / "catalog.json"
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "artifacts": [
+                    {
+                        "id": "validation-test",
+                        "kind": "validation",
+                        "qemu": QEMU_FALLBACK,
+                        "os_image_hash": OS_IMAGE_HASH,
+                        "compose_hash": compose_hash,
+                        "os_image_path": str(image_dir),
+                        "compose_path": str(compose_file),
+                        "init_script": str(init),
+                        "pre_launch_script": str(pre_launch),
+                    }
+                ],
+            }
+        )
+    )
+    return path
+
+
+@pytest.fixture
+def approved(catalog_file) -> Triple:
+    entry = json.loads(catalog_file.read_text())["artifacts"][0]
+    return Triple(
+        qemu=entry["qemu"],
+        os_image_hash=entry["os_image_hash"],
+        compose_hash=entry["compose_hash"],
+    )
+
+
+@pytest.fixture
+def launch_config(tmp_path, dstack_scripts, catalog_file, env_file, free_ports) -> LaunchConfig:
+    return LaunchConfig(
+        dstack_scripts_dir=dstack_scripts,
+        catalog_path=catalog_file,
+        run_dir=tmp_path / "vms",
+        vcpus=2,
+        memory="2G",
+        disk="20G",
+        gpus=(),
+        ports=(f"tcp:127.0.0.1:{free_ports[0]}:2200", f"tcp:127.0.0.1:{free_ports[1]}:8001"),
+        env_file=env_file,
+        ssh_guest_port=2200,
+        launch_timeout_seconds=2,
+    )
+
+
+@pytest.fixture
+def manager(state_dir, launch_config, monkeypatch) -> CvmManager:
+    # This host's QEMU is whatever the developer happens to have, or none. Pinning the reported
+    # version makes the catalog's `qemu` field meaningful in a test rather than machine-dependent.
+    monkeypatch.setattr(
+        "cvmd.cvm.measure.qemu_version", lambda _dstack: QEMU_FALLBACK, raising=True
+    )
+    return CvmManager(
+        config=launch_config, store=StateStore(state_dir), instances=InstanceStore(state_dir)
+    )
+
+
+@pytest.fixture
+def spawned(monkeypatch) -> list[dict]:
+    """Record spawns instead of starting QEMU, and report the fake pid as alive."""
+    calls: list[dict] = []
+
+    def fake_spawn(*, scripts_dir, vm_dir, kp_port):
+        calls.append({"scripts_dir": scripts_dir, "vm_dir": vm_dir, "kp_port": kp_port})
+        return 424242
+
+    monkeypatch.setattr(supervisor, "spawn", fake_spawn)
+    monkeypatch.setattr(
+        supervisor, "is_supervisor", lambda pid, vm_dir: pid == 424242 and bool(calls)
+    )
+    monkeypatch.setattr(supervisor, "running_cvms", list)
+    return calls
+
+
+@pytest.fixture
+def guest_is_up(monkeypatch):
+    monkeypatch.setattr(
+        "cvmd.cvm.sshkey.read_host_key", lambda host, port: "SHA256:testfingerprint"
+    )
+
+
+class TestASuccessfulLaunch:
+    def test_it_reports_the_instance_the_ports_and_the_fingerprint(
+        self, manager, approved, spawned, guest_is_up
+    ):
+        report = manager.create(kind="validation", triple=approved)
+
+        assert report["kind"] == "validation"
+        assert report["artifact_id"] == "validation-test"
+        assert report["instance_id"]
+        assert report["ssh_host_key_fingerprint"] == "SHA256:testfingerprint"
+        assert [p["guest_port"] for p in report["ports"]] == [2200, 8001]
+        assert report["measurements"]["compose_hash"] == approved.compose_hash
+        assert report["state"] == "VALIDATION_RUNNING"
+
+    def test_it_drives_the_states_the_task_asks_for(self, manager, approved, spawned, guest_is_up):
+        assert manager.reconcile() is NodeState.RECONCILING
+        manager.create(kind="validation", triple=approved)
+        assert manager._store.state is NodeState.VALIDATION_RUNNING
+
+    def test_the_supervisor_gets_the_scripts_directory_and_the_vm_directory(
+        self, manager, approved, spawned, guest_is_up, dstack_scripts
+    ):
+        manager.create(kind="validation", triple=approved)
+        assert spawned[0]["scripts_dir"] == dstack_scripts
+        assert (spawned[0]["vm_dir"] / "shared" / "app-compose.json").is_file()
+
+    def test_the_state_endpoint_describes_the_running_cvm(
+        self, manager, approved, spawned, guest_is_up
+    ):
+        report = manager.create(kind="validation", triple=approved)
+        described = manager.describe()
+        assert described["instance_id"] == report["instance_id"]
+        assert described["supervisor_alive"] is True
+
+
+class TestRefusals:
+    def test_a_triple_the_catalog_does_not_carry(self, manager, approved, spawned):
+        """The task's second verification case: refused, with an explicit reason."""
+        wrong = Triple(
+            qemu=approved.qemu, os_image_hash=approved.os_image_hash, compose_hash="e" * 64
+        )
+        with pytest.raises(LaunchFailure) as raised:
+            manager.create(kind="validation", triple=wrong)
+
+        assert raised.value.status == 422
+        assert "compose_hash" in raised.value.reason
+        assert not spawned, "nothing may be started for an unapproved triple"
+
+    def test_a_second_launch_while_one_runs(self, manager, approved, spawned, guest_is_up):
+        """The task's third verification case: rejected, node state stays consistent."""
+        manager.create(kind="validation", triple=approved)
+
+        with pytest.raises(LaunchFailure) as raised:
+            manager.create(kind="validation", triple=approved)
+
+        assert raised.value.status == 409
+        assert manager._store.state is NodeState.VALIDATION_RUNNING
+        assert len(spawned) == 1
+
+    def test_a_confidential_guest_started_outside_cvmd(
+        self, manager, approved, spawned, monkeypatch
+    ):
+        """GPU passthrough is exclusive whoever claimed it — including `lium-cvm.sh`."""
+        monkeypatch.setattr(
+            supervisor, "running_cvms", lambda: [(4242, "/opt/qemu-dstack/bin/qemu-system-x86_64")]
+        )
+        with pytest.raises(LaunchFailure) as raised:
+            manager.create(kind="validation", triple=approved)
+
+        assert raised.value.status == 409
+        assert "4242" in raised.value.reason
+        assert not spawned
+
+    def test_a_forwarded_port_already_in_use(self, manager, approved, spawned, free_ports):
+        with socket.socket() as held:
+            held.bind(("127.0.0.1", free_ports[0]))
+            held.listen()
+
+            with pytest.raises(LaunchFailure) as raised:
+                manager.create(kind="validation", triple=approved)
+
+        assert raised.value.status == 409
+        assert str(free_ports[0]) in raised.value.reason
+        assert not spawned
+
+    def test_a_host_with_no_launch_configuration(self, state_dir, approved):
+        manager = CvmManager(
+            config=LaunchConfig(), store=StateStore(state_dir), instances=InstanceStore(state_dir)
+        )
+        with pytest.raises(LaunchFailure) as raised:
+            manager.create(kind="validation", triple=approved)
+
+        assert raised.value.status == 503
+        assert "run_dir" in raised.value.reason
+
+    def test_a_stray_vm_directory_blocks_a_launch(self, manager, approved, spawned, launch_config):
+        """A stopped CVM still owns this node's GPUs and ports until its directory is gone."""
+        stray = launch_config.run_dir / "left-behind"
+        stray.mkdir(parents=True)
+        (stray / supervisor.DISK_IMAGE).write_bytes(b"")
+
+        with pytest.raises(LaunchFailure) as raised:
+            manager.create(kind="validation", triple=approved)
+
+        assert raised.value.status == 409
+        assert "left-behind" in raised.value.reason
+        assert not spawned
+
+
+class TestTheMeasurementGate:
+    def test_a_prepared_cvm_that_would_measure_differently_is_not_launched(
+        self, manager, approved, spawned, monkeypatch
+    ):
+        """The gate's whole reason to exist.
+
+        The catalog approves the triple, so resolution succeeds — but what lands on disk hashes
+        to something else. A launch here would attest as a stack nobody whitelisted.
+        """
+        monkeypatch.setattr(measure, "compose_hash", lambda vm_dir: "f" * 64)
+
+        with pytest.raises(LaunchFailure) as raised:
+            manager.create(kind="validation", triple=approved)
+
+        assert raised.value.status == 409
+        assert "would not measure as the requested triple" in raised.value.reason
+        assert not spawned
+
+    def test_the_refused_launch_leaves_nothing_behind(
+        self, manager, approved, spawned, monkeypatch, launch_config
+    ):
+        """A refusal has to return the node to where it was, or the next launch is blocked."""
+        monkeypatch.setattr(measure, "compose_hash", lambda vm_dir: "f" * 64)
+        with pytest.raises(LaunchFailure):
+            manager.create(kind="validation", triple=approved)
+
+        assert supervisor.vm_directories(launch_config.run_dir) == []
+        assert list(launch_config.run_dir.iterdir()) == []
+
+    def test_every_mismatch_is_named_at_once(self, manager, approved, spawned, monkeypatch):
+        monkeypatch.setattr(measure, "compose_hash", lambda vm_dir: "f" * 64)
+        monkeypatch.setattr(measure, "os_image_hash", lambda image_path: "9" * 64)
+
+        with pytest.raises(LaunchFailure) as raised:
+            manager.create(kind="validation", triple=approved)
+
+        assert "compose_hash" in raised.value.reason
+        assert "os_image_hash" in raised.value.reason
+
+
+class TestReconciliation:
+    def test_a_node_with_nothing_on_it_is_idle(self, manager):
+        assert manager.reconcile() is NodeState.RECONCILING
+
+    def test_a_running_cvm_is_adopted_after_a_restart(
+        self, manager, approved, spawned, guest_is_up, state_dir, launch_config, monkeypatch
+    ):
+        """A CVM outlives a cvmd restart; the daemon has to come back under it."""
+        manager.create(kind="validation", triple=approved)
+
+        restarted = CvmManager(
+            config=launch_config,
+            store=StateStore(state_dir),
+            instances=InstanceStore(state_dir),
+        )
+        assert restarted.reconcile() is NodeState.VALIDATION_RUNNING
+
+    def test_a_record_whose_supervisor_is_gone_fails_the_node(
+        self, manager, approved, spawned, guest_is_up, state_dir, launch_config, monkeypatch
+    ):
+        """Measured on au11: a stale `runtime.json` outlived its process by hours.
+
+        A recorded pid is a claim, so a record with no live process is a node in an unknown
+        state — not an idle one.
+        """
+        manager.create(kind="validation", triple=approved)
+        monkeypatch.setattr(supervisor, "is_supervisor", lambda pid, vm_dir: False)
+
+        restarted = CvmManager(
+            config=launch_config,
+            store=StateStore(state_dir),
+            instances=InstanceStore(state_dir),
+        )
+        assert restarted.reconcile() is NodeState.FAILED
+        assert "is gone but its directory" in restarted._store.document.last_error
+
+    def test_a_vm_directory_cvmd_never_recorded_fails_the_node(self, manager, launch_config):
+        stray = launch_config.run_dir / "unknown"
+        stray.mkdir(parents=True)
+        (stray / supervisor.DISK_IMAGE).write_bytes(b"")
+
+        assert manager.reconcile() is NodeState.FAILED
+        assert "no record of" in manager._store.document.last_error
+
+    def test_a_state_claiming_a_cvm_that_is_not_there_fails_the_node(self, manager):
+        """The daemon says VALIDATION_RUNNING, the host says nothing is running. That is a
+        failure to investigate, not a node quietly declaring itself free."""
+        manager._store.transition(NodeState.LAUNCHING)
+        manager._store.transition(NodeState.VALIDATION_RUNNING)
+
+        assert manager.reconcile() is NodeState.FAILED
+        assert "no CVM is running on it" in manager._store.document.last_error
+
+    def test_a_host_that_manages_no_cvms_is_left_alone(self, state_dir):
+        """cvmd installed before its catalog exists must not re-derive a state it cannot see."""
+        store = StateStore(state_dir)
+        store.transition(NodeState.LAUNCHING)
+        manager = CvmManager(config=LaunchConfig(), store=store, instances=InstanceStore(state_dir))
+
+        assert manager.reconcile() is NodeState.LAUNCHING
+
+    def test_an_unreadable_instance_record_fails_closed(self, state_dir, launch_config):
+        """Never "no record, therefore idle" — a CVM cvmd forgot may still be running."""
+        (state_dir / "instance.json").write_text("{ truncated")
+        manager = CvmManager(
+            config=launch_config, store=StateStore(state_dir), instances=InstanceStore(state_dir)
+        )
+
+        assert manager.reconcile() is NodeState.FAILED
+        assert "unreadable or malformed" in manager._store.document.last_error
+
+
+class TestOverHttp:
+    """The same paths through auth, the router and the worker-thread offload."""
+
+    @pytest.fixture
+    def launching_client(
+        self, clients_file, state_dir, launch_config, spawned, guest_is_up, monkeypatch
+    ):
+        from conftest import signed_request  # noqa: F401 - imported for the tests below
+        from cvmd.app import create_app
+        from fastapi.testclient import TestClient
+
+        monkeypatch.setattr(
+            "cvmd.cvm.measure.qemu_version", lambda _dstack: QEMU_FALLBACK, raising=True
+        )
+        config = Config(authorized_clients=clients_file, state_dir=state_dir, launch=launch_config)
+        with TestClient(create_app(config), raise_server_exceptions=False) as client:
+            yield client
+
+    def _body(self, approved: Triple) -> bytes:
+        return json.dumps(
+            {
+                "kind": "validation",
+                "qemu": approved.qemu,
+                "os_image_hash": approved.os_image_hash,
+                "compose_hash": approved.compose_hash,
+            }
+        ).encode()
+
+    def test_the_validator_key_launches_and_gets_the_report(
+        self, launching_client, validator_key, approved
+    ):
+        from conftest import signed_request
+
+        response = signed_request(
+            launching_client, validator_key, "POST", "/v1/cvm", body=self._body(approved)
+        )
+
+        assert response.status_code == 201
+        assert response.json()["ssh_host_key_fingerprint"] == "SHA256:testfingerprint"
+
+    def test_the_state_endpoint_then_shows_the_cvm(
+        self, launching_client, validator_key, platform_key, approved
+    ):
+        from conftest import signed_request
+
+        created = signed_request(
+            launching_client, validator_key, "POST", "/v1/cvm", body=self._body(approved)
+        ).json()
+        state = signed_request(launching_client, platform_key, "GET", "/v1/state").json()
+
+        assert state["state"] == "VALIDATION_RUNNING"
+        assert state["cvm"]["instance_id"] == created["instance_id"]
+
+    def test_a_triple_missing_from_the_body_is_422(self, launching_client, validator_key):
+        from conftest import signed_request
+
+        response = signed_request(
+            launching_client,
+            validator_key,
+            "POST",
+            "/v1/cvm",
+            body=json.dumps({"kind": "validation"}).encode(),
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.parametrize(
+        "value", ["A" * 64, "sha256:" + "a" * 64, "abc"], ids=["uppercase", "prefixed", "short"]
+    )
+    def test_a_hash_that_is_not_lowercase_hex_is_422(self, launching_client, validator_key, value):
+        """Rejected at the edge, so a malformed pin cannot read as an unapproved stack later."""
+        from conftest import signed_request
+
+        body = json.dumps(
+            {
+                "kind": "validation",
+                "qemu": "10.1.0",
+                "os_image_hash": value,
+                "compose_hash": "b" * 64,
+            }
+        ).encode()
+        assert (
+            signed_request(
+                launching_client, validator_key, "POST", "/v1/cvm", body=body
+            ).status_code
+            == 422
+        )
+
+    def test_the_platform_key_tears_the_cvm_down(
+        self, launching_client, validator_key, platform_key, approved, monkeypatch
+    ):
+        """DELETE carries no `kind`, so it is renter-scoped: letting the validation key call it
+        would let a validator destroy a renter's CVM."""
+        from conftest import signed_request
+
+        signed_request(
+            launching_client, validator_key, "POST", "/v1/cvm", body=self._body(approved)
+        )
+        monkeypatch.setattr(supervisor, "shutdown", lambda *a, **k: "guest powered off on request")
+        monkeypatch.setattr(supervisor, "is_supervisor", lambda pid, vm_dir: False)
+
+        response = signed_request(launching_client, platform_key, "DELETE", "/v1/cvm")
+
+        assert response.status_code == 200
+        assert response.json()["torn_down"] is True
+
+    def test_a_second_operation_while_one_is_in_flight_is_refused(
+        self, launching_client, validator_key, approved
+    ):
+        """The lock is acquired without blocking: the caller gets an answer, not a queue slot."""
+        from conftest import signed_request
+
+        launching_client.app.state.cvm_lock.acquire()
+        try:
+            response = signed_request(
+                launching_client, validator_key, "POST", "/v1/cvm", body=self._body(approved)
+            )
+        finally:
+            launching_client.app.state.cvm_lock.release()
+
+        assert response.status_code == 409
+        assert "already in progress" in response.json()["detail"]
+
+
+class TestTeardown:
+    def test_tearing_down_a_running_cvm_frees_the_node(
+        self, manager, approved, spawned, guest_is_up, launch_config, monkeypatch
+    ):
+        report = manager.create(kind="validation", triple=approved)
+        monkeypatch.setattr(supervisor, "shutdown", lambda *a, **k: "guest powered off on request")
+        monkeypatch.setattr(supervisor, "is_supervisor", lambda pid, vm_dir: False)
+
+        result = manager.destroy()
+
+        assert result["torn_down"] is True
+        assert result["instance_id"] == report["instance_id"]
+        assert manager._store.state is NodeState.RECONCILING
+        assert supervisor.vm_directories(launch_config.run_dir) == []
+
+    def test_a_relaunch_after_teardown_succeeds(
+        self, manager, approved, spawned, guest_is_up, monkeypatch
+    ):
+        """The point of removing the directory: the node is reusable without hand-cleanup."""
+        manager.create(kind="validation", triple=approved)
+        monkeypatch.setattr(supervisor, "shutdown", lambda *a, **k: "stopped")
+        monkeypatch.setattr(supervisor, "is_supervisor", lambda pid, vm_dir: False)
+        manager.destroy()
+
+        monkeypatch.setattr(supervisor, "is_supervisor", lambda pid, vm_dir: pid == 424242)
+        assert manager.create(kind="validation", triple=approved)["state"] == "VALIDATION_RUNNING"
+
+    def test_tearing_down_an_idle_node_is_not_an_error(self, manager):
+        """A platform that timed out mid-teardown has to be able to repeat the call."""
+        result = manager.destroy()
+        assert result == {"torn_down": False, "reason": "this node is running no CVM"}
+
+    def test_a_cvm_that_will_not_stop_fails_the_node(
+        self, manager, approved, spawned, guest_is_up, monkeypatch
+    ):
+        """Never report a teardown that did not happen — that is the DAH-2577 acceptance bar."""
+        manager.create(kind="validation", triple=approved)
+        monkeypatch.setattr(supervisor, "shutdown", lambda *a, **k: "still present after SIGKILL")
+
+        with pytest.raises(LaunchFailure) as raised:
+            manager.destroy()
+
+        assert raised.value.status == 500
+        assert manager._store.state is NodeState.FAILED

--- a/neurons/executor/cvmd/tests/test_launch.py
+++ b/neurons/executor/cvmd/tests/test_launch.py
@@ -11,6 +11,7 @@ exactly the paths where a bug would leave a node in a state someone has to clean
 
 import json
 import socket
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -262,6 +263,31 @@ class TestRefusals:
         assert "left-behind" in raised.value.reason
         assert not spawned
 
+    def test_an_ssh_guest_port_that_nothing_forwards(
+        self, state_dir, launch_config, approved, spawned, monkeypatch
+    ):
+        """A one-character config slip must not become "running, fingerprint null".
+
+        With no mapping to read the host key through there is no readiness check left, so the
+        launch would report VALIDATION_RUNNING milliseconds after spawning QEMU — before the
+        guest had booted. Refused before anything is prepared instead.
+        """
+        monkeypatch.setattr(
+            "cvmd.cvm.measure.qemu_version", lambda _dstack: QEMU_FALLBACK, raising=True
+        )
+        mismatched = replace(launch_config, ssh_guest_port=2201)
+        manager = CvmManager(
+            config=mismatched, store=StateStore(state_dir), instances=InstanceStore(state_dir)
+        )
+
+        with pytest.raises(LaunchFailure) as raised:
+            manager.create(kind="validation", triple=approved)
+
+        assert raised.value.status == 503
+        assert "cvm_ssh_guest_port" in raised.value.reason
+        assert not spawned
+        assert not mismatched.run_dir.exists()
+
 
 class TestTheMeasurementGate:
     def test_a_prepared_cvm_that_would_measure_differently_is_not_launched(
@@ -373,6 +399,30 @@ class TestReconciliation:
 
         assert manager.reconcile() is NodeState.FAILED
         assert "unreadable or malformed" in manager._store.document.last_error
+
+
+class TestSettling:
+    """`_settle` is the recovery path, so it must not raise the error it exists to avoid."""
+
+    @pytest.mark.parametrize(
+        "running",
+        [NodeState.LAUNCHING, NodeState.VALIDATION_RUNNING, NodeState.RENTER_RUNNING],
+    )
+    def test_settling_to_reconciling_from_a_running_state(self, manager, running):
+        """RECONCILING is the staging point *and* the destination here.
+
+        Reaching it is the whole move; asking for it again is RECONCILING -> RECONCILING, which
+        the machine rejects.
+        """
+        manager._store.transition(running)
+
+        assert manager._settle(NodeState.RECONCILING) is NodeState.RECONCILING
+        assert manager._store.state is NodeState.RECONCILING
+
+    def test_settling_to_a_running_state_still_goes_the_long_way(self, manager):
+        manager._store.transition(NodeState.FAILED)
+
+        assert manager._settle(NodeState.VALIDATION_RUNNING) is NodeState.VALIDATION_RUNNING
 
 
 class TestOverHttp:
@@ -498,6 +548,42 @@ class TestOverHttp:
         assert "already in progress" in response.json()["detail"]
 
 
+class TestReadinessWithoutKeyscan:
+    """A host with no `ssh-keyscan` still finishes its launch.
+
+    `read_host_key` returns None both when the tool is missing and when the guest is not up
+    yet, so a loop that cannot tell them apart polls for the whole launch timeout and then
+    fails a node whose CVM booted fine. The tool is looked up once, before the loop.
+    """
+
+    @pytest.fixture
+    def no_keyscan(self, monkeypatch):
+        monkeypatch.setattr("cvmd.cvm.sshkey.keyscan_available", lambda: False)
+
+        def unreachable(host, port):
+            raise AssertionError("ssh-keyscan is absent; read_host_key must not be polled")
+
+        monkeypatch.setattr("cvmd.cvm.sshkey.read_host_key", unreachable)
+        monkeypatch.setattr("cvmd.cvm.sshkey.accepts_connection", lambda host, port: True)
+
+    def test_it_falls_back_to_a_tcp_accept(self, manager, approved, spawned, no_keyscan):
+        report = manager.create(kind="validation", triple=approved)
+
+        assert report["state"] == "VALIDATION_RUNNING"
+        assert report["ssh_host_key_fingerprint"] is None
+        assert "ssh-keyscan" in report["note"]
+
+    def test_the_launch_does_not_burn_its_whole_timeout(
+        self, manager, approved, spawned, no_keyscan, monkeypatch
+    ):
+        """Sleeping at all here means the loop is waiting for a fingerprint that cannot come."""
+        monkeypatch.setattr(
+            "cvmd.cvm.manager.time.sleep",
+            lambda _s: (_ for _ in ()).throw(AssertionError("polled instead of falling back")),
+        )
+        assert manager.create(kind="validation", triple=approved)["state"] == "VALIDATION_RUNNING"
+
+
 class TestTeardown:
     def test_tearing_down_a_running_cvm_frees_the_node(
         self, manager, approved, spawned, guest_is_up, launch_config, monkeypatch
@@ -529,6 +615,64 @@ class TestTeardown:
         """A platform that timed out mid-teardown has to be able to repeat the call."""
         result = manager.destroy()
         assert result == {"torn_down": False, "reason": "this node is running no CVM"}
+
+    def test_a_stray_directory_with_a_live_guest_is_not_removed(
+        self, manager, launch_config, monkeypatch
+    ):
+        """ "No record" usually means "the record went missing", not "nothing is running".
+
+        Removing the disk from under a live QEMU would report a teardown that did not happen
+        and leave the node's GPUs held by a process nothing can name — the record that carried
+        its pid is exactly what is gone.
+        """
+        stray = launch_config.run_dir / "unrecorded"
+        stray.mkdir(parents=True)
+        (stray / supervisor.DISK_IMAGE).write_bytes(b"")
+        monkeypatch.setattr(supervisor, "running_cvms", lambda: [(4242, "qemu-system-x86_64")])
+
+        with pytest.raises(LaunchFailure) as raised:
+            manager.destroy()
+
+        assert raised.value.status == 409
+        assert "4242" in raised.value.reason
+        assert (stray / supervisor.DISK_IMAGE).exists()
+        assert manager._store.state is NodeState.FAILED
+
+    def test_a_stray_directory_with_no_guest_is_removed(self, manager, launch_config, monkeypatch):
+        stray = launch_config.run_dir / "unrecorded"
+        stray.mkdir(parents=True)
+        (stray / supervisor.DISK_IMAGE).write_bytes(b"")
+        monkeypatch.setattr(supervisor, "running_cvms", list)
+
+        result = manager.destroy()
+
+        assert result["torn_down"] is True
+        assert not stray.exists()
+        assert manager._store.state is NodeState.RECONCILING
+
+    def test_a_graceful_shutdown_that_raises_still_signals_the_group(self, monkeypatch):
+        """dstack reads runtime.json outside its own try block, so it can raise here.
+
+        Letting that propagate would skip the signal ladder entirely — the guest would never be
+        signalled at all, which is the one outcome `shutdown` exists to prevent.
+        """
+        signalled: list[int] = []
+
+        class Raising:
+            @staticmethod
+            def shutdown_instance(vm_dir, timeout, force):
+                raise KeyError("cid")
+
+        monkeypatch.setattr(
+            supervisor,
+            "shutdown_by_signal",
+            lambda pid, *, timeout: signalled.append(pid) or "process group stopped by SIGTERM",
+        )
+
+        detail = supervisor.shutdown(Raising, Path("/nonexistent"), 4242, timeout=1)
+
+        assert signalled == [4242]
+        assert detail == "process group stopped by SIGTERM"
 
     def test_a_cvm_that_will_not_stop_fails_the_node(
         self, manager, approved, spawned, guest_is_up, monkeypatch

--- a/neurons/executor/cvmd/tests/test_ports.py
+++ b/neurons/executor/cvmd/tests/test_ports.py
@@ -1,0 +1,84 @@
+"""Forwarded ports — parsed as dstack parses them, and never handed out twice."""
+
+import socket
+
+import pytest
+from cvmd.cvm.ports import PortError, assert_free, parse, parse_all
+
+
+class TestParsing:
+    def test_three_parts_default_to_loopback(self):
+        """dstack's own default. A mapping with no address is not a public one."""
+        mapping = parse("tcp:2200:22")
+        assert (mapping.protocol, mapping.address) == ("tcp", "127.0.0.1")
+        assert (mapping.host_port, mapping.guest_port) == (2200, 22)
+
+    def test_four_parts_carry_the_bind_address(self):
+        mapping = parse("tcp:0.0.0.0:12200:2200")
+        assert mapping.address == "0.0.0.0"
+        assert (mapping.host_port, mapping.guest_port) == (12200, 2200)
+
+    @pytest.mark.parametrize(
+        "spec",
+        ["tcp:22", "tcp:a:b:c:d:e", "tcp:0.0.0.0:notaport:22", "tcp:0:22", "tcp:70000:22"],
+        ids=["too-few", "too-many", "non-numeric", "port-zero", "port-too-high"],
+    )
+    def test_a_mapping_cvmd_cannot_parse_is_refused(self, spec):
+        with pytest.raises(PortError):
+            parse(spec)
+
+    def test_the_same_host_port_twice_is_refused(self):
+        """QEMU would take the first and drop the second silently; only one could ever work."""
+        with pytest.raises(PortError, match="mapped twice"):
+            parse_all(["tcp:0.0.0.0:12200:2200", "tcp:0.0.0.0:12200:8001"])
+
+    def test_the_same_host_port_on_different_protocols_is_fine(self):
+        assert len(parse_all(["tcp:0.0.0.0:12200:2200", "udp:0.0.0.0:12200:2200"])) == 2
+
+
+class TestAvailability:
+    def test_free_ports_pass(self):
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            free_port = probe.getsockname()[1]
+        # The socket is closed, so the port is free again — this is the happy path.
+        assert_free(parse_all([f"tcp:127.0.0.1:{free_port}:22"]))
+
+    def test_a_port_someone_else_holds_refuses_the_launch(self):
+        """The check that stops a second CVM answering on a live one's address."""
+        with socket.socket() as held:
+            held.bind(("127.0.0.1", 0))
+            held.listen()
+            port = held.getsockname()[1]
+
+            with pytest.raises(PortError, match=f"{port}"):
+                assert_free(parse_all([f"tcp:127.0.0.1:{port}:22"]))
+
+    def test_every_taken_port_is_named_at_once(self):
+        """One message, not one per relaunch: each retry is a chance to leave a CVM half-built."""
+        with socket.socket() as first, socket.socket() as second:
+            first.bind(("127.0.0.1", 0))
+            second.bind(("127.0.0.1", 0))
+            first.listen()
+            second.listen()
+            ports = [first.getsockname()[1], second.getsockname()[1]]
+
+            with pytest.raises(PortError) as raised:
+                assert_free(parse_all([f"tcp:127.0.0.1:{p}:22" for p in ports]))
+
+        message = str(raised.value)
+        assert all(str(port) in message for port in ports)
+
+    def test_a_loopback_holder_blocks_a_wildcard_bind(self):
+        """The realistic collision: a live CVM forwards 127.0.0.1:P, a new one wants 0.0.0.0:P.
+
+        SO_REUSEADDR is deliberately not set, so this is caught rather than allowed through to
+        two processes fighting over the same port.
+        """
+        with socket.socket() as held:
+            held.bind(("127.0.0.1", 0))
+            held.listen()
+            port = held.getsockname()[1]
+
+            with pytest.raises(PortError):
+                assert_free(parse_all([f"tcp:0.0.0.0:{port}:22"]))

--- a/neurons/executor/cvmd/tests/test_scope.py
+++ b/neurons/executor/cvmd/tests/test_scope.py
@@ -1,11 +1,31 @@
-"""The full 2-key x 5-endpoint-class scope matrix, plus single-parse enforcement."""
+"""The full 2-key x 5-endpoint-class scope matrix, plus single-parse enforcement.
+
+The `client` fixture's host has no launch configuration, which is what makes the authorized
+cells readable: an authorized create answers **503** ("this host has no launch configuration
+for ..."), a code only the handler can produce. Reaching a 503 therefore proves the request
+cleared auth and scope, exactly as the 501 did before DAH-2576 filled the handlers in.
+Launching for real is `test_launch.py`'s job; this file is about who may ask.
+"""
 
 import json
 
 import pytest
 from conftest import signed_request
 
-VALIDATION_CREATE = ("POST", "/v1/cvm", {"kind": "validation"})
+HASH_A = "a" * 64
+HASH_B = "b" * 64
+
+# The triple is required on a validation create, so the matrix has to send a complete body —
+# otherwise an authorized cell would fail model validation and report 422, which the scope
+# layer also produces, and the cell would stop distinguishing anything.
+VALIDATION_BODY = {
+    "kind": "validation",
+    "qemu": "10.1.0",
+    "os_image_hash": HASH_A,
+    "compose_hash": HASH_B,
+}
+
+VALIDATION_CREATE = ("POST", "/v1/cvm", VALIDATION_BODY)
 RENTER_CREATE = ("POST", "/v1/cvm", {"kind": "renter"})
 RENTER_DESTROY = ("DELETE", "/v1/cvm", None)
 STATE_READ = ("GET", "/v1/state", None)
@@ -13,16 +33,16 @@ HEALTH = ("GET", "/health", None)
 
 # Every cell of {validator, platform} x {the five endpoint classes}.
 #
-# 501 means the request was fully authorized and reached a handler that DAH-2576 will fill in;
-# it is a pass, not a gap. 403 is a scope violation on an otherwise valid request.
+# 403 is a scope violation on an otherwise valid request. 501 is the renter create, whose body
+# DAH-2580 defines. 503 and 200 are handlers that ran.
 MATRIX = [
-    ("validator", VALIDATION_CREATE, 501),
+    ("validator", VALIDATION_CREATE, 503),
     ("validator", RENTER_CREATE, 403),
     ("validator", RENTER_DESTROY, 403),
     ("validator", STATE_READ, 200),
     ("platform", VALIDATION_CREATE, 403),
     ("platform", RENTER_CREATE, 501),
-    ("platform", RENTER_DESTROY, 501),
+    ("platform", RENTER_DESTROY, 200),
     ("platform", STATE_READ, 200),
 ]
 
@@ -91,18 +111,27 @@ class TestSingleParse:
     parsers keep the first.
     """
 
-    DUPLICATE_KIND = b'{"kind":"renter","kind":"validation"}'
+    DUPLICATE_KIND = (
+        b'{"kind":"renter","kind":"validation","qemu":"10.1.0",'
+        b'"os_image_hash":"' + HASH_A.encode() + b'",'
+        b'"compose_hash":"' + HASH_B.encode() + b'"}'
+    )
 
     def test_scope_follows_the_last_duplicate(self, client, validator_key):
-        """cvmd's parse resolves `kind` to `validation`, so the validator key is the one allowed."""
+        """cvmd's parse resolves `kind` to `validation`, so the validator key is the one allowed.
+
+        503 rather than 501 is the tell: the request reached the *validation* handler. Had any
+        layer read `renter` — the first value — it would have been 501 instead.
+        """
         response = signed_request(
             client, validator_key, "POST", "/v1/cvm", body=self.DUPLICATE_KIND
         )
-        assert response.status_code == 501
+        assert response.status_code == 503
 
     def test_the_other_key_is_refused_on_the_same_bytes(self, client, platform_key):
         """The mirror of the above. If any part of the stack read `renter` — the *first* value —
-        this would be a 501 and the two halves would be disagreeing about the same request.
+        this would have reached a handler and the two halves would be disagreeing about the
+        same request.
         """
         response = signed_request(client, platform_key, "POST", "/v1/cvm", body=self.DUPLICATE_KIND)
         assert response.status_code == 403
@@ -110,8 +139,9 @@ class TestSingleParse:
     def test_handler_reads_state_not_the_stream(self, client, platform_key):
         """The middleware consumes the request stream to enforce the size cap.
 
-        A handler that re-read the body would find it spent, so a successful create here is
-        positive evidence that the handler is using the object the middleware passed forward.
+        A handler that re-read the body would find it spent, so reaching the renter handler's
+        501 here is positive evidence that the handler is using the object the middleware
+        passed forward.
         """
         body = json.dumps({"kind": "renter", "image": "sha256:abc"}).encode()
         response = signed_request(client, platform_key, "POST", "/v1/cvm", body=body)

--- a/neurons/executor/cvmd/tests/test_supervisor.py
+++ b/neurons/executor/cvmd/tests/test_supervisor.py
@@ -1,0 +1,161 @@
+"""The supervisor is independent of cvmd, and cvmd can tell truthfully when it is gone.
+
+Both properties were learned on hardware. On au11 the supervisor started as cvmd's direct child,
+and cvmd never calls `wait()` on it — so a stopped supervisor sat as a **zombie**. A zombie is
+still a member of its process group, so `killpg(pgid, 0)` kept succeeding: every teardown ran
+the whole signal ladder (measured: 260s) and ended by reporting "still present after SIGKILL"
+about a guest that had powered off gracefully minutes earlier. `os.kill(pid, 0)` shares the
+blind spot, and that is exactly what `shutdown_instance` waits on.
+
+These tests spawn the real `spawn()` against a stand-in that calls the real `_detach`, so the
+shipping code is what gets asserted — only the part that would start QEMU is replaced.
+"""
+
+import os
+import signal
+import time
+from pathlib import Path
+
+import pytest
+from cvmd.cvm import supervisor
+
+FIXTURE_MODULE = "fixtures.sleepy_supervisor"
+SETTLE_SECONDS = 10
+
+
+def process_field(pid: int, field: str) -> int | None:
+    """Read one field out of /proc/<pid>/stat. None if the process is gone."""
+    try:
+        raw = Path(f"/proc/{pid}/stat").read_text()
+    except OSError:
+        return None
+    # The comm field is parenthesised and may contain spaces, so split after it.
+    after_comm = raw[raw.rindex(")") + 2 :].split()
+    # stat fields from `state` (index 0 here) — ppid is 1, pgrp 2, session 3.
+    return {
+        "state": after_comm[0],
+        "ppid": int(after_comm[1]),
+        "pgid": int(after_comm[2]),
+        "sid": int(after_comm[3]),
+    }[field]
+
+
+def wait_until(predicate, seconds: int = SETTLE_SECONDS) -> bool:
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return predicate()
+
+
+@pytest.fixture
+def detached(tmp_path, monkeypatch):
+    """Spawn the stand-in supervisor and yield its pid, killing it afterwards whatever happens."""
+    monkeypatch.setattr(supervisor, "CHILD_MODULE", FIXTURE_MODULE)
+    # Prepended, not replaced: the subprocess still has to find `cvmd` the same way this
+    # process did, and the stand-in imports the real `_detach` from it.
+    existing = os.environ.get("PYTHONPATH", "")
+    monkeypatch.setenv(
+        "PYTHONPATH", os.pathsep.join(filter(None, [str(Path(__file__).parent), existing]))
+    )
+
+    vm_dir = tmp_path / "instance"
+    vm_dir.mkdir()
+    pid = supervisor.spawn(scripts_dir=tmp_path, vm_dir=vm_dir, kp_port=3443)
+    try:
+        yield pid, vm_dir
+    finally:
+        try:
+            os.killpg(pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+
+class TestDetachment:
+    def test_the_supervisor_is_not_cvmd_s_child(self, detached):
+        """Orphaned to init, so nothing has to reap it and nothing can leave it a zombie."""
+        pid, _ = detached
+        assert process_field(pid, "ppid") == 1
+
+    def test_it_leads_its_own_session_and_process_group(self, detached):
+        """QEMU lands in a group whose id is this pid, which is how teardown reaches both."""
+        pid, _ = detached
+        assert process_field(pid, "sid") == pid
+        assert process_field(pid, "pgid") == pid
+
+    def test_spawn_returns_the_pid_that_holds_the_vm(self, detached):
+        """Popen sees the process that forks and exits, never the one that matters."""
+        pid, vm_dir = detached
+        assert int((vm_dir / supervisor.PID_FILE).read_text().strip()) == pid
+        assert process_field(pid, "state") is not None
+
+    def test_it_survives_a_signal_aimed_at_cvmd_s_own_group(self, detached):
+        """A CVM must outlive a cvmd restart, so it must not share cvmd's process group."""
+        pid, _ = detached
+        assert process_field(pid, "pgid") != os.getpgid(0)
+
+    def test_cvmd_is_left_with_no_zombie(self, detached):
+        """The defect this file exists for.
+
+        Before the double-fork, a stopped supervisor stayed a zombie in its own process group,
+        so `killpg(pgid, 0)` never reported it gone and teardown ran the whole signal ladder
+        before declaring a failure that had not happened.
+        """
+        pid, _ = detached
+        os.killpg(pid, signal.SIGKILL)
+
+        assert wait_until(lambda: process_field(pid, "state") in (None, "X")), (
+            f"pid {pid} is still {process_field(pid, 'state')} — a zombie here means cvmd is "
+            f"its parent again, and every teardown will burn its full timeout"
+        )
+
+    def test_the_process_group_reads_as_gone_once_it_is(self, detached):
+        """The predicate teardown actually uses, against a real killed process."""
+        pid, _ = detached
+        os.killpg(pid, signal.SIGKILL)
+
+        assert wait_until(lambda: supervisor._process_group_gone(pid))
+
+
+class TestTheUnitLetsItSurvive:
+    """Detaching is not enough on its own — systemd kills by cgroup, not by session.
+
+    Measured on au11: with the default `KillMode=control-group`, `systemctl restart cvmd` logged
+    `cvmd.service: Killing process 218807 (qemu-system-x86) with signal SIGKILL` and the node
+    came back FAILED holding a CVM directory and no CVM. The double-fork puts the supervisor in
+    its own *session*; nothing in a process's control moves it out of its unit's *cgroup*.
+
+    Asserted against the packaged unit because no test host has systemd, and because the
+    property is entirely a property of that file.
+    """
+
+    UNIT = Path(__file__).resolve().parents[1] / "packaging" / "cvmd.service"
+
+    def test_the_unit_stops_only_the_daemon(self):
+        assert "KillMode=process" in self.UNIT.read_text(), (
+            "without KillMode=process, restarting cvmd kills the node's CVM — systemd's default "
+            "kills every process in the unit's cgroup, and detaching does not leave it"
+        )
+
+    def test_the_reason_is_recorded_beside_it(self):
+        """A one-word setting whose reason is off-page is a setting someone tidies away."""
+        text = self.UNIT.read_text()
+        assert "cgroup" in text and "RECONCILING" in text
+
+
+class TestConsoleLog:
+    def test_the_child_s_output_is_not_held_in_a_buffer(self, detached):
+        """`-u`, and why it matters.
+
+        Python block-buffers stdout when it is a file. Without `-u` the QEMU command line that
+        `run_instance` prints sits in the child's buffer for the VM's whole life, while QEMU
+        writes past it through the same descriptor — so the one line saying what was launched is
+        missing from the log for exactly as long as anyone would want to read it.
+        """
+        _pid, vm_dir = detached
+        log = supervisor.console_log_path(vm_dir)
+
+        assert wait_until(lambda: "detached" in log.read_text()), (
+            f"the console log is empty while the supervisor runs: {log.read_text()!r}"
+        )


### PR DESCRIPTION
## Describe your changes

DAH-2576: **cvmd launches and stops the validation CVM**, calling
`neurons/executor/dstacktee/scripts/dstack.py` as a library.

**Base is `feature/2462-cvm-v2`, not `main`.** It sits on top of #1205.

### The launch

```
POST /v1/cvm
{"kind": "validation", "qemu": "9.2.1",
 "os_image_hash": "<64 hex>", "compose_hash": "<64 hex>"}
```

The body names **which software stack to run** and nothing else. Sizing — vCPUs, memory, disk, GPUs, forwarded ports — is provider configuration read from `/etc/cvmd/config.toml`. That was your call on #1205, and it is why `CreateCvmRequest` carries no sizing fields.

The three hashes are a pinned triple, resolved against the local catalog; a triple the catalog does not carry is refused naming the component that was not approved. The request returns when the CVM is up, with the launch report — instance id, forwarded ports, SSH host-key fingerprint — while `/v1/state` moves `RECONCILING → LAUNCHING → VALIDATION_RUNNING`.

`POST {kind: renter}` still answers 501 (DAH-2580 defines that body). `DELETE` is implemented and stays platform-scoped: it carries no `kind`, so a validator holding that right could destroy a **renter's** CVM.

### No behavior fork, and it is checked rather than asserted

cvmd imports the real `dstack.py` and calls the same functions its CLI calls. `tests/test_dstack_library.py` prepares one CVM through cvmd's plan and through `dstack.py new` with the flags `lium-cvm.sh` builds, then compares **every file**. Dropping a single flag from `plan.py` fails it.

Calling the same code makes identical measurements likely. The gate makes them checked: between `setup_instance` writing the VM directory and QEMU starting, cvmd measures what it just built — `sha256(shared/app-compose.json)`, the image's `digest.txt`, `get_qemu_version_string()` — and refuses to launch anything that would not measure as the requested triple. The directory is removed and the node is left exactly where it was. Configuration says what was *intended*; only the files say what was *built*.

### One CVM per node

Checked by reading `/proc` for a running TDX guest, not cvmd's own records — during the rollout the CVM already on a host is most likely one `lium-cvm.sh` started, and cvmd's records cannot see those. Every forwarded port must also be bindable before QEMU starts, which is how a second CVM is stopped from answering on a live one's address.

## Verification

**Hardware acceptance on `au11`** — real Intel TDX, QEMU 9.2.1, `dstack-nvidia-0.5.11`. Full results in the comment below.

| | |
|---|---|
| Measured-byte parity on the host (app-compose.json, 95-line QEMU cmdline, `vm_config`) | **identical** |
| Live launch → teardown → relaunch over signed HTTPS | **37/37** |
| CVM survives a `systemctl restart cvmd` | **11/11** |
| cvmd unit suite | **223 passed** |
| Ansible: lint (`production`), syntax, yamllint, 10 shell suites, 10 fixture playbooks | all pass |

**Three defects were found by the hardware run and fixed here** (`49f4d694`). Each is about a process cvmd started and no longer controls, so none is reachable by an in-process test:

1. **Teardown reported a failure that had not happened, 260s late.** The supervisor was cvmd's direct child and cvmd never calls `wait()`, so a stopped supervisor sat as a zombie — and a zombie is still a process-group member, so `killpg(pgid, 0)` kept succeeding. `os.kill(pid, 0)` has the same blind spot, and that is what `shutdown_instance` waits on. The supervisor now double-forks. Teardown went **260s → 5s** and reports the graceful path.
2. **A cvmd restart killed the node's CVM.** Detaching into its own session is not enough: systemd kills by *cgroup*, and nothing a process does moves it out of its unit's. The journal read `Killing process 218807 (qemu-system-x86) with signal SIGKILL` and the node came back FAILED holding a CVM directory and no CVM. Fixed with `KillMode=process`.
3. **The QEMU command line never reached `console.log`** while the CVM ran — Python block-buffers stdout to a file, so the one line saying what was launched sat in the child's buffer for the VM's whole life. The child now runs with `-u`.

The graceful-poweroff window is now a setting rather than a constant, because a 1.13 TB guest was measured taking 43 minutes to return its memory and a fixed budget would SIGKILL a legitimate slow exit. Per-hardware-class values are DAH-2577's declared open item.

### Re-accepted after review (`a38e11af`)

A careful re-read of the branch found **five more defects**, all on paths the first acceptance did not stage — a lost record, a half-written file, a missing tool, a mismatched port. They are fixed in `a38e11af`, along with eight simplifications (`_exclusively` for the routes' shared lock, `_describe`, `HEX64` moved to `catalog.py`, dead `runtime_pid` / `RUNTIME_FILE` / `Measurements.as_dict` removed).

Because the earlier suite passes either way, each fix was **staged on the hardware** and the old failure asserted against:

| Staged condition | Before | Now |
|---|---|---|
| a stray VM directory with a guest still running under it | the disk was deleted from a live QEMU and success reported | **409**, guest and disk untouched |
| `runtime.json` half-written by a crashed host | dstack raised past the signal ladder — the guest was never signalled at all | falls back to the ladder, torn down in **4s** |
| `ssh-keyscan` absent while `cvm_ssh_guest_port` is set | polled for a fingerprint that could never arrive, then failed the node after the full 600s timeout | **201 in 5s**, null fingerprint, note says why |
| `cvm_ssh_guest_port` that no `cvm_ports` entry forwards | discovered only by timing out | **503 in 0.0s**, naming the setting |
| a malformed `cvm_ports` mapping | valid TOML, so the daemon started looking configured and refused every launch | fatal at startup; the role's `validate:` hook now runs `load_config` |

Re-run on `au11` against the exact bytes of `a38e11af`:

| | |
|---|---|
| Measured-byte parity (app-compose.json, 95-line QEMU cmdline, `vm_config`) | **identical** |
| `e2e_launch.py` | **37/37** |
| `e2e_restart.py` | **11/11** |
| the five fixes, staged on hardware | **39/39** |
| the installed config loader vs 4 malformed mappings + 1 valid | **5/5** |
| converges with a bad SSH port / a bad port range | **both refuse before install**, `changed=0` |
| clean converge afterwards | idempotent, `changed=0` |

The measured triple came back **byte-identical to the pre-review run** — same qemu `9.2.1`, same `os_image_hash`, same `compose_hash` `90d63529…`. That is the evidence the simplifications did not change what cvmd builds.

One caveat, declared here so it is not mistaken for something this PR introduced. The readiness fallback — a plain TCP connect, used when no fingerprint can be obtained — is weak. Measured on one launch: the forwarded port accepts at **1s**, the guest's SSH host key answers at **43s**, because QEMU binds the `hostfwd` listener before the guest boots. So on that path a 201 is returned while the CVM is still booting. It is **not a regression** — that configuration previously failed outright after 600s — but "port accepts connections" is close to vacuous, and the `note` field is the only thing distinguishing it. Worth its own ticket; a caller should not read a 201 with a null fingerprint as proof the guest is up.

### Left for the tasks that own them

- **The catalog is a local file** rendered by the Ansible role. DAH-2578 replaces the loader with the backend's signed-manifest client; only `load_catalog` changes.
- **Teardown confirms the process group is gone, and no more.** The four-condition predicate — VFIO descriptors closed, guest RAM returned, forwarded ports bindable — is DAH-2577, and so is the timeout budget per hardware class.
- **Quote comparison.** The task asks for MRTD/RTMR0-3 equal to a `lium-cvm.sh` launch. Rather than sample two quotes, the acceptance run proves the three artifacts those measurements are computed from are byte-identical — a proof by construction. Reproducing a full quote pair needs a validator in the loop and belongs with DAH-2581.

### ⚠️ This PR runs zero CI

`test.yml` is `on: pull_request: branches: [main, dev]`, and the filter matches the **target** branch, so a PR into the umbrella runs no checks — silently, while GitHub still reports `MERGEABLE`. The gate is deferred to the eventual `feature/2462-cvm-v2` → `main` PR. Please do not read an empty check list here as coverage; the evidence is the acceptance comment.

## Issue ticket number and link

[DAH-2576 — CVM v2 — cvmd validation-CVM launch path (dstack.py as a library)](https://app.notion.com/p/CVM-v2-cvmd-validation-CVM-launch-path-dstack-py-as-a-library-3b2b8bfdbde981089505c34e85fa0115)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?

