### PR TITLE
DAH-2639: harden startup restore execution

### DIFF
--- a/neurons/executor/src/storage/reporting.py
+++ b/neurons/executor/src/storage/reporting.py
@@ -40,7 +40,8 @@ class StorageEventReporter:
         self._clock = clock
         self._sleeper = sleeper
         self._last_success_at = self._clock()
-        self._state = ProgressState(stage=action.value.upper())
+        initial_stage = "PREPARING" if action is StorageAction.RESTORE else action.value.upper()
+        self._state = ProgressState(stage=initial_stage)
         self._cancel_requested = False
         self._restic_failure_detail: str | None = None
         self._diagnostic_detail: str | None = None
@@ -51,11 +52,19 @@ class StorageEventReporter:
 
     def send(self, event: Mapping[str, object]) -> None:
         event_type = event.get("event")
+        if event_type == "stage":
+            stage = event.get("stage")
+            if isinstance(stage, str) and stage:
+                self._state.stage = stage
+                self._put(self._progress_payload(status="IN_PROGRESS"), terminal=False)
+            return
         if event_type == "restic":
             payload = event.get("payload")
             if not isinstance(payload, Mapping):
                 return
             self._apply_progress(payload)
+            if self._state.stage == "PREPARING" and self._restore_has_started():
+                self._state.stage = "RESTORING"
             self._remember_restic_error(payload)
             self._put(self._progress_payload(status="IN_PROGRESS"), terminal=False)
             return
@@ -145,6 +154,13 @@ class StorageEventReporter:
         if message:
             self._restic_failure_detail = message[:2000]
 
+    def _restore_has_started(self) -> bool:
+        return bool(
+            self._state.progress > 0
+            or (self._state.processed_files or 0) > 0
+            or (self._state.processed_bytes or 0) > 0
+        )
+
     def _progress_payload(
         self,
         *,
@@ -183,6 +199,8 @@ class StorageEventReporter:
                     headers={"Authorization": f"Bearer {self._spec.auth_token}"},
                     timeout=10,
                 )
+                if getattr(response, "status_code", None) in (404, 410):
+                    raise ReportingLeaseExpired("storage operation is no longer active")
                 response.raise_for_status()
                 body = response.json()
                 self._last_success_at = self._clock()

--- a/neurons/executor/src/storage/restic.py
+++ b/neurons/executor/src/storage/restic.py
@@ -110,6 +110,9 @@ class JsonEventWriter:
     def diagnostic(self, message: str) -> None:
         self._write({"event": "diagnostic", "operation_id": self._operation_id, "message": message})
 
+    def stage(self, stage: str) -> None:
+        self._write({"event": "stage", "operation_id": self._operation_id, "stage": stage})
+
     def heartbeat_if_due(self) -> None:
         now = self._clock()
         if now - self._last_heartbeat_at < self._heartbeat_interval_seconds:
@@ -295,6 +298,7 @@ class ResticStorageRunner:
         exit_code, _ = self._stream_command(command, cwd)
         if exit_code != 0:
             raise ResticOperationError(f"restic restore failed with exit {exit_code}")
+        self._events.stage("FINALIZING")
         return ResticResult("COMPLETED", OperationResultQuality.FULL, snapshot_id, exit_code)
 
     def _restore_legacy_archive(self) -> ResticResult:
@@ -319,6 +323,7 @@ class ResticStorageRunner:
                 "bytes_restored": restore_stats.total_size,
             }
         )
+        self._events.stage("FINALIZING")
         return ResticResult("COMPLETED", OperationResultQuality.FULL, None, exit_code)
 
     def _stream(

--- a/neurons/executor/src/storage_runner.py
+++ b/neurons/executor/src/storage_runner.py
@@ -39,6 +39,8 @@ def main() -> int:
                 lambda: Path(arguments.cancel_file).exists() if arguments.cancel_file else False
             ),
         )
+        if operation.action.value == "restore":
+            event_writer.stage("PREPARING")
         workspace = WorkspaceResolver().resolve(operation)
         ResticStorageRunner(operation, workspace, event_writer=event_writer).run()
         return 0

--- a/neurons/executor/tests/test_storage_runner.py
+++ b/neurons/executor/tests/test_storage_runner.py
@@ -530,6 +530,8 @@ def test_restore_checkpoint_emits_bounded_progress(
 
 
 class _ReporterResponse:
+    status_code = 200
+
     def raise_for_status(self) -> None:
         return None
 
@@ -584,6 +586,38 @@ def test_reporter_preserves_zero_counters_and_receives_cancellation() -> None:
     assert payload["processed_bytes"] == 0
 
 
+def test_restore_reporter_surfaces_scan_then_restore_stages() -> None:
+    session = _ReporterSession()
+    reporter = StorageEventReporter(
+        OPERATION_ID,
+        StorageAction.RESTORE,
+        ReporterSpec(
+            api_url="https://api.example",
+            auth_token="token",
+            resource=ReporterResource.RESTORE,
+        ),
+        session=session,
+    )
+
+    reporter.send(
+        {"event": "restic", "payload": {"message_type": "status", "total_files": 123}}
+    )
+    reporter.send(
+        {
+            "event": "restic",
+            "payload": {"message_type": "status", "total_files": 123, "files_restored": 1},
+        }
+    )
+
+    first_payload = session.requests[0]["json"]
+    second_payload = session.requests[1]["json"]
+    assert isinstance(first_payload, dict)
+    assert isinstance(second_payload, dict)
+    assert first_payload["stage"] == "PREPARING"
+    assert first_payload["total_files"] == 123
+    assert second_payload["stage"] == "RESTORING"
+
+
 def test_reporter_includes_specific_restic_error_in_failed_result() -> None:
     session = _ReporterSession()
     reporter = StorageEventReporter(
@@ -619,6 +653,27 @@ def test_reporter_includes_specific_restic_error_in_failed_result() -> None:
 class _FailingReporterSession:
     def put(self, *args: object, **kwargs: object) -> None:
         raise requests.ConnectionError("backend unavailable")
+
+
+class _RevokedReporterSession:
+    def put(self, *args: object, **kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(status_code=404)
+
+
+def test_missing_restore_log_revokes_runner_without_waiting_for_lease() -> None:
+    reporter = StorageEventReporter(
+        OPERATION_ID,
+        StorageAction.RESTORE,
+        ReporterSpec(
+            api_url="https://api.example",
+            auth_token="token",
+            resource=ReporterResource.RESTORE,
+        ),
+        session=_RevokedReporterSession(),
+    )
+
+    with pytest.raises(ReportingLeaseExpired, match="no longer active"):
+        reporter.send({"event": "heartbeat"})
 
 
 class _ManualClock:

--- a/neurons/validators/src/services/storage_operations.py
+++ b/neurons/validators/src/services/storage_operations.py
@@ -70,6 +70,23 @@ async def start_storage_operation(
             f"install -d -m 0700 {shlex.quote(str(REMOTE_OPERATION_DIRECTORY))}",
             check=True,
         )
+        existing_state = await _operation_state(ssh_client, files)
+        if existing_state == "STARTING" and await _remote_file_exists(ssh_client, files.spec):
+            # A repeated backend dispatch can arrive while the first wrapper is between
+            # writing its spec and PID. Give that deterministic operation a chance to appear.
+            for _ in range(20):
+                await asyncio.sleep(0.25)
+                existing_state = await _operation_state(ssh_client, files)
+                if existing_state != "STARTING":
+                    break
+        if existing_state == "RUNNING" or existing_state.startswith("STATUS:"):
+            return files
+        if existing_state in {"EXITED", "INVALID"} or await _remote_file_exists(
+            ssh_client, files.spec
+        ):
+            await _remove_operation_artifacts(ssh_client, files)
+        await _remove_stale_helper_container(ssh_client, operation_id)
+
         async with ssh_client.start_sftp_client() as sftp:
             async with sftp.open(str(files.spec), "w") as remote_spec:
                 await remote_spec.write(
@@ -235,6 +252,25 @@ async def _read_operation_spec(
     except json.JSONDecodeError:
         return None
     return value if isinstance(value, Mapping) else None
+
+
+async def _remote_file_exists(
+    ssh_client: asyncssh.SSHClientConnection,
+    path: PurePosixPath,
+) -> bool:
+    result = await ssh_client.run(f"test -e {shlex.quote(str(path))}", check=False)
+    return result.exit_status == 0
+
+
+async def _remove_stale_helper_container(
+    ssh_client: asyncssh.SSHClientConnection,
+    operation_id: UUID,
+) -> None:
+    helper_name = f"lium-storage-{str(operation_id)[:12]}"
+    await ssh_client.run(
+        f"/usr/bin/docker rm -f -- {shlex.quote(helper_name)} >/dev/null 2>&1 || true",
+        check=False,
+    )
 
 
 async def _tail_operation_log(

--- a/neurons/validators/tests/test_storage_operations.py
+++ b/neurons/validators/tests/test_storage_operations.py
@@ -21,6 +21,26 @@ def _spec() -> dict[str, object]:
 
 
 @pytest.mark.asyncio
+async def test_repeated_dispatch_reuses_running_operation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ssh_client = AsyncMock()
+    monkeypatch.setattr(storage_operations, "supports_storage_operation", AsyncMock(return_value=True))
+    monkeypatch.setattr(storage_operations, "_operation_state", AsyncMock(return_value="RUNNING"))
+
+    files = await storage_operations.start_storage_operation(
+        ssh_client,
+        "/usr/bin/python3",
+        OPERATION_ID,
+        _spec(),
+        retain_terminal_artifacts=False,
+    )
+
+    assert files == storage_operations.StorageOperationFiles.for_operation(OPERATION_ID)
+    assert ssh_client.start_sftp_client.call_count == 0
+
+
+@pytest.mark.asyncio
 async def test_launch_failure_is_reported_before_the_error_is_reraised(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Describe your changes

Harden executor and validator support for restores that start after the customer pod is running.

- Make repeated operation dispatch reuse an existing runner or terminal result instead of launching a duplicate.
- Remove the exact stale per-operation helper container before a genuine retry.
- Stop runners immediately when their backend restore resource is missing or terminal.
- Report `PREPARING`, `RESTORING`, and `FINALIZING` stages using the existing Restic progress stream.
- Keep the existing new-or-empty destination guard for every restore; there is no startup exception for `/root`.
- Keep Restic format, native restore, S3 concurrency, repository layout, and restore request semantics unchanged.

This addresses the production case where a long restore looked stuck, a pending-pod retry launched a duplicate helper near completion, and deleting earlier attempts left repository admission occupied.

### Risks and compatibility

- No new wire field or restore mode is added to the validator/executor contract.
- Legacy backup restoration remains engine-dispatched.
- Restore execution remains restricted to a new or empty destination.

### Validation

- Executor storage-runner suite: 29 passed.
- Validator restore/workspace/storage-operation suites: 29 passed.
- `git diff --check`: clean.

## Issue ticket number and link

[DAH-2639 — Harden Backup V2 startup restore lifecycle and visibility](https://app.notion.com/p/3b8b8bfdbde981c786a6c82f3755b39b)

## Other PRs

- [Datura-ai/lium-io-backend#901](https://github.com/Datura-ai/lium-io-backend/pull/901)
- [Datura-ai/lium-io-frontend#238](https://github.com/Datura-ai/lium-io-frontend/pull/238)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [x] Need to take care of performance?
