### PR TITLE
DAH-2577 - Verify a teardown released the node, and give the switch its own state

### DIFF
--- a/neurons/executor/ansible/group_vars/all/main.yml
+++ b/neurons/executor/ansible/group_vars/all/main.yml
@@ -309,9 +309,25 @@ lium_cvmd_launch_timeout_seconds: 900
 # How long a graceful poweroff is given before cvmd signals the process group.
 # A large-memory TDX guest returns its RAM to the host as it exits, and that is
 # slow — 43 minutes was measured for a 1.13 TB guest on this fleet. Too low and
-# a legitimate slow exit is cut short by a SIGKILL. Per-hardware-class budgets
-# are DAH-2577's open item.
+# a legitimate slow exit is cut short by a SIGKILL.
 lium_cvmd_teardown_timeout_seconds: 600
+
+# How long the node's hardware then gets to come back: QEMU reaped with no
+# zombie, every /dev/vfio descriptor closed, the guest's memory returned and the
+# forwarded ports bindable. A teardown that runs out of this budget fails the
+# node naming the condition that did not hold, rather than reporting a success
+# the next launch would discover was false.
+#
+# A separate budget from the one above because it measures a different thing —
+# that one bounds how long the GUEST is given to power itself off, this one
+# bounds how long the HOST takes to get its hardware back afterwards. The two
+# are not proportional. See roles/cvmd/README.md for the measured values.
+lium_cvmd_teardown_verify_timeout_seconds: 1800
+
+# How much of the guest's configured memory must be back before the node counts
+# as free. Below 1.0 because MemAvailable is the kernel's own estimate and reads
+# a little short even on a host holding nothing.
+lium_cvmd_teardown_memory_tolerance: 0.9
 
 # --- CVM sizing: PROVIDER configuration, never an API field ------------------
 #

--- a/neurons/executor/ansible/roles/cvmd/README.md
+++ b/neurons/executor/ansible/roles/cvmd/README.md
@@ -37,6 +37,8 @@ request.
 | `lium_cvmd_key_provider_port` | dstack's key-provider port. `3443`. |
 | `lium_cvmd_launch_timeout_seconds` | How long a launch waits for the guest before failing the node. |
 | `lium_cvmd_teardown_timeout_seconds` | The graceful-poweroff window before cvmd signals the process group. |
+| `lium_cvmd_teardown_verify_timeout_seconds` | How long the node's hardware then gets to come back — see below. |
+| `lium_cvmd_teardown_memory_tolerance` | How much of the guest's configured memory must be back before the node counts as free. |
 | `lium_cvm_vcpus`, `lium_cvm_memory`, `lium_cvm_disk` | CVM sizing. |
 | `lium_cvm_gpus` | PCI slots to pass through, `["all"]`, or `[]` for none. |
 | `lium_cvm_ports` | Forwarded ports, `protocol[:address]:host:guest`. |
@@ -48,6 +50,34 @@ request.
 which software stack to run; the host decides how big it is. So there is nothing
 a caller could send to fill a gap here — a host missing a size refuses every
 launch, which is why the role refuses first.
+
+### The two teardown budgets
+
+They measure different things, which is why there are two.
+
+`lium_cvmd_teardown_timeout_seconds` bounds how long the **guest** is given to
+power itself off before cvmd signals its process group.
+`lium_cvmd_teardown_verify_timeout_seconds` bounds how long the **host** then
+takes to get its hardware back: QEMU reaped with no zombie left in the group,
+every `/dev/vfio` descriptor closed, the guest's memory returned, and the
+forwarded ports bindable again. A teardown reports success only when all four
+hold together; running out of the second budget fails the node naming the
+condition that did not.
+
+The two are not proportional. A guest that exits in seconds can leave its memory
+draining for tens of minutes, because that work happens in the kernel after the
+process is gone — which is exactly why confirming the process group is empty was
+never enough.
+
+Measured switch windows, for setting the budget per hardware class:
+
+| Host | Guest | Process reaped | Node fully released |
+|---|---|---|---|
+| au11 (Intel TDX, dstack-nvidia-0.5.11) | 16 GiB, no GPU passthrough | _measured during acceptance_ | _measured during acceptance_ |
+| — | 1.13 TB | — | ~43 min (observed under `lium-cvm.sh`, DAH-2544) |
+
+The default of 1800 s is sized for the ordinary case with room, not for the
+largest guests on the fleet. A host running 1 TB-class CVMs needs its own value.
 
 ### The catalog pins a triple
 

--- a/neurons/executor/ansible/roles/cvmd/README.md
+++ b/neurons/executor/ansible/roles/cvmd/README.md
@@ -69,15 +69,29 @@ draining for tens of minutes, because that work happens in the kernel after the
 process is gone — which is exactly why confirming the process group is empty was
 never enough.
 
-Measured switch windows, for setting the budget per hardware class:
+Measured switch windows, for setting the budget per hardware class. The two
+columns are what the two budgets bound, so read them against the settings above.
 
-| Host | Guest | Process reaped | Node fully released |
-|---|---|---|---|
-| au11 (Intel TDX, dstack-nvidia-0.5.11) | 16 GiB, no GPU passthrough | _measured during acceptance_ | _measured during acceptance_ |
-| — | 1.13 TB | — | ~43 min (observed under `lium-cvm.sh`, DAH-2544) |
+| Host | Guest | Guest powered off | Hardware back afterwards | `DELETE` end to end |
+|---|---|---|---|---|
+| au11 — Intel TDX, QEMU 9.2.1, `dstack-nvidia-0.5.11` | 8 vCPU, 16 GiB, no GPU passthrough | ~5 s | **0.2 s** | **5–6 s** |
+| the same fleet, under `lium-cvm.sh` | 1.13 TB | — | ~43 min | — |
 
-The default of 1800 s is sized for the ordinary case with room, not for the
-largest guests on the fleet. A host running 1 TB-class CVMs needs its own value.
+On a small guest the hardware is back before the first evaluation finishes: the
+process, the VFIO groups, the memory and the ports were all released 0.2 s after
+the stop, across three runs. The 43-minute figure is the other end of the range
+and the reason the default is 1800 s rather than a minute — it is sized for the
+ordinary case with room, not for the largest guests on the fleet. **A host
+running TB-class CVMs needs its own value**, and the measurement to set it from
+is the `memory_returned` timing in its own `last_switch` report.
+
+One outlier is worth knowing about: a single au11 teardown held on `ports_free`
+for 161 s while the other three conditions settled in 0.2 s. It did not recur in
+three later runs of the same shape, and a probe of the forwarded ports across a
+teardown showed them bindable 2 s after the guest stopped — with and without
+`SO_REUSEADDR`, so it was not `TIME_WAIT`. It is recorded rather than explained.
+`verify_released` now logs what it is still waiting for every 30 s, which is what
+was missing to diagnose it at the time.
 
 ### The catalog pins a triple
 

--- a/neurons/executor/ansible/roles/cvmd/tasks/main.yml
+++ b/neurons/executor/ansible/roles/cvmd/tasks/main.yml
@@ -189,6 +189,29 @@
     - lium_cvmd_dstack_scripts_dir | length > 0
     - lium_cvm_ssh_guest_port | int > 0
 
+# The same bounds cvmd's own loader enforces (config.py:_load_launch), named here
+# so the offending variable is reported instead of a daemon that will not start.
+# A tolerance above 1.0 is the one that matters: it would demand more memory back
+# than the guest was ever given, so no teardown on this host could ever complete
+# and every node would end up FAILED holding a CVM that had already stopped.
+- name: The teardown budgets are usable
+  ansible.builtin.assert:
+    that:
+      - lium_cvmd_teardown_timeout_seconds | int > 0
+      - lium_cvmd_teardown_verify_timeout_seconds | int > 0
+      - lium_cvmd_teardown_memory_tolerance | float > 0
+      - lium_cvmd_teardown_memory_tolerance | float <= 1
+    fail_msg: >-
+      The teardown settings are not usable: teardown_timeout_seconds
+      {{ lium_cvmd_teardown_timeout_seconds }}, teardown_verify_timeout_seconds
+      {{ lium_cvmd_teardown_verify_timeout_seconds }},
+      teardown_memory_tolerance {{ lium_cvmd_teardown_memory_tolerance }}. Both
+      timeouts must be positive and the tolerance must be in (0, 1] — above 1 it
+      asks for more memory back than the guest ever had, which no teardown on
+      this host could satisfy.
+    quiet: true
+  when: lium_cvmd_dstack_scripts_dir | length > 0
+
 - name: Read the host Python version
   ansible.builtin.command: python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])'
   register: cvmd_python_version

--- a/neurons/executor/ansible/roles/cvmd/templates/config.toml.j2
+++ b/neurons/executor/ansible/roles/cvmd/templates/config.toml.j2
@@ -39,7 +39,13 @@ catalog_path = "{{ cvmd_catalog_path }}"
 run_dir = "{{ lium_cvmd_run_dir }}"
 key_provider_port = {{ lium_cvmd_key_provider_port }}
 launch_timeout_seconds = {{ lium_cvmd_launch_timeout_seconds }}
+
+# Two teardown budgets, because they measure two different things: how long the
+# guest is given to power itself off, and how long the host then takes to get
+# its hardware back.
 teardown_timeout_seconds = {{ lium_cvmd_teardown_timeout_seconds }}
+teardown_verify_timeout_seconds = {{ lium_cvmd_teardown_verify_timeout_seconds }}
+teardown_memory_tolerance = {{ lium_cvmd_teardown_memory_tolerance }}
 
 # CVM sizing — provider configuration, never sent in a request.
 {% if lium_cvm_vcpus %}

--- a/neurons/executor/ansible/tests/test_cvmd_launch.yml
+++ b/neurons/executor/ansible/tests/test_cvmd_launch.yml
@@ -268,6 +268,77 @@
           valid configuration. msg={{ ssh_match_msg }}
         quiet: true
 
+    # --- teardown budgets (DAH-2577) --------------------------------------
+    #
+    # A tolerance above 1.0 asks for more memory back than the guest was ever
+    # given, so NO teardown on the host could ever satisfy it: every node would
+    # end up FAILED holding a CVM that had already stopped. cvmd's own loader
+    # refuses it too, but only once the config has been rendered — and by then
+    # the previous, working config is what is being replaced.
+    - name: Run cvmd with a memory tolerance above 1
+      block:
+        - name: Include cvmd with an unsatisfiable tolerance
+          ansible.builtin.include_role:
+            name: cvmd
+          vars:
+            lium_cvm_ssh_guest_port: 2200
+            lium_cvmd_teardown_memory_tolerance: 1.5
+
+        - name: Record that cvmd accepted an unsatisfiable teardown budget
+          ansible.builtin.set_fact:
+            tolerance_refused: false
+            tolerance_msg: ""
+      rescue:
+        - name: Record the tolerance refusal
+          ansible.builtin.set_fact:
+            tolerance_refused: true
+            tolerance_msg: >-
+              {{ ansible_failed_result.msg | default('') }}
+              {{ ansible_failed_result.results | default([]) | map(attribute='msg') | join(' ') }}
+
+    - name: A teardown budget no host could meet is refused before install
+      ansible.builtin.assert:
+        that:
+          - tolerance_refused | bool
+          - "'teardown_memory_tolerance' in tolerance_msg"
+        fail_msg: >-
+          cvmd accepted teardown_memory_tolerance above 1. No teardown on this
+          host could complete, so every node would end up FAILED holding a CVM
+          that had already stopped.
+          refused={{ tolerance_refused }} msg={{ tolerance_msg }}
+        quiet: true
+
+    # The matching case, so the assert cannot pass by refusing everything.
+    - name: Run cvmd with the default teardown budgets
+      block:
+        - name: Include cvmd with a usable tolerance
+          ansible.builtin.include_role:
+            name: cvmd
+          vars:
+            lium_cvm_ssh_guest_port: 2200
+            lium_cvmd_teardown_memory_tolerance: 0.9
+
+        - name: Record that the teardown checks passed
+          ansible.builtin.set_fact:
+            tolerance_ok_refused: false
+            tolerance_ok_msg: ""
+      rescue:
+        - name: Record where the matching case stopped
+          ansible.builtin.set_fact:
+            tolerance_ok_refused: true
+            tolerance_ok_msg: >-
+              {{ ansible_failed_result.msg | default('') }}
+              {{ ansible_failed_result.results | default([]) | map(attribute='msg') | join(' ') }}
+
+    - name: A usable teardown budget passes the launch checks
+      ansible.builtin.assert:
+        that:
+          - not (tolerance_ok_refused | bool) or 'teardown' not in tolerance_ok_msg
+        fail_msg: >-
+          cvmd refused a teardown budget that is inside its own loader's bounds,
+          so the check rejects valid configuration. msg={{ tolerance_ok_msg }}
+        quiet: true
+
 - name: The rendered catalog is what cvmd's loader reads
   hosts: localhost
   gather_facts: false

--- a/neurons/executor/cvmd/README.md
+++ b/neurons/executor/cvmd/README.md
@@ -12,7 +12,7 @@ stops the node's CVM.
 | `GET /v1/state` | either key | the state document plus the running CVM |
 | `POST /v1/cvm` `kind=validation` | validator key | launches the validation CVM (DAH-2576) |
 | `POST /v1/cvm` `kind=renter` | platform key | `501` — DAH-2580 |
-| `DELETE /v1/cvm` | platform key | tears the CVM down |
+| `DELETE /v1/cvm` | platform key | tears the CVM down and waits for the node's hardware to actually come back (DAH-2577) |
 
 A scope violation on an otherwise valid request is `403`. Everything else that fails auth is
 `401`. A validly signed body that is not usable is `422`, never a scope bypass.
@@ -102,10 +102,57 @@ line stays in the buffer for the VM's whole life while QEMU writes past it.
 Teardown asks the guest to power off through dstack's own path, then signals the supervisor's
 **process group**. dstack's own `--force` kills the pid in `runtime.json`, which is the
 supervisor's — QEMU is its child, so killing that pid alone leaves a running VM holding the
-guest's RAM and the GPUs while every layer above reports success. Confirming the group is gone
-is the floor; the four-condition predicate (VFIO descriptors closed, RAM returned, ports
-bindable) is DAH-2577, as is the per-hardware-class value for `teardown_timeout_seconds` — a
-1.13 TB guest was measured taking 43 minutes to return its memory.
+guest's RAM and the GPUs while every layer above reports success.
+
+## Tearing a CVM down
+
+`DELETE /v1/cvm` returns `200` only when this node's hardware is **verifiably** free. That is
+the point of the endpoint. `lium-cvm.sh stop` reports success when its wait loop gives up, and
+QEMU is still holding the guest's memory afterwards — a stopped process is the start of a
+teardown, not the end of one.
+
+So "destroyed" is four conditions read off the host, not cvmd's own records
+(`cvm/release.py`):
+
+| | |
+|---|---|
+| `process_reaped` | the supervisor's process group has no members left, **zombies included**, and no TDX guest is running anywhere on this host |
+| `vfio_released` | nothing holds a descriptor under `/dev/vfio`, so the next guest can claim the GPUs. A device stays bound to `vfio-pci` across a teardown by design, so the driver says nothing; the open descriptor does |
+| `memory_returned` | the host has the guest's RAM back, and its hugepages are back in the pool |
+| `ports_free` | every port this CVM forwarded can be bound again |
+
+All four are re-evaluated together every couple of seconds, and the teardown completes on one
+evaluation in which all four hold — a condition that held a minute ago is not evidence now. The
+first moment each one holds is recorded, so the report says *which* part was slow rather than
+just how long the whole thing took:
+
+```
+DELETE /v1/cvm  ->  200
+{"torn_down": true, "instance_id": "...", "detail": "guest powered off on request",
+ "switch": {"outcome": "released", "complete": true, "duration_seconds": 41.2,
+            "conditions": {"process_reaped":  {"satisfied_after_seconds": 12.4, ...},
+                           "memory_returned": {"satisfied_after_seconds": 38.9, ...}, ...}}}
+```
+
+A teardown that stops the CVM but leaves the node holding hardware answers **504** naming the
+conditions that did not hold, fails the node, and **keeps the VM directory** — which is what
+`_assert_node_is_free` reads, so the next launch is refused rather than merely discouraged. The
+call is idempotent: a repeat continues the switch already in flight instead of opening a new
+one, because the memory baseline is only meaningful taken while the guest was still running.
+
+Meanwhile `/v1/state` moves `VALIDATION_RUNNING → TEARDOWN → SWITCHING → RECONCILING`.
+`TEARDOWN` is cvmd still stopping the CVM; `SWITCHING` is the process gone and the hardware not
+back yet. Both are the window FR-C7 calls "switching" — neither rentable nor reachable, and not
+offline either — and `/v1/state` reports the last one under `last_switch` so availability
+accounting can tell the two apart. `SWITCHING` has no edge to `LAUNCHING`: FR-C6 forbids
+starting the next CVM before the last one's resources are free, and leaving the edge out is what
+enforces it.
+
+The budgets are `teardown_timeout_seconds` (how long the guest gets to power itself off) and
+`teardown_verify_timeout_seconds` (how long the host then gets to return the hardware). They are
+not proportional — a guest that exits in seconds can leave its memory draining for tens of
+minutes, and a 1.13 TB guest was measured taking 43 minutes. Per-hardware-class values are in
+`ansible/roles/cvmd/README.md`.
 
 ## Signing a request
 

--- a/neurons/executor/cvmd/packaging/config.toml
+++ b/neurons/executor/cvmd/packaging/config.toml
@@ -45,8 +45,18 @@ max_body_bytes = 65536
 #
 # The graceful-poweroff window before cvmd signals the process group. A large-memory TDX guest
 # returns its RAM to the host as it exits and that is slow — 43 minutes was measured for a
-# 1.13 TB guest. Per-hardware-class budgets are DAH-2577's open item.
+# 1.13 TB guest.
 # teardown_timeout_seconds = 600
+#
+# How long the node's hardware then gets to come back — QEMU reaped, VFIO descriptors closed,
+# the guest's memory returned, the forwarded ports bindable. A separate budget because it
+# measures a different thing: a guest that exits in seconds can leave its memory draining for
+# tens of minutes. See roles/cvmd/README.md for the measured per-hardware-class values.
+# teardown_verify_timeout_seconds = 1800
+#
+# How much of the guest's configured memory must be back before the node counts as free. Below
+# 1.0 because MemAvailable is the kernel's own estimate.
+# teardown_memory_tolerance = 0.9
 #
 # CVM sizing is PROVIDER configuration and is never sent in a request: a caller names which
 # software stack to run, and the host decides how big it is.

--- a/neurons/executor/cvmd/src/cvmd/app.py
+++ b/neurons/executor/cvmd/src/cvmd/app.py
@@ -16,6 +16,7 @@ from cvmd.auth.replay import ReplayStore
 from cvmd.config import Config
 from cvmd.cvm.instance import InstanceStore
 from cvmd.cvm.manager import CvmManager
+from cvmd.cvm.switching import SwitchStore
 from cvmd.routes.cvm import router
 from cvmd.state.store import StateStore
 
@@ -29,7 +30,8 @@ def create_app(config: Config) -> FastAPI:
     store = StateStore(config.state_dir)
     replay = ReplayStore(config.state_dir, skew_seconds=config.skew_seconds)
     instances = InstanceStore(config.state_dir)
-    manager = CvmManager(config=config.launch, store=store, instances=instances)
+    switches = SwitchStore(config.state_dir)
+    manager = CvmManager(config=config.launch, store=store, instances=instances, switches=switches)
 
     app = FastAPI(title="cvmd", docs_url=None, redoc_url=None, openapi_url=None)
     app.state.config = config
@@ -37,6 +39,7 @@ def create_app(config: Config) -> FastAPI:
     app.state.replay = replay
     app.state.clients = clients
     app.state.instances = instances
+    app.state.switches = switches
     app.state.cvm = manager
     # One CVM operation at a time. Held by the route rather than inside the manager so a second
     # request is refused immediately instead of blocking a worker thread for the whole launch.

--- a/neurons/executor/cvmd/src/cvmd/config.py
+++ b/neurons/executor/cvmd/src/cvmd/config.py
@@ -26,9 +26,24 @@ DEFAULT_LAUNCH_TIMEOUT_SECONDS = 900
 # A large-memory TDX guest returns its RAM to the host as it exits, and that is slow — 43
 # minutes was measured for a 1.13 TB guest on this fleet. So this is a floor for ordinary
 # sizes, not a budget for the largest ones; setting it too low turns a legitimate slow exit
-# into a SIGKILL partway through. Per-hardware-class budgets are DAH-2577's open item, which
-# is why this is a setting rather than a constant.
+# into a SIGKILL partway through. See roles/cvmd/README.md for the measured per-hardware-class
+# values these two defaults come from.
 DEFAULT_TEARDOWN_TIMEOUT_SECONDS = 600
+
+# How long the four release conditions get, counted from the moment the CVM was asked to stop.
+#
+# A separate budget from the one above because it measures a different thing: that one bounds
+# how long the guest is given to power itself off, this one bounds how long the *host* takes to
+# get its hardware back afterwards. The two are not proportional — a guest that exits in seconds
+# can leave its memory draining for tens of minutes.
+DEFAULT_TEARDOWN_VERIFY_TIMEOUT_SECONDS = 1800
+
+# How much of the guest's configured memory must be back before the node counts as free.
+#
+# Below 1.0 because MemAvailable is the kernel's own estimate and a host reads a little short of
+# a round number even when nothing is held. It is a tolerance on a measurement, not a licence to
+# launch into memory that has not come back — see `cvm/release.py:memory_returned`.
+DEFAULT_TEARDOWN_MEMORY_TOLERANCE = 0.9
 
 # dstack's default key-provider port. lium-cvm.sh relies on the same default.
 DEFAULT_KEY_PROVIDER_PORT = 3443
@@ -62,6 +77,8 @@ class LaunchConfig:
     key_provider_port: int = DEFAULT_KEY_PROVIDER_PORT
     launch_timeout_seconds: int = DEFAULT_LAUNCH_TIMEOUT_SECONDS
     teardown_timeout_seconds: int = DEFAULT_TEARDOWN_TIMEOUT_SECONDS
+    teardown_verify_timeout_seconds: int = DEFAULT_TEARDOWN_VERIFY_TIMEOUT_SECONDS
+    teardown_memory_tolerance: float = DEFAULT_TEARDOWN_MEMORY_TOLERANCE
 
     vcpus: int | None = None
     memory: str | None = None
@@ -143,6 +160,13 @@ def _as_optional_int(value, key: str) -> int | None:
     return _as_int(value, key)
 
 
+def _as_float(value, key: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ConfigError(f"{key} must be a number, got {value!r}") from exc
+
+
 def _as_optional_str(value) -> str | None:
     if value is None:
         return None
@@ -201,6 +225,18 @@ def _load_launch(table: dict) -> LaunchConfig:
             _get(table, "teardown_timeout_seconds", DEFAULT_TEARDOWN_TIMEOUT_SECONDS),
             "teardown_timeout_seconds",
         ),
+        teardown_verify_timeout_seconds=_as_int(
+            _get(
+                table,
+                "teardown_verify_timeout_seconds",
+                DEFAULT_TEARDOWN_VERIFY_TIMEOUT_SECONDS,
+            ),
+            "teardown_verify_timeout_seconds",
+        ),
+        teardown_memory_tolerance=_as_float(
+            _get(table, "teardown_memory_tolerance", DEFAULT_TEARDOWN_MEMORY_TOLERANCE),
+            "teardown_memory_tolerance",
+        ),
         vcpus=_as_optional_int(_get(table, "cvm_vcpus"), "cvm_vcpus"),
         memory=_as_optional_str(_get(table, "cvm_memory")),
         disk=_as_optional_str(_get(table, "cvm_disk")),
@@ -229,6 +265,15 @@ def _load_launch(table: dict) -> LaunchConfig:
         raise ConfigError("`launch_timeout_seconds` must be positive")
     if launch.teardown_timeout_seconds <= 0:
         raise ConfigError("`teardown_timeout_seconds` must be positive")
+    if launch.teardown_verify_timeout_seconds <= 0:
+        raise ConfigError("`teardown_verify_timeout_seconds` must be positive")
+    # Above 1.0 would demand more memory back than the guest was ever given, so no teardown on
+    # this host could ever complete — a value that turns every node FAILED, accepted at startup.
+    if not 0 < launch.teardown_memory_tolerance <= 1:
+        raise ConfigError(
+            "`teardown_memory_tolerance` must be greater than 0 and at most 1, got "
+            f"{launch.teardown_memory_tolerance}"
+        )
     return launch
 
 

--- a/neurons/executor/cvmd/src/cvmd/cvm/manager.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/manager.py
@@ -21,8 +21,9 @@ from pathlib import Path
 
 from cvmd import catalog
 from cvmd.config import LaunchConfig
-from cvmd.cvm import measure, ports, sshkey, supervisor
+from cvmd.cvm import measure, ports, release, sshkey, supervisor
 from cvmd.cvm.instance import Instance, InstanceStore, PortReport, now_iso
+from cvmd.cvm.switching import RELEASED, TIMED_OUT, SwitchRecord, SwitchStore
 from cvmd.dstack.loader import DStackUnavailable, load_dstack
 from cvmd.dstack.plan import setup_namespace
 from cvmd.state.machine import NodeState, is_legal
@@ -77,13 +78,24 @@ class Triple:
 
 class CvmManager:
     def __init__(
-        self, *, config: LaunchConfig, store: StateStore, instances: InstanceStore
+        self,
+        *,
+        config: LaunchConfig,
+        store: StateStore,
+        instances: InstanceStore,
+        switches: SwitchStore,
     ) -> None:
         self._config = config
         self._store = store
         self._instances = instances
+        self._switches = switches
 
     # ------------------------------------------------------------------ reporting
+
+    def last_switch(self) -> dict | None:
+        """What `/v1/state` reports about the node's last mode change, if it has had one."""
+        record = self._switches.current
+        return record.report() if record is not None else None
 
     def describe(self) -> dict | None:
         """What `/v1/state` reports about the CVM, if there is one."""
@@ -334,14 +346,18 @@ class CvmManager:
             )
 
     def _enter_launching(self) -> None:
-        # FAILED reaches LAUNCHING only through RECONCILING — recovery is deliberate, so the
-        # daemon re-derives the host's real state instead of assuming the failure cleared.
-        if self._store.state == NodeState.FAILED:
+        # Neither FAILED nor SWITCHING reaches LAUNCHING directly, and for the same reason:
+        # recovery is deliberate, so the daemon re-derives the host's real state instead of
+        # assuming the condition cleared. SWITCHING only survives a crash mid-teardown — every
+        # other path leaves it before returning — but a launch into a node whose last CVM's
+        # memory is still draining is precisely what FR-C6 forbids.
+        if self._store.state in (NodeState.FAILED, NodeState.SWITCHING):
+            blocked = self._store.state
             self.reconcile()
-            if self._store.state == NodeState.FAILED:
+            if self._store.state in (NodeState.FAILED, NodeState.SWITCHING):
                 raise LaunchFailure(
                     409,
-                    f"this node is FAILED and reconciliation did not clear it: "
+                    f"this node is {blocked} and reconciliation did not clear it: "
                     f"{self._store.document.last_error}",
                 )
         self._store.transition(NodeState.LAUNCHING)
@@ -502,15 +518,24 @@ class CvmManager:
     # ------------------------------------------------------------------ destroy
 
     def destroy(self) -> dict:
-        """Stop the CVM and free the node. Safe to call when nothing is running.
+        """Stop the CVM and hold until this node's hardware is verifiably free.
 
-        Idempotent on purpose: a platform that timed out mid-teardown has to be able to repeat
-        the call, and answering "there was nothing here" is more useful to it than an error it
-        has to special-case.
+        Returns only when all four conditions in `cvm/release.py` hold together, which is what
+        makes a 200 here mean the node can take the next CVM. The fleet's standing bug is the
+        opposite of that: `lium-cvm.sh stop` reports success when its wait loop gives up, and
+        QEMU is still holding the guest's memory afterwards. A stopped process is the start of
+        a teardown, not the end of one.
 
-        The VM directory is removed, disk included. A CVM's disk is not durable state — the
-        validation CVM must measure identically on every launch, and a renter's is gone with
-        the rental — and leaving it behind would block the next launch on this node.
+        Idempotent on purpose: a platform whose teardown timed out has to be able to repeat the
+        call, and answering "there was nothing here" is more useful to it than an error it has
+        to special-case. A repeat continues the switch already in flight rather than starting a
+        new one — see `_begin_switch`.
+
+        The VM directory is removed once the node is verified free, disk included. A CVM's disk
+        is not durable state — the validation CVM must measure identically on every launch, and
+        a renter's is gone with the rental — and leaving it behind would block the next launch.
+        A teardown that did NOT verify keeps the directory, which is what stops the node
+        accepting a launch it cannot honour.
         """
         instance = self._instances.current
         if instance is None:
@@ -543,38 +568,139 @@ class CvmManager:
             }
 
         vm_dir = Path(instance.vm_dir)
+        # Written before the first signal. cvmd is restartable by design, and the baseline the
+        # memory condition compares against is only meaningful if it was read while the guest
+        # was still running — a daemon that came back afterwards could never take it again.
+        record = self._begin_switch(instance)
+
         if self._store.state == NodeState.FAILED:
             self._store.transition(NodeState.RECONCILING)
         if self._store.state != NodeState.TEARDOWN:
             self._store.transition(NodeState.TEARDOWN)
 
-        detail = "the supervisor was already gone"
-        if supervisor.is_supervisor(instance.supervisor_pid, vm_dir):
-            try:
-                dstack = self._load_dstack()
-            except LaunchFailure as exc:
-                # Without dstack there is no graceful path, but the process group is still
-                # ours to signal — refusing to stop would be worse than stopping abruptly.
-                logger.warning("%s; falling back to signalling the process group", exc.reason)
-                detail = supervisor.shutdown_by_signal(
-                    instance.supervisor_pid, timeout=self._config.teardown_timeout_seconds
-                )
-            else:
-                detail = supervisor.shutdown(
-                    dstack,
-                    vm_dir,
-                    instance.supervisor_pid,
-                    timeout=self._config.teardown_timeout_seconds,
-                )
+        detail = self._stop(instance, vm_dir)
 
-        still_there = supervisor.is_supervisor(instance.supervisor_pid, vm_dir)
+        self._store.transition(NodeState.SWITCHING)
+        report = release.verify_released(
+            self._release_checks(record),
+            timeout=self._config.teardown_verify_timeout_seconds,
+        )
+
+        if not report.complete:
+            reason = (
+                f"CVM {instance.instance_id} was stopped ({detail}) but this node's hardware is "
+                f"still held {report.duration_seconds:.0f}s later — {report.why_incomplete()}"
+            )
+            # The directory stays. It is the fail-closed record that this node still owes
+            # something to a CVM that is gone, and `_assert_node_is_free` reads it, so a launch
+            # into half-released hardware is refused rather than merely discouraged.
+            self._switches.finish(outcome=TIMED_OUT, detail=detail, release=report.to_json())
+            self._store.transition(NodeState.FAILED, last_error=reason)
+            raise LaunchFailure(504, reason)
+
         self._discard(vm_dir)
         self._instances.clear()
-
-        if still_there:
-            reason = f"CVM {instance.instance_id} did not stop: {detail}"
-            self._store.transition(NodeState.FAILED, last_error=reason)
-            raise LaunchFailure(500, reason)
-
+        finished = self._switches.finish(outcome=RELEASED, detail=detail, release=report.to_json())
         self._store.transition(NodeState.RECONCILING)
-        return {"torn_down": True, "instance_id": instance.instance_id, "detail": detail}
+        logger.info(
+            "CVM %s released this node in %.0fs (%s)",
+            instance.instance_id,
+            report.duration_seconds,
+            detail,
+        )
+        return {
+            "torn_down": True,
+            "instance_id": instance.instance_id,
+            "detail": detail,
+            "switch": finished.report(),
+        }
+
+    def _stop(self, instance: Instance, vm_dir: Path) -> str:
+        """Ask the CVM to stop, escalating as far as it takes. Reports; never raises."""
+        if not supervisor.is_supervisor(instance.supervisor_pid, vm_dir):
+            return "the supervisor was already gone"
+        try:
+            dstack = self._load_dstack()
+        except LaunchFailure as exc:
+            # Without dstack there is no graceful path, but the process group is still ours to
+            # signal — refusing to stop would be worse than stopping abruptly.
+            logger.warning("%s; falling back to signalling the process group", exc.reason)
+            return supervisor.shutdown_by_signal(
+                instance.supervisor_pid, timeout=self._config.teardown_timeout_seconds
+            )
+        return supervisor.shutdown(
+            dstack,
+            vm_dir,
+            instance.supervisor_pid,
+            timeout=self._config.teardown_timeout_seconds,
+        )
+
+    def _begin_switch(self, instance: Instance) -> SwitchRecord:
+        """Start — or resume — the record of this node's crossing between modes.
+
+        A repeat teardown continues the switch it finds in flight instead of opening a new one.
+        Two reasons, and both are about honesty rather than tidiness: the memory baseline has to
+        be a reading from while the guest was running, and the window FR-I3 budgets for began at
+        the platform's first call, not at whichever retry happened to succeed.
+        """
+        unfinished = self._switches.unfinished
+        if unfinished is not None and unfinished.instance_id == instance.instance_id:
+            return unfinished
+        return self._switches.begin(
+            SwitchRecord(
+                instance_id=instance.instance_id,
+                kind=instance.kind,
+                vm_dir=instance.vm_dir,
+                supervisor_pid=instance.supervisor_pid,
+                started_at=now_iso(),
+                guest_memory_kib=self._guest_memory_kib(),
+                baseline_mem_available_kib=self._mem_available(),
+                ports=list(instance.ports),
+            )
+        )
+
+    def _guest_memory_kib(self) -> int | None:
+        """How much memory this host gives a guest, in KiB, or None if it cannot be read.
+
+        Degrades rather than refuses. A teardown is the wrong moment to discover a malformed
+        size — the launch that used it already succeeded — and the memory condition says plainly
+        that it has nothing to compare against.
+        """
+        if self._config.memory is None:
+            return None
+        try:
+            return release.memory_kib(self._config.memory)
+        except release.MemoryUnreadable as exc:
+            logger.warning("this teardown cannot check the guest's memory: %s", exc)
+            return None
+
+    def _mem_available(self) -> int | None:
+        try:
+            return release.mem_available_kib()
+        except release.MemoryUnreadable as exc:
+            logger.warning("this teardown has no memory baseline: %s", exc)
+            return None
+
+    def _release_checks(self, record: SwitchRecord) -> release.ReleaseChecks:
+        """The four conditions, bound to the CVM being torn down.
+
+        Ports come from the instance record rather than from the config: those are the mappings
+        QEMU was actually started with, and a config edited since the launch would have this
+        check probing addresses no guest ever held.
+        """
+        return release.ReleaseChecks(
+            supervisor_pid=record.supervisor_pid,
+            mappings=[
+                ports.PortMapping(
+                    protocol=port.protocol,
+                    address=port.address,
+                    host_port=port.host_port,
+                    guest_port=port.guest_port,
+                )
+                for port in record.ports
+            ],
+            guest_memory_kib=record.guest_memory_kib,
+            baseline_mem_available_kib=record.baseline_mem_available_kib,
+            memory_tolerance=self._config.teardown_memory_tolerance,
+            hugepages=self._config.hugepages,
+        )

--- a/neurons/executor/cvmd/src/cvmd/cvm/release.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/release.py
@@ -44,6 +44,14 @@ VFIO_PREFIX = "/dev/vfio/"
 # sleep, so a node that is already free answers immediately; this only paces the waiting.
 POLL_SECONDS = 2
 
+# How often a wait that is still going says what it is waiting for.
+#
+# Not decoration. A teardown on au11 once held for 161s on `ports_free` while everything else
+# had settled in 0.2s, and the journal recorded nothing until it finished — by which time the
+# condition was satisfied and its `detail` no longer named what had been held. A long switch
+# window is the thing FR-I3 budgets for, so it has to be diagnosable while it is happening.
+PROGRESS_SECONDS = 30
+
 PROCESS_REAPED = "process_reaped"
 VFIO_RELEASED = "vfio_released"
 MEMORY_RETURNED = "memory_returned"
@@ -414,6 +422,7 @@ def verify_released(
     """
     started = now()
     deadline = started + timeout
+    reported = started
     report = ReleaseReport(timings={name: Timing() for name in CONDITION_NAMES})
 
     while True:
@@ -439,4 +448,12 @@ def verify_released(
                 "the node was not released in %.0fs: %s", elapsed, report.why_incomplete()
             )
             return report
+
+        if now() - reported >= PROGRESS_SECONDS:
+            reported = now()
+            logger.info(
+                "%.0fs after the stop this node is still held by %s",
+                elapsed,
+                report.why_incomplete(),
+            )
         sleep(min(poll, max(deadline - now(), 0)))

--- a/neurons/executor/cvmd/src/cvmd/cvm/release.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/release.py
@@ -1,0 +1,442 @@
+"""Is this node's hardware actually free? Four conditions, each measured on the host.
+
+A stopped CVM is not a free node. `lium-cvm.sh stop` reports success as soon as its wait loop
+gives up, and the fleet's standing bug is exactly that: the shell says the CVM is gone while
+QEMU is still holding the guest's RAM. Confirming the process group is gone — all DAH-2576
+could do — is necessary and nowhere near sufficient, because the expensive part of a TDX
+teardown happens *after* the process exits.
+
+So "destroyed" is a predicate over host facts, not over cvmd's own records:
+
+    1. process_reaped   the process group has no members left, zombies included, and no TDX
+                        guest is running anywhere on this host
+    2. vfio_released    no process holds a descriptor on /dev/vfio, so the GPUs can be claimed
+                        by the next guest
+    3. memory_returned  the host has the guest's RAM back, and its hugepages are back in the pool
+    4. ports_free       every port this CVM forwarded can be bound again
+
+Each is polled until it holds or the budget runs out; the first moment each one holds is
+recorded, which is what turns "the switch took 41s" into "the process went at 12s and the
+memory took another 29". That per-condition breakdown is the point — the switch window is what
+FR-I3 has to budget for, and a single total tells an operator nothing about which hardware
+class is slow.
+
+Reading `/proc` is parameterised so the tests can point these functions at a fixture tree
+instead of the machine running them. Everything else here reads the real host.
+"""
+
+import logging
+import os
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from cvmd.cvm import ports, supervisor
+
+logger = logging.getLogger(__name__)
+
+PROC = Path("/proc")
+MEMINFO = Path("/proc/meminfo")
+VFIO_PREFIX = "/dev/vfio/"
+
+# How often the four conditions are re-evaluated. The first evaluation happens before any
+# sleep, so a node that is already free answers immediately; this only paces the waiting.
+POLL_SECONDS = 2
+
+PROCESS_REAPED = "process_reaped"
+VFIO_RELEASED = "vfio_released"
+MEMORY_RETURNED = "memory_returned"
+PORTS_FREE = "ports_free"
+
+CONDITION_NAMES = (PROCESS_REAPED, VFIO_RELEASED, MEMORY_RETURNED, PORTS_FREE)
+
+# `dstack.py:_convert_memory_to_mb`. Mirrored rather than imported: dstack.py is loaded from a
+# host path that may not exist, and this has to work on a node whose launcher is missing.
+_MEMORY_SUFFIXES = {"T": 1024 * 1024, "G": 1024, "M": 1}
+
+
+class MemoryUnreadable(Exception):
+    """/proc/meminfo could not be read or did not carry the field asked for."""
+
+
+def _gib(kib: int) -> str:
+    return f"{kib / 1024 / 1024:.1f} GiB"
+
+
+@dataclass(frozen=True)
+class Condition:
+    """One condition, evaluated once. `detail` says what was observed, satisfied or not."""
+
+    name: str
+    satisfied: bool
+    detail: str
+
+
+@dataclass
+class Timing:
+    """When a condition first held, and what was last observed about it."""
+
+    satisfied_after_seconds: float | None = None
+    detail: str = "not evaluated"
+
+    def to_json(self) -> dict:
+        return {
+            "satisfied_after_seconds": self.satisfied_after_seconds,
+            "detail": self.detail,
+        }
+
+
+@dataclass
+class ReleaseReport:
+    """The outcome of one verification, with per-condition timings."""
+
+    complete: bool = False
+    duration_seconds: float = 0.0
+    timings: dict[str, Timing] = field(default_factory=dict)
+
+    @property
+    def unsatisfied(self) -> list[str]:
+        return [name for name, t in self.timings.items() if t.satisfied_after_seconds is None]
+
+    def why_incomplete(self) -> str:
+        """The failing conditions, named, with what was observed about each."""
+        return "; ".join(f"{name}: {self.timings[name].detail}" for name in self.unsatisfied)
+
+    def to_json(self) -> dict:
+        return {
+            "complete": self.complete,
+            "duration_seconds": round(self.duration_seconds, 1),
+            "conditions": {name: t.to_json() for name, t in self.timings.items()},
+        }
+
+
+# ------------------------------------------------------------------ host facts
+
+
+def _stat(proc: Path, pid: int) -> tuple[str, str, int] | None:
+    """(comm, state, pgrp) for `pid`, or None if it is gone.
+
+    Read from `stat` rather than `cmdline` because a zombie has an empty `cmdline` — which is
+    the whole reason this file exists. The command name is parenthesised and may itself contain
+    spaces and parentheses, so the fields after it are found from the LAST `)`.
+    """
+    try:
+        raw = (proc / str(pid) / "stat").read_text()
+    except OSError:
+        return None
+    opened, closed = raw.find("("), raw.rfind(")")
+    if opened == -1 or closed == -1 or closed < opened:
+        return None
+    fields = raw[closed + 1 :].split()
+    if len(fields) < 3:
+        return None
+    try:
+        return raw[opened + 1 : closed], fields[0], int(fields[2])
+    except ValueError:
+        return None
+
+
+def _pids(proc: Path) -> list[int]:
+    if not proc.is_dir():
+        return []
+    return sorted(int(e.name) for e in proc.iterdir() if e.name.isdigit())
+
+
+def group_members(pgid: int, *, proc: Path = PROC) -> list[str]:
+    """Every process still in process group `pgid`, described, zombies included.
+
+    A zombie is why this is not `os.killpg(pgid, 0)`. It is still a group member, so killpg
+    keeps succeeding against a process that has already exited and holds nothing — measured on
+    au11, where it made every teardown burn the full signal ladder and then report a failure
+    that had not happened. Naming the state is what lets a reader tell "the guest is still
+    running" from "something never reaped its child".
+    """
+    members = []
+    for pid in _pids(proc):
+        entry = _stat(proc, pid)
+        if entry is None:
+            continue
+        comm, state, group = entry
+        if group == pgid:
+            members.append(f"pid {pid} ({comm}{', zombie' if state == 'Z' else ''})")
+    return members
+
+
+def vfio_holders(*, proc: Path = PROC) -> tuple[list[str], list[int]]:
+    """Who holds a descriptor under /dev/vfio, and whose descriptors could not be read.
+
+    The open descriptor is the binding that matters. A GPU stays bound to `vfio-pci` across a
+    teardown by design — that is the day-zero setup, not a leak — so the driver a device sits
+    on says nothing about whether the next guest can claim it. An open group descriptor says
+    exactly that, and it is released by the kernel only once the holder is fully gone.
+
+    Descriptors this process may not read are returned separately rather than ignored: cvmd
+    runs as root, so that list is empty in production, and treating "could not look" as "found
+    nothing" would be the one direction this check must not fail in.
+    """
+    holders: list[str] = []
+    unreadable: list[int] = []
+    for pid in _pids(proc):
+        fd_dir = proc / str(pid) / "fd"
+        try:
+            entries = list(fd_dir.iterdir())
+        except PermissionError:
+            unreadable.append(pid)
+            continue
+        except OSError:
+            # Gone between listing /proc and reading it. Nothing that exited is holding a
+            # descriptor.
+            continue
+        for entry in entries:
+            try:
+                target = os.readlink(entry)
+            except OSError:
+                continue
+            if target.startswith(VFIO_PREFIX):
+                comm = _stat(proc, pid)
+                holders.append(f"pid {pid} ({comm[0] if comm else '?'}) holds {target}")
+                break
+    return holders, unreadable
+
+
+def meminfo(*, path: Path = MEMINFO) -> dict[str, int]:
+    """`/proc/meminfo` as a name -> kibibytes mapping. Lines without a kB value are skipped."""
+    try:
+        raw = path.read_text()
+    except OSError as exc:
+        raise MemoryUnreadable(f"cannot read {path}: {exc}") from exc
+
+    values: dict[str, int] = {}
+    for line in raw.splitlines():
+        name, _, rest = line.partition(":")
+        parts = rest.split()
+        if not parts:
+            continue
+        try:
+            values[name.strip()] = int(parts[0])
+        except ValueError:
+            continue
+    return values
+
+
+def mem_available_kib(*, path: Path = MEMINFO) -> int:
+    values = meminfo(path=path)
+    if "MemAvailable" not in values:
+        raise MemoryUnreadable(f"{path} carries no MemAvailable")
+    return values["MemAvailable"]
+
+
+def memory_kib(spec: str) -> int:
+    """A dstack memory string — "2G", "512M", "1T", or a bare number of mebibytes — in KiB.
+
+    Mirrors `DStackManager._convert_memory_to_mb`, which is what turned this string into the
+    number QEMU was started with. Reading it any other way would compare the host's recovery
+    against a size the guest never had.
+    """
+    text = spec.strip()
+    factor = _MEMORY_SUFFIXES.get(text[-1:].upper())
+    number = text[:-1] if factor else text
+    try:
+        return int(number) * (factor or 1) * 1024
+    except ValueError as exc:
+        raise MemoryUnreadable(f"{spec!r} is not a memory size dstack would accept") from exc
+
+
+# ------------------------------------------------------------------ the four conditions
+
+
+@dataclass(frozen=True)
+class ReleaseChecks:
+    """Everything the four conditions need, bound to one CVM that has been asked to stop.
+
+    `baseline_mem_available_kib` is sampled while the guest is still running, so the memory
+    condition can be answered two ways (see `memory_returned`). It is optional because a cvmd
+    that restarted mid-teardown has no baseline and must still be able to finish the job.
+    """
+
+    supervisor_pid: int
+    mappings: list[ports.PortMapping]
+    guest_memory_kib: int | None = None
+    baseline_mem_available_kib: int | None = None
+    memory_tolerance: float = 0.9
+    hugepages: bool = False
+    proc: Path = PROC
+    meminfo_path: Path = MEMINFO
+
+    def process_reaped(self) -> Condition:
+        members = group_members(self.supervisor_pid, proc=self.proc)
+        if members:
+            return Condition(
+                PROCESS_REAPED,
+                False,
+                f"process group {self.supervisor_pid} still has {', '.join(members)}",
+            )
+        # Host-wide, not just this group: a guest that escaped its group — or one `lium-cvm.sh`
+        # started — holds the same GPUs and the same TDX capacity, so the node is not free
+        # while it runs.
+        running = supervisor.running_cvms()
+        if running:
+            return Condition(
+                PROCESS_REAPED,
+                False,
+                "a confidential guest is still running on this host: "
+                + ", ".join(f"pid {pid} ({name})" for pid, name in running),
+            )
+        return Condition(PROCESS_REAPED, True, "no process group members and no TDX guest")
+
+    def vfio_released(self) -> Condition:
+        holders, unreadable = vfio_holders(proc=self.proc)
+        if holders:
+            return Condition(VFIO_RELEASED, False, "; ".join(holders))
+        if unreadable:
+            return Condition(
+                VFIO_RELEASED,
+                False,
+                f"{len(unreadable)} process(es) would not let their open descriptors be read "
+                f"(first: pid {unreadable[0]}), so no VFIO group can be proven closed",
+            )
+        return Condition(VFIO_RELEASED, True, "nothing holds a /dev/vfio descriptor")
+
+    def memory_returned(self) -> Condition:
+        """Has the host got the guest's RAM back, and its hugepages?
+
+        Answered two ways, either of which is enough, because neither alone is honest on every
+        host:
+
+        * **absolute** — MemAvailable is at least the size the guest was configured with, so
+          this node could host that CVM again. This is the operational meaning of "the memory
+          is free", and it is the one that catches the slow case: a 1.13 TB guest's memory
+          comes back to the host over tens of minutes after QEMU has exited.
+        * **relative** — MemAvailable has risen by the guest's size since teardown began. This
+          is what answers on a host that is legitimately short of memory for other reasons: the
+          guest gave back what it held, which is all a teardown can be responsible for.
+
+        A relative-only rule would fail a perfectly clean teardown, because a guest that never
+        faulted in its full allocation has less to give back than it was configured with — and
+        under TDX the private memory is not in QEMU's RSS, so there is no way to ask how much
+        it really held.
+        """
+        try:
+            values = meminfo(path=self.meminfo_path)
+        except MemoryUnreadable as exc:
+            return Condition(MEMORY_RETURNED, False, str(exc))
+
+        hugepages = self._hugepages(values)
+        if hugepages is not None:
+            return hugepages
+
+        available = values.get("MemAvailable")
+        if available is None:
+            return Condition(MEMORY_RETURNED, False, f"{self.meminfo_path} carries no MemAvailable")
+        if self.guest_memory_kib is None:
+            # Nothing to compare against. The process is what held the memory, and that is
+            # condition 1's to answer.
+            return Condition(
+                MEMORY_RETURNED, True, "no guest memory size is configured, so nothing to reclaim"
+            )
+
+        want = int(self.guest_memory_kib * self.memory_tolerance)
+        detail = f"MemAvailable {_gib(available)} of the {_gib(want)} this guest needs"
+        recovered = None
+        if self.baseline_mem_available_kib is not None:
+            recovered = available - self.baseline_mem_available_kib
+            detail += f", up {_gib(recovered)} since teardown began"
+
+        satisfied = available >= want or (recovered is not None and recovered >= want)
+        return Condition(MEMORY_RETURNED, satisfied, detail)
+
+    def _hugepages(self, values: dict[str, int]) -> Condition | None:
+        """The unsatisfied hugepage condition, or None when there is nothing to wait for.
+
+        Only meaningful on a host configured to back its guests with hugepages: elsewhere the
+        pool is empty and `HugePages_Free == HugePages_Total == 0` says nothing.
+        """
+        if not self.hugepages:
+            return None
+        total = values.get("HugePages_Total", 0)
+        free = values.get("HugePages_Free", 0)
+        if total == 0 or free >= total:
+            return None
+        return Condition(
+            MEMORY_RETURNED,
+            False,
+            f"{total - free} of {total} hugepages are still out of the pool",
+        )
+
+    def ports_free(self) -> Condition:
+        if not self.mappings:
+            return Condition(PORTS_FREE, True, "this CVM forwarded no ports")
+        try:
+            ports.assert_free(self.mappings)
+        except ports.PortError as exc:
+            return Condition(PORTS_FREE, False, str(exc))
+        return Condition(
+            PORTS_FREE, True, f"all {len(self.mappings)} forwarded port(s) can be bound again"
+        )
+
+    def evaluate(self) -> list[Condition]:
+        """All four, in the order DAH-2577 numbers them. Every one is evaluated every poll.
+
+        None of them short-circuits on an earlier failure: a condition that is already
+        satisfied while another is still pending has a real first-satisfied moment, and losing
+        it would make the per-condition timings useless for exactly the hosts they exist for.
+        """
+        return [
+            self.process_reaped(),
+            self.vfio_released(),
+            self.memory_returned(),
+            self.ports_free(),
+        ]
+
+
+# ------------------------------------------------------------------ the wait
+
+
+def verify_released(
+    checks: ReleaseChecks,
+    *,
+    timeout: float,
+    poll: float = POLL_SECONDS,
+    now: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> ReleaseReport:
+    """Poll the four conditions until all hold together, or the budget runs out.
+
+    "Together" is the whole point. A condition that held ten seconds ago is not evidence now —
+    a port can be re-bound by something else, and a guest can still be running while its
+    memory reads as free — so completion requires one evaluation in which all four are true.
+    The first-satisfied timings are still recorded per condition, because they are what the
+    per-hardware-class budget is measured from.
+
+    Returns rather than raises: a teardown that did not complete is a report the caller has to
+    put in the node's state and in its answer, not an exception to interpret.
+    """
+    started = now()
+    deadline = started + timeout
+    report = ReleaseReport(timings={name: Timing() for name in CONDITION_NAMES})
+
+    while True:
+        conditions = checks.evaluate()
+        elapsed = now() - started
+        for condition in conditions:
+            timing = report.timings[condition.name]
+            timing.detail = condition.detail
+            if condition.satisfied and timing.satisfied_after_seconds is None:
+                timing.satisfied_after_seconds = round(elapsed, 1)
+            elif not condition.satisfied:
+                # It held earlier and does not now, so the earlier moment was not release. The
+                # report has to describe the host as it is at the end, not at its best moment.
+                timing.satisfied_after_seconds = None
+
+        report.duration_seconds = elapsed
+        if all(condition.satisfied for condition in conditions):
+            report.complete = True
+            return report
+
+        if now() >= deadline:
+            logger.warning(
+                "the node was not released in %.0fs: %s", elapsed, report.why_incomplete()
+            )
+            return report
+        sleep(min(poll, max(deadline - now(), 0)))

--- a/neurons/executor/cvmd/src/cvmd/cvm/supervisor.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/supervisor.py
@@ -236,9 +236,10 @@ def shutdown(dstack: ModuleType, vm_dir: Path, pid: int, *, timeout: int) -> str
        `spawn` started a new session.
     3. SIGKILL the group.
 
-    Confirming the process group is gone is the floor, not the ceiling. DAH-2577 adds the real
-    predicate — VFIO file descriptors closed, guest RAM returned, forwarded ports bindable —
-    because a reaped QEMU is necessary for those and nowhere near sufficient.
+    Returning does not mean the node is free. This function's job ends when the process is
+    gone; `cvm/release.py` answers the question that matters — VFIO descriptors closed, guest
+    RAM returned, forwarded ports bindable — because a reaped QEMU is necessary for those and
+    nowhere near sufficient.
     """
     try:
         dstack.shutdown_instance(str(vm_dir), timeout=timeout, force=False)

--- a/neurons/executor/cvmd/src/cvmd/cvm/switching.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/switching.py
@@ -1,0 +1,131 @@
+"""The switch record: what this node's last mode change cost, and whether one is still running.
+
+A node spends its life crossing between validation and rented (FR-C5), and every crossing means
+destroying one CVM before launching the next. That crossing is not instant — on a large-memory
+guest it is the slowest thing the node does — so it is an explicit window with its own state
+(`SWITCHING`) and its own measured duration.
+
+The record is written twice: once when a teardown begins, and once when the four conditions in
+`cvm/release.py` settle. The first write is what makes the window survivable. cvmd is restartable
+by design, and a daemon that came back mid-teardown with no record would have to choose between
+declaring a node free it had not checked and failing one that was fine — so the facts the
+conditions need (which process, which ports, how much memory the guest had, and what the host had
+free before it stopped) are on disk before the first signal is sent.
+
+The second write is the deliverable: per-condition timings for FR-I3's availability accounting,
+which needs to know how long a node is legitimately unreachable before it starts counting as
+offline. Kept out of `state.json`, whose small schema DAH-2575 pinned and its tests assert field
+by field, and out of `instance.json`, which is deleted by the very operation being measured.
+"""
+
+from dataclasses import asdict, dataclass, field, replace
+from pathlib import Path
+
+from cvmd.atomic import read_json, write_json_durable
+from cvmd.cvm.instance import PortReport, now_iso
+
+SWITCH_FILENAME = "switch.json"
+SCHEMA_VERSION = 1
+
+RELEASED = "released"
+TIMED_OUT = "timed_out"
+
+
+@dataclass(frozen=True)
+class SwitchRecord:
+    """One teardown. `outcome` is None while it is still running."""
+
+    instance_id: str
+    kind: str
+    vm_dir: str
+    supervisor_pid: int
+    started_at: str
+    guest_memory_kib: int | None = None
+    baseline_mem_available_kib: int | None = None
+    ports: list[PortReport] = field(default_factory=list)
+    completed_at: str | None = None
+    outcome: str | None = None
+    detail: str | None = None
+    release: dict = field(default_factory=dict)
+
+    def to_json(self) -> dict:
+        return {"version": SCHEMA_VERSION, **asdict(self)}
+
+    def report(self) -> dict:
+        """What `/v1/state` and the teardown response say about the switch window."""
+        return {
+            "instance_id": self.instance_id,
+            "kind": self.kind,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+            "outcome": self.outcome,
+            "detail": self.detail,
+            **self.release,
+        }
+
+
+def _decode(raw) -> SwitchRecord | None:
+    if not isinstance(raw, dict) or raw.get("version") != SCHEMA_VERSION:
+        return None
+    try:
+        return SwitchRecord(
+            instance_id=str(raw["instance_id"]),
+            kind=str(raw["kind"]),
+            vm_dir=str(raw["vm_dir"]),
+            supervisor_pid=int(raw["supervisor_pid"]),
+            started_at=str(raw["started_at"]),
+            guest_memory_kib=raw.get("guest_memory_kib"),
+            baseline_mem_available_kib=raw.get("baseline_mem_available_kib"),
+            ports=[PortReport(**port) for port in raw.get("ports", [])],
+            completed_at=raw.get("completed_at"),
+            outcome=raw.get("outcome"),
+            detail=raw.get("detail"),
+            release=raw.get("release") or {},
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+class SwitchStore:
+    """Holds the last switch, running or finished.
+
+    Unlike the instance record this is never cleared. A finished switch is the node's only
+    account of how long its last crossing took, and the next teardown overwrites it — so there
+    is exactly one, always the most recent.
+
+    An undecodable file is treated as absent. Losing the timings of a past switch costs a
+    measurement; refusing to start over it would cost the node.
+    """
+
+    def __init__(self, state_dir: Path) -> None:
+        self._path = state_dir / SWITCH_FILENAME
+        self._record = _decode(read_json(self._path)) if self._path.exists() else None
+
+    @property
+    def current(self) -> SwitchRecord | None:
+        return self._record
+
+    @property
+    def unfinished(self) -> SwitchRecord | None:
+        """The switch this node still owes, if it owes one.
+
+        Anything but `released` counts: a teardown that timed out has not ended the window it
+        opened — the node is still holding hardware the platform asked it to give back — and a
+        record with no outcome at all is a cvmd that died mid-teardown. Both are continued by
+        the next teardown rather than replaced by it.
+        """
+        record = self._record
+        return None if record is None or record.outcome == RELEASED else record
+
+    def begin(self, record: SwitchRecord) -> SwitchRecord:
+        return self._write(record)
+
+    def finish(self, **changes) -> SwitchRecord:
+        if self._record is None:
+            raise ValueError("no switch to finish")
+        return self._write(replace(self._record, completed_at=now_iso(), **changes))
+
+    def _write(self, record: SwitchRecord) -> SwitchRecord:
+        self._record = record
+        write_json_durable(self._path, record.to_json())
+        return record

--- a/neurons/executor/cvmd/src/cvmd/routes/cvm.py
+++ b/neurons/executor/cvmd/src/cvmd/routes/cvm.py
@@ -9,9 +9,14 @@ values.
 still answers 501: the renter body is DAH-2580's to define, and validating it against a
 validation-shaped model now would be inventing its contract.
 
-Both mutating handlers run the manager on a worker thread. A launch waits minutes for a guest
-to boot, and holding the event loop for that would make `/v1/state` unanswerable for exactly
-the period during which someone wants to read it.
+Both mutating handlers run the manager on a worker thread, and both are slow on purpose. A
+launch waits for the guest to boot; a `DELETE` waits for the node's hardware to actually come
+back, which on a large-memory guest is longer still. Holding the event loop for either would
+make `/v1/state` unanswerable for exactly the period during which someone wants to read it.
+
+`DELETE` is the FRD's teardown endpoint. Its 200 means the four conditions in `cvm/release.py`
+held together; a teardown that stopped the CVM but left the node holding hardware answers 504
+naming the conditions that did not.
 """
 
 import asyncio
@@ -92,7 +97,14 @@ async def health() -> dict:
 
 @router.get("/v1/state")
 async def get_state(request: Request) -> dict:
-    return {**_store(request).document.to_json(), "cvm": _manager(request).describe()}
+    manager = _manager(request)
+    return {
+        **_store(request).document.to_json(),
+        "cvm": manager.describe(),
+        # The node's last crossing between modes, with the per-condition timings a caller needs
+        # to tell "still switching" from "offline" (FR-I3). Present whether or not a CVM is.
+        "last_switch": manager.last_switch(),
+    }
 
 
 @router.post("/v1/cvm")

--- a/neurons/executor/cvmd/src/cvmd/state/machine.py
+++ b/neurons/executor/cvmd/src/cvmd/state/machine.py
@@ -1,11 +1,16 @@
 """The node state machine.
 
-Names come from the CVM v2 architecture doc §04. The backend's "SWITCHING" is its surface word
-for any non-terminal transition, not a state cvmd holds.
+Names come from the CVM v2 architecture doc §04. Every transition is driven by a fact about the
+host — a process observed in `/proc`, a descriptor observed open, a port observed bindable — not
+by what cvmd last recorded.
 
-DAH-2575 ships the machine and its persistence only. Nothing here drives a transition from real
-host facts — reconciling against QEMU/VFIO is DAH-2576's job, and until then RECONCILING is just
-the initial state.
+`TEARDOWN` and `SWITCHING` split the crossing between validation and rented (FR-C5, FR-C7) at the
+moment the two halves stop being the same question. In `TEARDOWN` cvmd is still stopping the CVM:
+asking the guest to power off, then escalating. In `SWITCHING` the process is gone and the node is
+still not free — the GPUs, the guest's memory and the forwarded ports come back to the host after
+the process does, and on a large-memory TDX guest that tail is the slowest part of the whole
+crossing. Both are the window FR-C7 calls "switching": neither rentable nor reachable, and not
+offline either.
 """
 
 from enum import StrEnum
@@ -17,6 +22,7 @@ class NodeState(StrEnum):
     VALIDATION_RUNNING = "VALIDATION_RUNNING"
     RENTER_RUNNING = "RENTER_RUNNING"
     TEARDOWN = "TEARDOWN"
+    SWITCHING = "SWITCHING"
     FAILED = "FAILED"
 
 
@@ -41,7 +47,13 @@ LEGAL_TRANSITIONS: dict[NodeState, frozenset[NodeState]] = {
     ),
     NodeState.VALIDATION_RUNNING: frozenset({NodeState.TEARDOWN, NodeState.FAILED}),
     NodeState.RENTER_RUNNING: frozenset({NodeState.TEARDOWN, NodeState.FAILED}),
-    NodeState.TEARDOWN: frozenset({NodeState.RECONCILING, NodeState.FAILED}),
+    # RECONCILING as well as SWITCHING, because a teardown call that found nothing to stop has
+    # no process to wait for and no resources to reclaim.
+    NodeState.TEARDOWN: frozenset({NodeState.SWITCHING, NodeState.RECONCILING, NodeState.FAILED}),
+    # Deliberately NOT to LAUNCHING. FR-C6 forbids starting the next CVM before the last one's
+    # resources are actually free, and leaving that edge out is what enforces it structurally
+    # rather than by remembering to check.
+    NodeState.SWITCHING: frozenset({NodeState.RECONCILING, NodeState.FAILED}),
     # Recovery is deliberate, not automatic: FAILED goes back through reconciliation so the
     # daemon re-derives the host's real state instead of assuming the failure cleared.
     NodeState.FAILED: frozenset({NodeState.RECONCILING}),

--- a/neurons/executor/cvmd/tests/test_launch.py
+++ b/neurons/executor/cvmd/tests/test_launch.py
@@ -16,9 +16,10 @@ from pathlib import Path
 
 import pytest
 from cvmd.config import Config, LaunchConfig
-from cvmd.cvm import measure, supervisor
+from cvmd.cvm import measure, release, supervisor
 from cvmd.cvm.instance import InstanceStore
 from cvmd.cvm.manager import CvmManager, LaunchFailure, Triple
+from cvmd.cvm.switching import SwitchStore
 from cvmd.state.machine import NodeState
 from cvmd.state.store import StateStore
 
@@ -116,6 +117,7 @@ def launch_config(tmp_path, dstack_scripts, catalog_file, env_file, free_ports) 
         env_file=env_file,
         ssh_guest_port=2200,
         launch_timeout_seconds=2,
+        teardown_verify_timeout_seconds=2,
     )
 
 
@@ -127,8 +129,26 @@ def manager(state_dir, launch_config, monkeypatch) -> CvmManager:
         "cvmd.cvm.measure.qemu_version", lambda _dstack: QEMU_FALLBACK, raising=True
     )
     return CvmManager(
-        config=launch_config, store=StateStore(state_dir), instances=InstanceStore(state_dir)
+        config=launch_config,
+        store=StateStore(state_dir),
+        instances=InstanceStore(state_dir),
+        switches=SwitchStore(state_dir),
     )
+
+
+@pytest.fixture
+def host_is_free(monkeypatch):
+    """Report the host's hardware as released, which on a test machine it is not.
+
+    The four release conditions read this machine's `/proc` and `/proc/meminfo`, where the
+    supervisor pid is invented and the memory belongs to whatever else is running. Each fact is
+    replaced by what it would read on a node whose CVM has fully gone, so a teardown test
+    exercises the path it names; a test about a condition NOT holding overrides that one fact
+    on top.
+    """
+    monkeypatch.setattr(release, "group_members", lambda pgid, **kwargs: [])
+    monkeypatch.setattr(release, "vfio_holders", lambda **kwargs: ([], []))
+    monkeypatch.setattr(release, "meminfo", lambda **kwargs: {"MemAvailable": 64 * 1024 * 1024})
 
 
 @pytest.fixture
@@ -242,7 +262,10 @@ class TestRefusals:
 
     def test_a_host_with_no_launch_configuration(self, state_dir, approved):
         manager = CvmManager(
-            config=LaunchConfig(), store=StateStore(state_dir), instances=InstanceStore(state_dir)
+            config=LaunchConfig(),
+            store=StateStore(state_dir),
+            instances=InstanceStore(state_dir),
+            switches=SwitchStore(state_dir),
         )
         with pytest.raises(LaunchFailure) as raised:
             manager.create(kind="validation", triple=approved)
@@ -277,7 +300,10 @@ class TestRefusals:
         )
         mismatched = replace(launch_config, ssh_guest_port=2201)
         manager = CvmManager(
-            config=mismatched, store=StateStore(state_dir), instances=InstanceStore(state_dir)
+            config=mismatched,
+            store=StateStore(state_dir),
+            instances=InstanceStore(state_dir),
+            switches=SwitchStore(state_dir),
         )
 
         with pytest.raises(LaunchFailure) as raised:
@@ -343,6 +369,7 @@ class TestReconciliation:
             config=launch_config,
             store=StateStore(state_dir),
             instances=InstanceStore(state_dir),
+            switches=SwitchStore(state_dir),
         )
         assert restarted.reconcile() is NodeState.VALIDATION_RUNNING
 
@@ -361,6 +388,7 @@ class TestReconciliation:
             config=launch_config,
             store=StateStore(state_dir),
             instances=InstanceStore(state_dir),
+            switches=SwitchStore(state_dir),
         )
         assert restarted.reconcile() is NodeState.FAILED
         assert "is gone but its directory" in restarted._store.document.last_error
@@ -386,7 +414,12 @@ class TestReconciliation:
         """cvmd installed before its catalog exists must not re-derive a state it cannot see."""
         store = StateStore(state_dir)
         store.transition(NodeState.LAUNCHING)
-        manager = CvmManager(config=LaunchConfig(), store=store, instances=InstanceStore(state_dir))
+        manager = CvmManager(
+            config=LaunchConfig(),
+            store=store,
+            instances=InstanceStore(state_dir),
+            switches=SwitchStore(state_dir),
+        )
 
         assert manager.reconcile() is NodeState.LAUNCHING
 
@@ -394,7 +427,10 @@ class TestReconciliation:
         """Never "no record, therefore idle" — a CVM cvmd forgot may still be running."""
         (state_dir / "instance.json").write_text("{ truncated")
         manager = CvmManager(
-            config=launch_config, store=StateStore(state_dir), instances=InstanceStore(state_dir)
+            config=launch_config,
+            store=StateStore(state_dir),
+            instances=InstanceStore(state_dir),
+            switches=SwitchStore(state_dir),
         )
 
         assert manager.reconcile() is NodeState.FAILED
@@ -513,7 +549,7 @@ class TestOverHttp:
         )
 
     def test_the_platform_key_tears_the_cvm_down(
-        self, launching_client, validator_key, platform_key, approved, monkeypatch
+        self, launching_client, validator_key, platform_key, approved, host_is_free, monkeypatch
     ):
         """DELETE carries no `kind`, so it is renter-scoped: letting the validation key call it
         would let a validator destroy a renter's CVM."""
@@ -586,7 +622,7 @@ class TestReadinessWithoutKeyscan:
 
 class TestTeardown:
     def test_tearing_down_a_running_cvm_frees_the_node(
-        self, manager, approved, spawned, guest_is_up, launch_config, monkeypatch
+        self, manager, approved, spawned, guest_is_up, host_is_free, launch_config, monkeypatch
     ):
         report = manager.create(kind="validation", triple=approved)
         monkeypatch.setattr(supervisor, "shutdown", lambda *a, **k: "guest powered off on request")
@@ -600,7 +636,7 @@ class TestTeardown:
         assert supervisor.vm_directories(launch_config.run_dir) == []
 
     def test_a_relaunch_after_teardown_succeeds(
-        self, manager, approved, spawned, guest_is_up, monkeypatch
+        self, manager, approved, spawned, guest_is_up, host_is_free, monkeypatch
     ):
         """The point of removing the directory: the node is reusable without hand-cleanup."""
         manager.create(kind="validation", triple=approved)
@@ -675,14 +711,201 @@ class TestTeardown:
         assert detail == "process group stopped by SIGTERM"
 
     def test_a_cvm_that_will_not_stop_fails_the_node(
-        self, manager, approved, spawned, guest_is_up, monkeypatch
+        self, manager, approved, spawned, guest_is_up, host_is_free, launch_config, monkeypatch
     ):
         """Never report a teardown that did not happen — that is the DAH-2577 acceptance bar."""
         manager.create(kind="validation", triple=approved)
+        vm_dir = Path(manager._instances.current.vm_dir)
         monkeypatch.setattr(supervisor, "shutdown", lambda *a, **k: "still present after SIGKILL")
+        monkeypatch.setattr(
+            release, "group_members", lambda pgid, **kwargs: [f"pid {pgid} (qemu-system-x86_64)"]
+        )
 
         with pytest.raises(LaunchFailure) as raised:
             manager.destroy()
 
-        assert raised.value.status == 500
+        assert raised.value.status == 504
+        assert "process_reaped" in raised.value.reason
         assert manager._store.state is NodeState.FAILED
+        # The directory and the record both stay. They are what `_assert_node_is_free` reads, so
+        # a node that never released its hardware refuses the next launch rather than merely
+        # being marked FAILED.
+        assert vm_dir.exists()
+        assert manager._instances.current is not None
+
+
+class TestVerifiedRelease:
+    """DAH-2577: a teardown reports complete only when the node's hardware is actually free.
+
+    The four conditions read the host, so each test here replaces one host fact and asserts the
+    teardown's answer to it. What cannot be reached from a test process — a real TDX guest
+    holding a real VFIO group while its memory drains — is the hardware run's job.
+    """
+
+    def _record_transitions(self, manager, monkeypatch) -> list[NodeState]:
+        seen: list[NodeState] = []
+        original = manager._store.transition
+
+        def recording(requested, **kwargs):
+            seen.append(requested)
+            return original(requested, **kwargs)
+
+        monkeypatch.setattr(manager._store, "transition", recording)
+        return seen
+
+    def _stopped(self, monkeypatch) -> None:
+        monkeypatch.setattr(supervisor, "shutdown", lambda *a, **k: "guest powered off on request")
+        monkeypatch.setattr(supervisor, "is_supervisor", lambda pid, vm_dir: False)
+
+    def test_the_node_passes_through_switching_on_its_way_to_free(
+        self, manager, approved, spawned, guest_is_up, host_is_free, monkeypatch
+    ):
+        """TEARDOWN is stopping the CVM; SWITCHING is waiting for the hardware to come back.
+
+        They are separate states because they are separate questions, and because FR-C7 needs a
+        node that is neither running nor available to read as switching rather than as offline.
+        """
+        manager.create(kind="validation", triple=approved)
+        self._stopped(monkeypatch)
+        seen = self._record_transitions(manager, monkeypatch)
+
+        manager.destroy()
+
+        assert seen == [NodeState.TEARDOWN, NodeState.SWITCHING, NodeState.RECONCILING]
+
+    def test_the_teardown_report_times_every_condition(
+        self, manager, approved, spawned, guest_is_up, host_is_free, monkeypatch
+    ):
+        """One total says nothing about which hardware class is slow; four numbers do."""
+        manager.create(kind="validation", triple=approved)
+        self._stopped(monkeypatch)
+
+        switch = manager.destroy()["switch"]
+
+        assert switch["complete"] is True
+        assert switch["outcome"] == "released"
+        assert set(switch["conditions"]) == set(release.CONDITION_NAMES)
+        assert all(
+            condition["satisfied_after_seconds"] is not None
+            for condition in switch["conditions"].values()
+        )
+        assert switch["duration_seconds"] >= 0
+
+    def test_a_held_vfio_descriptor_is_not_a_free_node(
+        self, manager, approved, spawned, guest_is_up, host_is_free, launch_config, monkeypatch
+    ):
+        """The GPUs are the point of the node. A descriptor still open means the next CVM
+        cannot have them, whatever the process table says."""
+        manager.create(kind="validation", triple=approved)
+        vm_dir = Path(manager._instances.current.vm_dir)
+        self._stopped(monkeypatch)
+        monkeypatch.setattr(
+            release, "vfio_holders", lambda **kwargs: (["pid 9 (qemu) holds /dev/vfio/42"], [])
+        )
+
+        with pytest.raises(LaunchFailure) as raised:
+            manager.destroy()
+
+        assert raised.value.status == 504
+        assert "vfio_released" in raised.value.reason
+        assert "/dev/vfio/42" in raised.value.reason
+        assert manager._store.state is NodeState.FAILED
+        assert vm_dir.exists()
+
+    def test_memory_still_out_with_the_guest_is_not_a_free_node(
+        self, manager, approved, spawned, guest_is_up, host_is_free, monkeypatch
+    ):
+        """The fleet's standing bug, stated as a condition: QEMU is gone and the RAM is not
+        back yet, so the node cannot host the CVM the platform is about to send it."""
+        manager.create(kind="validation", triple=approved)
+        self._stopped(monkeypatch)
+        # The guest is 2G and nothing like that is available.
+        monkeypatch.setattr(release, "meminfo", lambda **kwargs: {"MemAvailable": 64 * 1024})
+
+        with pytest.raises(LaunchFailure) as raised:
+            manager.destroy()
+
+        assert raised.value.status == 504
+        assert "memory_returned" in raised.value.reason
+        assert manager._store.state is NodeState.FAILED
+
+    def test_hugepages_still_out_of_the_pool_are_not_a_free_node(
+        self, state_dir, launch_config, approved, spawned, guest_is_up, host_is_free, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "cvmd.cvm.measure.qemu_version", lambda _dstack: QEMU_FALLBACK, raising=True
+        )
+        manager = CvmManager(
+            config=replace(launch_config, hugepages=True),
+            store=StateStore(state_dir),
+            instances=InstanceStore(state_dir),
+            switches=SwitchStore(state_dir),
+        )
+        manager.create(kind="validation", triple=approved)
+        self._stopped(monkeypatch)
+        monkeypatch.setattr(
+            release,
+            "meminfo",
+            lambda **kwargs: {
+                "MemAvailable": 64 * 1024 * 1024,
+                "HugePages_Total": 100,
+                "HugePages_Free": 40,
+            },
+        )
+
+        with pytest.raises(LaunchFailure) as raised:
+            manager.destroy()
+
+        assert "60 of 100 hugepages are still out of the pool" in raised.value.reason
+
+    def test_a_repeat_teardown_continues_the_switch_it_finds_in_flight(
+        self, manager, approved, spawned, guest_is_up, host_is_free, monkeypatch
+    ):
+        """The baseline is only meaningful taken while the guest was running, and the window
+        FR-I3 budgets for began at the platform's first call, not at the retry that worked."""
+        manager.create(kind="validation", triple=approved)
+        self._stopped(monkeypatch)
+        monkeypatch.setattr(
+            release, "vfio_holders", lambda **kwargs: (["pid 9 (qemu) holds /dev/vfio/42"], [])
+        )
+        with pytest.raises(LaunchFailure):
+            manager.destroy()
+        first = manager._switches.current
+
+        monkeypatch.setattr(release, "vfio_holders", lambda **kwargs: ([], []))
+        manager.destroy()
+
+        second = manager._switches.current
+        assert second.started_at == first.started_at
+        assert second.baseline_mem_available_kib == first.baseline_mem_available_kib
+        assert second.outcome == "released"
+
+    def test_a_node_that_never_released_refuses_the_next_launch(
+        self, manager, approved, spawned, guest_is_up, host_is_free, monkeypatch
+    ):
+        """FR-C6 in one assertion: do not start the next CVM on hardware the last one holds."""
+        manager.create(kind="validation", triple=approved)
+        self._stopped(monkeypatch)
+        monkeypatch.setattr(
+            release, "vfio_holders", lambda **kwargs: (["pid 9 (qemu) holds /dev/vfio/42"], [])
+        )
+        with pytest.raises(LaunchFailure):
+            manager.destroy()
+
+        with pytest.raises(LaunchFailure) as raised:
+            manager.create(kind="validation", triple=approved)
+
+        assert raised.value.status == 409
+
+    def test_the_last_switch_is_reported_after_the_cvm_is_gone(
+        self, manager, approved, spawned, guest_is_up, host_is_free, monkeypatch
+    ):
+        """`/v1/state` has to answer "how long has this node been switching" when there is no
+        instance left to describe — that is exactly when FR-I3 needs the number."""
+        assert manager.last_switch() is None
+        manager.create(kind="validation", triple=approved)
+        self._stopped(monkeypatch)
+        manager.destroy()
+
+        assert manager.describe() is None
+        assert manager.last_switch()["outcome"] == "released"

--- a/neurons/executor/cvmd/tests/test_release.py
+++ b/neurons/executor/cvmd/tests/test_release.py
@@ -1,0 +1,358 @@
+"""The four release conditions, and the loop that waits on them.
+
+These read `/proc` and `/proc/meminfo`, so every test here points them at a fixture tree it
+built itself. That is the only way to assert what a zombie, a held VFIO descriptor or a host
+still short of memory look like from a test process — the real conditions are staged against
+real hardware in the acceptance run, and the two are meant to be read together.
+"""
+
+import os
+import socket
+from pathlib import Path
+
+import pytest
+from cvmd.cvm import ports, release
+
+ONE_GIB_KIB = 1024 * 1024
+
+
+def make_proc(tmp_path, processes: dict) -> Path:
+    """A fake `/proc`. `processes` maps pid -> (comm, state, pgrp, [fd targets])."""
+    root = tmp_path / "proc"
+    root.mkdir()
+    for pid, (comm, state, pgrp, fds) in processes.items():
+        entry = root / str(pid)
+        entry.mkdir()
+        (entry / "stat").write_text(f"{pid} ({comm}) {state} 1 {pgrp} 0 0 0 0 0\n")
+        fd_dir = entry / "fd"
+        fd_dir.mkdir()
+        for number, target in enumerate(fds):
+            (fd_dir / str(number)).symlink_to(target)
+    return root
+
+
+def make_meminfo(tmp_path, **values) -> Path:
+    path = tmp_path / "meminfo"
+    path.write_text("".join(f"{name}:{value:>12} kB\n" for name, value in values.items()))
+    return path
+
+
+class TestGroupMembers:
+    def test_it_finds_the_members_of_the_group_and_no_others(self, tmp_path):
+        proc = make_proc(
+            tmp_path,
+            {
+                100: ("python3", "S", 100, []),
+                101: ("qemu-system-x86_64", "S", 100, []),
+                200: ("sshd", "S", 200, []),
+            },
+        )
+
+        assert release.group_members(100, proc=proc) == [
+            "pid 100 (python3)",
+            "pid 101 (qemu-system-x86_64)",
+        ]
+
+    def test_a_zombie_is_a_member_and_is_named_as_one(self, tmp_path):
+        """The DAH-2576 bug, as a condition. `killpg(pgid, 0)` succeeds against a zombie, so a
+        teardown that trusts it reports a failure that never happened — or, worse, a success."""
+        proc = make_proc(tmp_path, {101: ("qemu-system-x86_64", "Z", 100, [])})
+
+        assert release.group_members(100, proc=proc) == ["pid 101 (qemu-system-x86_64, zombie)"]
+
+    def test_an_empty_group_is_an_empty_list(self, tmp_path):
+        proc = make_proc(tmp_path, {200: ("sshd", "S", 200, [])})
+
+        assert release.group_members(100, proc=proc) == []
+
+    def test_a_command_name_with_spaces_and_parentheses_still_parses(self, tmp_path):
+        """`comm` is not escaped in /proc/<pid>/stat, so the fields after it are found from the
+        LAST `)`. Getting this wrong reads the state and the group from the command name."""
+        proc = make_proc(tmp_path, {7: ("qemu (tdx) x86", "Z", 7, [])})
+
+        assert release.group_members(7, proc=proc) == ["pid 7 (qemu (tdx) x86, zombie)"]
+
+
+class TestVfioHolders:
+    def test_a_process_holding_a_vfio_group_is_named_with_the_device(self, tmp_path):
+        proc = make_proc(
+            tmp_path,
+            {
+                100: ("qemu-system-x86_64", "S", 100, ["/dev/vfio/42", "/dev/null"]),
+                200: ("sshd", "S", 200, ["/dev/null"]),
+            },
+        )
+
+        holders, unreadable = release.vfio_holders(proc=proc)
+
+        assert holders == ["pid 100 (qemu-system-x86_64) holds /dev/vfio/42"]
+        assert unreadable == []
+
+    def test_a_host_with_nothing_open_reports_nothing(self, tmp_path):
+        proc = make_proc(tmp_path, {200: ("sshd", "S", 200, ["/dev/null", "/etc/hosts"])})
+
+        assert release.vfio_holders(proc=proc) == ([], [])
+
+    @pytest.mark.skipif(os.geteuid() == 0, reason="root can read every /proc/<pid>/fd")
+    def test_descriptors_that_cannot_be_read_are_reported_rather_than_ignored(self, tmp_path):
+        """Could not look is not the same as found nothing. Reporting it is what keeps this
+        check fail-closed on a host where cvmd is not root."""
+        proc = make_proc(tmp_path, {100: ("qemu-system-x86_64", "S", 100, ["/dev/vfio/42"])})
+        (proc / "100" / "fd").chmod(0o000)
+        try:
+            holders, unreadable = release.vfio_holders(proc=proc)
+        finally:
+            (proc / "100" / "fd").chmod(0o700)
+
+        assert holders == []
+        assert unreadable == [100]
+
+
+class TestMemorySizes:
+    @pytest.mark.parametrize(
+        ("spec", "kib"),
+        [
+            ("1T", 1024 * 1024 * 1024),
+            ("2G", 2 * 1024 * 1024),
+            ("512M", 512 * 1024),
+            ("2048", 2048 * 1024),
+        ],
+    )
+    def test_it_reads_a_size_the_way_dstack_does(self, spec, kib):
+        """A bare number is mebibytes to `DStackManager._convert_memory_to_mb`, which is what
+        turned this string into the number QEMU was started with."""
+        assert release.memory_kib(spec) == kib
+
+    def test_a_size_dstack_would_not_accept_is_refused(self):
+        with pytest.raises(release.MemoryUnreadable):
+            release.memory_kib("lots")
+
+    def test_meminfo_is_read_as_kibibytes(self, tmp_path):
+        path = make_meminfo(tmp_path, MemTotal=100, MemAvailable=42)
+
+        assert release.meminfo(path=path)["MemAvailable"] == 42
+        assert release.mem_available_kib(path=path) == 42
+
+    def test_a_meminfo_without_memavailable_is_an_error_not_a_zero(self, tmp_path):
+        path = make_meminfo(tmp_path, MemTotal=100)
+
+        with pytest.raises(release.MemoryUnreadable):
+            release.mem_available_kib(path=path)
+
+
+class TestTheMemoryCondition:
+    def _checks(self, tmp_path, **overrides):
+        return release.ReleaseChecks(
+            supervisor_pid=1,
+            mappings=[],
+            guest_memory_kib=8 * ONE_GIB_KIB,
+            memory_tolerance=0.9,
+            proc=make_proc(tmp_path, {}),
+            **overrides,
+        )
+
+    def test_enough_free_for_this_guest_again_is_enough(self, tmp_path):
+        checks = self._checks(
+            tmp_path, meminfo_path=make_meminfo(tmp_path, MemAvailable=16 * ONE_GIB_KIB)
+        )
+
+        assert checks.memory_returned().satisfied
+
+    def test_memory_still_out_with_the_guest_is_not(self, tmp_path):
+        """The fleet's standing bug: QEMU has exited and the host has not got its RAM back."""
+        checks = self._checks(
+            tmp_path, meminfo_path=make_meminfo(tmp_path, MemAvailable=1 * ONE_GIB_KIB)
+        )
+
+        condition = checks.memory_returned()
+
+        assert not condition.satisfied
+        assert "1.0 GiB of the 7.2 GiB this guest needs" in condition.detail
+
+    def test_a_busy_host_that_gave_the_guest_s_memory_back_is_free(self, tmp_path):
+        """The absolute rule alone would fail this node forever: something else on the host is
+        using the memory, and a teardown is not responsible for that."""
+        checks = self._checks(
+            tmp_path,
+            meminfo_path=make_meminfo(tmp_path, MemAvailable=9 * ONE_GIB_KIB),
+            baseline_mem_available_kib=1 * ONE_GIB_KIB,
+        )
+
+        condition = checks.memory_returned()
+
+        assert condition.satisfied
+        assert "up 8.0 GiB since teardown began" in condition.detail
+
+    def test_a_guest_that_never_touched_its_allocation_still_completes(self, tmp_path):
+        """And the relative rule alone would fail this one: a guest gives back what it held,
+        which under TDX is not something QEMU's RSS can be asked about."""
+        checks = self._checks(
+            tmp_path,
+            meminfo_path=make_meminfo(tmp_path, MemAvailable=64 * ONE_GIB_KIB),
+            baseline_mem_available_kib=64 * ONE_GIB_KIB,
+        )
+
+        assert checks.memory_returned().satisfied
+
+    def test_hugepages_out_of_the_pool_hold_the_condition_open(self, tmp_path):
+        checks = self._checks(
+            tmp_path,
+            hugepages=True,
+            meminfo_path=make_meminfo(
+                tmp_path, MemAvailable=64 * ONE_GIB_KIB, HugePages_Total=100, HugePages_Free=40
+            ),
+        )
+
+        condition = checks.memory_returned()
+
+        assert not condition.satisfied
+        assert "60 of 100 hugepages are still out of the pool" in condition.detail
+
+    def test_an_empty_hugepage_pool_is_not_something_to_wait_for(self, tmp_path):
+        checks = self._checks(
+            tmp_path,
+            hugepages=True,
+            meminfo_path=make_meminfo(
+                tmp_path, MemAvailable=64 * ONE_GIB_KIB, HugePages_Total=0, HugePages_Free=0
+            ),
+        )
+
+        assert checks.memory_returned().satisfied
+
+    def test_a_host_with_no_configured_guest_size_has_nothing_to_reclaim(self, tmp_path):
+        checks = release.ReleaseChecks(
+            supervisor_pid=1,
+            mappings=[],
+            guest_memory_kib=None,
+            proc=make_proc(tmp_path, {}),
+            meminfo_path=make_meminfo(tmp_path, MemAvailable=1),
+        )
+
+        assert checks.memory_returned().satisfied
+
+
+class TestThePortCondition:
+    def test_a_port_something_else_holds_is_not_free(self, tmp_path):
+        with socket.socket() as held:
+            held.bind(("127.0.0.1", 0))
+            held.listen(1)
+            port = held.getsockname()[1]
+            checks = release.ReleaseChecks(
+                supervisor_pid=1,
+                mappings=[ports.parse(f"tcp:127.0.0.1:{port}:2200")],
+                proc=make_proc(tmp_path, {}),
+            )
+
+            condition = checks.ports_free()
+
+        assert not condition.satisfied
+        assert str(port) in condition.detail
+
+    def test_a_cvm_that_forwarded_nothing_has_nothing_to_release(self, tmp_path):
+        checks = release.ReleaseChecks(supervisor_pid=1, mappings=[], proc=make_proc(tmp_path, {}))
+
+        assert checks.ports_free().satisfied
+
+
+class Fake:
+    """A stand-in for ReleaseChecks that replays a scripted sequence of evaluations."""
+
+    def __init__(self, *rounds):
+        self._rounds = list(rounds)
+
+    def evaluate(self):
+        flags = self._rounds.pop(0) if len(self._rounds) > 1 else self._rounds[0]
+        return [
+            release.Condition(name, satisfied, f"{name} {satisfied}")
+            for name, satisfied in zip(release.CONDITION_NAMES, flags, strict=True)
+        ]
+
+
+def virtual_clock():
+    """A clock that only moves when the loop sleeps, so the timings are the loop's own arithmetic
+    rather than the test machine's scheduling."""
+    elapsed = [0.0]
+
+    def now():
+        return elapsed[0]
+
+    def sleep(seconds):
+        elapsed[0] += seconds
+
+    return now, sleep
+
+
+class TestTheWait:
+    def test_a_node_that_is_already_free_answers_without_sleeping(self):
+        now, sleep = virtual_clock()
+        slept = []
+
+        report = release.verify_released(
+            Fake((True, True, True, True)),
+            timeout=100,
+            poll=5,
+            now=now,
+            sleep=lambda seconds: slept.append(seconds) or sleep(seconds),
+        )
+
+        assert report.complete
+        assert slept == []
+        assert all(t.satisfied_after_seconds == 0.0 for t in report.timings.values())
+
+    def test_every_condition_is_timed_from_when_it_first_held(self):
+        """One total says nothing about which hardware class is slow. Four numbers do."""
+        now, sleep = virtual_clock()
+
+        report = release.verify_released(
+            Fake(
+                (False, False, False, False),
+                (True, True, False, True),
+                (True, True, True, True),
+            ),
+            timeout=100,
+            poll=5,
+            now=now,
+            sleep=sleep,
+        )
+
+        assert report.complete
+        assert report.timings[release.PROCESS_REAPED].satisfied_after_seconds == 5.0
+        assert report.timings[release.MEMORY_RETURNED].satisfied_after_seconds == 10.0
+
+    def test_a_condition_that_stops_holding_loses_its_timing(self):
+        """Completion means all four true in ONE evaluation. A port that was free a minute ago
+        and is bound now is not evidence of anything."""
+        now, sleep = virtual_clock()
+
+        report = release.verify_released(
+            Fake((False, True, True, True), (True, True, True, False)),
+            timeout=5,
+            poll=5,
+            now=now,
+            sleep=sleep,
+        )
+
+        assert not report.complete
+        assert report.timings[release.PORTS_FREE].satisfied_after_seconds is None
+
+    def test_a_timeout_names_every_condition_that_did_not_hold(self):
+        now, sleep = virtual_clock()
+
+        report = release.verify_released(
+            Fake((True, False, False, True)), timeout=5, poll=5, now=now, sleep=sleep
+        )
+
+        assert not report.complete
+        assert report.unsatisfied == [release.VFIO_RELEASED, release.MEMORY_RETURNED]
+        assert "vfio_released" in report.why_incomplete()
+        assert "memory_returned" in report.why_incomplete()
+
+    def test_the_report_carries_all_four_conditions_whatever_the_outcome(self):
+        now, sleep = virtual_clock()
+
+        report = release.verify_released(
+            Fake((False, False, False, False)), timeout=0, poll=5, now=now, sleep=sleep
+        )
+
+        assert not report.complete
+        assert set(report.to_json()["conditions"]) == set(release.CONDITION_NAMES)

--- a/neurons/executor/cvmd/tests/test_release.py
+++ b/neurons/executor/cvmd/tests/test_release.py
@@ -347,6 +347,24 @@ class TestTheWait:
         assert "vfio_released" in report.why_incomplete()
         assert "memory_returned" in report.why_incomplete()
 
+    def test_a_long_wait_says_what_it_is_waiting_for_while_it_waits(self, caplog):
+        """A switch window that takes minutes has to be diagnosable before it ends. Once it
+        ends, the satisfied condition's own detail no longer says what had been holding it."""
+        now, sleep = virtual_clock()
+
+        with caplog.at_level("INFO", logger="cvmd.cvm.release"):
+            release.verify_released(
+                Fake((True, False, True, True)),
+                timeout=release.PROGRESS_SECONDS * 2,
+                poll=release.PROGRESS_SECONDS,
+                now=now,
+                sleep=sleep,
+            )
+
+        progress = [r.getMessage() for r in caplog.records if "still held by" in r.getMessage()]
+        assert progress, "a wait past the progress interval logged nothing"
+        assert "vfio_released" in progress[0]
+
     def test_the_report_carries_all_four_conditions_whatever_the_outcome(self):
         now, sleep = virtual_clock()
 

--- a/neurons/executor/cvmd/tests/test_state.py
+++ b/neurons/executor/cvmd/tests/test_state.py
@@ -45,6 +45,18 @@ class TestTransitions:
     def test_failed_recovers_only_through_reconciling(self):
         assert LEGAL_TRANSITIONS[NodeState.FAILED] == frozenset({NodeState.RECONCILING})
 
+    def test_a_stopped_cvm_leaves_the_node_switching_not_free(self):
+        """Stopping the CVM ends TEARDOWN, not the crossing: the GPUs, the guest's memory and
+        the forwarded ports come back to the host after the process does."""
+        assert NodeState.SWITCHING in LEGAL_TRANSITIONS[NodeState.TEARDOWN]
+
+    def test_switching_cannot_reach_launching(self):
+        """FR-C6 enforced by the machine rather than by remembering to check it. A node whose
+        last CVM's memory is still draining has no edge to LAUNCHING to take."""
+        assert LEGAL_TRANSITIONS[NodeState.SWITCHING] == frozenset(
+            {NodeState.RECONCILING, NodeState.FAILED}
+        )
+
     def test_illegal_transition_names_what_was_allowed(self, state_dir):
         """The error has to be actionable — 'illegal transition' alone is not."""
         store = StateStore(state_dir)  # starts in RECONCILING; the self-edge is illegal


### PR DESCRIPTION
## Describe your changes

DAH-2577: **a teardown reports complete only when the node's hardware is actually free**, and
the crossing between modes gets its own state.

**Base is `feature/2462-cvm-v2`, not `main`.** It sits on top of #1206.

A stopped CVM is not a free node. `lium-cvm.sh stop` reports success when its wait loop gives
up and QEMU is still holding the guest's memory afterwards — that is the acceptance bar the
task names. DAH-2576 could only confirm the process group was empty, which is necessary and
nowhere near sufficient, because the expensive part of a TDX teardown happens *after* the
process exits.

### The four conditions (FR-C6)

`DELETE /v1/cvm` now returns `200` only when all four hold **in one evaluation** — a condition
that held a minute ago is not evidence now. They are read off the host, never off cvmd's own
records:

| | |
|---|---|
| `process_reaped` | the supervisor's process group has no members left, **zombies included**, and no TDX guest runs anywhere on this host |
| `vfio_released` | nothing holds a descriptor under `/dev/vfio`. A device stays bound to `vfio-pci` across a teardown by design, so the driver says nothing about availability; an open group descriptor says exactly that |
| `memory_returned` | the host has the guest's RAM back, and its hugepages are back in the pool |
| `ports_free` | every port this CVM forwarded can be bound again — the same check the launch path makes, so "torn down" and "launchable" cannot disagree |

`DELETE /v1/cvm` **is** the FRD's `/teardown` endpoint. The API shape was settled in
DAH-2575/2576 and adding a second route that does the same thing would be worse than reusing
the one that already exists.

### The switch window (FR-C7, FR-I3)

`SWITCHING` is the state between the process going and the hardware coming back. `TEARDOWN` is
cvmd still stopping the CVM; both are the window FR-C7 calls "switching" — neither rentable nor
reachable, and not offline either. **`SWITCHING` has no edge to `LAUNCHING`**, which is how
FR-C6 is enforced structurally rather than by remembering to check it.

The first moment each condition holds is recorded, so the report says *which* part was slow
rather than only how long the whole crossing took — that per-condition breakdown is what FR-I3
needs to tell a switching node from an offline one. `/v1/state` reports the last switch under
`last_switch`, present whether or not a CVM is.

```
DELETE /v1/cvm  ->  200
{"torn_down": true, "instance_id": "...", "detail": "guest powered off on request",
 "switch": {"outcome": "released", "complete": true, "duration_seconds": 0.2,
            "conditions": {"process_reaped": {"satisfied_after_seconds": 0.2, "detail": "..."},
                           ...}}}
```

A teardown that stops the CVM but leaves the node holding hardware answers **504** naming the
conditions that did not hold, fails the node, and **keeps the VM directory** — which is what
`_assert_node_is_free` reads, so the next launch is refused rather than merely discouraged.

The switch record is written **before the first signal**, carrying the memory baseline. A
repeat teardown continues the crossing it finds unfinished rather than opening a new one: the
baseline is only meaningful taken while the guest was still running, and the window FR-I3
budgets for began at the platform's first call, not at whichever retry worked.

### Two budgets, because they measure two different things

`teardown_timeout_seconds` bounds how long the **guest** is given to power itself off.
`teardown_verify_timeout_seconds` (new, default 1800) bounds how long the **host** then takes to
return the hardware. They are not proportional — a guest that exits in seconds can leave its
memory draining for tens of minutes.

`teardown_memory_tolerance` (new, default 0.9) is a tolerance on a kernel estimate, not a
licence to launch into memory that has not come back. Above 1.0 no teardown could ever complete,
so the loader and the Ansible role both refuse it.

## Verification

**Hardware acceptance on `au11`** — real Intel TDX, QEMU 9.2.1, `dstack-nvidia-0.5.11`. Full
results in the comment below.

| | |
|---|---|
| Measured-byte parity with `dstack.py new` (app-compose.json, 95-line QEMU cmdline, `vm_config`) | **identical** |
| `e2e_launch.py` (DAH-2576's suite, unchanged) | **37/37** |
| `e2e_restart.py` (DAH-2576's suite, unchanged) | **11/11** |
| DAH-2577 fault-injection matrix, five blocks | **57/57** |
| cvmd unit suite | **275 passed** |
| Ansible: lint (`production`), syntax, yamllint, shellcheck, 10 shell suites, 11 fixture playbooks | all pass |

The triple this host produces came back **byte-identical to the DAH-2576 run** — qemu `9.2.1`,
`os_image_hash a6eafc5f…`, `compose_hash 90d63529…`. That is the evidence this change did not
alter what cvmd builds.

### The faults, staged on the hardware

| Staged condition | Before | Now |
|---|---|---|
| a **zombie** in the recorded supervisor's process group | `is_supervisor()` reads a zombie as gone — it has no `cmdline` — so teardown answered `200 {"torn_down": true}` | **504** `process group N still has pid N (python, zombie)`, disk kept, node FAILED |
| a `/dev/vfio` descriptor held by another process | nothing looked, so the GPUs could be handed to the next CVM while still held | **504** naming the pid and `/dev/vfio/101`; a launch into that node is refused **409** |
| a forwarded port taken after the CVM stopped | nothing looked | **504** naming the port |
| a **SIGSTOPped** supervisor | — | the ladder gets past it and teardown completes in 21s, and nothing reported the node free while the process was still there |

The zombie case is the headline, and it is the DAH-2576 bug reproduced deliberately: a zombie is
still a process-group member, so `killpg(pgid, 0)` keeps succeeding, while `is_supervisor()`
reads it as gone. The old teardown reported success on exactly that state.

### Measured switch windows

The per-hardware-class budget the task asks for, recorded in `roles/cvmd/README.md`:

| Host | Guest | Guest powered off | Hardware back afterwards | `DELETE` end to end |
|---|---|---|---|---|
| au11 | 8 vCPU, 16 GiB, no GPU passthrough | ~5 s | **0.2 s** | **5–6 s** |
| the same fleet under `lium-cvm.sh` | 1.13 TB | — | ~43 min | — |

## Declared, not hidden

- **One unexplained outlier.** A single au11 teardown held on `ports_free` for **161 s** while
  the other three conditions settled in 0.2 s. It did not recur across three later runs of the
  same shape, and a probe across a teardown found the forwarded ports bindable 2 s after the
  guest stopped — with *and* without `SO_REUSEADDR`, so it was not `TIME_WAIT`. I have not
  explained it, so it is recorded rather than explained away. `verify_released` now logs its
  outstanding conditions every 30 s, which is exactly what was missing to diagnose it at the
  time (`bedf14a6`).
- **The SIGSTOP fault cannot end in a timeout** on a host where cvmd is root and the
  supervisor's parent is init: SIGKILL always reaches a stopped process, and init reaps it at
  once. What that block proves is the other half — nothing reported the node free while the
  process was there. The zombie block is the one that reaches FAILED.
- **The zombie and port blocks stage a supervisor record rather than a real guest.** Not a
  shortcut: a zombie inside a real supervisor's group cannot outlive the SIGKILL that ends the
  group, because the kernel reparents it to init, which reaps it. The only way to hold that
  condition open is the shape the original bug had — a group leader whose parent is alive and
  outside the group.
- **`ports_free` uses the launch path's own check.** Deliberate: if the release check were more
  lenient than the launch check, a teardown could report the node free while the next launch was
  refused for the same ports.
- **The 1.13 TB figure is from DAH-2544's observation under `lium-cvm.sh`**, not from a run of
  this code. au11 has no TB-class guest configured, and sizing is provider configuration.
- **The cost of looking.** Two of the conditions scan `/proc`. Measured on au11 — 1601 processes
  holding 962 open descriptors — one full evaluation takes **60 ms**, so a 2 s poll is ~3% of one
  core, and only while a teardown is in flight. Measured rather than assumed, because a scan of
  every descriptor of every process is the kind of thing that is cheap until it is not.

## Issue ticket number and link

[DAH-2577 — CVM v2 — verified teardown + SWITCHING state (FR-C6/C7)](https://app.notion.com/p/CVM-v2-verified-teardown-SWITCHING-state-FR-C6-C7-3b2b8bfdbde98194bbc4ef03bc663b78)

## ⚠️ This PR runs zero CI

`test.yml` is `on: pull_request: branches: [main, dev]`, and the filter matches the **target**
branch, so a PR into the umbrella runs no checks — silently, while GitHub still reports
`MERGEABLE`. The gate is deferred to the eventual `feature/2462-cvm-v2` → `main` PR. Please do
not read an empty check list here as coverage; the evidence is the acceptance comment.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?
