### PR TITLE
DAH-2614: send the scraped GPU UUIDs with the rental health check

### DIFF
--- a/neurons/validators/src/clients/backend_client.py
+++ b/neurons/validators/src/clients/backend_client.py
@@ -9,10 +9,6 @@ from urllib.parse import urlencode
 
 import aiohttp
 import bittensor
-from pydantic import BaseModel, ValidationError
-from tenacity import retry, retry_if_result, stop_after_attempt, wait_fixed
-
-from core.utils import _m, get_extra_info
 from protocol.vc_protocol.compute_requests import (
     DefaultDockerImage,
     DefaultDockerImagesResponse,
@@ -23,6 +19,10 @@ from protocol.vc_protocol.compute_requests import (
     PodRentalActiveResponse,
     RentedExecutorsResponse,
 )
+from pydantic import BaseModel, ValidationError
+from tenacity import retry, retry_if_result, stop_after_attempt, wait_fixed
+
+from core.utils import _m, get_extra_info
 
 logger = logging.getLogger(__name__)
 
@@ -291,6 +291,7 @@ class BackendClient:
         container_port: int,
         executor_id: str | None = None,
         rental_in_progress: bool = False,
+        gpu_uuids: list[str] | None = None,
     ) -> ExecutorHealthCheckResponse | None:
         """Check executor health via backend API.
 
@@ -303,6 +304,9 @@ class BackendClient:
             rental_in_progress: True if this validator already sees an active customer rental for the
                 executor. Lets the backend skip the container-creating check immediately; the backend
                 still re-checks the DB itself when this is False.
+            gpu_uuids: GPU UUIDs from the scrape this cycle. The backend's probe asks the container
+                runtime to resolve exactly these instead of `--gpus all`, which never names a card
+                and so let a host advertising GPUs it cannot hand over pass the check (DAH-2614).
 
         Returns:
             ExecutorHealthCheckResponse if successful, None otherwise
@@ -316,6 +320,10 @@ class BackendClient:
             "miner_hotkey": miner_hotkey,
             "container_port": container_port,
             "rental_in_progress": rental_in_progress,
+            # Sent from this cycle's scrape rather than read from the backend's stored specs: those
+            # are a cycle behind and absent entirely on an executor's first pass — the very check
+            # where a fabricated GPU matters most.
+            "gpu_uuids": gpu_uuids or [],
         }
 
         if executor_id:

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -4,8 +4,6 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 import asyncssh
-
-from core.config import settings
 from core.docker_utils import DockerCommand, collect_container_death_diagnostics
 from protocol.vc_protocol.compute_requests import (
     GPU_RUNTIME_DEVICE_FAULT_REASON,
@@ -13,9 +11,13 @@ from protocol.vc_protocol.compute_requests import (
     FillerRunActiveResponse,
 )
 
+from core.config import settings
+
 from ...const import FILLER_CONTAINER_PREFIX, FILLER_LIVENESS_GRACE_MINUTES
-from ..messages import MessageTemplate, RentalVerificationMessages as Msg, render_message
+from ..messages import MessageTemplate, render_message
+from ..messages import RentalVerificationMessages as Msg
 from ..pipeline import CheckResult, Context
+
 
 @dataclass(frozen=True)
 class GpuRuntimeQuarantine:
@@ -143,6 +145,13 @@ class RentalVerificationCheck:
         # Use the first verified port
         container_port = verified_ports[0]
 
+        # The UUIDs this cycle's scrape saw. The backend probes for exactly these instead of
+        # `--gpus all`, so a host advertising cards it cannot hand over fails here rather than in a
+        # customer's rental (DAH-2614). Sent from the scrape, not read from the backend's stored
+        # specs: those lag a cycle and do not exist at all on an executor's first pass.
+        gpu_details = ctx.state.gpu_details or (ctx.state.specs or {}).get("gpu", {}).get("details", [])
+        gpu_uuids = [detail["uuid"] for detail in gpu_details if isinstance(detail, dict) and detail.get("uuid")]
+
         try:
             # Call backend API to verify executor health. Pass the rental hint: when this validator
             # already sees an active customer rental, the backend skips the container-creating check
@@ -154,6 +163,7 @@ class RentalVerificationCheck:
                 container_port=container_port,
                 executor_id=executor.uuid,
                 rental_in_progress=has_customer_rental,
+                gpu_uuids=gpu_uuids,
             )
 
             # Handle API failure (None response) - fail this executor

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -1,20 +1,19 @@
 from datetime import datetime, timedelta
+from unittest.mock import Mock, patch
 
 import asyncssh
 import pytest
-from unittest.mock import Mock, patch
-
 from neurons.validators.src.protocol.vc_protocol.compute_requests import (
     GPU_RUNTIME_DEVICE_FAULT_REASON,
     GPU_RUNTIME_NVML_MISMATCH_REASON,
     ExecutorHealthCheckResponse,
     FillerRunActiveResponse,
 )
-from protocol.vc_protocol.compute_requests import RentedExecutor, RentedExecutorsResponse, RentedPod
 from neurons.validators.src.services.container_cleanup import ContainerCleanup
 from neurons.validators.src.services.task.checks.rental_verification import RentalVerificationCheck
 from neurons.validators.src.services.task.messages import RentalVerificationMessages as Msg
 from neurons.validators.src.services.task.pipeline import CheckResult, Context
+from protocol.vc_protocol.compute_requests import RentedExecutor, RentedExecutorsResponse, RentedPod
 
 from tests.helpers import build_services, build_state
 
@@ -47,6 +46,7 @@ class DummyBackendClient:
         container_port: int,
         executor_id: str | None = None,
         rental_in_progress: bool = False,
+        gpu_uuids: list[str] | None = None,
     ):
         self.called_with = {
             "miner_address": miner_address,
@@ -55,6 +55,7 @@ class DummyBackendClient:
             "container_port": container_port,
             "executor_id": executor_id,
             "rental_in_progress": rental_in_progress,
+            "gpu_uuids": gpu_uuids,
         }
         return self.response
 
@@ -153,6 +154,7 @@ async def test_rental_verification_success():
         "container_port": 8080,  # First verified port
         "executor_id": "executor-123",
         "rental_in_progress": False,  # no customer rental in this state
+        "gpu_uuids": [],  # this state carries no scraped gpu details
     }
 
 
@@ -859,3 +861,96 @@ async def test_unreachable_bundle_does_not_mask_a_kill_behind_it():
         Msg.FILLER_TRANSPORT_UNREACHABLE.reason,
         Msg.FILLER_KILLED.reason,
     ]
+
+
+# ---------------------------------------------------------------------------
+# DAH-2614: the backend's probe must name the cards this cycle's scrape saw,
+# instead of `--gpus all`, which never names one.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rental_verification_sends_scraped_gpu_uuids():
+    backend_client = DummyBackendClient(
+        response=ExecutorHealthCheckResponse(success=True, error=None, details={})
+    )
+    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
+    state = build_state(
+        specs={
+            "verified_ports": [9001],
+            "gpu": {
+                "count": 2,
+                "details": [
+                    {"uuid": "GPU-f2bfa67f-5281-aabc-aa90-c91764f90d17", "name": "B200"},
+                    {"uuid": "GPU-f2bfa67f-5281-aabc-aa90-c91764f90d18", "name": "B200"},
+                ],
+            },
+        }
+    )
+
+    from tests.helpers import make_context
+
+    ctx = make_context(services=services, state=state)
+
+    with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
+        mock_settings.SKIP_RENTAL_VERIFICATION = False
+        result = await RentalVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert backend_client.called_with["gpu_uuids"] == [
+        "GPU-f2bfa67f-5281-aabc-aa90-c91764f90d17",
+        "GPU-f2bfa67f-5281-aabc-aa90-c91764f90d18",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_rental_verification_sends_empty_list_when_the_scrape_has_no_gpu_details():
+    # The backend falls back to `--gpus all`, i.e. exactly the behaviour before this change.
+    backend_client = DummyBackendClient(
+        response=ExecutorHealthCheckResponse(success=True, error=None, details={})
+    )
+    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
+    state = build_state(specs={"verified_ports": [9001]})
+
+    from tests.helpers import make_context
+
+    ctx = make_context(services=services, state=state)
+
+    with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
+        mock_settings.SKIP_RENTAL_VERIFICATION = False
+        result = await RentalVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert backend_client.called_with["gpu_uuids"] == []
+
+
+@pytest.mark.asyncio
+async def test_rental_verification_skips_gpu_details_without_a_uuid():
+    backend_client = DummyBackendClient(
+        response=ExecutorHealthCheckResponse(success=True, error=None, details={})
+    )
+    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
+    state = build_state(
+        specs={
+            "verified_ports": [9001],
+            "gpu": {
+                "count": 3,
+                "details": [
+                    {"uuid": "GPU-f2bfa67f-5281-aabc-aa90-c91764f90d17"},
+                    {"uuid": ""},
+                    {"name": "B200"},
+                ],
+            },
+        }
+    )
+
+    from tests.helpers import make_context
+
+    ctx = make_context(services=services, state=state)
+
+    with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
+        mock_settings.SKIP_RENTAL_VERIFICATION = False
+        result = await RentalVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert backend_client.called_with["gpu_uuids"] == ["GPU-f2bfa67f-5281-aabc-aa90-c91764f90d17"]


### PR DESCRIPTION
Validator half of DAH-2614. Backend half: Datura-ai/compute-app#885 — **merge that one first**,
the field is additive and the backend ignores it until then.

## Why

The backend's pre-rental probe starts its container with `--gpus all`. That value never names a
card, so a host advertising GPUs it does not physically have passes the check, and the first party
to touch the nonexistent GPU is a paying customer. Confirmed live on two executors this week
(`056b4cbd-14e6-4b6f-9d09-10cae3a00c15`, `53aa775e-cead-4475-ba6e-a820059c55a1`): one real card
advertised as eight, via an `/etc/ld.so.preload` shim over three NVML symbols.

For the probe to name the cards, someone has to tell it which. The backend's own
`Executor.specs` is the wrong source twice over: it is written one cycle behind (specs are
published from `ResultHandler`, after the pipeline), and on an executor's **first** pass there is no
row at all — precisely the check where a fabricated GPU matters most.

This validator already holds the answer. `MachineSpecScrapeCheck` runs at
`pipeline_factory.py:250`, `RentalVerificationCheck` at `:296`, so the fresh scrape is in
`ctx.state` when we call the backend — the same place the check already reads `verified_ports` from.

## Change

- `RentalVerificationCheck` pulls the UUIDs out of `ctx.state.gpu_details` (falling back to
  `specs["gpu"]["details"]`, as `gpu_model_valid` and `collateral` do) and passes them along. Details
  without a `uuid` are skipped.
- `BackendClient.check_executor_health` takes `gpu_uuids` and always puts the key in the payload,
  empty list included, so the backend's fallback branch is exercised the same way in every case.

No scoring change, no protocol version bump, no new failure mode on this side: if the scrape has no
GPU details the list is empty and the backend probes `--gpus all`, exactly as today.

## Tests

`37 passed` in `tests/test_rental_verification_check.py`, `1498 passed, 9 skipped` for the suite.
New: UUIDs from the scrape reach the client; an empty scrape sends `[]`; details without a `uuid`
are skipped. `DummyBackendClient` and the existing full-payload assertion in
`test_rental_verification_success` were extended to cover the new key.

Three failures in `tests/test_sshd_bootstrap_script.py` reproduce on clean `origin/main` and are
unrelated to this change.


## Staging (2026-08-10, `lium-io:f452d74` + `compute-app:b32bd0d`)

Wave at `04:12`, executor `66e9c110-d9db-4a1e-a2cd-6ea1647ae81b`: the UUID this cycle's scrape saw,
`GPU-e3dc8584-a071-75ba-425b-1c078b5f7b0b`, arrives at the backend and is what the probe asks the
container runtime to resolve — visible on every line of the backend's check as `gpus_requested`.
The check passes. Asking the same host for a fabricated neighbour returns
`GPU_RUNTIME_DEVICE_FAULT`, which is the code this check quarantines on.