### PR TITLE
DAH-2622: floor a live miner's weight at one u16 unit funded from burn

### DIFF
--- a/neurons/validators/src/clients/subtensor_client.py
+++ b/neurons/validators/src/clients/subtensor_client.py
@@ -83,6 +83,61 @@ def _convert_weights_with_positive_floor(
     return out_uids, out_vals, floored
 
 
+def _select_floor_candidates(
+    uint_uids,
+    miners,
+    active_hotkeys: set[str],
+    burn_uids: set[int],
+) -> list[tuple[int, str]]:
+    """Pick the hotkeys that had a live executor last cycle but are missing from the
+    u16 vector. Burn uids are never candidates — they fund the floor, they don't take it.
+
+    Returns a list of `(uid, hotkey)` tuples sorted by uid so the transfer is deterministic.
+    """
+    present = {int(u) for u in uint_uids}
+    return sorted(
+        (int(miner.uid), miner.hotkey)
+        for miner in miners
+        if miner.hotkey in active_hotkeys
+        and int(miner.uid) not in present
+        and int(miner.uid) not in burn_uids
+    )
+
+
+def _largest_burn_index(uids: list[int], weights: list[int], burn_uids: set[int]) -> int | None:
+    """Index of the burn entry currently carrying the most u16 mass, or None when the vector has no burner."""
+    burn_indexes = [ind for ind, uid in enumerate(uids) if uid in burn_uids]
+    if not burn_indexes:
+        return None
+    return max(burn_indexes, key=lambda ind: weights[ind])
+
+
+def _apply_eligibility_floor(
+    uint_uids,
+    uint_weights,
+    miners,
+    active_hotkeys: set[str],
+    burn_uids: set[int],
+) -> tuple[list[int], list[int], list[str]]:
+    """Give one u16 unit to every live hotkey the vector dropped, taken from the largest
+    burn entry so no earning miner is diluted. Builds new lists, never mutates the inputs.
+
+    Returns (uids, weights, floored_hotkeys).
+    """
+    out_uids = [int(u) for u in uint_uids]
+    out_weights = [int(w) for w in uint_weights]
+    floored_hotkeys: list[str] = []
+    for uid, hotkey in _select_floor_candidates(out_uids, miners, active_hotkeys, burn_uids):
+        donor = _largest_burn_index(out_uids, out_weights, burn_uids)
+        if donor is None or out_weights[donor] <= 1:
+            break
+        out_weights[donor] -= 1
+        out_uids.append(uid)
+        out_weights.append(1)
+        floored_hotkeys.append(hotkey)
+    return out_uids, out_weights, floored_hotkeys
+
+
 class SubtensorClient:
     # Static class variables (shared across all instances)
     _instance = None
@@ -350,11 +405,14 @@ class SubtensorClient:
         except Exception as e:
             logger.error(_m("[send_weights_to_lium] Failed to post latest-set-weights", extra=get_extra_info({"error": str(e)})))
 
-    async def set_weights(self, miner_scores: dict[str, float]):
+    async def set_weights(self, miner_scores: dict[str, float], active_hotkeys: set[str] | None = None):
         """Set weights using accumulated scores with burning already applied.
 
         The miner_scores dict already includes burning logic from calculate_final_weights
         called per cycle. This method just normalizes and sends to chain.
+
+        `active_hotkeys` are the hotkeys with at least one live executor in the last
+        completed cycle — they get the u16 floor when the vector would drop them.
         """
         miners = await self.get_miners()
         logger.info(
@@ -422,6 +480,27 @@ class SubtensorClient:
 
         uint_uids, uint_weights, floored = _convert_weights_with_positive_floor(
             processed_uids, processed_weights
+        )
+
+        # DAH-2622: a hotkey that had a live executor last cycle keeps u16=1 even when it
+        # scored nothing, so the chain never deregisters it for a zero emission.
+        uint_uids, uint_weights, floor_hotkeys = _apply_eligibility_floor(
+            uint_uids,
+            uint_weights,
+            miners,
+            active_hotkeys or set(),
+            set(settings.BURNERS + settings.NEW_BURNERS),
+        )
+
+        logger.info(
+            _m(
+                "[set_weights] eligibility floor applied",
+                extra=get_extra_info({
+                    **self.default_extra,
+                    "floor_hotkeys": floor_hotkeys,
+                    "floor_count": len(floor_hotkeys),
+                }),
+            ),
         )
 
         # Resolve floored uids back to hotkeys so the log row is human-debuggable.

--- a/neurons/validators/src/clients/subtensor_client.py
+++ b/neurons/validators/src/clients/subtensor_client.py
@@ -489,7 +489,9 @@ class SubtensorClient:
             uint_weights,
             miners,
             active_hotkeys or set(),
-            set(settings.BURNERS + settings.NEW_BURNERS),
+            # only the uids that actually receive burn, mirroring BurnService.is_burner —
+            # a retired burner slot is an ordinary miner uid and must be able to take the floor
+            set(settings.NEW_BURNERS if settings.ENABLE_NEW_BURN_LOGIC else settings.BURNERS),
         )
 
         logger.info(

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -48,6 +48,9 @@ class Validator:
         self.default_extra = {}
 
         self.miner_scores = {}
+        # Hotkeys with at least one live executor in the last completed cycle. Rebuilt
+        # every cycle, never persisted — set_weights floors them to u16=1.
+        self.active_hotkeys: set[str] = set()
         # Number of fully-completed sync cycles since this process started.
         # Used to skip the first post-restart set_weights when the in-memory
         # accumulator may have been re-built from a partial cycle.
@@ -185,7 +188,10 @@ class Validator:
                                 )
                             )
                         else:
-                            await self.subtensor_client.set_weights(miner_scores=self.miner_scores)
+                            await self.subtensor_client.set_weights(
+                                miner_scores=self.miner_scores,
+                                active_hotkeys=self.active_hotkeys,
+                            )
                         self.miner_scores = {}
             except Exception as e:
                 logger.error(
@@ -406,6 +412,14 @@ class Validator:
                             ),
                         ),
                     )
+
+                    # DAH-2622: a miner whose machine passed validation must keep its UID even
+                    # when it earned nothing this cycle. Overwrite, never accumulate.
+                    self.active_hotkeys = {
+                        miner_hotkey
+                        for miner_hotkey, results in all_job_results.items()
+                        if any(result.is_successful for result in results)
+                    }
 
                     incentive = IncentiveFactory.create(
                         config=self.incentive,

--- a/neurons/validators/tests/test_incentive_flow.py
+++ b/neurons/validators/tests/test_incentive_flow.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 from unittest.mock import AsyncMock, patch
 
@@ -40,6 +41,14 @@ def expected_score(
 pytest_plugins = ["fixtures.incentive_fixtures"]
 
 
+def _floor_log_extras(caplog):
+    return [
+        {"floor_hotkeys": record.msg.extra["floor_hotkeys"], "floor_count": record.msg.extra["floor_count"]}
+        for record in caplog.records
+        if hasattr(record.msg, "extra") and "floor_hotkeys" in record.msg.extra
+    ]
+
+
 def _weights_by_uid(captured):
     return {
         int(uid): float(weight)
@@ -47,7 +56,9 @@ def _weights_by_uid(captured):
     }
 
 
-async def _run_set_weights_and_capture(mock_subtensor_client, miners, miner_scores, *, normalize=False):
+async def _run_set_weights_and_capture(
+    mock_subtensor_client, miners, miner_scores, *, normalize=False, active_hotkeys=None
+):
     captured = {}
 
     def capture_weights(uids, weights, netuid, subtensor, metagraph):
@@ -65,7 +76,9 @@ async def _run_set_weights_and_capture(mock_subtensor_client, miners, miner_scor
 
     with patch("clients.subtensor_client.process_weights_for_netuid", side_effect=capture_weights):
         mock_subtensor_client.get_miners = AsyncMock(return_value=miners)
-        await mock_subtensor_client.set_weights(miner_scores=miner_scores)
+        await mock_subtensor_client.set_weights(
+            miner_scores=miner_scores, active_hotkeys=active_hotkeys
+        )
 
     return captured
 
@@ -1253,6 +1266,72 @@ def test_convert_weights_with_positive_floor_handles_empty_and_all_zero():
     assert all_zero == ([], [], [])
 
 
+# ---------------------------------------------------------------------------
+# DAH-2622: a hotkey with a live executor must never fall out of the vector
+# ---------------------------------------------------------------------------
+
+
+def test_select_floor_candidates_live_zero_selected_burn_inactive_positive_excluded(
+    create_neuron_info,
+):
+    from clients.subtensor_client import _select_floor_candidates
+
+    miners = [
+        create_neuron_info(uid=5, hotkey="live_absent"),
+        create_neuron_info(uid=100, hotkey="live_burner"),
+        create_neuron_info(uid=6, hotkey="inactive"),
+        create_neuron_info(uid=7, hotkey="live_present"),
+    ]
+    uint_uids = [100, 7]
+    active_hotkeys = {"live_absent", "live_burner", "live_present"}
+
+    candidates = _select_floor_candidates(uint_uids, miners, active_hotkeys, {100, 101})
+
+    assert candidates == [(5, "live_absent")]
+
+
+def test_apply_eligibility_floor_funds_candidate_from_largest_burn_uid(create_neuron_info):
+    from clients.subtensor_client import _apply_eligibility_floor
+
+    miners = [
+        create_neuron_info(uid=100, hotkey="big_burner"),
+        create_neuron_info(uid=101, hotkey="small_burner"),
+        create_neuron_info(uid=3, hotkey="earner"),
+        create_neuron_info(uid=5, hotkey="live_absent"),
+    ]
+    uint_uids = [100, 101, 3]
+    uint_weights = [65535, 30000, 500]
+
+    out_uids, out_weights, floored_hotkeys = _apply_eligibility_floor(
+        uint_uids, uint_weights, miners, {"live_absent"}, {100, 101}
+    )
+
+    assert dict(zip(out_uids, out_weights)) == {100: 65534, 101: 30000, 3: 500, 5: 1}
+    assert floored_hotkeys == ["live_absent"]
+    assert uint_uids == [100, 101, 3]
+    assert uint_weights == [65535, 30000, 500]
+
+
+def test_apply_eligibility_floor_stops_when_burn_exhausted(create_neuron_info):
+    from clients.subtensor_client import _apply_eligibility_floor
+
+    miners = [
+        create_neuron_info(uid=100, hotkey="burner"),
+        create_neuron_info(uid=5, hotkey="live_a"),
+        create_neuron_info(uid=6, hotkey="live_b"),
+    ]
+    # the single burn entry carries exactly one spare unit above the u16 minimum
+    uint_uids = [100]
+    uint_weights = [2]
+
+    out_uids, out_weights, floored_hotkeys = _apply_eligibility_floor(
+        uint_uids, uint_weights, miners, {"live_a", "live_b"}, {100}
+    )
+
+    assert floored_hotkeys == ["live_a"]
+    assert dict(zip(out_uids, out_weights)) == {100: 1, 5: 1}
+
+
 @pytest.mark.asyncio
 async def test_set_weights_floors_positive_scores_to_min_one(
     mock_subtensor_client,
@@ -1268,9 +1347,11 @@ async def test_set_weights_floors_positive_scores_to_min_one(
     ]
     miner_scores = {"burner": 1.0, "tiny": 1e-9}  # "zero" deliberately absent
 
-    # normalize=True → captured floats sum to ~1, mirroring the SDK's real output
+    # normalize=True → captured floats sum to ~1, mirroring the SDK's real output.
+    # active_hotkeys=set() pins the pre-DAH-2622 baseline: with no live hotkey the
+    # eligibility floor never fires, so a zero-score miner stays out of the vector.
     await _run_set_weights_and_capture(
-        mock_subtensor_client, miners, miner_scores, normalize=True
+        mock_subtensor_client, miners, miner_scores, normalize=True, active_hotkeys=set()
     )
 
     call = mock_subtensor_client.subtensor.set_weights.call_args
@@ -1282,3 +1363,190 @@ async def test_set_weights_floors_positive_scores_to_min_one(
     assert by_uid[2] >= 1
     assert by_uid[100] == 65535
     assert 3 not in by_uid
+
+
+@pytest.mark.asyncio
+async def test_set_weights_floors_active_hotkey_with_zero_score(
+    mock_subtensor_client,
+    create_neuron_info,
+):
+    miners = [
+        create_neuron_info(uid=100, hotkey="burner"),
+        create_neuron_info(uid=2, hotkey="earner"),
+        create_neuron_info(uid=3, hotkey="idle"),
+    ]
+    miner_scores = {"burner": 0.8, "earner": 0.2}  # "idle" scored nothing this epoch
+
+    await _run_set_weights_and_capture(
+        mock_subtensor_client, miners, miner_scores, normalize=True, active_hotkeys={"idle"}
+    )
+
+    call = mock_subtensor_client.subtensor.set_weights.call_args
+    by_uid = dict(zip(list(call.kwargs["uids"]), list(call.kwargs["weights"])))
+
+    assert by_uid[3] == 1, f"live idle miner was dropped from the vector: {by_uid}"
+    assert by_uid[100] == 65534
+
+
+@pytest.mark.asyncio
+async def test_set_weights_logs_eligibility_floor_applied(
+    mock_subtensor_client,
+    create_neuron_info,
+    caplog,
+):
+    miners = [
+        create_neuron_info(uid=100, hotkey="burner"),
+        create_neuron_info(uid=2, hotkey="earner"),
+        create_neuron_info(uid=3, hotkey="idle"),
+    ]
+
+    with caplog.at_level(logging.INFO):
+        await _run_set_weights_and_capture(
+            mock_subtensor_client,
+            miners,
+            {"burner": 0.8, "earner": 0.2},
+            normalize=True,
+            active_hotkeys={"idle"},
+        )
+
+    assert _floor_log_extras(caplog) == [{"floor_hotkeys": ["idle"], "floor_count": 1}]
+
+
+@pytest.mark.asyncio
+async def test_set_weights_logs_eligibility_floor_even_when_empty(
+    mock_subtensor_client,
+    create_neuron_info,
+    caplog,
+):
+    miners = [
+        create_neuron_info(uid=100, hotkey="burner"),
+        create_neuron_info(uid=2, hotkey="earner"),
+    ]
+
+    with caplog.at_level(logging.INFO):
+        await _run_set_weights_and_capture(
+            mock_subtensor_client,
+            miners,
+            {"burner": 0.8, "earner": 0.2},
+            normalize=True,
+            active_hotkeys=set(),
+        )
+
+    assert _floor_log_extras(caplog) == [{"floor_hotkeys": [], "floor_count": 0}]
+
+
+@pytest.mark.asyncio
+async def test_set_weights_floor_does_not_dilute_earning_miners(
+    mock_subtensor_client,
+    create_neuron_info,
+):
+    miners = [
+        create_neuron_info(uid=100, hotkey="burner"),
+        create_neuron_info(uid=2, hotkey="earner_big"),
+        create_neuron_info(uid=3, hotkey="earner_small"),
+        create_neuron_info(uid=4, hotkey="idle"),
+    ]
+    miner_scores = {"burner": 0.8, "earner_big": 0.15, "earner_small": 0.05}
+
+    await _run_set_weights_and_capture(
+        mock_subtensor_client, miners, miner_scores, normalize=True, active_hotkeys=set()
+    )
+    without_floor = dict(
+        zip(
+            list(mock_subtensor_client.subtensor.set_weights.call_args.kwargs["uids"]),
+            list(mock_subtensor_client.subtensor.set_weights.call_args.kwargs["weights"]),
+        )
+    )
+    await _run_set_weights_and_capture(
+        mock_subtensor_client, miners, miner_scores, normalize=True, active_hotkeys={"idle"}
+    )
+    with_floor = dict(
+        zip(
+            list(mock_subtensor_client.subtensor.set_weights.call_args.kwargs["uids"]),
+            list(mock_subtensor_client.subtensor.set_weights.call_args.kwargs["weights"]),
+        )
+    )
+
+    assert with_floor[2] == without_floor[2]
+    assert with_floor[3] == without_floor[3]
+    assert with_floor[4] == 1
+    assert with_floor[100] == without_floor[100] - 1
+
+
+@pytest.mark.asyncio
+async def test_set_weights_floor_leaves_normalized_scores_untouched(
+    mock_subtensor_client,
+    create_neuron_info,
+):
+    miners = [
+        create_neuron_info(uid=100, hotkey="burner"),
+        create_neuron_info(uid=2, hotkey="earner"),
+        create_neuron_info(uid=4, hotkey="idle"),
+    ]
+    miner_scores = {"burner": 0.8, "earner": 0.2}
+
+    await _run_set_weights_and_capture(
+        mock_subtensor_client, miners, miner_scores, normalize=True, active_hotkeys=set()
+    )
+    without_floor = mock_subtensor_client.redis_service.publish.call_args.args
+    await _run_set_weights_and_capture(
+        mock_subtensor_client, miners, miner_scores, normalize=True, active_hotkeys={"idle"}
+    )
+    with_floor = mock_subtensor_client.redis_service.publish.call_args.args
+
+    assert with_floor == without_floor
+
+
+@pytest.mark.asyncio
+async def test_active_hotkeys_reflects_successful_executors_only(
+    validator_with_mocks,
+    mock_settings,
+    create_job_result,
+    create_neuron_info,
+):
+    validator = validator_with_mocks
+    validator.miner_scores = {}
+    validator.active_hotkeys = {"stale_from_previous_cycle"}
+
+    miners = [
+        create_neuron_info(uid=100, hotkey="burner1"),
+        create_neuron_info(uid=2, hotkey="idle_miner"),
+        create_neuron_info(uid=3, hotkey="spot_miner"),
+        create_neuron_info(uid=4, hotkey="dead_miner"),
+    ]
+    spot_result = create_job_result(gpu_model="H100", gpu_count=1)
+    spot_result.is_spot = True
+
+    all_job_results = {
+        "idle_miner": [create_job_result(gpu_model="H100", gpu_count=1)],
+        "spot_miner": [spot_result],
+        "dead_miner": [create_job_result(score=0.0, job_score=0.0, gpu_model="A100", gpu_count=2)],
+    }
+
+    await _run_sync_with_jobs(validator, miners, all_job_results)
+
+    assert validator.active_hotkeys == {"idle_miner", "spot_miner"}
+
+
+@pytest.mark.asyncio
+async def test_sync_passes_active_hotkeys_to_set_weights(
+    validator_with_mocks,
+    mock_settings,
+    create_neuron_info,
+):
+    validator = validator_with_mocks
+    validator.miner_scores = {"live_miner": 1.0}
+    validator.active_hotkeys = {"live_miner"}
+    validator.completed_cycles_since_start = 1
+    # current_block == 100 in the fixture, so no new job cycle starts in this sync()
+    validator.last_job_run_blocks = 100
+    validator.subtensor_client.get_miners = AsyncMock(
+        return_value=[create_neuron_info(uid=2, hotkey="live_miner")]
+    )
+    validator.subtensor_client.should_set_weights = AsyncMock(return_value=True)
+    validator.subtensor_client.set_weights = AsyncMock()
+
+    await validator.sync()
+
+    call = validator.subtensor_client.set_weights.call_args
+    assert call.kwargs["active_hotkeys"] == {"live_miner"}

--- a/neurons/validators/tests/test_incentive_flow.py
+++ b/neurons/validators/tests/test_incentive_flow.py
@@ -1278,12 +1278,13 @@ def test_select_floor_candidates_live_zero_selected_burn_inactive_positive_exclu
 
     miners = [
         create_neuron_info(uid=5, hotkey="live_absent"),
-        create_neuron_info(uid=100, hotkey="live_burner"),
+        # uid 101 is a burn uid that the vector dropped: only the burn check can exclude it
+        create_neuron_info(uid=101, hotkey="live_burner_absent"),
         create_neuron_info(uid=6, hotkey="inactive"),
         create_neuron_info(uid=7, hotkey="live_present"),
     ]
     uint_uids = [100, 7]
-    active_hotkeys = {"live_absent", "live_burner", "live_present"}
+    active_hotkeys = {"live_absent", "live_burner_absent", "live_present"}
 
     candidates = _select_floor_candidates(uint_uids, miners, active_hotkeys, {100, 101})
 
@@ -1330,6 +1331,71 @@ def test_apply_eligibility_floor_stops_when_burn_exhausted(create_neuron_info):
 
     assert floored_hotkeys == ["live_a"]
     assert dict(zip(out_uids, out_weights)) == {100: 1, 5: 1}
+
+
+def test_apply_eligibility_floor_floors_several_miners_in_one_publish(create_neuron_info):
+    from clients.subtensor_client import _apply_eligibility_floor
+
+    miners = [
+        create_neuron_info(uid=100, hotkey="big_burner"),
+        create_neuron_info(uid=101, hotkey="small_burner"),
+        create_neuron_info(uid=5, hotkey="live_a"),
+        create_neuron_info(uid=6, hotkey="live_b"),
+        create_neuron_info(uid=7, hotkey="live_c"),
+    ]
+    # the donor is re-picked per candidate, so the two burn entries drain evenly
+    uint_uids = [100, 101]
+    uint_weights = [10, 9]
+
+    out_uids, out_weights, floored_hotkeys = _apply_eligibility_floor(
+        uint_uids, uint_weights, miners, {"live_a", "live_b", "live_c"}, {100, 101}
+    )
+
+    assert floored_hotkeys == ["live_a", "live_b", "live_c"]
+    assert dict(zip(out_uids, out_weights)) == {100: 8, 101: 8, 5: 1, 6: 1, 7: 1}
+    assert sum(out_weights) == sum(uint_weights)
+
+
+def test_apply_eligibility_floor_without_any_burn_entry_changes_nothing(create_neuron_info):
+    from clients.subtensor_client import _apply_eligibility_floor
+
+    miners = [
+        create_neuron_info(uid=3, hotkey="earner"),
+        create_neuron_info(uid=5, hotkey="live_absent"),
+    ]
+    uint_uids = [3]
+    uint_weights = [500]
+
+    out_uids, out_weights, floored_hotkeys = _apply_eligibility_floor(
+        uint_uids, uint_weights, miners, {"live_absent"}, {100}
+    )
+
+    assert floored_hotkeys == []
+    assert (out_uids, out_weights) == ([3], [500])
+
+
+@pytest.mark.asyncio
+async def test_set_weights_mirror_payload_carries_the_floored_entries(
+    mock_subtensor_client,
+    create_neuron_info,
+):
+    miners = [
+        create_neuron_info(uid=100, hotkey="burner"),
+        create_neuron_info(uid=2, hotkey="earner"),
+        create_neuron_info(uid=3, hotkey="idle"),
+    ]
+
+    with patch.object(mock_subtensor_client, "send_weights_to_lium", AsyncMock()) as mirror:
+        await _run_set_weights_and_capture(
+            mock_subtensor_client,
+            miners,
+            {"burner": 0.8, "earner": 0.2},
+            normalize=True,
+            active_hotkeys={"idle"},
+        )
+
+    payload = mirror.call_args.args[0]
+    assert dict(zip(payload["uids"], payload["weights"]))[3] == 1
 
 
 @pytest.mark.asyncio
@@ -1385,6 +1451,34 @@ async def test_set_weights_floors_active_hotkey_with_zero_score(
     by_uid = dict(zip(list(call.kwargs["uids"]), list(call.kwargs["weights"])))
 
     assert by_uid[3] == 1, f"live idle miner was dropped from the vector: {by_uid}"
+    assert by_uid[100] == 65534
+
+
+@pytest.mark.asyncio
+async def test_set_weights_floors_live_miner_on_a_retired_burner_uid(
+    mock_subtensor_client,
+    create_neuron_info,
+):
+    # BURNERS holds the pre-DAH-2274 slots; with the new burn logic on they receive nothing
+    # and are ordinary miner uids, so a live miner sitting there still deserves the floor.
+    miners = [
+        create_neuron_info(uid=100, hotkey="burner"),
+        create_neuron_info(uid=2, hotkey="earner"),
+        create_neuron_info(uid=1, hotkey="idle_on_retired_burner_uid"),
+    ]
+
+    await _run_set_weights_and_capture(
+        mock_subtensor_client,
+        miners,
+        {"burner": 0.8, "earner": 0.2},
+        normalize=True,
+        active_hotkeys={"idle_on_retired_burner_uid"},
+    )
+
+    call = mock_subtensor_client.subtensor.set_weights.call_args
+    by_uid = dict(zip(list(call.kwargs["uids"]), list(call.kwargs["weights"])))
+
+    assert by_uid[1] == 1, f"live miner on a retired burner uid was dropped: {by_uid}"
     assert by_uid[100] == 65534
 
 


### PR DESCRIPTION
## Problem

A miner whose machine is online and passes validation can still compute to an incentive of exactly `0` — for
example an idle machine whose GPU model is not in the unrented program. The SDK's `process_weights_for_netuid`
drops every uid whose weight is exactly zero before our own `_convert_weights_with_positive_floor` ever sees
the vector, so that hotkey is simply absent from what we publish. The chain then deregisters the UID with the
lowest emission (`get_neuron_to_prune`: `(emission, registration block, uid)` ascending), which means the
longer a miner has honestly held a UID, the sooner it is pruned once it drops to zero.

Measured on 2026-08-12 (block 8825772): 54 miner hotkeys have active executors, 48 earn, **6 sit at exactly
zero** — queue positions 49/125/160/189/191/193 among 193 zero-emission non-immune UIDs.

## Change

After quantisation, every hotkey that had at least one live executor in the validator's last completed cycle
and is missing from the u16 vector gets **one u16 unit**, taken from the largest burn entry:

- `_select_floor_candidates` / `_apply_eligibility_floor` / `_largest_burn_index` in `subtensor_client.py` —
  pure functions that build new lists, they never mutate their arguments;
- `Validator.active_hotkeys` — the hotkeys with a successful `JobResult` last cycle, overwritten every cycle,
  never persisted, passed into `set_weights`;
- an unconditional `[set_weights] eligibility floor applied` log line carrying `floor_hotkeys` and
  `floor_count`, so every published vector says who got the minimum from us.

The transfer is integer and post-quantisation on purpose: `_convert_weights_with_positive_floor` upscales by
`round(w / max_w * 65535)`, so deducting from burn *before* quantisation would move the anchor and silently
rewrite every other miner's u16 value. Here the mass is conserved exactly — earning miners' entries are
untouched integers.

Nothing upstream moves: `miner_scores`, `cycle_scores` and the `NORMALIZED_SCORE_CHANNEL` publish keep showing
the honest zero. Only the vector that goes on chain and its `send_weights_to_lium` mirror carry the floor.

Cost: one floored miner receives 1/65535 of the vector ≈ $0.041/h (measured from four UIDs currently sitting at
u16 = 1), so today's six candidates cost ≈ $178/month — drawn from burn, which currently takes ~72 % of the
miner pool.

## Testing

- `pdm run pytest tests/test_incentive_flow.py tests/test_rental_price_incentive_flow.py tests/prod_snapshot/`
  → 97 passed, 4 skipped (87 before this change: the 10 new tests, nothing else moved).
- Full validator suite: 1529 passed; the 3 failures in `tests/test_sshd_bootstrap_script.py` reproduce on
  `origin/main` and are unrelated.
- The floor was temporarily neutered to confirm the new tests really catch its absence:
  `test_set_weights_floors_active_hotkey_with_zero_score` and
  `test_set_weights_floor_does_not_dilute_earning_miners` fail without it.
- No new `JobResult` field, so the prod-snapshot baselines are untouched.

Notion: DAH-2622.
