### PR TITLE
DAH-2629 + DAH-2630 + DAH-2632 + DAH-2633 - Launch validation CVMs from the validator, account for the switch window, publish the attest-agent by digest, and drive it all with one E2E command

### DIFF
--- a/.github/workflows/attest-agent-publish.yml
+++ b/.github/workflows/attest-agent-publish.yml
@@ -1,0 +1,83 @@
+# DAH-2632 — build and publish the renter CVM's attest-agent image, pinned by digest.
+#
+# The digest this job prints is THE deployment artifact: CVM_ATTEST_AGENT_IMAGE must name
+# the image by digest, never by tag, because the injected compose is measured — a mutable
+# tag would mean the approved bytes stay approved while the image behind them changes.
+#
+# Re-publishing is a CATALOG event, not a swap: a new digest changes every derived renter
+# compose hash, so it rolls out through new catalog rows (with grace for in-flight
+# rentals) and the old digest stays valid until its rows are deprecated. See
+# neurons/executor/attest-agent/PUBLISHING.md.
+
+name: "Publish: attest-agent image"
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "attest-agent-v*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: datura-ai/lium-attest-agent
+
+concurrency:
+  group: attest-agent-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./neurons/executor/attest-agent
+          push: true
+          # Provenance attestations wrap the image in an OCI index whose digest differs
+          # from the plain manifest's; disabled so the digest below is the one a docker
+          # pull resolves.
+          provenance: false
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          cache-from: type=gha,scope=attest-agent
+          cache-to: type=gha,mode=max,scope=attest-agent
+
+      - name: Summary — the digest to pin
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          COMMIT: ${{ github.sha }}
+        run: |
+          echo "### attest-agent published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Pin this, by digest (DAH-2632):**" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "CVM_ATTEST_AGENT_IMAGE=$IMAGE@$DIGEST" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** \`$COMMIT\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "A new digest changes every derived renter compose hash — roll it through" >> $GITHUB_STEP_SUMMARY
+          echo "the catalog (new rows, grace for in-flight rentals); never swap in place." >> $GITHUB_STEP_SUMMARY

--- a/neurons/executor/attest-agent/PUBLISHING.md
+++ b/neurons/executor/attest-agent/PUBLISHING.md
@@ -1,0 +1,44 @@
+# Publishing the attest-agent image (DAH-2632)
+
+The attest-agent ships **through the measured customer compose**, injected by the backend
+(`services/cvm_compose.py`) as an image reference pinned **by digest**. That digest is
+folded into every derived renter `compose_hash`, which is what the host measures and the
+validator verifies. Three consequences follow, and they are the whole of this document:
+
+1. **Only a digest may be deployed.** `CVM_ATTEST_AGENT_IMAGE` must be of the form
+   `ghcr.io/datura-ai/lium-attest-agent@sha256:<64 hex>`. A tag is refused by review, not
+   by code: a mutable tag would mean the approved compose bytes stay approved while the
+   image behind them changes.
+
+2. **A new digest is a catalog rollout, never a swap.** Changing the env var changes the
+   compose hash of every rental derived after it — but every rental derived *before* it
+   still measures as the old hash, and validators verify rentals against what was sold.
+   So a re-publish rolls out as:
+
+   1. Run the `Publish: attest-agent image` workflow (or push an `attest-agent-v*` tag).
+      The job summary prints the exact `CVM_ATTEST_AGENT_IMAGE` line to deploy.
+   2. Set the new value in the target environment's config and restart the backend.
+      New orders derive with the new digest from that moment.
+   3. Leave the old digest's rentals alone: they re-attest against the compose hash the
+      backend stored for their order (`pod.cvm_info.expectations`), so they stay valid
+      until they end. There is nothing to migrate.
+
+3. **The published image must never be a personal namespace.** The au11 hardware
+   acceptance used a personal test namespace; that reference must not appear in staging
+   or production config. The org image is `ghcr.io/datura-ai/lium-attest-agent`,
+   published by CI from this directory with `GITHUB_TOKEN` — reproducible from the
+   commit named in the job summary.
+
+## Verifying a build before pinning it
+
+The golden loop that matters: the backend's derive with the pinned digest must produce a
+compose whose hash the host measures identically. That property is pinned by tests on
+both sides (`lium-io-backend: test_dah2580_renter_provisioning.py` derives with a
+digest-pinned image; `cvmd: tests/test_renter_launch.py` measures what dstack writes), so
+a green suite on both repos plus the digest from the job summary is the whole check.
+
+To inspect what a digest actually resolves to:
+
+```bash
+docker buildx imagetools inspect ghcr.io/datura-ai/lium-attest-agent@sha256:<digest>
+```

--- a/neurons/validators/src/clients/compute_client.py
+++ b/neurons/validators/src/clients/compute_client.py
@@ -758,6 +758,45 @@ class ComputeClient:
         miner = await self.subtensor_client.get_miner(hotkey)
         return miner.axon_info
 
+    def _schedule_validation_cvm_return(self, job_request, logging_extra: dict) -> None:
+        """After a renter teardown, put the validation CVM back (DAH-2629). Never raises."""
+        try:
+            from core.config import settings as _settings
+
+            if not _settings.ENABLE_CVM_LIFECYCLE:
+                return
+
+            async def _return_validation_cvm():
+                from urllib.parse import urlparse
+
+                from services.cvm_lifecycle import CvmdHost
+
+                lifecycle = self.miner_service._cvm_lifecycle()
+                host = None
+                for registered in await lifecycle.hosts_for_miner(job_request.miner_hotkey):
+                    if registered.executor_uuid == str(job_request.executor_id):
+                        host = registered
+                        break
+                if host is None:
+                    # Not registered yet (e.g. first rental before any attested cycle) —
+                    # the cvmd_url this very relay used is authoritative for reachability.
+                    address = urlparse(job_request.cvmd_url).hostname or ""
+                    host = CvmdHost(
+                        executor_uuid=str(job_request.executor_id),
+                        address=address,
+                        miner_hotkey=job_request.miner_hotkey,
+                    )
+                await lifecycle.ensure_validation_cvm(host)
+
+            asyncio.create_task(_return_validation_cvm())
+        except Exception as exc:  # noqa: BLE001 - the relay's answer must reach the backend regardless
+            logger.warning(
+                _m(
+                    "Could not schedule the validation-CVM return",
+                    extra=get_extra_info({**logging_extra, "error": str(exc)}),
+                )
+            )
+
     async def cvm_driver(self, job_request: CvmProvisionRequest | CvmTeardownRequest):
         """Replay one platform-signed cvmd call and hand the host's answer straight back.
 
@@ -819,6 +858,12 @@ class ComputeClient:
                         extra=get_extra_info({**logging_extra, "status": result.status}),
                     )
                 )
+                if not provisioning:
+                    # DAH-2629 — the switch back: a verified teardown means the node is free
+                    # RIGHT NOW, so the validation CVM goes back up without waiting for the
+                    # next cycle's sweep to notice. Best-effort and fire-and-forget; the
+                    # sweep remains the safety net.
+                    self._schedule_validation_cvm_return(job_request, logging_extra)
             else:
                 response = FailedCvmRequest(
                     miner_hotkey=job_request.miner_hotkey,

--- a/neurons/validators/src/clients/compute_client.py
+++ b/neurons/validators/src/clients/compute_client.py
@@ -858,11 +858,13 @@ class ComputeClient:
                         extra=get_extra_info({**logging_extra, "status": result.status}),
                     )
                 )
-                if not provisioning:
+                if not provisioning and getattr(job_request, "intent", "release") != "switch":
                     # DAH-2629 — the switch back: a verified teardown means the node is free
                     # RIGHT NOW, so the validation CVM goes back up without waiting for the
                     # next cycle's sweep to notice. Best-effort and fire-and-forget; the
-                    # sweep remains the safety net.
+                    # sweep remains the safety net. A "switch" teardown is the opposite case:
+                    # the backend cleared the node for a renter launch it is about to send,
+                    # and a relaunch here would race that order for the node.
                     self._schedule_validation_cvm_return(job_request, logging_extra)
             else:
                 response = FailedCvmRequest(

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -392,6 +392,66 @@ class Settings(BaseSettings):
         env="ATTESTED_IDENTITY_TTL_SECONDS", default=21600
     )
 
+    # ------------------------------------------------------------------ DAH-2629 / DAH-2630
+    #
+    # Same flag family, same posture: default-off, per-environment turn-on.
+
+    # This validator brings validation CVMs up itself via cvmd — on a host with no CVM, and
+    # back up after a renter teardown — instead of providers running lium-cvm.sh by hand.
+    ENABLE_CVM_LIFECYCLE: bool = Field(env="ENABLE_CVM_LIFECYCLE", default=False)
+
+    # Where a node's cvmd listens. The port is fleet configuration; the address is the node's own.
+    CVMD_PORT: int = Field(env="CVMD_PORT", default=8443)
+
+    # Test-only: the local E2E harness reaches one host's cvmd through an SSH tunnel, so every
+    # cvmd call goes to this URL instead of https://<node address>:CVMD_PORT. Empty in real
+    # deployments.
+    CVMD_URL_OVERRIDE: str = Field(env="CVMD_URL_OVERRIDE", default="")
+
+    # Minimum seconds between validation-CVM launch attempts on one host. A launch takes minutes
+    # and a failing one should be read, not hammered.
+    CVM_LAUNCH_COOLDOWN_SECONDS: int = Field(env="CVM_LAUNCH_COOLDOWN_SECONDS", default=600)
+
+    # How long a cvmd host stays in this validator's registry without being re-seen. The registry
+    # is what the lifecycle sweep and the switch-grace synthesis iterate — an entry that never
+    # ages out would keep probing a decommissioned node forever.
+    CVMD_HOST_REGISTRY_TTL_SECONDS: int = Field(
+        env="CVMD_HOST_REGISTRY_TTL_SECONDS", default=7 * 24 * 3600
+    )
+
+    # DAH-2630 — FR-I3: the RENTED↔UNRENTED switch is availability-accounted. A node inside its
+    # budgeted switch window is neither rentable nor probeable BY DESIGN, so it is exempt from
+    # downtime penalties; a switch that exceeds its budget is a real signal and is flagged.
+    # Off = observe: the sweep logs what it would have graced and changes no score.
+    ENABLE_SWITCHING_GRACE: bool = Field(env="ENABLE_SWITCHING_GRACE", default=False)
+
+    # The default budget, and per-hardware-class overrides as a JSON object keyed by GPU model
+    # (e.g. '{"NVIDIA H200": 600}'). The dominant switch cost is guest RAM return, which grows
+    # with CVM memory — au11 (no GPUs, small guest) measured 5–6 s; large-memory hosts take
+    # minutes. Budgets are deliberately generous: the flag for a genuinely stuck node matters
+    # more than shaving seconds off a grace nobody abuses.
+    CVM_SWITCH_BUDGET_SECONDS_DEFAULT: int = Field(
+        env="CVM_SWITCH_BUDGET_SECONDS_DEFAULT", default=300
+    )
+    CVM_SWITCH_BUDGET_SECONDS_BY_GPU_MODEL: str = Field(
+        env="CVM_SWITCH_BUDGET_SECONDS_BY_GPU_MODEL", default=""
+    )
+
+    def get_cvm_switch_budget_seconds(self, gpu_model: str | None) -> int:
+        """The switch budget for one hardware class. Unparseable config falls back to the
+        default rather than failing the cycle — a bad JSON here must not zero a fleet."""
+        if gpu_model and self.CVM_SWITCH_BUDGET_SECONDS_BY_GPU_MODEL:
+            try:
+                import json as _json
+
+                overrides = _json.loads(self.CVM_SWITCH_BUDGET_SECONDS_BY_GPU_MODEL)
+                value = overrides.get(gpu_model)
+                if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                    return value
+            except (ValueError, AttributeError):
+                pass
+        return self.CVM_SWITCH_BUDGET_SECONDS_DEFAULT
+
     def get_report_data_recipes(self) -> list[str]:
         """The accepted recipes, in the order they are tried. Always at least v1."""
         recipes = [r.strip().lower() for r in self.TDX_REPORT_DATA_RECIPES.split(",") if r.strip()]

--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -488,6 +488,11 @@ class CvmTeardownRequest(ContainerBaseRequest):
     message_type: ContainerRequestType = ContainerRequestType.CvmTeardownRequest
     cvmd_url: str
     call: SignedCvmdCall
+    # Why the node is being cleared. "release" ends a rental, and this validator may put its
+    # validation CVM straight back up. "switch" clears the node for a renter launch the
+    # backend is about to dispatch — relaunching here would race the very order the teardown
+    # serves, and the loser of that race is a customer's 409.
+    intent: str = "release"
 
 
 class ContainerWarningCode(enum.Enum):

--- a/neurons/validators/src/services/cvm_lifecycle.py
+++ b/neurons/validators/src/services/cvm_lifecycle.py
@@ -269,6 +269,17 @@ class CvmLifecycleService:
         except Exception:  # noqa: BLE001 - no Redis, no cooldown; the in-process set still guards
             pass
 
+        # Refresh before reading the catalog. The sweep path runs inside a validation cycle,
+        # which already refreshes via attestation — but the switch-back trigger runs in the
+        # connector process (compute_client), which never runs attestation, so its catalog
+        # would otherwise be perpetually None and every immediate relaunch would fail-closed
+        # with "no signed catalog entry". refresh() is itself fail-closed (a network error
+        # leaves the held manifest untouched) and is_due-gated, so this is safe on both paths.
+        try:
+            await self.whitelist_source.refresh()
+        except Exception:  # noqa: BLE001 - refresh never raises, but the launch must not depend on that
+            pass
+
         catalog = self.whitelist_source.current()
         entry = catalog.newest_validation_entry() if catalog else None
         if entry is None:

--- a/neurons/validators/src/services/cvm_lifecycle.py
+++ b/neurons/validators/src/services/cvm_lifecycle.py
@@ -1,0 +1,353 @@
+"""The validation-CVM lifecycle, driven by this validator (DAH-2629 + DAH-2630).
+
+Two closely-related jobs share this module because they share everything else — the host
+registry, the signed state read, and the budgets:
+
+**DAH-2629 — bring the validation CVM up.** The locked design says the validator requests
+validation CVMs from the daemon; cvmd grants ``validation`` to the validator key alone.
+So when a cvmd host has no CVM — first sight after registration, after a renter teardown,
+after a crash — this validator launches one, pinning the triple from the newest
+validation entry of the platform's signed catalog, and verifies the launch report against
+that same triple. A launch failure is a scoring signal against the node (it simply stays
+unverifiable), not an operator page.
+
+**DAH-2630 — account for the switch window (FR-I3).** During the RENTED↔UNRENTED
+transition the node is neither rentable nor probeable *by design*, so a node inside its
+budgeted switch window is exempt from the zero-score its unreachability would otherwise
+earn. The grace is synthesized the same way the special-manual-rental forced pass is —
+a JobResult with ``spec=None`` so the backend's executor upsert is untouched — and a
+switch that exceeds its budget is a flag, never a silently longer window.
+
+**The registry.** Both jobs need to know, for a node that is currently unreachable, that
+it is a cvmd host at all and where its daemon listens. That cannot come from the miner's
+per-cycle answer (the executor inside a torn-down CVM is exactly what is missing), so it
+is remembered: every attested validation cycle records the host, and every relayed
+provision/teardown refreshes it. Entries age out so a decommissioned node stops being
+probed. A brand-new host therefore enters the registry with its first attested cycle —
+the very first CVM on a virgin host still comes from day-zero provisioning.
+"""
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from core.config import settings
+from core.utils import _m, get_extra_info
+from services.cvmd_client import CvmdClient
+from services.cvmd_relay import CvmdRelayError
+from services.redis_service import RedisService
+
+logger = logging.getLogger(__name__)
+
+CVMD_HOSTS_KEY = "cvmd_hosts"
+CVM_LAUNCH_ATTEMPT_PREFIX = "cvm_launch_attempt"
+
+# Node states as cvmd's /v1/state reports them (cvmd/state/machine.py — string values are
+# the wire contract; RECONCILING doubles as idle).
+STATE_RECONCILING = "RECONCILING"
+STATE_LAUNCHING = "LAUNCHING"
+STATE_VALIDATION_RUNNING = "VALIDATION_RUNNING"
+STATE_RENTER_RUNNING = "RENTER_RUNNING"
+STATE_TEARDOWN = "TEARDOWN"
+STATE_SWITCHING = "SWITCHING"
+STATE_FAILED = "FAILED"
+
+# Log event names — Grafana/Loki query keys, so they are constants rather than prose.
+CVM_SWITCH_GRACE_EVENT = "CVM_SWITCH_GRACE"
+CVM_SWITCH_GRACE_OBSERVED_EVENT = "CVM_SWITCH_GRACE_OBSERVED"
+CVM_SWITCH_BUDGET_EXCEEDED_EVENT = "CVM_SWITCH_BUDGET_EXCEEDED"
+CVM_LAUNCH_STARTED_EVENT = "CVM_VALIDATION_LAUNCH_STARTED"
+CVM_LAUNCH_VERIFIED_EVENT = "CVM_VALIDATION_LAUNCH_VERIFIED"
+CVM_LAUNCH_FAILED_EVENT = "CVM_VALIDATION_LAUNCH_FAILED"
+
+
+@dataclass(frozen=True)
+class CvmdHost:
+    """One registered cvmd host: enough to reach its daemon and to score its grace."""
+
+    executor_uuid: str
+    address: str
+    miner_hotkey: str
+    gpu_model: str | None = None
+    gpu_count: int = 0
+    updated_at: float = 0.0
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "executor_uuid": self.executor_uuid,
+                "address": self.address,
+                "miner_hotkey": self.miner_hotkey,
+                "gpu_model": self.gpu_model,
+                "gpu_count": self.gpu_count,
+                "updated_at": self.updated_at,
+            }
+        )
+
+    @classmethod
+    def from_json(cls, raw: str | bytes) -> "CvmdHost | None":
+        try:
+            data = json.loads(raw)
+            return cls(
+                executor_uuid=str(data["executor_uuid"]),
+                address=str(data["address"]),
+                miner_hotkey=str(data["miner_hotkey"]),
+                gpu_model=data.get("gpu_model"),
+                gpu_count=int(data.get("gpu_count") or 0),
+                updated_at=float(data.get("updated_at") or 0.0),
+            )
+        except (ValueError, KeyError, TypeError):
+            return None
+
+    def cvmd_url(self) -> str:
+        if settings.CVMD_URL_OVERRIDE:
+            return settings.CVMD_URL_OVERRIDE
+        return f"https://{self.address}:{settings.CVMD_PORT}"
+
+
+@dataclass(frozen=True)
+class SwitchAssessment:
+    """What one state read says about a possibly-switching node."""
+
+    reachable: bool
+    state: str | None = None
+    has_cvm: bool = False
+    switching: bool = False
+    elapsed_seconds: float | None = None
+
+    @property
+    def idle_without_cvm(self) -> bool:
+        return self.state == STATE_RECONCILING and not self.has_cvm
+
+
+def _parse_started_at(last_switch: dict | None) -> datetime | None:
+    if not isinstance(last_switch, dict):
+        return None
+    raw = last_switch.get("started_at")
+    if not isinstance(raw, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+class CvmLifecycleService:
+    """Registry, state assessment, and validation-CVM launches for cvmd hosts."""
+
+    def __init__(self, redis_service: RedisService, whitelist_source, keypair) -> None:
+        self.redis_service = redis_service
+        self.whitelist_source = whitelist_source
+        self.client = CvmdClient(keypair)
+        # Hosts with a launch in flight in THIS process, so one slow launch is not joined
+        # by a second from the next cycle. The Redis cooldown covers everything else.
+        self._launching: set[str] = set()
+
+    # ------------------------------------------------------------------ registry
+
+    async def record_host(
+        self,
+        *,
+        executor_uuid: str,
+        address: str,
+        miner_hotkey: str,
+        gpu_model: str | None = None,
+        gpu_count: int = 0,
+    ) -> None:
+        """Remember (or refresh) one cvmd host. Merge-updates so a relay that knows only
+        the address does not erase the gpu shape an attested cycle recorded."""
+        existing = None
+        try:
+            raw = await self.redis_service.hget(CVMD_HOSTS_KEY, executor_uuid)
+            if raw:
+                existing = CvmdHost.from_json(raw)
+        except Exception:  # noqa: BLE001 - registry reads must never break a cycle
+            existing = None
+
+        host = CvmdHost(
+            executor_uuid=executor_uuid,
+            address=address,
+            miner_hotkey=miner_hotkey,
+            gpu_model=gpu_model or (existing.gpu_model if existing else None),
+            gpu_count=gpu_count or (existing.gpu_count if existing else 0),
+            updated_at=time.time(),
+        )
+        try:
+            await self.redis_service.hset(CVMD_HOSTS_KEY, executor_uuid, host.to_json())
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(_m(
+                "Could not record a cvmd host",
+                extra=get_extra_info({"executor_uuid": executor_uuid, "error": str(exc)}),
+            ))
+
+    async def hosts_for_miner(self, miner_hotkey: str) -> list[CvmdHost]:
+        """This miner's registered cvmd hosts, with aged-out entries pruned as they are seen."""
+        try:
+            raw_map = await self.redis_service.hgetall(CVMD_HOSTS_KEY) or {}
+        except Exception:  # noqa: BLE001
+            return []
+
+        hosts: list[CvmdHost] = []
+        now = time.time()
+        for field, raw in raw_map.items():
+            host = CvmdHost.from_json(raw)
+            if host is None:
+                continue
+            if now - host.updated_at > settings.CVMD_HOST_REGISTRY_TTL_SECONDS:
+                field_name = field.decode() if isinstance(field, bytes) else str(field)
+                try:
+                    await self.redis_service.hdel(CVMD_HOSTS_KEY, field_name)
+                except Exception:  # noqa: BLE001
+                    pass
+                continue
+            if host.miner_hotkey == miner_hotkey:
+                hosts.append(host)
+        return hosts
+
+    # ------------------------------------------------------------------ assessment
+
+    async def assess(self, host: CvmdHost) -> SwitchAssessment:
+        """One signed state read, folded into what the two callers need to decide."""
+        try:
+            result = await self.client.state(host.cvmd_url())
+        except CvmdRelayError as exc:
+            logger.info(_m(
+                "cvmd unreachable during lifecycle assessment",
+                extra=get_extra_info({"executor_uuid": host.executor_uuid, "error": str(exc)}),
+            ))
+            return SwitchAssessment(reachable=False)
+        if not result.ok:
+            return SwitchAssessment(reachable=False)
+
+        body = result.body
+        state = body.get("state")
+        has_cvm = body.get("cvm") is not None
+        switching = state in (STATE_TEARDOWN, STATE_SWITCHING)
+        elapsed = None
+        if switching:
+            started_at = _parse_started_at(body.get("last_switch"))
+            if started_at is not None:
+                elapsed = max(0.0, (datetime.now(UTC) - started_at).total_seconds())
+        return SwitchAssessment(
+            reachable=True,
+            state=state,
+            has_cvm=has_cvm,
+            switching=switching,
+            elapsed_seconds=elapsed,
+        )
+
+    # ------------------------------------------------------------------ DAH-2629: launch
+
+    async def ensure_validation_cvm(self, host: CvmdHost, *, assessment: SwitchAssessment | None = None) -> bool:
+        """Launch the validation CVM on an idle, empty host. True only on a verified launch.
+
+        Refusals are all fail-closed and named: no catalog in force, no validation entry,
+        a host that is not actually idle, a cooldown still running. The launch itself is
+        slow (it holds until the guest boots) — callers run this as its own task.
+        """
+        if not settings.ENABLE_CVM_LIFECYCLE:
+            return False
+        if host.executor_uuid in self._launching:
+            return False
+
+        extra = get_extra_info({
+            "executor_uuid": host.executor_uuid,
+            "miner_hotkey": host.miner_hotkey,
+            "cvmd_url": host.cvmd_url(),
+        })
+
+        cooldown_key = f"{CVM_LAUNCH_ATTEMPT_PREFIX}:{host.executor_uuid}"
+        try:
+            if await self.redis_service.get(cooldown_key):
+                return False
+        except Exception:  # noqa: BLE001 - no Redis, no cooldown; the in-process set still guards
+            pass
+
+        catalog = self.whitelist_source.current()
+        entry = catalog.newest_validation_entry() if catalog else None
+        if entry is None:
+            # Never guess a stack. A validator that launched from anything but the signed
+            # catalog would be creating exactly the unattributable CVM the design forbids.
+            logger.warning(_m(
+                f"{CVM_LAUNCH_FAILED_EVENT} — no signed catalog entry to launch from",
+                extra=extra,
+            ))
+            return False
+
+        if assessment is None:
+            assessment = await self.assess(host)
+        if not assessment.reachable or not assessment.idle_without_cvm:
+            return False
+
+        self._launching.add(host.executor_uuid)
+        try:
+            try:
+                await self.redis_service.set_with_expiration(
+                    cooldown_key, str(time.time()), settings.CVM_LAUNCH_COOLDOWN_SECONDS
+                )
+            except Exception:  # noqa: BLE001
+                pass
+
+            logger.info(_m(
+                CVM_LAUNCH_STARTED_EVENT,
+                extra={**extra, "artifact_id": entry.id, "qemu": entry.qemu,
+                       "compose_hash": entry.compose_hash},
+            ))
+            try:
+                result = await self.client.launch_validation(
+                    host.cvmd_url(),
+                    qemu=entry.qemu,
+                    os_image_hash=entry.os_image_hash,
+                    compose_hash=entry.compose_hash,
+                )
+            except CvmdRelayError as exc:
+                logger.warning(_m(
+                    f"{CVM_LAUNCH_FAILED_EVENT} — host not reached",
+                    extra={**extra, "error": str(exc)},
+                ))
+                return False
+
+            if not result.ok:
+                logger.warning(_m(
+                    f"{CVM_LAUNCH_FAILED_EVENT} — cvmd refused",
+                    extra={**extra, "status": result.status, "detail": result.reason()},
+                ))
+                return False
+
+            measurements = (result.body or {}).get("measurements") or {}
+            mismatched = [
+                field
+                for field, expected in (
+                    ("qemu", entry.qemu),
+                    ("os_image_hash", entry.os_image_hash),
+                    ("compose_hash", entry.compose_hash),
+                )
+                if measurements.get(field) != expected
+            ]
+            if mismatched:
+                # A 201 measuring as something else is worse than a refusal: the host is
+                # running a stack the catalog does not describe. The normal verification
+                # cycle will fail it; this log says why before it does.
+                logger.error(_m(
+                    f"{CVM_LAUNCH_FAILED_EVENT} — launch report disagrees with the pinned triple",
+                    extra={**extra, "mismatched": mismatched},
+                ))
+                return False
+
+            logger.info(_m(
+                CVM_LAUNCH_VERIFIED_EVENT,
+                extra={**extra, "instance_id": (result.body or {}).get("instance_id")},
+            ))
+            return True
+        finally:
+            self._launching.discard(host.executor_uuid)
+
+    def schedule_ensure(self, host: CvmdHost, *, assessment: SwitchAssessment | None = None) -> None:
+        """Fire the launch as its own task — a boot must never extend a validation cycle."""
+        asyncio.create_task(self.ensure_validation_cvm(host, assessment=assessment))

--- a/neurons/validators/src/services/cvm_whitelist.py
+++ b/neurons/validators/src/services/cvm_whitelist.py
@@ -56,6 +56,31 @@ class CvmCatalogError(Exception):
 
 
 @dataclass(frozen=True)
+class CvmCatalogEntry:
+    """One launchable stack, as the manifest published it (DAH-2629).
+
+    Retained so this validator can *launch* from the catalog, not only check against it: a
+    validation-CVM launch must name a pinned triple, and the triple has to come from the
+    same signed document the measurement check reads — two sources would drift.
+    """
+
+    id: str
+    kind: str
+    qemu: str
+    os_image_hash: str
+    compose_hash: str
+    versions: dict[str, int] = field(default_factory=dict)
+
+    def version_key(self) -> tuple[int, int, int]:
+        """Orders entries newest-first the way the backend ratchets them."""
+        return (
+            self.versions.get("compose", 0),
+            self.versions.get("os_image", 0),
+            self.versions.get("qemu", 0),
+        )
+
+
+@dataclass(frozen=True)
 class CvmCatalog:
     """One verified manifest: the approved set, and when it stops being usable."""
 
@@ -65,6 +90,9 @@ class CvmCatalog:
     compose_hashes: frozenset[str]
     # Keyed by kind, so a renter compose cannot satisfy a validation check or the reverse.
     compose_hashes_by_kind: dict[str, frozenset[str]] = field(default_factory=dict)
+    # The full stack entries, for choosing what to launch (DAH-2629). Empty for a manifest
+    # that predates the fields — checking still works, launching refuses.
+    entries: tuple[CvmCatalogEntry, ...] = ()
 
     def is_expired(self, now: datetime | None = None) -> bool:
         return (now or datetime.now(UTC)) >= self.expires_at
@@ -75,6 +103,18 @@ class CvmCatalog:
         if kind is None:
             return compose_hash in self.compose_hashes
         return compose_hash in self.compose_hashes_by_kind.get(kind, frozenset())
+
+    def newest_validation_entry(self) -> CvmCatalogEntry | None:
+        """The stack a validation-CVM launch should pin: newest approved, validation kind.
+
+        "Newest approved" and "what the platform currently stands behind" are the same set
+        by construction — the floors are how an old version is withdrawn — so there is no
+        version choice to make here, only the newest to find.
+        """
+        candidates = [entry for entry in self.entries if entry.kind == "validation"]
+        if not candidates:
+            return None
+        return max(candidates, key=CvmCatalogEntry.version_key)
 
 
 def parse_manifest(raw: bytes, *, signer: str, now: datetime | None = None) -> CvmCatalog:
@@ -157,6 +197,7 @@ def _decode_payload(payload: str, *, now: datetime) -> CvmCatalog:
     os_images: set[str] = set()
     composes: set[str] = set()
     by_kind: dict[str, set[str]] = {}
+    entries: list[CvmCatalogEntry] = []
     for entry in artifacts:
         if not isinstance(entry, dict):
             raise CvmCatalogError("a manifest artifact is not an object")
@@ -170,12 +211,34 @@ def _decode_payload(payload: str, *, now: datetime) -> CvmCatalog:
         if isinstance(kind, str):
             by_kind.setdefault(kind, set()).add(compose_hash)
 
+        # DAH-2629: keep the full stack row when it carries what a launch needs. Tolerant of
+        # absence — an older manifest still checks measurements; it just cannot be launched
+        # from, and `newest_validation_entry` answers None rather than guessing a qemu.
+        qemu = entry.get("qemu")
+        versions = entry.get("versions")
+        if isinstance(kind, str) and isinstance(qemu, str) and qemu:
+            entries.append(
+                CvmCatalogEntry(
+                    id=str(entry.get("id") or ""),
+                    kind=kind,
+                    qemu=qemu,
+                    os_image_hash=os_image_hash,
+                    compose_hash=compose_hash,
+                    versions={
+                        component: value
+                        for component, value in (versions or {}).items()
+                        if isinstance(value, int) and not isinstance(value, bool)
+                    },
+                )
+            )
+
     return CvmCatalog(
         serial=serial,
         expires_at=expires_at,
         os_image_hashes=frozenset(os_images),
         compose_hashes=frozenset(composes),
         compose_hashes_by_kind={k: frozenset(v) for k, v in by_kind.items()},
+        entries=tuple(entries),
     )
 
 

--- a/neurons/validators/src/services/cvmd_client.py
+++ b/neurons/validators/src/services/cvmd_client.py
@@ -1,0 +1,176 @@
+"""Sign and make this validator's own cvmd calls (DAH-2629).
+
+Until now the validator only *relayed* cvmd calls the backend signed (DAH-2580). The
+validation-CVM lifecycle is different: cvmd's scope table gives ``validation`` to the
+validator key alone, so launching a validation CVM is a call this process signs itself,
+with the same wallet it signs everything else with.
+
+The signing half is a mirror of ``lium-io-backend: services/cvmd_request.py`` — one wire
+protocol, two signers with two scopes. cvmd's ``tests/test_golden_vector.py`` is the
+committed fixture that pins the blob formula across both repos; the formula test in this
+repo's DAH-2629 suite pins this mirror to the same bytes.
+
+What this client can and cannot do is decided by cvmd, not here:
+
+    POST /v1/cvm {kind: validation}   allowed — the validator's own scope
+    GET  /v1/state, /v1/catalog       allowed — reads are open to either authorized key
+    POST /v1/cvm {kind: renter}       403 — platform scope, this key is refused
+    DELETE /v1/cvm                    403 — teardown is the platform's alone
+
+So "the validator never destroys a CVM" stays a property of what this process can sign.
+
+Transport is the existing ``CvmdRelay`` — same TLS stance (the host's certificate is
+self-signed; the request signature and the measured launch report are what authenticate
+this exchange), same no-retry stance (a repeated launch lands a second request on a node
+already committed to the first; cvmd's own 409 is the better answer).
+"""
+
+import hashlib
+import json
+import logging
+import secrets
+import time
+from dataclasses import dataclass
+
+from services.cvmd_relay import (
+    DEFAULT_PROVISION_TIMEOUT_SECONDS,
+    CvmdRelay,
+    CvmdRelayError,
+    RelayResult,
+)
+
+logger = logging.getLogger(__name__)
+
+DOMAIN_SEPARATOR = b"cvmd-v1\x00"
+
+HOTKEY_HEADER = "X-Cvmd-Hotkey"
+TIMESTAMP_HEADER = "X-Cvmd-Timestamp"
+NONCE_HEADER = "X-Cvmd-Nonce"
+SIGNATURE_HEADER = "X-Cvmd-Signature"
+
+NONCE_BYTES = 16
+
+CVM_PATH = "/v1/cvm"
+STATE_PATH = "/v1/state"
+
+KIND_VALIDATION = "validation"
+
+# A state read answers from memory; only the network is being waited on.
+DEFAULT_STATE_TIMEOUT_SECONDS = 30
+
+
+def _lp(value: bytes) -> bytes:
+    return len(value).to_bytes(4, "big") + value
+
+
+def signing_blob(*, method: str, request_target: str, body: bytes, timestamp: str, nonce: str) -> bytes:
+    """The 32-byte digest cvmd recomputes and verifies. Byte-identical to the backend's."""
+    return hashlib.sha256(
+        DOMAIN_SEPARATOR
+        + _lp(method.encode())
+        + _lp(request_target.encode())
+        + _lp(body)
+        + _lp(timestamp.encode())
+        + _lp(nonce.encode())
+    ).digest()
+
+
+@dataclass(frozen=True)
+class SignedCall:
+    method: str
+    path: str
+    body: str
+    headers: dict[str, str]
+
+
+def sign_request(keypair, *, method: str, path: str, body: str = "") -> SignedCall:
+    """Sign one cvmd call with this validator's keypair.
+
+    ``path`` is the request target — path plus query, exactly as sent — and it is inside
+    the blob, so a captured call cannot be redirected or replayed as a different verb.
+    """
+    timestamp = str(time.time_ns())
+    nonce = secrets.token_hex(NONCE_BYTES)
+    blob = signing_blob(
+        method=method,
+        request_target=path,
+        body=body.encode(),
+        timestamp=timestamp,
+        nonce=nonce,
+    )
+    return SignedCall(
+        method=method,
+        path=path,
+        body=body,
+        headers={
+            HOTKEY_HEADER: keypair.ss58_address,
+            TIMESTAMP_HEADER: timestamp,
+            NONCE_HEADER: nonce,
+            SIGNATURE_HEADER: keypair.sign(blob).hex(),
+        },
+    )
+
+
+def canonical_body(payload: dict) -> str:
+    """Serialize once, with pinned separators — the exact bytes that are signed and sent."""
+    return json.dumps(payload, separators=(",", ":"))
+
+
+class CvmdClient:
+    """This validator's own cvmd calls: read a node's state, launch its validation CVM."""
+
+    def __init__(self, keypair, *, relay: CvmdRelay | None = None) -> None:
+        self._keypair = keypair
+        self._relay = relay or CvmdRelay()
+
+    async def state(self, base_url: str) -> RelayResult:
+        """Signed ``GET /v1/state``: the node's mode, its CVM if any, and its last switch."""
+        signed = sign_request(self._keypair, method="GET", path=STATE_PATH)
+        return await self._relay.forward(
+            base_url=base_url,
+            method=signed.method,
+            path=signed.path,
+            body=signed.body,
+            headers=signed.headers,
+            timeout_seconds=DEFAULT_STATE_TIMEOUT_SECONDS,
+        )
+
+    async def launch_validation(
+        self, base_url: str, *, qemu: str, os_image_hash: str, compose_hash: str
+    ) -> RelayResult:
+        """Signed ``POST /v1/cvm {kind: validation}`` naming the pinned triple.
+
+        The triple is required by cvmd's contract — a host that chose the stack itself
+        would give this validator no way to tell "the CVM I asked for" from "whatever the
+        host felt like running". Slow on purpose: the call holds until the guest boots.
+        """
+        body = canonical_body(
+            {
+                "kind": KIND_VALIDATION,
+                "qemu": qemu,
+                "os_image_hash": os_image_hash,
+                "compose_hash": compose_hash,
+            }
+        )
+        signed = sign_request(self._keypair, method="POST", path=CVM_PATH, body=body)
+        return await self._relay.forward(
+            base_url=base_url,
+            method=signed.method,
+            path=signed.path,
+            body=signed.body,
+            headers=signed.headers,
+            timeout_seconds=DEFAULT_PROVISION_TIMEOUT_SECONDS,
+        )
+
+
+__all__ = [
+    "CVM_PATH",
+    "STATE_PATH",
+    "KIND_VALIDATION",
+    "CvmdClient",
+    "CvmdRelayError",
+    "SignedCall",
+    "canonical_body",
+    "sign_request",
+    "signing_blob",
+]

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -175,6 +175,20 @@ class MinerService:
         self.task_service = task_service
         self.redis_service = redis_service
         self.attestation_service = attestation_service
+        # DAH-2629/2630 — built on first use, not here: the wallet read prompts for a
+        # keystore, and most MinerService instances (tests, tooling) never touch cvmd.
+        self._cvm_lifecycle_service = None
+
+    def _cvm_lifecycle(self):
+        from services.cvm_lifecycle import CvmLifecycleService
+
+        if self._cvm_lifecycle_service is None:
+            self._cvm_lifecycle_service = CvmLifecycleService(
+                self.redis_service,
+                self.attestation_service.whitelist_source,
+                settings.get_bittensor_wallet().get_hotkey(),
+            )
+        return self._cvm_lifecycle_service
 
     @staticmethod
     def _normalize_public_key(public_key: bytes | str) -> str:
@@ -371,6 +385,11 @@ class MinerService:
                     results = self._filter_task_results(msg.executors, raw_results, default_extra)
                     results.extend(
                         self._build_manual_rental_results(payload, rented_data, existing=results)
+                    )
+                    # DAH-2629/2630: record this cycle's cvmd hosts, grace the ones inside a
+                    # budgeted switch window, and bring empty ones back up.
+                    results.extend(
+                        await self._record_and_grace_cvm_hosts(payload, existing=results)
                     )
 
                     logger.info(
@@ -684,6 +703,176 @@ class MinerService:
             )
 
         return results
+
+    async def _record_and_grace_cvm_hosts(
+        self,
+        payload: MinerJobRequestPayload,
+        existing: list[JobResult],
+    ) -> list[JobResult]:
+        """Record this cycle's attested cvmd hosts, then account for the ones that are
+        switching or empty (DAH-2629 + DAH-2630).
+
+        Runs after the real results, exactly like the manual-rental synthesis: a node that
+        answered normally is already scored and is skipped. Everything here is best-effort
+        against a validation cycle — a Redis or cvmd hiccup logs and contributes nothing,
+        it never fails the batch.
+        """
+        from services.cvm_lifecycle import (
+            CVM_SWITCH_BUDGET_EXCEEDED_EVENT,
+            CVM_SWITCH_GRACE_EVENT,
+            CVM_SWITCH_GRACE_OBSERVED_EVENT,
+        )
+
+        # getattr, not attribute access: results in this pipeline are duck-typed (tests and
+        # synthesized paths pass reduced shapes), and a missing field must read as "not
+        # attested", never as a failed batch.
+        attested = [
+            result
+            for result in existing
+            if getattr(result, "tdx_attestation_passed", False)
+            and getattr(result, "executor_info", None) is not None
+            and getattr(result.executor_info, "address", None)
+        ]
+        # Nothing to record and nothing to sweep: don't even build the lifecycle service.
+        # This is the common case on a fleet without CVM hosts, and it keeps the wallet
+        # read out of every cycle that has no use for it.
+        if not attested and not settings.ENABLE_CVM_LIFECYCLE:
+            return []
+
+        try:
+            lifecycle = self._cvm_lifecycle()
+        except Exception as exc:
+            logger.warning(_m(
+                "CVM lifecycle unavailable; skipping the sweep",
+                extra=get_extra_info({"miner_hotkey": payload.miner_hotkey, "error": str(exc)}),
+            ))
+            return []
+
+        # The registry feed: every executor that attested this cycle is a cvmd host, and its
+        # address/shape are fresh right now — which is the only time they are.
+        for result in attested:
+            await lifecycle.record_host(
+                executor_uuid=str(result.executor_info.uuid),
+                address=result.executor_info.address,
+                miner_hotkey=payload.miner_hotkey,
+                gpu_model=getattr(result, "gpu_model", None),
+                gpu_count=getattr(result, "gpu_count", 0) or 0,
+            )
+
+        if not settings.ENABLE_CVM_LIFECYCLE:
+            return []
+
+        already_scored = {
+            str(result.executor_info.uuid)
+            for result in existing
+            if getattr(result, "executor_info", None) is not None
+        }
+        graces: list[JobResult] = []
+        hosts = await lifecycle.hosts_for_miner(payload.miner_hotkey)
+        for host in hosts:
+            if host.executor_uuid in already_scored:
+                continue
+
+            extra = get_extra_info({
+                "job_batch_id": payload.job_batch_id,
+                "miner_hotkey": payload.miner_hotkey,
+                "executor_uuid": host.executor_uuid,
+                "gpu_model": host.gpu_model,
+            })
+
+            assessment = await lifecycle.assess(host)
+            if not assessment.reachable:
+                # An unreachable daemon says nothing about switching; the node scores as it
+                # would have anyway.
+                continue
+
+            if assessment.idle_without_cvm:
+                # DAH-2629: no CVM at all — bring the validation CVM up. Fire-and-forget:
+                # a boot takes minutes and must not extend this cycle. This cycle the node
+                # still scores nothing, which is exactly the "launch failure is a scoring
+                # signal" semantics until the launch lands.
+                lifecycle.schedule_ensure(host)
+                continue
+
+            if not assessment.switching:
+                continue
+
+            budget = settings.get_cvm_switch_budget_seconds(host.gpu_model)
+            elapsed = assessment.elapsed_seconds
+            if elapsed is None:
+                logger.warning(_m(
+                    f"{CVM_SWITCH_BUDGET_EXCEEDED_EVENT} — switching with no readable start time",
+                    extra=extra,
+                ))
+                continue
+            if elapsed > budget:
+                # The real signal FR-I3 wants: a switch that is taking too long is flagged,
+                # never silently extended. No grace — the node scores zero this cycle.
+                logger.warning(_m(
+                    CVM_SWITCH_BUDGET_EXCEEDED_EVENT,
+                    extra={**extra, "elapsed_seconds": round(elapsed, 1), "budget_seconds": budget},
+                ))
+                continue
+
+            if host.gpu_model not in BASE_GPU_MAP:
+                # Same guard as the manual-rental synthesis, same reason: an unknown model
+                # reaching the incentive layer aborts weight-setting for the whole subnet.
+                logger.warning(_m(
+                    "Switching node's GPU model is not in BASE_GPU_MAP; skipping its grace",
+                    extra=extra,
+                ))
+                continue
+
+            if not settings.ENABLE_SWITCHING_GRACE:
+                logger.info(_m(
+                    CVM_SWITCH_GRACE_OBSERVED_EVENT,
+                    extra={**extra, "elapsed_seconds": round(elapsed, 1), "budget_seconds": budget},
+                ))
+                continue
+
+            log_text = _m(
+                CVM_SWITCH_GRACE_EVENT,
+                extra={**extra, "elapsed_seconds": round(elapsed, 1), "budget_seconds": budget},
+            ).to_full_string()
+            logger.info(log_text)
+            graces.append(
+                JobResult(
+                    # spec=None on purpose: the backend skips its executor upsert on a null
+                    # spec, so a graced cycle cannot flip the stored row.
+                    spec=None,
+                    executor_info=ExecutorSSHInfo(
+                        uuid=host.executor_uuid,
+                        address=host.address,
+                        port=0,
+                        ssh_username="",
+                        ssh_port=0,
+                        python_path="",
+                        root_dir="",
+                    ),
+                    score=1.0,
+                    job_score=1.0,
+                    job_batch_id=payload.job_batch_id,
+                    log_status="success",
+                    log_text=log_text,
+                    gpu_model=host.gpu_model,
+                    gpu_count=host.gpu_count,
+                    # Not measurable mid-switch; a false reading would silently cut the score.
+                    sysbox_runtime=True,
+                    tdx_attestation_passed=True,
+                )
+            )
+
+        if graces:
+            logger.info(_m(
+                "Grace results for switching CVM nodes",
+                extra=get_extra_info({
+                    "job_batch_id": payload.job_batch_id,
+                    "miner_hotkey": payload.miner_hotkey,
+                    "executors": len(graces),
+                    "executor_uuids": [str(g.executor_info.uuid) for g in graces],
+                }),
+            ))
+        return graces
 
     def _build_failed_job_result(self, payload: MinerJobRequestPayload, reason: str):
         executor_info = ExecutorSSHInfo(
@@ -1897,6 +2086,10 @@ class MinerService:
                 results = self._filter_task_results(msg.executors, raw_results, default_extra)
                 results.extend(
                     self._build_manual_rental_results(payload, rented_data, existing=results)
+                )
+                # DAH-2629/2630 — same accounting as the WebSocket path.
+                results.extend(
+                    await self._record_and_grace_cvm_hosts(payload, existing=results)
                 )
 
                 logger.info(

--- a/neurons/validators/tests/test_dah2580_cvm_relay.py
+++ b/neurons/validators/tests/test_dah2580_cvm_relay.py
@@ -311,6 +311,55 @@ class TestTheDriver:
         assert response.status is None
         assert "could not be reached" in response.msg
 
+    async def test_a_release_teardown_triggers_the_switch_back(self, monkeypatch):
+        """A rental ended; the node is verifiably free, so the validation CVM goes back up."""
+        monkeypatch.setattr(
+            CvmdRelay,
+            "forward",
+            AsyncMock(return_value=RelayResult(status=200, body={"torn_down": True})),
+        )
+        client = _client()
+        client._schedule_validation_cvm_return = Mock()
+
+        await client.cvm_driver(
+            CvmTeardownRequest(
+                miner_hotkey="miner",
+                executor_id=EXECUTOR_ID,
+                pod_id="pod-1",
+                cvmd_url="https://10.0.0.1:8443",
+                call=SignedCvmdCall(method="DELETE", path="/v1/cvm", headers=SIGNED_HEADERS),
+            )
+        )
+
+        client._schedule_validation_cvm_return.assert_called_once()
+
+    async def test_a_switch_teardown_does_not_relaunch_under_the_renter(self, monkeypatch):
+        """intent="switch" clears the node for a renter launch the backend is about to send.
+        A relaunch here would race that very order for the node, and the loser of the race is
+        a customer's 409."""
+        monkeypatch.setattr(
+            CvmdRelay,
+            "forward",
+            AsyncMock(return_value=RelayResult(status=200, body={"torn_down": True})),
+        )
+        client = _client()
+        client._schedule_validation_cvm_return = Mock()
+
+        await client.cvm_driver(
+            CvmTeardownRequest(
+                miner_hotkey="miner",
+                executor_id=EXECUTOR_ID,
+                pod_id="pod-1",
+                cvmd_url="https://10.0.0.1:8443",
+                call=SignedCvmdCall(method="DELETE", path="/v1/cvm", headers=SIGNED_HEADERS),
+                intent="switch",
+            )
+        )
+
+        client._schedule_validation_cvm_return.assert_not_called()
+        (response,) = client.message_queue
+        assert isinstance(response, CvmTornDown)
+
     async def test_the_two_operations_get_different_timeouts(self, monkeypatch):
         """A verified teardown holds until the node's memory is back, which on a large guest is
         tens of minutes — far longer than a launch waits for a guest to boot."""

--- a/neurons/validators/tests/test_dah2629_cvm_lifecycle.py
+++ b/neurons/validators/tests/test_dah2629_cvm_lifecycle.py
@@ -212,6 +212,7 @@ def make_lifecycle(catalog_entry, *, cooldown_active=False):
     catalog = MagicMock()
     catalog.newest_validation_entry = MagicMock(return_value=catalog_entry)
     whitelist.current = MagicMock(return_value=catalog if catalog_entry is not None else None)
+    whitelist.refresh = AsyncMock()
     service = CvmLifecycleService(redis, whitelist, Keypair.create_from_uri("//Alice"))
     service.client = MagicMock()
     return service
@@ -282,6 +283,29 @@ class TestEnsureValidationCvm:
 
         assert await service.ensure_validation_cvm(HOST, assessment=IDLE) is False
         service.client.launch_validation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_it_refreshes_the_catalog_before_reading_it(self, monkeypatch):
+        """The switch-back trigger runs in the connector process, which never runs an
+        attestation cycle — so without a refresh here its catalog is perpetually None and
+        every immediate relaunch fails-closed. Model that: current() is empty until refresh
+        populates it."""
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+        service = make_lifecycle(catalog_entry())
+        catalog = service.whitelist_source.current.return_value
+        service.whitelist_source.current = MagicMock(side_effect=[None, catalog])
+
+        async def _populate():
+            service.whitelist_source.current = MagicMock(return_value=catalog)
+
+        service.whitelist_source.refresh = AsyncMock(side_effect=_populate)
+        service.client.launch_validation = AsyncMock(
+            return_value=RelayResult(status=201, body=launch_report())
+        )
+
+        assert await service.ensure_validation_cvm(HOST, assessment=IDLE) is True
+        service.whitelist_source.refresh.assert_awaited_once()
+        service.client.launch_validation.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_a_host_that_is_not_idle_and_empty_is_left_alone(self, monkeypatch):

--- a/neurons/validators/tests/test_dah2629_cvm_lifecycle.py
+++ b/neurons/validators/tests/test_dah2629_cvm_lifecycle.py
@@ -1,0 +1,330 @@
+"""DAH-2629: this validator brings validation CVMs up itself, via cvmd.
+
+Four claims carry the task, and each gets its own class below:
+
+  * the validator's signer is byte-identical to the platform's — one wire protocol, two
+    keys with two scopes. The blob formula is restated by hand exactly as the backend's
+    own suite restates it, so a drift in either mirror breaks a test rather than a host;
+  * the launch triple comes from the signed catalog and nowhere else. No catalog, no
+    validation entry, no qemu fields — each one refuses the launch instead of guessing;
+  * a launch happens only on an idle, empty host, at most once per cooldown, and its 201
+    is believed only when the reported measurements equal the pinned triple;
+  * the whole thing sits behind ENABLE_CVM_LIFECYCLE, default off.
+"""
+
+import hashlib
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from bittensor_wallet import Keypair
+
+from core.config import settings
+from services.cvm_lifecycle import CvmdHost, CvmLifecycleService, SwitchAssessment
+from services.cvm_whitelist import DOMAIN_SEPARATOR as CATALOG_DOMAIN_SEPARATOR
+from services.cvm_whitelist import parse_manifest
+from services.cvmd_client import (
+    HOTKEY_HEADER,
+    NONCE_HEADER,
+    SIGNATURE_HEADER,
+    TIMESTAMP_HEADER,
+    CvmdClient,
+    sign_request,
+    signing_blob,
+)
+from services.cvmd_relay import RelayResult
+
+OS_IMAGE = "a" * 64
+VALIDATION_COMPOSE = "b" * 64
+RENTER_COMPOSE = "c" * 64
+
+
+@pytest.fixture
+def signer() -> Keypair:
+    return Keypair.create_from_uri("//Alice")
+
+
+class TestTheSigningMirror:
+    def test_the_blob_is_the_documented_formula(self):
+        """Restated as bytes, not by calling the function twice: this is the wire contract
+        with cvmd, shared with the backend's signer."""
+
+        def lp(value: bytes) -> bytes:
+            return len(value).to_bytes(4, "big") + value
+
+        expected = hashlib.sha256(
+            b"cvmd-v1\x00" + lp(b"POST") + lp(b"/v1/cvm") + lp(b"{}") + lp(b"7") + lp(b"beef")
+        ).digest()
+        assert (
+            signing_blob(method="POST", request_target="/v1/cvm", body=b"{}", timestamp="7", nonce="beef")
+            == expected
+        )
+
+    def test_the_signature_verifies_over_exactly_what_is_sent(self, signer):
+        signed = sign_request(signer, method="POST", path="/v1/cvm", body='{"kind":"validation"}')
+        blob = signing_blob(
+            method="POST",
+            request_target="/v1/cvm",
+            body=signed.body.encode(),
+            timestamp=signed.headers[TIMESTAMP_HEADER],
+            nonce=signed.headers[NONCE_HEADER],
+        )
+        assert Keypair(ss58_address=signer.ss58_address).verify(
+            blob, bytes.fromhex(signed.headers[SIGNATURE_HEADER])
+        )
+        assert signed.headers[HOTKEY_HEADER] == signer.ss58_address
+
+    @pytest.mark.asyncio
+    async def test_launch_validation_sends_the_canonical_validation_body(self, signer):
+        """The body names the kind and the pinned triple, serialized with pinned separators
+        — the same bytes the signature covers."""
+        relay = MagicMock()
+        relay.forward = AsyncMock(return_value=RelayResult(status=201, body={}))
+        client = CvmdClient(signer, relay=relay)
+
+        await client.launch_validation(
+            "https://127.0.0.1:8443",
+            qemu="10.1.0",
+            os_image_hash=OS_IMAGE,
+            compose_hash=VALIDATION_COMPOSE,
+        )
+
+        kwargs = relay.forward.call_args.kwargs
+        assert kwargs["method"] == "POST"
+        assert kwargs["path"] == "/v1/cvm"
+        assert kwargs["body"] == (
+            '{"kind":"validation","qemu":"10.1.0",'
+            f'"os_image_hash":"{OS_IMAGE}","compose_hash":"{VALIDATION_COMPOSE}"}}'
+        )
+        assert set(kwargs["headers"]) == {
+            HOTKEY_HEADER,
+            TIMESTAMP_HEADER,
+            NONCE_HEADER,
+            SIGNATURE_HEADER,
+        }
+
+    @pytest.mark.asyncio
+    async def test_a_state_read_is_a_signed_get_with_no_body(self, signer):
+        relay = MagicMock()
+        relay.forward = AsyncMock(return_value=RelayResult(status=200, body={"state": "RECONCILING"}))
+        client = CvmdClient(signer, relay=relay)
+
+        await client.state("https://127.0.0.1:8443")
+
+        kwargs = relay.forward.call_args.kwargs
+        assert kwargs["method"] == "GET"
+        assert kwargs["path"] == "/v1/state"
+        assert kwargs["body"] == ""
+        assert SIGNATURE_HEADER in kwargs["headers"]
+
+
+def manifest_payload(artifacts) -> str:
+    now = datetime.now(UTC)
+    return json.dumps(
+        {
+            "version": 1,
+            "serial": 1,
+            "issued_at": now.isoformat(),
+            "expires_at": (now + timedelta(seconds=86400)).isoformat(),
+            "floors": {"os_image": 1, "qemu": 1, "compose": 1},
+            "artifacts": artifacts,
+        }
+    )
+
+
+def signed_envelope(text: str, keypair: Keypair) -> bytes:
+    return json.dumps(
+        {
+            "schema": "lium-cvm-catalog/1",
+            "payload": text,
+            "signer": keypair.ss58_address,
+            "signature": "0x" + keypair.sign(CATALOG_DOMAIN_SEPARATOR + text.encode()).hex(),
+        }
+    ).encode()
+
+
+def entry(kind: str, *, qemu="10.1.0", compose_hash=VALIDATION_COMPOSE, versions=None, id_="e"):
+    return {
+        "id": id_,
+        "kind": kind,
+        "qemu": qemu,
+        "os_image_hash": OS_IMAGE,
+        "compose_hash": compose_hash,
+        "versions": versions if versions is not None else {"os_image": 1, "qemu": 1, "compose": 1},
+    }
+
+
+class TestTheLaunchTripleComesFromTheCatalog:
+    def test_the_newest_validation_entry_wins(self, signer):
+        artifacts = [
+            entry("validation", id_="old", versions={"os_image": 1, "qemu": 1, "compose": 1}),
+            entry("validation", id_="new", compose_hash="d" * 64, versions={"os_image": 2, "qemu": 1, "compose": 2}),
+            entry("renter", id_="renter", compose_hash=RENTER_COMPOSE, versions={"os_image": 3, "qemu": 3, "compose": 3}),
+        ]
+        catalog = parse_manifest(
+            signed_envelope(manifest_payload(artifacts), signer), signer=signer.ss58_address
+        )
+
+        chosen = catalog.newest_validation_entry()
+        assert chosen is not None
+        assert chosen.id == "new"
+        assert chosen.compose_hash == "d" * 64
+
+    def test_a_renter_only_catalog_offers_nothing_to_launch(self, signer):
+        catalog = parse_manifest(
+            signed_envelope(manifest_payload([entry("renter", compose_hash=RENTER_COMPOSE)]), signer),
+            signer=signer.ss58_address,
+        )
+        assert catalog.newest_validation_entry() is None
+
+    def test_a_manifest_without_launch_fields_still_checks_but_cannot_launch(self, signer):
+        """Older manifests carry only the hashes. Checking measurements keeps working;
+        launching answers None instead of guessing a qemu."""
+        bare = [{"id": "e", "kind": "validation", "os_image_hash": OS_IMAGE, "compose_hash": VALIDATION_COMPOSE}]
+        catalog = parse_manifest(
+            signed_envelope(manifest_payload(bare), signer), signer=signer.ss58_address
+        )
+        assert catalog.approves(os_image_hash=OS_IMAGE, compose_hash=VALIDATION_COMPOSE, kind="validation")
+        assert catalog.newest_validation_entry() is None
+
+
+HOST = CvmdHost(
+    executor_uuid="e-1",
+    address="203.0.113.7",
+    miner_hotkey="5Miner",
+    gpu_model="NVIDIA H200",
+    gpu_count=8,
+    updated_at=0.0,
+)
+
+IDLE = SwitchAssessment(reachable=True, state="RECONCILING", has_cvm=False)
+
+
+def make_lifecycle(catalog_entry, *, cooldown_active=False):
+    redis = MagicMock()
+    redis.get = AsyncMock(return_value="1" if cooldown_active else None)
+    redis.set_with_expiration = AsyncMock()
+    redis.hget = AsyncMock(return_value=None)
+    redis.hset = AsyncMock()
+    redis.hgetall = AsyncMock(return_value={})
+    whitelist = MagicMock()
+    catalog = MagicMock()
+    catalog.newest_validation_entry = MagicMock(return_value=catalog_entry)
+    whitelist.current = MagicMock(return_value=catalog if catalog_entry is not None else None)
+    service = CvmLifecycleService(redis, whitelist, Keypair.create_from_uri("//Alice"))
+    service.client = MagicMock()
+    return service
+
+
+def catalog_entry(**overrides):
+    from services.cvm_whitelist import CvmCatalogEntry
+
+    defaults = {
+        "id": "validation-v1+img+qemu",
+        "kind": "validation",
+        "qemu": "10.1.0",
+        "os_image_hash": OS_IMAGE,
+        "compose_hash": VALIDATION_COMPOSE,
+        "versions": {"os_image": 1, "qemu": 1, "compose": 1},
+    }
+    defaults.update(overrides)
+    return CvmCatalogEntry(**defaults)
+
+
+def launch_report(**overrides):
+    report = {
+        "instance_id": "abc123",
+        "measurements": {
+            "qemu": "10.1.0",
+            "os_image_hash": OS_IMAGE,
+            "compose_hash": VALIDATION_COMPOSE,
+        },
+    }
+    report.update(overrides)
+    return report
+
+
+class TestEnsureValidationCvm:
+    @pytest.mark.asyncio
+    async def test_flag_off_never_launches(self, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", False, raising=False)
+        service = make_lifecycle(catalog_entry())
+        service.client.launch_validation = AsyncMock()
+
+        assert await service.ensure_validation_cvm(HOST, assessment=IDLE) is False
+        service.client.launch_validation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_an_idle_empty_host_gets_the_pinned_triple(self, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+        service = make_lifecycle(catalog_entry())
+        service.client.launch_validation = AsyncMock(
+            return_value=RelayResult(status=201, body=launch_report())
+        )
+
+        assert await service.ensure_validation_cvm(HOST, assessment=IDLE) is True
+
+        kwargs = service.client.launch_validation.call_args.kwargs
+        assert kwargs == {
+            "qemu": "10.1.0",
+            "os_image_hash": OS_IMAGE,
+            "compose_hash": VALIDATION_COMPOSE,
+        }
+
+    @pytest.mark.asyncio
+    async def test_no_catalog_refuses_rather_than_guessing(self, monkeypatch):
+        """A validator launching from anything but the signed catalog would create exactly
+        the unattributable CVM the design forbids."""
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+        service = make_lifecycle(None)
+        service.client.launch_validation = AsyncMock()
+
+        assert await service.ensure_validation_cvm(HOST, assessment=IDLE) is False
+        service.client.launch_validation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_host_that_is_not_idle_and_empty_is_left_alone(self, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+        service = make_lifecycle(catalog_entry())
+        service.client.launch_validation = AsyncMock()
+
+        for assessment in (
+            SwitchAssessment(reachable=True, state="RENTER_RUNNING", has_cvm=True),
+            SwitchAssessment(reachable=True, state="SWITCHING", has_cvm=True, switching=True),
+            SwitchAssessment(reachable=True, state="FAILED", has_cvm=False),
+            SwitchAssessment(reachable=False),
+        ):
+            assert await service.ensure_validation_cvm(HOST, assessment=assessment) is False
+        service.client.launch_validation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_201_measuring_something_else_is_not_a_success(self, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+        service = make_lifecycle(catalog_entry())
+        bad = launch_report()
+        bad["measurements"]["compose_hash"] = "9" * 64
+        service.client.launch_validation = AsyncMock(return_value=RelayResult(status=201, body=bad))
+
+        assert await service.ensure_validation_cvm(HOST, assessment=IDLE) is False
+
+    @pytest.mark.asyncio
+    async def test_the_cooldown_stops_a_second_attempt(self, monkeypatch):
+        """A launch takes minutes; a failing one should be read, not hammered."""
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+        service = make_lifecycle(catalog_entry(), cooldown_active=True)
+        service.client.launch_validation = AsyncMock()
+
+        assert await service.ensure_validation_cvm(HOST, assessment=IDLE) is False
+        service.client.launch_validation.assert_not_awaited()
+
+
+class TestCvmdUrl:
+    def test_built_from_the_node_address_and_the_fleet_port(self, monkeypatch):
+        monkeypatch.setattr(settings, "CVMD_URL_OVERRIDE", "", raising=False)
+        monkeypatch.setattr(settings, "CVMD_PORT", 8443, raising=False)
+        assert HOST.cvmd_url() == "https://203.0.113.7:8443"
+
+    def test_the_harness_override_wins(self, monkeypatch):
+        monkeypatch.setattr(settings, "CVMD_URL_OVERRIDE", "https://127.0.0.1:18443", raising=False)
+        assert HOST.cvmd_url() == "https://127.0.0.1:18443"

--- a/neurons/validators/tests/test_dah2630_switching_grace.py
+++ b/neurons/validators/tests/test_dah2630_switching_grace.py
@@ -1,0 +1,270 @@
+"""DAH-2630: the RENTED↔UNRENTED switch window is availability-accounted (FR-I3).
+
+A node mid-switch is neither rentable nor probeable BY DESIGN, so the accounting must
+recognize the window instead of reading it as downtime. The claims pinned here:
+
+  * a switching node inside its hardware-class budget gets a synthesized grace result —
+    the same forced-pass shape as a special manual rental, ``spec=None`` so the backend's
+    executor upsert is untouched;
+  * a switch beyond its budget is a FLAG, never a longer window: no grace, a loud event;
+  * with ENABLE_SWITCHING_GRACE off the sweep only observes — logs what it would have
+    graced, contributes nothing;
+  * a node that answered its validation normally is already scored and is never touched;
+  * budgets resolve per GPU model with a safe fallback, because guest RAM return grows
+    with CVM memory and one budget cannot fit both au11 and an H200 host.
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from datura.requests.miner_requests import ExecutorSSHInfo
+
+from core.config import settings
+from services.cvm_lifecycle import (
+    CvmdHost,
+    CvmLifecycleService,
+    SwitchAssessment,
+)
+from services.cvmd_relay import RelayResult
+from services.miner_service import MinerService
+from services.task.models import JobResult
+
+HOST = CvmdHost(
+    executor_uuid="e-switch",
+    address="203.0.113.7",
+    miner_hotkey="5Miner",
+    gpu_model="NVIDIA H200",
+    gpu_count=8,
+    updated_at=0.0,
+)
+
+PAYLOAD = SimpleNamespace(miner_hotkey="5Miner", miner_coldkey="5Cold", job_batch_id="batch-1")
+
+
+def make_miner_service(hosts, assessment):
+    service = MinerService.__new__(MinerService)
+    service.redis_service = MagicMock()
+    lifecycle = MagicMock(spec=CvmLifecycleService)
+    lifecycle.record_host = AsyncMock()
+    lifecycle.hosts_for_miner = AsyncMock(return_value=hosts)
+    lifecycle.assess = AsyncMock(return_value=assessment)
+    lifecycle.schedule_ensure = MagicMock()
+    service._cvm_lifecycle_service = lifecycle
+    return service, lifecycle
+
+
+def switching(elapsed_seconds):
+    return SwitchAssessment(
+        reachable=True,
+        state="SWITCHING",
+        has_cvm=True,
+        switching=True,
+        elapsed_seconds=elapsed_seconds,
+    )
+
+
+def scored_result(executor_uuid="already-scored", tdx=False):
+    return JobResult(
+        spec=None,
+        executor_info=ExecutorSSHInfo(
+            uuid=executor_uuid,
+            address="198.51.100.3",
+            port=1,
+            ssh_username="",
+            ssh_port=0,
+            python_path="",
+            root_dir="",
+        ),
+        score=1.0,
+        job_score=1.0,
+        job_batch_id="batch-1",
+        log_status="success",
+        log_text="ok",
+        gpu_model="NVIDIA H200",
+        gpu_count=8,
+        tdx_attestation_passed=tdx,
+    )
+
+
+@pytest.fixture
+def grace_on(monkeypatch):
+    monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+    monkeypatch.setattr(settings, "ENABLE_SWITCHING_GRACE", True, raising=False)
+    monkeypatch.setattr(settings, "CVM_SWITCH_BUDGET_SECONDS_DEFAULT", 300, raising=False)
+    monkeypatch.setattr(settings, "CVM_SWITCH_BUDGET_SECONDS_BY_GPU_MODEL", "", raising=False)
+
+
+class TestGraceWithinBudget:
+    @pytest.mark.asyncio
+    async def test_a_switching_node_inside_budget_is_graced(self, grace_on):
+        service, _ = make_miner_service([HOST], switching(30.0))
+
+        results = await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[])
+
+        assert len(results) == 1
+        grace = results[0]
+        assert grace.score == 1.0
+        assert grace.spec is None, "a graced cycle must not touch the backend's executor row"
+        assert grace.gpu_model == "NVIDIA H200"
+        assert grace.gpu_count == 8
+        assert str(grace.executor_info.uuid) == "e-switch"
+        assert "CVM_SWITCH_GRACE" in grace.log_text
+
+    @pytest.mark.asyncio
+    async def test_a_node_that_already_answered_is_untouched(self, grace_on):
+        service, lifecycle = make_miner_service([HOST], switching(30.0))
+
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD, existing=[scored_result(executor_uuid="e-switch")]
+        )
+
+        assert results == []
+        lifecycle.assess.assert_not_awaited()
+
+
+class TestTheBudgetIsAHardEdge:
+    @pytest.mark.asyncio
+    async def test_beyond_budget_is_a_flag_not_a_longer_window(self, grace_on):
+        service, _ = make_miner_service([HOST], switching(301.0))
+
+        results = await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[])
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_switching_with_no_readable_start_time_earns_no_grace(self, grace_on):
+        service, _ = make_miner_service([HOST], switching(None))
+
+        assert await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[]) == []
+
+    def test_budgets_resolve_per_gpu_model_with_a_safe_fallback(self, monkeypatch):
+        monkeypatch.setattr(settings, "CVM_SWITCH_BUDGET_SECONDS_DEFAULT", 300, raising=False)
+        monkeypatch.setattr(
+            settings,
+            "CVM_SWITCH_BUDGET_SECONDS_BY_GPU_MODEL",
+            json.dumps({"NVIDIA H200": 900}),
+            raising=False,
+        )
+        assert settings.get_cvm_switch_budget_seconds("NVIDIA H200") == 900
+        assert settings.get_cvm_switch_budget_seconds("NVIDIA A100") == 300
+        assert settings.get_cvm_switch_budget_seconds(None) == 300
+
+        monkeypatch.setattr(
+            settings, "CVM_SWITCH_BUDGET_SECONDS_BY_GPU_MODEL", "not json", raising=False
+        )
+        assert settings.get_cvm_switch_budget_seconds("NVIDIA H200") == 300, (
+            "bad config falls back rather than failing the cycle"
+        )
+
+
+class TestObserveMode:
+    @pytest.mark.asyncio
+    async def test_grace_off_observes_and_contributes_nothing(self, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+        monkeypatch.setattr(settings, "ENABLE_SWITCHING_GRACE", False, raising=False)
+        monkeypatch.setattr(settings, "CVM_SWITCH_BUDGET_SECONDS_DEFAULT", 300, raising=False)
+        monkeypatch.setattr(settings, "CVM_SWITCH_BUDGET_SECONDS_BY_GPU_MODEL", "", raising=False)
+        service, _ = make_miner_service([HOST], switching(30.0))
+
+        assert await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[]) == []
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_off_probes_nothing_at_all(self, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", False, raising=False)
+        service, lifecycle = make_miner_service([HOST], switching(30.0))
+
+        assert await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[]) == []
+        lifecycle.hosts_for_miner.assert_not_awaited()
+
+
+class TestLifecycleHandoff:
+    @pytest.mark.asyncio
+    async def test_an_empty_idle_host_is_scheduled_for_a_launch_not_graced(self, grace_on):
+        service, lifecycle = make_miner_service(
+            [HOST], SwitchAssessment(reachable=True, state="RECONCILING", has_cvm=False)
+        )
+
+        results = await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[])
+
+        assert results == []
+        lifecycle.schedule_ensure.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_gpu_model_is_never_graced(self, grace_on):
+        """Same guard as the manual-rental synthesis: an unknown model reaching the
+        incentive layer aborts weight-setting for the whole subnet."""
+        odd_host = CvmdHost(
+            executor_uuid="e-odd",
+            address="203.0.113.9",
+            miner_hotkey="5Miner",
+            gpu_model="Prototype GPU X",
+            gpu_count=1,
+            updated_at=0.0,
+        )
+        service, _ = make_miner_service([odd_host], switching(10.0))
+
+        assert await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[]) == []
+
+
+class TestTheRegistryFeed:
+    @pytest.mark.asyncio
+    async def test_attested_results_are_recorded_as_cvmd_hosts(self, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", False, raising=False)
+        service, lifecycle = make_miner_service([], SwitchAssessment(reachable=False))
+
+        attested = scored_result(executor_uuid="e-new", tdx=True)
+        plain = scored_result(executor_uuid="e-plain", tdx=False)
+        await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[attested, plain])
+
+        lifecycle.record_host.assert_awaited_once()
+        kwargs = lifecycle.record_host.await_args.kwargs
+        assert kwargs["executor_uuid"] == "e-new"
+        assert kwargs["address"] == "198.51.100.3"
+        assert kwargs["gpu_model"] == "NVIDIA H200"
+
+
+class TestAssessmentParsing:
+    @pytest.mark.asyncio
+    async def test_a_state_answer_becomes_a_switch_assessment(self):
+        started = (datetime.now(UTC) - timedelta(seconds=42)).isoformat()
+        redis = MagicMock()
+        whitelist = MagicMock()
+        from bittensor_wallet import Keypair
+
+        service = CvmLifecycleService(redis, whitelist, Keypair.create_from_uri("//Alice"))
+        service.client = MagicMock()
+        service.client.state = AsyncMock(
+            return_value=RelayResult(
+                status=200,
+                body={
+                    "state": "SWITCHING",
+                    "cvm": {"instance_id": "abc"},
+                    "last_switch": {"started_at": started, "outcome": None},
+                },
+            )
+        )
+
+        assessment = await service.assess(HOST)
+
+        assert assessment.reachable and assessment.switching
+        assert assessment.elapsed_seconds == pytest.approx(42.0, abs=5.0)
+
+    @pytest.mark.asyncio
+    async def test_an_idle_answer_reads_as_empty(self):
+        redis = MagicMock()
+        whitelist = MagicMock()
+        from bittensor_wallet import Keypair
+
+        service = CvmLifecycleService(redis, whitelist, Keypair.create_from_uri("//Alice"))
+        service.client = MagicMock()
+        service.client.state = AsyncMock(
+            return_value=RelayResult(status=200, body={"state": "RECONCILING", "cvm": None, "last_switch": None})
+        )
+
+        assessment = await service.assess(HOST)
+
+        assert assessment.idle_without_cvm
+        assert not assessment.switching

--- a/tools/cvm-local-e2e/README.md
+++ b/tools/cvm-local-e2e/README.md
@@ -1,0 +1,64 @@
+# CVM local E2E harness (DAH-2633)
+
+One command that drives the whole renter path and the validation-CVM lifecycle against a
+real TDX host, without deploying anything: local code from both repos, one remote cvmd,
+an SSH tunnel in between.
+
+```bash
+neurons/validators/.venv/bin/python tools/cvm-local-e2e/run.py \
+    --host ubuntu@<cvm-host> \
+    --ssh-key ~/.ssh/<key> \
+    --backend-src ../lium-io-backend/apps/server/src \
+    --agent-image "ghcr.io/datura-ai/lium-attest-agent@sha256:<digest>"
+```
+
+A clean run walks: idle host → renter order (compose derived and signed by the backend's
+own modules) → measured launch (the host's `compose_hash` must equal the derived one) →
+scope proofs (the validator key can neither create nor destroy a renter CVM) → verified
+teardown with the switch window observed as `SWITCHING` (the facts DAH-2630's grace
+decides on) → validator-signed validation-CVM launch from the host's signed catalog
+(DAH-2629's switch back) → final teardown, host left exactly as found.
+
+## What it deliberately does and does not touch
+
+- **Never binds port 32000.** The tunnel uses high local ports, and the run aborts before
+  launching anything if the remote cvmd's configured port range could allocate 32000 —
+  that port belongs to the production subnet on shared hosts.
+- **Only an idle host.** If `/v1/state` shows any CVM, the run aborts rather than
+  competing with whatever owns it.
+- **Restores the host.** Unless `--keep-validation-cvm` is passed, the run ends with a
+  verified teardown and asserts no disks and no staged composes remain.
+
+## Keys
+
+`--platform-uri` (default `//Bob`, renter scope) and `--validator-uri` (default
+`//Alice`, validation scope) are the dev keys of a **test** cvmd that binds
+`127.0.0.1` and is reached only through this tunnel. They must never appear in a
+production `authorized_clients.json`. Point these at real keys when running against a
+host whose daemon lists them.
+
+## Full-stack mode (through the backend API)
+
+The direct mode above exercises the real derivation, signing, measurement, scope, and
+lifecycle code. To drive the same flow through the **backend API and the validator
+relay** (DAH-2628's order path end to end), run the local stack and let it do the
+talking:
+
+1. Bring up the backend locally (postgres + redis + `apps/server`) with:
+   - `CVM_RENTAL_ENABLED=true`
+   - `CVM_ATTEST_AGENT_IMAGE=<digest-pinned image>`
+   - `CVMD_URL_OVERRIDE=https://127.0.0.1:18443` (this tunnel)
+   - a seeded artifact catalog (os image, QEMU, validation compose rows) whose
+     entries match what the remote host has staged
+2. Run a local validator connected to that backend, with
+   `CVMD_URL_OVERRIDE=https://127.0.0.1:18443` so its relay and lifecycle client reach
+   the same tunnel.
+3. Place the order through the API and read access back:
+
+   ```bash
+   curl -X POST localhost:8100/executors/<uuid>/rent-cvm -d '{"compose": "..."}'
+   curl localhost:8100/pods/<pod_id>/cvm
+   ```
+
+The tunnel, the safety guards, and the host expectations are identical in both modes —
+the stack mode simply replaces this script's in-process calls with the deployed wiring.

--- a/tools/cvm-local-e2e/run.py
+++ b/tools/cvm-local-e2e/run.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""DAH-2633 — the local full-flow CVM E2E: local code, one remote TDX host, one command.
+
+Drives the whole renter path and the validation-CVM lifecycle against a real cvmd over an
+SSH tunnel, using the REAL modules from both repos wherever their imports allow:
+
+    order derive + sign     lium-io-backend  services/cvm_compose.py, services/cvmd_request.py
+    validator's own calls   lium-io          services/cvmd_client.py (validation scope)
+    the host's verdicts     the remote cvmd itself — measurement gate, scopes, teardown
+
+What one run proves, in order:
+
+    1. the host starts idle and its port range cannot touch the production port
+    2. a renter order derived by the backend launches, and the host MEASURES the same
+       compose hash the backend derived (the DAH-2632 golden loop, on hardware)
+    3. the validator key cannot create or destroy a renter CVM (403 by scope)
+    4. teardown is verified, and the switch window is observed as SWITCHING with a
+       readable start time — the exact facts DAH-2630's grace decides on
+    5. the validator brings the validation CVM back from the signed catalog and the
+       launch report matches the pinned triple (DAH-2629's switch-back)
+    6. the host ends as it began: idle, no leftover disks, no staged composes
+
+Never binds port 32000 anywhere: the tunnel uses high local ports, and step 1 aborts the
+whole run if the REMOTE cvmd's configured port range could allocate 32000.
+
+The //Alice and //Bob defaults are the dev keys of a cvmd that binds 127.0.0.1 — they are
+acceptable ONLY because that daemon is loopback-only and reached through this tunnel.
+Never put them in a production authorized_clients.json.
+
+Usage (from a lium-io checkout, with the validators venv):
+
+    neurons/validators/.venv/bin/python tools/cvm-local-e2e/run.py \\
+        --host ubuntu@203.98.89.178 --ssh-key ~/.ssh/waris_local \\
+        --backend-src ../lium-io-backend/apps/server/src \\
+        --agent-image "$CVM_ATTEST_AGENT_IMAGE"
+"""
+
+import argparse
+import atexit
+import json
+import socket
+import ssl
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "neurons" / "validators" / "src"))
+
+CUSTOMER_COMPOSE = """services:
+  app:
+    image: alpine:3.20
+    command: sleep infinity
+"""
+
+FORBIDDEN_PORT = 32000
+
+CTX = ssl.create_default_context()
+CTX.check_hostname = False
+CTX.verify_mode = ssl.CERT_NONE
+
+results: list[tuple[bool, str]] = []
+
+
+def check(ok: bool, label: str, detail: str = "") -> bool:
+    results.append((ok, label))
+    print(f"  [{'PASS' if ok else 'FAIL'}] {label}" + (f"  — {detail}" if detail else ""))
+    return ok
+
+
+def summary() -> int:
+    passed = sum(1 for ok, _ in results if ok)
+    print(f"\n== {passed}/{len(results)} checks passed")
+    for ok, label in results:
+        if not ok:
+            print(f"   FAILED: {label}")
+    return 0 if passed == len(results) else 1
+
+
+def ssh(args, command: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["ssh", "-i", args.ssh_key, "-o", "BatchMode=yes", args.host, command],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def open_tunnel(args) -> subprocess.Popen:
+    process = subprocess.Popen(
+        [
+            "ssh",
+            "-i", args.ssh_key,
+            "-o", "BatchMode=yes",
+            "-o", "ExitOnForwardFailure=yes",
+            "-N",
+            "-L", f"{args.local_port}:127.0.0.1:{args.remote_port}",
+            args.host,
+        ]
+    )
+    atexit.register(process.terminate)
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", args.local_port), timeout=1):
+                return process
+        except OSError:
+            time.sleep(0.3)
+    raise SystemExit("the SSH tunnel never came up")
+
+
+def call(base_url: str, keypair, method: str, path: str, body: str = "", timeout: int = 900):
+    """One signed cvmd call through the tunnel, using the validator repo's real signer."""
+    from services.cvmd_client import sign_request
+
+    signed = sign_request(keypair, method=method, path=path, body=body)
+    request = urllib.request.Request(
+        base_url + path,
+        data=signed.body.encode(),
+        method=method,
+        headers={**signed.headers, "Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, context=CTX, timeout=timeout) as response:
+            return response.status, json.loads(response.read() or b"{}")
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        try:
+            return exc.code, json.loads(raw or b"{}")
+        except ValueError:
+            return exc.code, {"detail": raw.decode()[:200]}
+
+
+def newest(entries: list[dict], kind: str | None = None) -> dict | None:
+    pool = [e for e in entries if kind is None or e.get("kind") == kind]
+    if not pool:
+        return None
+
+    def key(entry):
+        versions = entry.get("versions") or {}
+        return (versions.get("compose", 0), versions.get("os_image", 0), versions.get("qemu", 0))
+
+    return max(pool, key=key)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", required=True, help="ssh target of the CVM host, e.g. ubuntu@203.98.89.178")
+    parser.add_argument("--ssh-key", required=True)
+    parser.add_argument("--backend-src", required=True, help="path to lium-io-backend/apps/server/src")
+    parser.add_argument("--agent-image", required=True, help="attest-agent image, pinned by digest")
+    parser.add_argument("--local-port", type=int, default=18443)
+    parser.add_argument("--remote-port", type=int, default=8443)
+    parser.add_argument("--platform-uri", default="//Bob", help="renter-scope key (dev key of the test daemon)")
+    parser.add_argument("--validator-uri", default="//Alice", help="validation-scope key (dev key of the test daemon)")
+    parser.add_argument("--switch-budget", type=int, default=300, help="DAH-2630 budget to judge the observed switch against")
+    parser.add_argument("--keep-validation-cvm", action="store_true", help="leave the validation CVM running at the end")
+    args = parser.parse_args()
+
+    sys.path.insert(0, str(Path(args.backend_src).resolve()))
+    from bittensor_wallet import Keypair
+
+    from services.cvm_compose import AgentSpec, derive  # the backend's real derivation
+    from services.cvmd_client import CvmdClient  # noqa: F401 — imported to prove the module loads
+
+    platform = Keypair.create_from_uri(args.platform_uri)
+    validator = Keypair.create_from_uri(args.validator_uri)
+    base_url = f"https://127.0.0.1:{args.local_port}"
+
+    open_tunnel(args)
+
+    print("== 1. the host starts idle, and its port range cannot touch production")
+    status, state = call(base_url, platform, "GET", "/v1/state")
+    if not check(status == 200, "cvmd answers through the tunnel", f"HTTP {status}"):
+        return summary()
+    if not check(
+        state.get("state") == "RECONCILING" and state.get("cvm") is None,
+        "the host is idle with no CVM",
+        f"state={state.get('state')}",
+    ):
+        print("   aborting: this harness only runs against an idle host")
+        return summary()
+
+    config_read = ssh(args, "cat /etc/cvmd/config.toml")
+    ranges = [line for line in config_read.stdout.splitlines() if "port" in line.lower()]
+    check(
+        config_read.returncode == 0 and str(FORBIDDEN_PORT) not in config_read.stdout,
+        f"the remote port configuration cannot allocate {FORBIDDEN_PORT}",
+        "; ".join(ranges)[:160],
+    )
+    if str(FORBIDDEN_PORT) in config_read.stdout:
+        print("   aborting: the test daemon's port range could touch the production port")
+        return summary()
+
+    print("== 2. the catalog in force on the host")
+    status, catalog = call(base_url, validator, "GET", "/v1/catalog")
+    manifest = (catalog or {}).get("manifest") or {}
+    entries = manifest.get("entries") or []
+    check(status == 200 and catalog.get("usable") is True, "the catalog is usable", f"serial={manifest.get('serial')}")
+    base = newest(entries)
+    validation_entry = newest(entries, kind="validation")
+    if not check(base is not None, "the catalog offers an image and a QEMU build"):
+        return summary()
+
+    print("== 3. a renter order, derived by the backend's own code")
+    injected, compose_hash = derive(CUSTOMER_COMPOSE, AgentSpec(image=args.agent_image))
+    order = {
+        "kind": "renter",
+        "qemu": base["qemu"],
+        "os_image_hash": base["os_image_hash"],
+        "compose_hash": compose_hash,
+        "compose": injected,
+        "rental_id": "dah2633-e2e",
+    }
+    body = json.dumps(order, separators=(",", ":"))
+
+    status, refused = call(base_url, validator, "POST", "/v1/cvm", body)
+    check(status == 403, "the validator key cannot create a renter CVM", f"HTTP {status}")
+
+    status, report = call(base_url, platform, "POST", "/v1/cvm", body)
+    if not check(status == 201, "the renter launch is accepted", f"HTTP {status} {str(report)[:160]}"):
+        return summary()
+    measured = report.get("measurements") or {}
+    check(
+        measured.get("compose_hash") == compose_hash,
+        "the host measured the hash the backend derived (golden loop)",
+        str(measured.get("compose_hash"))[:20],
+    )
+    check(measured.get("qemu") == base["qemu"], "qemu as pinned")
+    check(measured.get("os_image_hash") == base["os_image_hash"], "os image as pinned")
+    check(report.get("state") == "RENTER_RUNNING", "node is RENTER_RUNNING", report.get("state"))
+    ports = report.get("ports") or []
+    check(bool(ports), "the report carries forwarded ports", str([p.get("host_port") for p in ports]))
+    check(
+        all(p.get("host_port") != FORBIDDEN_PORT for p in ports),
+        f"no forwarded port is {FORBIDDEN_PORT}",
+    )
+
+    print("== 4. the validator key cannot destroy it either")
+    status, _ = call(base_url, validator, "DELETE", "/v1/cvm")
+    check(status == 403, "validator-signed DELETE is 403", f"HTTP {status}")
+
+    print("== 5. verified teardown, with the switch window observed (DAH-2630's facts)")
+    teardown_result: dict = {}
+
+    def teardown():
+        teardown_result["answer"] = call(base_url, platform, "DELETE", "/v1/cvm", timeout=2100)
+
+    worker = threading.Thread(target=teardown)
+    started = time.time()
+    worker.start()
+    observed_states: set[str] = set()
+    observed_start: str | None = None
+    while worker.is_alive() and time.time() - started < 2100:
+        status, state = call(base_url, validator, "GET", "/v1/state", timeout=15)
+        if status == 200:
+            observed_states.add(str(state.get("state")))
+            last_switch = state.get("last_switch") or {}
+            if state.get("state") in ("TEARDOWN", "SWITCHING") and last_switch.get("started_at"):
+                observed_start = last_switch["started_at"]
+        time.sleep(0.5)
+    worker.join()
+    status, torn = teardown_result["answer"]
+    check(status == 200, "teardown verified (hardware came back)", f"HTTP {status} {str(torn)[:120]}")
+    switch_seconds = time.time() - started
+    check(
+        bool({"TEARDOWN", "SWITCHING"} & observed_states) or switch_seconds < 2.0,
+        "the switch window was observable as TEARDOWN/SWITCHING",
+        f"states={sorted(observed_states)} in {switch_seconds:.1f}s",
+    )
+    if observed_start is not None:
+        parsed = datetime.fromisoformat(observed_start)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        elapsed_when_seen = (datetime.now(UTC) - parsed).total_seconds()
+        check(
+            0 <= elapsed_when_seen <= args.switch_budget,
+            f"the observed switch stayed inside the {args.switch_budget}s budget",
+            f"started_at readable, total {switch_seconds:.1f}s",
+        )
+
+    print("== 6. the switch back: the validator launches the validation CVM (DAH-2629)")
+    if validation_entry is None:
+        check(False, "the catalog carries a validation entry to launch from")
+        return summary()
+    triple_body = json.dumps(
+        {
+            "kind": "validation",
+            "qemu": validation_entry["qemu"],
+            "os_image_hash": validation_entry["os_image_hash"],
+            "compose_hash": validation_entry["compose_hash"],
+        },
+        separators=(",", ":"),
+    )
+    status, launch = call(base_url, validator, "POST", "/v1/cvm", triple_body)
+    if check(status == 201, "the validation CVM launch is accepted", f"HTTP {status} {str(launch)[:160]}"):
+        measured = launch.get("measurements") or {}
+        check(
+            measured.get("compose_hash") == validation_entry["compose_hash"]
+            and measured.get("os_image_hash") == validation_entry["os_image_hash"]
+            and measured.get("qemu") == validation_entry["qemu"],
+            "the launch report matches the pinned catalog triple",
+        )
+        check(launch.get("state") == "VALIDATION_RUNNING", "node is VALIDATION_RUNNING", launch.get("state"))
+
+    print("== 7. the host is restored")
+    if args.keep_validation_cvm:
+        print("  (leaving the validation CVM running, as asked)")
+    else:
+        status, _ = call(base_url, platform, "DELETE", "/v1/cvm", timeout=2100)
+        check(status == 200, "final teardown verified", f"HTTP {status}")
+        status, state = call(base_url, platform, "GET", "/v1/state")
+        check(
+            state.get("state") == "RECONCILING" and state.get("cvm") is None,
+            "the host ends idle, as it began",
+            f"state={state.get('state')}",
+        )
+        disks = ssh(args, "ls /var/lib/cvmd/vms/*/hda.img 2>/dev/null | wc -l")
+        check(disks.stdout.strip() == "0", "no CVM disks left behind", disks.stdout.strip())
+        staged = ssh(args, "ls -A /var/lib/cvmd/renter 2>/dev/null | wc -l")
+        check(staged.stdout.strip() == "0", "no staged composes left behind", staged.stdout.strip())
+
+    return summary()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/cvm-local-e2e/run.py
+++ b/tools/cvm-local-e2e/run.py
@@ -52,10 +52,17 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "neurons" / "validators" / "src"))
 
+# The customer's own half of the order. It must open the guest SSH port cvmd's readiness
+# gate waits on (2200 by fleet convention — `cvm_ssh_guest_port`): a compose with nothing
+# listening there launches a guest that is never declared ready and the create answers 504.
+# That is also what a real customer ships — SSH access to their CVM is the product.
 CUSTOMER_COMPOSE = """services:
-  app:
+  ssh:
     image: alpine:3.20
-    command: sleep infinity
+    command: sh -c "apk add --no-cache openssh && ssh-keygen -A && /usr/sbin/sshd -D -e"
+    ports:
+      - "2200:22"
+    restart: unless-stopped
 """
 
 FORBIDDEN_PORT = 32000
@@ -162,11 +169,19 @@ def main() -> int:
     parser.add_argument("--keep-validation-cvm", action="store_true", help="leave the validation CVM running at the end")
     args = parser.parse_args()
 
-    sys.path.insert(0, str(Path(args.backend_src).resolve()))
     from bittensor_wallet import Keypair
 
-    from services.cvm_compose import AgentSpec, derive  # the backend's real derivation
-    from services.cvmd_client import CvmdClient  # noqa: F401 — imported to prove the module loads
+    # The backend's real derivation, loaded by explicit file path: both repos ship a
+    # `services` package, and letting them shadow each other on sys.path is exactly the
+    # kind of silent wrong-module import this harness exists to rule out.
+    import importlib.util
+
+    compose_path = Path(args.backend_src).resolve() / "services" / "cvm_compose.py"
+    spec = importlib.util.spec_from_file_location("backend_cvm_compose", compose_path)
+    backend_cvm_compose = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(backend_cvm_compose)
+    AgentSpec = backend_cvm_compose.AgentSpec
+    derive = backend_cvm_compose.derive
 
     platform = Keypair.create_from_uri(args.platform_uri)
     validator = Keypair.create_from_uri(args.validator_uri)
@@ -186,7 +201,7 @@ def main() -> int:
         print("   aborting: this harness only runs against an idle host")
         return summary()
 
-    config_read = ssh(args, "cat /etc/cvmd/config.toml")
+    config_read = ssh(args, "sudo cat /etc/cvmd/config.toml")
     ranges = [line for line in config_read.stdout.splitlines() if "port" in line.lower()]
     check(
         config_read.returncode == 0 and str(FORBIDDEN_PORT) not in config_read.stdout,
@@ -320,9 +335,9 @@ def main() -> int:
             "the host ends idle, as it began",
             f"state={state.get('state')}",
         )
-        disks = ssh(args, "ls /var/lib/cvmd/vms/*/hda.img 2>/dev/null | wc -l")
+        disks = ssh(args, "sudo sh -c 'ls /var/lib/cvmd/vms/*/hda.img 2>/dev/null | wc -l'")
         check(disks.stdout.strip() == "0", "no CVM disks left behind", disks.stdout.strip())
-        staged = ssh(args, "ls -A /var/lib/cvmd/renter 2>/dev/null | wc -l")
+        staged = ssh(args, "sudo sh -c 'ls -A /var/lib/cvmd/renter 2>/dev/null | wc -l'")
         check(staged.stdout.strip() == "0", "no staged composes left behind", staged.stdout.strip())
 
     return summary()


### PR DESCRIPTION
## Describe your changes

Four tasks of the CVM v2 epic, stacked on #1213 (DAH-2580–2582) because they are its missing callers and accounting:

**DAH-2629 — the validator launches validation CVMs via cvmd.** New `services/cvmd_client.py` signs this validator's own cvmd calls (`validation` scope; the blob formula mirrors the backend's signer and is pinned by test to the same bytes). `services/cvm_whitelist.py` now retains the signed manifest's full stack entries so the launch triple comes from the same document the measurement check reads (`newest_validation_entry()`). New `services/cvm_lifecycle.py` keeps a Redis registry of cvmd hosts (fed by every attested cycle and by the relay), and launches the validation CVM on an idle, empty host — pinned triple, verified launch report, per-host cooldown, fail-closed without a catalog. Two triggers: the per-cycle sweep, and immediately after a successful renter-teardown relay (`compute_client._schedule_validation_cvm_return`). A launch failure is a scoring signal (the node stays unverifiable), not an operator page.

**DAH-2630 — the switch window is availability-accounted (FR-I3).** `miner_service._record_and_grace_cvm_hosts` runs after real results, exactly like the manual-rental forced pass: a registered host that is mid-switch (`SWITCHING`/`TEARDOWN` with a readable `started_at`) and inside its per-hardware-class budget gets a synthesized grace JobResult (`spec=None`, so the backend's executor row is untouched); beyond budget is a flagged event (`CVM_SWITCH_BUDGET_EXCEEDED`), never a longer window. Budgets: `CVM_SWITCH_BUDGET_SECONDS_DEFAULT` + per-GPU-model JSON overrides.

**DAH-2632 — the attest-agent image is published by CI, pinned by digest.** `.github/workflows/attest-agent-publish.yml` builds `neurons/executor/attest-agent` and pushes `ghcr.io/datura-ai/lium-attest-agent`; the job summary prints the exact `CVM_ATTEST_AGENT_IMAGE=...@sha256:...` line to deploy. `PUBLISHING.md` documents why a new digest is a catalog rollout, never a swap.

**DAH-2633 — the local full-flow E2E harness.** `tools/cvm-local-e2e/run.py`: one command that drives renter order → measured launch → scope proofs → verified teardown (switch window observed) → validator-signed validation-CVM relaunch → restored host, against a remote cvmd over an SSH tunnel, using the real modules from both repos. Hard guards: aborts on a busy host, aborts if the remote port range could allocate 32000, restores the host at the end.

Flags (all default-off, DAH-2581 posture): `ENABLE_CVM_LIFECYCLE`, `ENABLE_SWITCHING_GRACE`; plus `CVMD_PORT`, `CVMD_URL_OVERRIDE` (harness only), `CVM_LAUNCH_COOLDOWN_SECONDS`, `CVMD_HOST_REGISTRY_TTL_SECONDS`.

**Verified on hardware (au11, 2026-08-10):** the DAH-2633 harness against au11 (2026-08-10): **24/24 checks passed** — renter launch measured the derived compose hash (golden loop), validator key 403 on renter create AND delete, verified teardown with the switch window observed as RENTER_RUNNING → TEARDOWN → SWITCHING in 12.3 s (inside the 300 s budget, started_at readable), validator-signed validation-CVM relaunch matching the pinned catalog triple, and the host restored to idle with zero leftover disks or staged composes. No forwarded port was 32000 at any point.

Test suites: validators 1602 passed, cvmd 357 passed. No cvmd code changes — the daemon already implements everything these clients call.

Known boundary, tracked in the epic: a virgin cvmd host enters the lifecycle registry with its first attested cycle; the very first CVM on a brand-new host still comes from day-zero provisioning (DAH-2634 owns the staging bring-up).

## Issue ticket number and link

[DAH-2629](https://www.notion.so/DAH-2629) · [DAH-2630](https://www.notion.so/DAH-2630) · [DAH-2632](https://www.notion.so/DAH-2632) · [DAH-2633](https://www.notion.so/DAH-2633)

Backend counterpart (DAH-2628 + DAH-2631): https://github.com/Datura-ai/lium-io-backend/pull/893. The two merge in either order — the wire contract (`cvm_expectations`, CVM response message types) is additive on both sides.

## Checklist before requesting a review

- [x] Full validators + cvmd suites green locally (this PR targets a feature branch, so CI does not run — the umbrella → main PR is the CI gate)
- [x] Hardware acceptance on au11 via the DAH-2633 harness
- [x] Every new check is flag-gated off by default
