### PR TITLE
DAH-2674 + DAH-2678 + DAH-2679 (+ DAH-2675 partial) - Rental scoring on two-party proof, scoring-cycle net, renter CVM relaunch, log-only attest probe

### DIFF
--- a/neurons/executor/cvmd/src/cvmd/config.py
+++ b/neurons/executor/cvmd/src/cvmd/config.py
@@ -109,6 +109,13 @@ class LaunchConfig:
     ssh_guest_port: int | None = None
     pin_numa: bool = False
     hugepages: bool = False
+    # DAH-2679, opt-in: when reconciliation finds a RENTER CVM whose supervisor is gone but
+    # whose directory (disk included) survived — the shape a host reboot leaves — re-spawn the
+    # supervisor over the same directory instead of failing the node. Renter only: a validation
+    # CVM's disk is deliberately not durable state (it must measure identically on every fresh
+    # launch), while a renter's disk IS the customer's data. Default off so a fleet that has
+    # not decided its durability posture keeps today's fail-loudly behavior exactly.
+    relaunch_renter: bool = False
 
     # Required for a launch. `gpus` is deliberately absent: a CVM with no GPUs is a legal
     # configuration, so an empty list cannot be distinguished from an unset one and must not
@@ -266,6 +273,7 @@ def _load_launch(table: dict, state_dir: Path) -> LaunchConfig:
         ssh_guest_port=_as_optional_int(_get(table, "cvm_ssh_guest_port"), "cvm_ssh_guest_port"),
         pin_numa=_as_bool(_get(table, "cvm_pin_numa"), "cvm_pin_numa"),
         hugepages=_as_bool(_get(table, "cvm_hugepages"), "cvm_hugepages"),
+        relaunch_renter=_as_bool(_get(table, "cvm_relaunch_renter"), "cvm_relaunch_renter"),
     )
     # Parsed with the launch path's own parser, not re-described here. Without this a mapping
     # like "tcp:0.0.0.0:0:22" is well-formed TOML, so the daemon starts looking configured and

--- a/neurons/executor/cvmd/src/cvmd/cvm/instance.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/instance.py
@@ -91,6 +91,12 @@ def now_iso() -> str:
 def _decode(raw) -> Instance | None:
     if not isinstance(raw, dict) or raw.get("version") != SCHEMA_VERSION:
         return None
+    # Tolerant like the other optional fields: this counter exists for bookkeeping, and a
+    # corrupted value must not make the whole record read as absent — that would fail a node
+    # holding a live CVM over a field nothing critical depends on.
+    attempts = raw.get("relaunch_attempts")
+    if not isinstance(attempts, int) or attempts < 0:
+        attempts = 0
     try:
         ports = [PortReport(**port) for port in raw.get("ports", [])]
         return Instance(
@@ -106,7 +112,7 @@ def _decode(raw) -> Instance | None:
             ports=ports,
             ssh_fingerprint=raw.get("ssh_fingerprint"),
             rental_id=raw.get("rental_id"),
-            relaunch_attempts=int(raw.get("relaunch_attempts") or 0),
+            relaunch_attempts=attempts,
         )
     except (KeyError, TypeError, ValueError):
         return None

--- a/neurons/executor/cvmd/src/cvmd/cvm/instance.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/instance.py
@@ -49,6 +49,12 @@ class Instance:
     # what a validation CVM has and what a record written before this task has — so an older
     # instance.json still decodes rather than reading as corrupt and failing the node.
     rental_id: str | None = None
+    # DAH-2679: how many times reconciliation has re-spawned this CVM's supervisor over the
+    # same directory (host reboot, QEMU exit). Cumulative for the instance's whole life, never
+    # reset — reconciliation has no "the guest is healthy again" signal it could reset on, and
+    # a cap on the total is what stops a dying guest from crash-looping through every cvmd
+    # restart. Defaults to 0 so an older instance.json still decodes.
+    relaunch_attempts: int = 0
 
     def to_json(self) -> dict:
         return {"version": SCHEMA_VERSION, **asdict(self)}
@@ -71,6 +77,10 @@ class Instance:
         # shipped and its tests pin.
         if self.rental_id is not None:
             report["rental_id"] = self.rental_id
+        # Same reasoning: only present once a relaunch has actually happened, so every report
+        # for a CVM that booted once and stayed up keeps its pinned shape.
+        if self.relaunch_attempts:
+            report["relaunch_attempts"] = self.relaunch_attempts
         return report
 
 
@@ -96,6 +106,7 @@ def _decode(raw) -> Instance | None:
             ports=ports,
             ssh_fingerprint=raw.get("ssh_fingerprint"),
             rental_id=raw.get("rental_id"),
+            relaunch_attempts=int(raw.get("relaunch_attempts") or 0),
         )
     except (KeyError, TypeError, ValueError):
         return None

--- a/neurons/executor/cvmd/src/cvmd/cvm/manager.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/manager.py
@@ -41,6 +41,11 @@ RUNNING_STATE = {
 
 READINESS_POLL_SECONDS = 5
 
+# DAH-2679: how many supervisor re-spawns one renter CVM gets over its whole life. The count
+# is cumulative in the instance record and never reset (see `Instance.relaunch_attempts`), so
+# this bounds a guest that keeps dying, not a host that rebooted once.
+RELAUNCH_MAX_ATTEMPTS = 3
+
 # Probing localhost, not the mapping's bind address: 0.0.0.0 is not a destination, and a
 # forward bound to a public address is still reachable from the host it runs on.
 PROBE_HOST = "127.0.0.1"
@@ -155,6 +160,9 @@ class CvmManager:
                         f"CVM {instance.instance_id} has unknown kind {instance.kind!r}"
                     )
                 return self._settle(state)
+            relaunched = self._try_relaunch(instance, vm_dir)
+            if relaunched is not None:
+                return relaunched
             return self._fail(
                 f"the supervisor for CVM {instance.instance_id} (pid {instance.supervisor_pid}) "
                 f"is gone but its directory {vm_dir} remains"
@@ -183,6 +191,81 @@ class CvmManager:
     def _stray_directories(self) -> list[Path]:
         run_dir = self._config.run_dir
         return supervisor.vm_directories(run_dir) if run_dir else []
+
+    def _try_relaunch(self, instance: Instance, vm_dir: Path) -> NodeState | None:
+        """Boot a renter CVM's surviving directory again instead of failing the node (DAH-2679).
+
+        The shape this answers is the one a host reboot leaves: the instance record and the VM
+        directory — `hda.img` included — survived on disk, and the supervisor did not. Today
+        that is a hard FAILED and the renter's data is stranded on a disk nothing will ever
+        boot. Re-spawning the supervisor over the SAME directory is safe to attempt precisely
+        because of what protects that disk: it is encrypted, and its key is released by the key
+        provider only to a guest measuring as the same triple that created it. So an unmodified
+        directory boots back into the renter's data, and a tampered one fails to unlock rather
+        than booting into something else — which is why no local re-measurement happens here.
+
+        Renter CVMs only. A validation CVM's disk is deliberately not durable state (it must
+        measure identically on every fresh launch, and the validator relaunches it itself), so
+        for every non-renter shape this method declines and the caller fails the node exactly
+        as before.
+
+        No readiness probe, on purpose. Reconciliation runs at daemon startup and must not hold
+        for the minutes a guest takes to boot; a live supervisor is the same evidence the adopt
+        branch accepts for a CVM cvmd did not start. A guest that dies while booting leaves the
+        supervisor gone again, and the attempt cap turns that into FAILED instead of a loop.
+        """
+        if not self._config.relaunch_renter or instance.kind != KIND_RENTER:
+            return None
+        if not (vm_dir / supervisor.DISK_IMAGE).exists():
+            # Whatever removed the disk, there is nothing left to boot — the fail branch's
+            # message about a directory with no supervisor is the honest answer.
+            return None
+        if instance.relaunch_attempts >= RELAUNCH_MAX_ATTEMPTS:
+            logger.error(
+                "not relaunching CVM %s: %d relaunch attempts already spent",
+                instance.instance_id,
+                instance.relaunch_attempts,
+            )
+            return None
+        if supervisor.running_cvms():
+            # Some other TDX guest holds this host's GPUs — launching over it would double-book
+            # them. The stray-guest handling in the caller is the right refusal.
+            return None
+        if self._config.missing():
+            return None
+
+        # Spent before the spawn, not after: a spawn that dies between starting a process and
+        # the pid file would otherwise retry unbounded, and an attempt that consumed host
+        # resources is an attempt whether or not it produced a supervisor.
+        attempt = instance.relaunch_attempts + 1
+        instance = self._instances.update(relaunch_attempts=attempt)
+        try:
+            pid = supervisor.spawn(
+                scripts_dir=self._config.dstack_scripts_dir,
+                vm_dir=vm_dir,
+                kp_port=self._config.key_provider_port,
+            )
+        except supervisor.SupervisorError as exc:
+            logger.error(
+                "relaunch %d/%d of CVM %s failed: %s",
+                attempt,
+                RELAUNCH_MAX_ATTEMPTS,
+                instance.instance_id,
+                exc,
+            )
+            return None
+
+        self._instances.update(supervisor_pid=pid)
+        logger.info(
+            "relaunched the renter CVM %s over its surviving directory %s (attempt %d/%d, "
+            "supervisor pid %d)",
+            instance.instance_id,
+            vm_dir,
+            attempt,
+            RELAUNCH_MAX_ATTEMPTS,
+            pid,
+        )
+        return self._settle(NodeState.RENTER_RUNNING)
 
     def _sweep_staging(self) -> None:
         """Remove every renter staging directory left on this host.

--- a/neurons/executor/cvmd/src/cvmd/cvm/manager.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/manager.py
@@ -248,11 +248,6 @@ class CvmManager:
         attempt = instance.relaunch_attempts + 1
         self._instances.update(relaunch_attempts=attempt)
 
-        # The surviving directory still holds the PREVIOUS life's pid file, and `spawn`
-        # returns the first pid it can read from that file — the fresh launch paths never
-        # see this because their directory is brand new. Without the unlink, the record
-        # would name a dead (or recycled) pid while the new guest boots.
-        (vm_dir / supervisor.PID_FILE).unlink(missing_ok=True)
         try:
             pid = supervisor.spawn(
                 scripts_dir=self._config.dstack_scripts_dir,

--- a/neurons/executor/cvmd/src/cvmd/cvm/manager.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/manager.py
@@ -216,6 +216,12 @@ class CvmManager:
         """
         if not self._config.relaunch_renter or instance.kind != KIND_RENTER:
             return None
+        if self._store.state is not NodeState.RENTER_RUNNING:
+            # Only a rental that was LIVE relaunches. An interrupted teardown persists
+            # TEARDOWN or SWITCHING before it kills anything, so this is the guard that
+            # keeps a cvmd restart from resurrecting a CVM the platform already destroyed —
+            # over hardware `destroy` was in the middle of verifiably releasing.
+            return None
         if not (vm_dir / supervisor.DISK_IMAGE).exists():
             # Whatever removed the disk, there is nothing left to boot — the fail branch's
             # message about a directory with no supervisor is the honest answer.
@@ -227,18 +233,26 @@ class CvmManager:
                 instance.relaunch_attempts,
             )
             return None
+        if self._config.missing():
+            return None
         if supervisor.running_cvms():
             # Some other TDX guest holds this host's GPUs — launching over it would double-book
-            # them. The stray-guest handling in the caller is the right refusal.
-            return None
-        if self._config.missing():
+            # them. The stray-guest handling in the caller is the right refusal. Checked last:
+            # it is the one guard that walks /proc, and the in-memory refusals above decide
+            # most declines for free.
             return None
 
         # Spent before the spawn, not after: a spawn that dies between starting a process and
         # the pid file would otherwise retry unbounded, and an attempt that consumed host
         # resources is an attempt whether or not it produced a supervisor.
         attempt = instance.relaunch_attempts + 1
-        instance = self._instances.update(relaunch_attempts=attempt)
+        self._instances.update(relaunch_attempts=attempt)
+
+        # The surviving directory still holds the PREVIOUS life's pid file, and `spawn`
+        # returns the first pid it can read from that file — the fresh launch paths never
+        # see this because their directory is brand new. Without the unlink, the record
+        # would name a dead (or recycled) pid while the new guest boots.
+        (vm_dir / supervisor.PID_FILE).unlink(missing_ok=True)
         try:
             pid = supervisor.spawn(
                 scripts_dir=self._config.dstack_scripts_dir,

--- a/neurons/executor/cvmd/src/cvmd/cvm/supervisor.py
+++ b/neurons/executor/cvmd/src/cvmd/cvm/supervisor.py
@@ -156,6 +156,15 @@ def spawn(*, scripts_dir: Path, vm_dir: Path, kp_port: int) -> int:
     reaps the intermediate; the real pid comes from the file the grandchild writes once it has
     detached.
     """
+    # A surviving directory (a renter relaunch after a host reboot) still holds the previous
+    # life's pid file, and `_await_pid_file` returns the first pid it can parse — so the stale
+    # file must be gone before the child that writes the new one exists. Fresh directories
+    # make this a no-op, which is why it lives here and not at any single call site.
+    try:
+        (vm_dir / PID_FILE).unlink(missing_ok=True)
+    except OSError as exc:
+        raise SupervisorError(f"cannot remove the stale pid file in {vm_dir}: {exc}") from exc
+
     log_path = console_log_path(vm_dir)
     try:
         log_handle = log_path.open("ab", buffering=0)

--- a/neurons/executor/cvmd/tests/test_relaunch.py
+++ b/neurons/executor/cvmd/tests/test_relaunch.py
@@ -1,0 +1,248 @@
+"""DAH-2679: a renter CVM's surviving directory is booted again, not stranded.
+
+The shape under test is the one a host reboot leaves behind: the instance record and the VM
+directory — disk included — are on disk, and the supervisor process is not. Before this task
+that was a hard FAILED with the renter's data stranded on a disk nothing would ever boot.
+
+The claims pinned here:
+
+  * with `cvm_relaunch_renter` on, reconciliation re-spawns the supervisor over the SAME
+    directory and lands back on RENTER_RUNNING;
+  * the flag defaults OFF, and off keeps the fail-loudly behavior byte for byte;
+  * only a RENTER CVM relaunches — a validation CVM's disk is deliberately not durable state;
+  * the attempt count is spent even when the spawn fails, and the cap turns a dying guest
+    into FAILED instead of a crash loop through every cvmd restart;
+  * a missing disk, a stray TDX guest, or an unconfigured host all decline and fail as before.
+
+No readiness is asserted because none is probed: a live supervisor is the same evidence the
+adopt path accepts, and whether the sealing key actually unlocks the same disk is the
+hardware half of DAH-2679 (a TDX host, not this suite).
+"""
+
+from pathlib import Path
+
+import pytest
+from cvmd.config import LaunchConfig
+from cvmd.cvm import supervisor
+from cvmd.cvm.instance import Instance, InstanceStore
+from cvmd.cvm.manager import RELAUNCH_MAX_ATTEMPTS, CvmManager
+from cvmd.cvm.switching import SwitchStore
+from cvmd.state.machine import NodeState
+from cvmd.state.store import StateStore
+
+STALE_PID = 999_999_999
+NEW_PID = 424242
+
+
+def seed_cvm(
+    state_dir: Path,
+    launch_config: LaunchConfig,
+    *,
+    kind: str = "renter",
+    attempts: int = 0,
+    with_disk: bool = True,
+) -> Path:
+    """Persist what a host reboot leaves: a record, a directory, a disk — and no process."""
+    vm_dir = launch_config.run_dir / "cvm-under-test"
+    vm_dir.mkdir(parents=True, exist_ok=True)
+    if with_disk:
+        (vm_dir / supervisor.DISK_IMAGE).write_bytes(b"")
+
+    InstanceStore(state_dir).set(
+        Instance(
+            instance_id="cvm-under-test",
+            kind=kind,
+            artifact_id="base-test",
+            vm_dir=str(vm_dir),
+            supervisor_pid=STALE_PID,
+            created_at="2026-08-13T00:00:00+00:00",
+            qemu="10.1.0",
+            os_image_hash="a" * 64,
+            compose_hash="b" * 64,
+            rental_id="rental-1" if kind == "renter" else None,
+            relaunch_attempts=attempts,
+        )
+    )
+    store = StateStore(state_dir)
+    store.transition(NodeState.LAUNCHING)
+    store.transition(NodeState.RENTER_RUNNING if kind == "renter" else NodeState.VALIDATION_RUNNING)
+    return vm_dir
+
+
+def make_manager(state_dir: Path, config: LaunchConfig) -> CvmManager:
+    # catalog_store=None on purpose: reconciliation reads the host, never the catalog, and a
+    # relaunch that suddenly needed one would be a regression this argument turns into a crash.
+    return CvmManager(
+        config=config,
+        catalog_store=None,
+        store=StateStore(state_dir),
+        instances=InstanceStore(state_dir),
+        switches=SwitchStore(state_dir),
+    )
+
+
+@pytest.fixture
+def relaunch_config(launch_config: LaunchConfig) -> LaunchConfig:
+    from dataclasses import replace
+
+    return replace(launch_config, relaunch_renter=True)
+
+
+@pytest.fixture
+def dead_supervisor(monkeypatch):
+    """The recorded pid is gone, and nothing else holds a TDX guest on this host."""
+    monkeypatch.setattr(supervisor, "is_supervisor", lambda pid, vm_dir: False)
+    monkeypatch.setattr(supervisor, "running_cvms", list)
+
+
+@pytest.fixture
+def respawn(monkeypatch, dead_supervisor) -> list[dict]:
+    """Record the re-spawn instead of starting QEMU."""
+    calls: list[dict] = []
+
+    def fake_spawn(*, scripts_dir, vm_dir, kp_port):
+        calls.append({"scripts_dir": scripts_dir, "vm_dir": vm_dir, "kp_port": kp_port})
+        return NEW_PID
+
+    monkeypatch.setattr(supervisor, "spawn", fake_spawn)
+    return calls
+
+
+class TestTheRelaunch:
+    def test_a_rebooted_renter_cvm_comes_back_over_its_own_directory(
+        self, state_dir, relaunch_config, respawn
+    ):
+        vm_dir = seed_cvm(state_dir, relaunch_config)
+        manager = make_manager(state_dir, relaunch_config)
+
+        assert manager.reconcile() is NodeState.RENTER_RUNNING
+        assert respawn == [
+            {
+                "scripts_dir": relaunch_config.dstack_scripts_dir,
+                "vm_dir": vm_dir,
+                "kp_port": relaunch_config.key_provider_port,
+            }
+        ], "the SAME directory must be booted — a fresh one would not hold the renter's disk"
+        assert manager._store.document.last_error is None
+
+    def test_the_record_carries_the_new_pid_and_the_spent_attempt(
+        self, state_dir, relaunch_config, respawn
+    ):
+        seed_cvm(state_dir, relaunch_config)
+        manager = make_manager(state_dir, relaunch_config)
+        manager.reconcile()
+
+        instance = manager._instances.current
+        assert instance.supervisor_pid == NEW_PID
+        assert instance.relaunch_attempts == 1
+        assert instance.report()["relaunch_attempts"] == 1
+
+    def test_a_report_that_never_relaunched_keeps_its_pinned_shape(
+        self, state_dir, relaunch_config
+    ):
+        seed_cvm(state_dir, relaunch_config)
+        instance = InstanceStore(state_dir).current
+        assert "relaunch_attempts" not in instance.report()
+
+
+class TestWhatDeclines:
+    def test_the_flag_defaults_off_and_off_fails_exactly_as_before(
+        self, state_dir, launch_config, respawn
+    ):
+        assert LaunchConfig().relaunch_renter is False
+        seed_cvm(state_dir, launch_config)
+        manager = make_manager(state_dir, launch_config)
+
+        assert manager.reconcile() is NodeState.FAILED
+        assert "is gone but its directory" in manager._store.document.last_error
+        assert respawn == []
+
+    def test_a_validation_cvm_never_relaunches(self, state_dir, relaunch_config, respawn):
+        seed_cvm(state_dir, relaunch_config, kind="validation")
+        manager = make_manager(state_dir, relaunch_config)
+
+        assert manager.reconcile() is NodeState.FAILED
+        assert respawn == []
+
+    def test_a_directory_whose_disk_is_gone_has_nothing_to_boot(
+        self, state_dir, relaunch_config, respawn, monkeypatch
+    ):
+        vm_dir = seed_cvm(state_dir, relaunch_config, with_disk=False)
+        # Keep something in the directory so it "remains" for the failure message's purposes.
+        (vm_dir / "console.log").write_text("old boot\n")
+        manager = make_manager(state_dir, relaunch_config)
+
+        assert manager.reconcile() is NodeState.FAILED
+        assert respawn == []
+
+    def test_a_stray_tdx_guest_blocks_the_relaunch(
+        self, state_dir, relaunch_config, respawn, monkeypatch
+    ):
+        """GPU passthrough is exclusive — booting over a foreign guest double-books it."""
+        seed_cvm(state_dir, relaunch_config)
+        monkeypatch.setattr(
+            supervisor, "running_cvms", lambda: [(4242, "/opt/qemu-dstack/bin/qemu")]
+        )
+        manager = make_manager(state_dir, relaunch_config)
+
+        assert manager.reconcile() is NodeState.FAILED
+        assert respawn == []
+
+
+class TestTheAttemptCap:
+    def test_a_failed_spawn_spends_the_attempt_and_fails_the_node(
+        self, state_dir, relaunch_config, dead_supervisor, monkeypatch
+    ):
+        seed_cvm(state_dir, relaunch_config)
+
+        def refuse(**kwargs):
+            raise supervisor.SupervisorError("no QEMU on this host")
+
+        monkeypatch.setattr(supervisor, "spawn", refuse)
+        manager = make_manager(state_dir, relaunch_config)
+
+        assert manager.reconcile() is NodeState.FAILED
+        assert manager._instances.current.relaunch_attempts == 1, (
+            "an attempt that consumed host resources is spent whether or not it produced "
+            "a supervisor — otherwise a spawn dying mid-way retries unbounded"
+        )
+
+    def test_past_the_cap_the_node_fails_instead_of_looping(
+        self, state_dir, relaunch_config, respawn
+    ):
+        seed_cvm(state_dir, relaunch_config, attempts=RELAUNCH_MAX_ATTEMPTS)
+        manager = make_manager(state_dir, relaunch_config)
+
+        assert manager.reconcile() is NodeState.FAILED
+        assert respawn == []
+
+
+class TestOldRecordsStillDecode:
+    def test_an_instance_json_written_before_this_task_reads_as_zero_attempts(
+        self, state_dir, relaunch_config
+    ):
+        """The field is new; the fleet's records are not. An old record must not read as
+        corrupt — that would fail the node for a schema change."""
+        import json
+
+        vm_dir = relaunch_config.run_dir / "old-cvm"
+        record = {
+            "version": 1,
+            "instance_id": "old-cvm",
+            "kind": "renter",
+            "artifact_id": "base-test",
+            "vm_dir": str(vm_dir),
+            "supervisor_pid": STALE_PID,
+            "created_at": "2026-08-01T00:00:00+00:00",
+            "qemu": "10.1.0",
+            "os_image_hash": "a" * 64,
+            "compose_hash": "b" * 64,
+            "ports": [],
+            "ssh_fingerprint": None,
+            "rental_id": "rental-0",
+        }
+        (state_dir / "instance.json").write_text(json.dumps(record))
+
+        loaded = InstanceStore(state_dir).current
+        assert loaded is not None
+        assert loaded.relaunch_attempts == 0

--- a/neurons/executor/cvmd/tests/test_relaunch.py
+++ b/neurons/executor/cvmd/tests/test_relaunch.py
@@ -16,9 +16,11 @@ The claims pinned here:
 
 No readiness is asserted because none is probed: a live supervisor is the same evidence the
 adopt path accepts, and whether the sealing key actually unlocks the same disk is the
-hardware half of DAH-2679 (a TDX host, not this suite).
+hardware half of DAH-2679 (a TDX host, not this suite). The stale pid file a surviving
+directory still holds is `spawn`'s own concern, pinned in test_supervisor.py.
 """
 
+import json
 from pathlib import Path
 
 import pytest
@@ -31,7 +33,7 @@ from cvmd.state.machine import NodeState
 from cvmd.state.store import StateStore
 
 STALE_PID = 999_999_999
-NEW_PID = 424242
+NEW_PID = 424242  # the pid conftest's `spawned` fixture reports for every fake spawn
 
 
 def seed_cvm(
@@ -95,35 +97,15 @@ def relaunch_config(launch_config: LaunchConfig) -> LaunchConfig:
     return replace(launch_config, relaunch_renter=True)
 
 
-@pytest.fixture
-def dead_supervisor(monkeypatch):
-    """The recorded pid is gone, and nothing else holds a TDX guest on this host."""
-    monkeypatch.setattr(supervisor, "is_supervisor", lambda pid, vm_dir: False)
-    monkeypatch.setattr(supervisor, "running_cvms", list)
-
-
-@pytest.fixture
-def respawn(monkeypatch, dead_supervisor) -> list[dict]:
-    """Record the re-spawn instead of starting QEMU."""
-    calls: list[dict] = []
-
-    def fake_spawn(*, scripts_dir, vm_dir, kp_port):
-        calls.append({"scripts_dir": scripts_dir, "vm_dir": vm_dir, "kp_port": kp_port})
-        return NEW_PID
-
-    monkeypatch.setattr(supervisor, "spawn", fake_spawn)
-    return calls
-
-
 class TestTheRelaunch:
     def test_a_rebooted_renter_cvm_comes_back_over_its_own_directory(
-        self, state_dir, relaunch_config, respawn
+        self, state_dir, relaunch_config, spawned
     ):
         vm_dir = seed_cvm(state_dir, relaunch_config)
         manager = make_manager(state_dir, relaunch_config)
 
         assert manager.reconcile() is NodeState.RENTER_RUNNING
-        assert respawn == [
+        assert spawned == [
             {
                 "scripts_dir": relaunch_config.dstack_scripts_dir,
                 "vm_dir": vm_dir,
@@ -133,7 +115,7 @@ class TestTheRelaunch:
         assert manager._store.document.last_error is None
 
     def test_the_record_carries_the_new_pid_and_the_spent_attempt(
-        self, state_dir, relaunch_config, respawn
+        self, state_dir, relaunch_config, spawned
     ):
         seed_cvm(state_dir, relaunch_config)
         manager = make_manager(state_dir, relaunch_config)
@@ -151,31 +133,10 @@ class TestTheRelaunch:
         instance = InstanceStore(state_dir).current
         assert "relaunch_attempts" not in instance.report()
 
-    def test_the_previous_lifes_pid_file_is_removed_before_the_spawn(
-        self, state_dir, relaunch_config, dead_supervisor, monkeypatch
-    ):
-        """`spawn` returns the first pid it can read from `supervisor.pid`, and the surviving
-        directory still holds the OLD life's file — without the unlink, the record would name
-        a dead (or recycled) pid while the new guest boots."""
-        vm_dir = seed_cvm(state_dir, relaunch_config)
-        (vm_dir / "supervisor.pid").write_text(f"{STALE_PID}\n")
-        seen: list[bool] = []
-
-        def fake_spawn(*, scripts_dir, vm_dir, kp_port):
-            seen.append((vm_dir / "supervisor.pid").exists())
-            return NEW_PID
-
-        monkeypatch.setattr(supervisor, "spawn", fake_spawn)
-        manager = make_manager(state_dir, relaunch_config)
-
-        assert manager.reconcile() is NodeState.RENTER_RUNNING
-        assert seen == [False], "the stale pid file must be gone before the supervisor starts"
-        assert manager._instances.current.supervisor_pid == NEW_PID
-
 
 class TestWhatDeclines:
     def test_the_flag_defaults_off_and_off_fails_exactly_as_before(
-        self, state_dir, launch_config, respawn
+        self, state_dir, launch_config, spawned
     ):
         assert LaunchConfig().relaunch_renter is False
         seed_cvm(state_dir, launch_config)
@@ -183,17 +144,17 @@ class TestWhatDeclines:
 
         assert manager.reconcile() is NodeState.FAILED
         assert "is gone but its directory" in manager._store.document.last_error
-        assert respawn == []
+        assert spawned == []
 
-    def test_a_validation_cvm_never_relaunches(self, state_dir, relaunch_config, respawn):
+    def test_a_validation_cvm_never_relaunches(self, state_dir, relaunch_config, spawned):
         seed_cvm(state_dir, relaunch_config, kind="validation")
         manager = make_manager(state_dir, relaunch_config)
 
         assert manager.reconcile() is NodeState.FAILED
-        assert respawn == []
+        assert spawned == []
 
     def test_an_interrupted_teardown_is_never_resurrected(
-        self, state_dir, relaunch_config, respawn
+        self, state_dir, relaunch_config, spawned
     ):
         """`destroy` persists TEARDOWN before it kills anything. A crash mid-teardown must
         stay dead: relaunching it would boot a rental the platform already destroyed, over
@@ -202,10 +163,10 @@ class TestWhatDeclines:
         manager = make_manager(state_dir, relaunch_config)
 
         assert manager.reconcile() is NodeState.FAILED
-        assert respawn == []
+        assert spawned == []
 
     def test_a_directory_whose_disk_is_gone_has_nothing_to_boot(
-        self, state_dir, relaunch_config, respawn, monkeypatch
+        self, state_dir, relaunch_config, spawned
     ):
         vm_dir = seed_cvm(state_dir, relaunch_config, with_disk=False)
         # Keep something in the directory so it "remains" for the failure message's purposes.
@@ -213,10 +174,10 @@ class TestWhatDeclines:
         manager = make_manager(state_dir, relaunch_config)
 
         assert manager.reconcile() is NodeState.FAILED
-        assert respawn == []
+        assert spawned == []
 
     def test_a_stray_tdx_guest_blocks_the_relaunch(
-        self, state_dir, relaunch_config, respawn, monkeypatch
+        self, state_dir, relaunch_config, spawned, monkeypatch
     ):
         """GPU passthrough is exclusive — booting over a foreign guest double-books it."""
         seed_cvm(state_dir, relaunch_config)
@@ -226,12 +187,12 @@ class TestWhatDeclines:
         manager = make_manager(state_dir, relaunch_config)
 
         assert manager.reconcile() is NodeState.FAILED
-        assert respawn == []
+        assert spawned == []
 
 
 class TestTheAttemptCap:
     def test_a_failed_spawn_spends_the_attempt_and_fails_the_node(
-        self, state_dir, relaunch_config, dead_supervisor, monkeypatch
+        self, state_dir, relaunch_config, spawned, monkeypatch
     ):
         seed_cvm(state_dir, relaunch_config)
 
@@ -248,13 +209,13 @@ class TestTheAttemptCap:
         )
 
     def test_past_the_cap_the_node_fails_instead_of_looping(
-        self, state_dir, relaunch_config, respawn
+        self, state_dir, relaunch_config, spawned
     ):
         seed_cvm(state_dir, relaunch_config, attempts=RELAUNCH_MAX_ATTEMPTS)
         manager = make_manager(state_dir, relaunch_config)
 
         assert manager.reconcile() is NodeState.FAILED
-        assert respawn == []
+        assert spawned == []
 
 
 class TestOldRecordsStillDecode:
@@ -263,8 +224,6 @@ class TestOldRecordsStillDecode:
     ):
         """The field is new; the fleet's records are not. An old record must not read as
         corrupt — that would fail the node for a schema change."""
-        import json
-
         vm_dir = relaunch_config.run_dir / "old-cvm"
         record = {
             "version": 1,

--- a/neurons/executor/cvmd/tests/test_relaunch.py
+++ b/neurons/executor/cvmd/tests/test_relaunch.py
@@ -41,8 +41,13 @@ def seed_cvm(
     kind: str = "renter",
     attempts: int = 0,
     with_disk: bool = True,
+    torn_down: bool = False,
 ) -> Path:
-    """Persist what a host reboot leaves: a record, a directory, a disk — and no process."""
+    """Persist what a host reboot leaves: a record, a directory, a disk — and no process.
+
+    `torn_down=True` seeds the interrupted-teardown shape instead: `destroy` persists
+    TEARDOWN before it kills anything, so that is the state a crash mid-teardown leaves.
+    """
     vm_dir = launch_config.run_dir / "cvm-under-test"
     vm_dir.mkdir(parents=True, exist_ok=True)
     if with_disk:
@@ -66,6 +71,8 @@ def seed_cvm(
     store = StateStore(state_dir)
     store.transition(NodeState.LAUNCHING)
     store.transition(NodeState.RENTER_RUNNING if kind == "renter" else NodeState.VALIDATION_RUNNING)
+    if torn_down:
+        store.transition(NodeState.TEARDOWN)
     return vm_dir
 
 
@@ -144,6 +151,27 @@ class TestTheRelaunch:
         instance = InstanceStore(state_dir).current
         assert "relaunch_attempts" not in instance.report()
 
+    def test_the_previous_lifes_pid_file_is_removed_before_the_spawn(
+        self, state_dir, relaunch_config, dead_supervisor, monkeypatch
+    ):
+        """`spawn` returns the first pid it can read from `supervisor.pid`, and the surviving
+        directory still holds the OLD life's file — without the unlink, the record would name
+        a dead (or recycled) pid while the new guest boots."""
+        vm_dir = seed_cvm(state_dir, relaunch_config)
+        (vm_dir / "supervisor.pid").write_text(f"{STALE_PID}\n")
+        seen: list[bool] = []
+
+        def fake_spawn(*, scripts_dir, vm_dir, kp_port):
+            seen.append((vm_dir / "supervisor.pid").exists())
+            return NEW_PID
+
+        monkeypatch.setattr(supervisor, "spawn", fake_spawn)
+        manager = make_manager(state_dir, relaunch_config)
+
+        assert manager.reconcile() is NodeState.RENTER_RUNNING
+        assert seen == [False], "the stale pid file must be gone before the supervisor starts"
+        assert manager._instances.current.supervisor_pid == NEW_PID
+
 
 class TestWhatDeclines:
     def test_the_flag_defaults_off_and_off_fails_exactly_as_before(
@@ -159,6 +187,18 @@ class TestWhatDeclines:
 
     def test_a_validation_cvm_never_relaunches(self, state_dir, relaunch_config, respawn):
         seed_cvm(state_dir, relaunch_config, kind="validation")
+        manager = make_manager(state_dir, relaunch_config)
+
+        assert manager.reconcile() is NodeState.FAILED
+        assert respawn == []
+
+    def test_an_interrupted_teardown_is_never_resurrected(
+        self, state_dir, relaunch_config, respawn
+    ):
+        """`destroy` persists TEARDOWN before it kills anything. A crash mid-teardown must
+        stay dead: relaunching it would boot a rental the platform already destroyed, over
+        hardware the teardown was in the middle of verifiably releasing."""
+        seed_cvm(state_dir, relaunch_config, torn_down=True)
         manager = make_manager(state_dir, relaunch_config)
 
         assert manager.reconcile() is NodeState.FAILED

--- a/neurons/executor/cvmd/tests/test_supervisor.py
+++ b/neurons/executor/cvmd/tests/test_supervisor.py
@@ -118,6 +118,34 @@ class TestDetachment:
         assert wait_until(lambda: supervisor._process_group_gone(pid))
 
 
+class TestSpawnOverASurvivingDirectory:
+    def test_a_stale_pid_file_from_a_previous_life_never_wins(self, tmp_path, monkeypatch):
+        """DAH-2679: a renter relaunch spawns over a directory that still holds the OLD
+        life's pid file, and `_await_pid_file` returns the first pid it can parse — so
+        `spawn` must remove the stale file before the child that writes the new one exists.
+        Without the unlink, the very first poll would return the dead (or recycled) pid."""
+        monkeypatch.setattr(supervisor, "CHILD_MODULE", FIXTURE_MODULE)
+        existing = os.environ.get("PYTHONPATH", "")
+        monkeypatch.setenv(
+            "PYTHONPATH", os.pathsep.join(filter(None, [str(Path(__file__).parent), existing]))
+        )
+        vm_dir = tmp_path / "instance"
+        vm_dir.mkdir()
+        stale = 999_999_999
+        (vm_dir / supervisor.PID_FILE).write_text(f"{stale}\n")
+
+        pid = supervisor.spawn(scripts_dir=tmp_path, vm_dir=vm_dir, kp_port=3443)
+        try:
+            assert pid != stale
+            assert int((vm_dir / supervisor.PID_FILE).read_text().strip()) == pid
+            assert process_field(pid, "state") is not None
+        finally:
+            try:
+                os.killpg(pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
+
+
 class TestTheUnitLetsItSurvive:
     """Detaching is not enough on its own — systemd kills by cgroup, not by session.
 
@@ -156,6 +184,6 @@ class TestConsoleLog:
         _pid, vm_dir = detached
         log = supervisor.console_log_path(vm_dir)
 
-        assert wait_until(lambda: "detached" in log.read_text()), (
-            f"the console log is empty while the supervisor runs: {log.read_text()!r}"
-        )
+        assert wait_until(
+            lambda: "detached" in log.read_text()
+        ), f"the console log is empty while the supervisor runs: {log.read_text()!r}"

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -465,6 +465,31 @@ class Settings(BaseSettings):
         env="CVM_SWITCH_BUDGET_SECONDS_BY_GPU_MODEL", default=""
     )
 
+    # DAH-2674 — provider scoring while a renter holds the node's CVM. During RENTER_RUNNING the
+    # executor process is gone with the validation CVM, so the node cannot answer a normal
+    # validation and would score zero for the whole rental — up to 720 hours for a node doing
+    # exactly what it was rented to do. The sweep synthesizes the same forced-pass shape as a
+    # special manual rental instead, from host-side signals alone (cvmd's signed state read), so
+    # nothing the renter does inside the guest can lower the provider's score.
+    # Off = observe: the sweep logs what it would have scored and changes nothing.
+    ENABLE_CVM_RENTAL_SCORING: bool = Field(env="ENABLE_CVM_RENTAL_SCORING", default=False)
+
+    # DAH-2675 — log-only probe of the attest-agent inside a rented CVM. The agent is the one
+    # thing the platform may talk to in a rental; this flag makes the sweep read its /health
+    # (liveness + the identity a verifier would pin) and LOG it. By construction the probe can
+    # never touch a score — enforcement needs the renter-fault attribution rules (DAH-2676)
+    # settled first, and a probe that failed open would be worse than no probe.
+    ENABLE_CVM_ATTEST_PROBE: bool = Field(env="ENABLE_CVM_ATTEST_PROBE", default=False)
+
+    # The guest-side port the attest-agent listens on — a fleet convention like the SSH guest
+    # port, resolved to a host port through the launch report's forward list.
+    CVM_ATTEST_AGENT_GUEST_PORT: int = Field(env="CVM_ATTEST_AGENT_GUEST_PORT", default=8451)
+
+    # A /health read answers from memory; only the network is being waited on.
+    CVM_ATTEST_PROBE_TIMEOUT_SECONDS: int = Field(
+        env="CVM_ATTEST_PROBE_TIMEOUT_SECONDS", default=15
+    )
+
     def get_cvm_switch_budget_seconds(self, gpu_model: str | None) -> int:
         """The switch budget for one hardware class. Unparseable config falls back to the
         default rather than failing the cycle — a bad JSON here must not zero a fleet."""

--- a/neurons/validators/src/services/cvm_lifecycle.py
+++ b/neurons/validators/src/services/cvm_lifecycle.py
@@ -31,7 +31,7 @@ import asyncio
 import json
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 
 from core.config import settings
@@ -118,17 +118,40 @@ class CvmdHost:
 
 
 @dataclass(frozen=True)
+class PortForward:
+    """One host-side port forward from cvmd's state answer, reduced to what callers decide on."""
+
+    host_port: int
+    address: str
+
+    @property
+    def is_loopback(self) -> bool:
+        return self.address.startswith("127.") or self.address == "localhost"
+
+
+@dataclass(frozen=True)
 class SwitchAssessment:
-    """What one state read says about a possibly-switching node."""
+    """What one state read says about a possibly-switching node.
+
+    `assess` is the only reader of cvmd's wire format: every fact a caller decides on
+    (has_cvm, supervisor_alive, a port forward) is folded here, so no other module carries
+    the state answer's key names or their absent-means-what conventions.
+    """
 
     reachable: bool
     state: str | None = None
-    has_cvm: bool = False
     switching: bool = False
     elapsed_seconds: float | None = None
     # The state answer's `cvm` object, verbatim. Carried so the renter-CVM handling can read
     # the forward list (the attest-agent probe needs a host port) without a second state call.
     cvm: dict | None = None
+    # cvmd's own /proc read of its supervisor. Tri-state on purpose: None means the state
+    # answer did not carry the field (an older cvmd), which must never read as "dead".
+    supervisor_alive: bool | None = None
+
+    @property
+    def has_cvm(self) -> bool:
+        return self.cvm is not None
 
     @property
     def idle_without_cvm(self) -> bool:
@@ -138,6 +161,27 @@ class SwitchAssessment:
     def renter_running(self) -> bool:
         """A renter holds this node's CVM — the state cvmd reports for the whole rental."""
         return self.state == STATE_RENTER_RUNNING and self.has_cvm
+
+    def forward_for(self, guest_port: int) -> PortForward | None:
+        """The host-side forward for one guest port, or None when the list carries nothing
+        this validator could dial — a missing, portless, or malformed entry all read as
+        "no forward"."""
+        ports = (self.cvm or {}).get("ports") or []
+        entry = next(
+            (
+                item
+                for item in ports
+                if isinstance(item, dict) and item.get("guest_port") == guest_port
+            ),
+            None,
+        )
+        if entry is None or not entry.get("host_port"):
+            return None
+        try:
+            host_port = int(entry["host_port"])
+        except (TypeError, ValueError):
+            return None
+        return PortForward(host_port=host_port, address=str(entry.get("address") or ""))
 
 
 def _parse_started_at(last_switch: dict | None) -> datetime | None:
@@ -212,6 +256,26 @@ class CvmLifecycleService:
                 extra=get_extra_info({"executor_uuid": executor_uuid, "error": str(exc)}),
             ))
 
+    async def touch_host(self, host: CvmdHost) -> None:
+        """Refresh one host's registry TTL from a record the caller just read out of it.
+
+        Write-only on purpose: `record_host`'s merge re-read exists for callers holding
+        fresh payload data, and this caller's fields ARE the stored record, so a re-read
+        could never contribute anything. A rental can run 720 hours against a 7-day TTL;
+        without the refresh the host would age out of the very sweep that scores it.
+        """
+        try:
+            await self.redis_service.hset(
+                CVMD_HOSTS_KEY,
+                host.executor_uuid,
+                replace(host, updated_at=time.time()).to_json(),
+            )
+        except Exception as exc:  # noqa: BLE001 - registry writes must never break a cycle
+            logger.warning(_m(
+                "Could not refresh a cvmd host's registry entry",
+                extra=get_extra_info({"executor_uuid": host.executor_uuid, "error": str(exc)}),
+            ))
+
     async def hosts_for_miner(self, miner_hotkey: str) -> list[CvmdHost]:
         """This miner's registered cvmd hosts, with aged-out entries pruned as they are seen."""
         try:
@@ -260,7 +324,9 @@ class CvmLifecycleService:
         cvm = body.get("cvm")
         if not isinstance(cvm, dict):
             cvm = None
-        has_cvm = cvm is not None
+        supervisor_alive = cvm.get("supervisor_alive") if cvm else None
+        if not isinstance(supervisor_alive, bool):
+            supervisor_alive = None
         switching = state in (STATE_TEARDOWN, STATE_SWITCHING)
         elapsed = None
         if switching:
@@ -270,10 +336,10 @@ class CvmLifecycleService:
         return SwitchAssessment(
             reachable=True,
             state=state,
-            has_cvm=has_cvm,
             switching=switching,
             elapsed_seconds=elapsed,
             cvm=cvm,
+            supervisor_alive=supervisor_alive,
         )
 
     # ------------------------------------------------------------------ DAH-2629: launch
@@ -438,17 +504,8 @@ class CvmLifecycleService:
             "executor_uuid": host.executor_uuid,
             "miner_hotkey": host.miner_hotkey,
         })
-        ports = (assessment.cvm or {}).get("ports") or []
-        mapping = next(
-            (
-                entry
-                for entry in ports
-                if isinstance(entry, dict)
-                and entry.get("guest_port") == settings.CVM_ATTEST_AGENT_GUEST_PORT
-            ),
-            None,
-        )
-        if mapping is None or not mapping.get("host_port"):
+        forward = assessment.forward_for(settings.CVM_ATTEST_AGENT_GUEST_PORT)
+        if forward is None:
             # The fleet forward list does not carry the agent's port — a config gap worth
             # a log line, not an error: the probe is optional until enforcement exists.
             logger.info(_m(
@@ -457,8 +514,7 @@ class CvmLifecycleService:
             ))
             return
 
-        bind_address = str(mapping.get("address") or "")
-        if bind_address.startswith("127.") or bind_address == "localhost":
+        if forward.is_loopback:
             # cvmd's port parser defaults the bind address to 127.0.0.1, and a loopback
             # forward is reachable from the CVM host alone. Dialing the public address would
             # time out every cycle and read, fleet-wide, as "the agent is never up" — the
@@ -467,7 +523,7 @@ class CvmLifecycleService:
             logger.info(_m(
                 f"{CVM_ATTEST_PROBE_FAILED_EVENT} — the agent's forward is bound to loopback "
                 f"on the host, so this validator cannot reach it",
-                extra={**extra, "bind_address": bind_address, "host_port": mapping.get("host_port")},
+                extra={**extra, "bind_address": forward.address, "host_port": forward.host_port},
             ))
             return
 
@@ -476,7 +532,7 @@ class CvmLifecycleService:
         # Anything truly unexpected surfaces through `_reap_background`.
         try:
             result = await self.agent_relay.forward(
-                base_url=f"https://{host.address}:{mapping['host_port']}",
+                base_url=f"https://{host.address}:{forward.host_port}",
                 method="GET",
                 path="/health",
                 body="",
@@ -511,4 +567,8 @@ class CvmLifecycleService:
 
     def schedule_attest_probe(self, host: CvmdHost, assessment: SwitchAssessment) -> None:
         """Fire the probe as its own task — a slow agent must never extend a validation cycle."""
+        if not settings.ENABLE_CVM_ATTEST_PROBE:
+            # The coroutine guards itself too (for direct callers); checking here as well keeps
+            # the default-off configuration from allocating a task just to throw it away.
+            return
         self._spawn_background(self.probe_attest_agent(host, assessment))

--- a/neurons/validators/src/services/cvm_lifecycle.py
+++ b/neurons/validators/src/services/cvm_lifecycle.py
@@ -37,7 +37,7 @@ from datetime import UTC, datetime
 from core.config import settings
 from core.utils import _m, get_extra_info
 from services.cvmd_client import CvmdClient
-from services.cvmd_relay import CvmdRelayError
+from services.cvmd_relay import CvmdRelay, CvmdRelayError
 from services.redis_service import RedisService
 
 logger = logging.getLogger(__name__)
@@ -62,6 +62,12 @@ CVM_SWITCH_BUDGET_EXCEEDED_EVENT = "CVM_SWITCH_BUDGET_EXCEEDED"
 CVM_LAUNCH_STARTED_EVENT = "CVM_VALIDATION_LAUNCH_STARTED"
 CVM_LAUNCH_VERIFIED_EVENT = "CVM_VALIDATION_LAUNCH_VERIFIED"
 CVM_LAUNCH_FAILED_EVENT = "CVM_VALIDATION_LAUNCH_FAILED"
+# DAH-2674 — the rental forced pass and its observe-mode twin.
+CVM_RENTAL_PASS_EVENT = "CVM_RENTAL_FORCED_PASS"
+CVM_RENTAL_PASS_OBSERVED_EVENT = "CVM_RENTAL_FORCED_PASS_OBSERVED"
+# DAH-2675 — what the log-only attest-agent probe reports.
+CVM_ATTEST_PROBE_OK_EVENT = "CVM_RENTER_ATTEST_PROBE_OK"
+CVM_ATTEST_PROBE_FAILED_EVENT = "CVM_RENTER_ATTEST_PROBE_FAILED"
 
 
 @dataclass(frozen=True)
@@ -117,10 +123,18 @@ class SwitchAssessment:
     has_cvm: bool = False
     switching: bool = False
     elapsed_seconds: float | None = None
+    # The state answer's `cvm` object, verbatim. Carried so the renter-CVM handling can read
+    # the forward list (the attest-agent probe needs a host port) without a second state call.
+    cvm: dict | None = None
 
     @property
     def idle_without_cvm(self) -> bool:
         return self.state == STATE_RECONCILING and not self.has_cvm
+
+    @property
+    def renter_running(self) -> bool:
+        """A renter holds this node's CVM — the state cvmd reports for the whole rental."""
+        return self.state == STATE_RENTER_RUNNING and self.has_cvm
 
 
 def _parse_started_at(last_switch: dict | None) -> datetime | None:
@@ -145,6 +159,10 @@ class CvmLifecycleService:
         self.redis_service = redis_service
         self.whitelist_source = whitelist_source
         self.client = CvmdClient(keypair)
+        # The attest-agent is not cvmd: its /health takes no signature (it answers anyone who
+        # reaches its port) and its TLS certificate is the self-signed one whose key the quote
+        # binds — so the transport stance is the relay's, and the call is unsigned.
+        self.agent_relay = CvmdRelay()
         # Hosts with a launch in flight in THIS process, so one slow launch is not joined
         # by a second from the next cycle. The Redis cooldown covers everything else.
         self._launching: set[str] = set()
@@ -227,7 +245,8 @@ class CvmLifecycleService:
 
         body = result.body
         state = body.get("state")
-        has_cvm = body.get("cvm") is not None
+        cvm = body.get("cvm")
+        has_cvm = cvm is not None
         switching = state in (STATE_TEARDOWN, STATE_SWITCHING)
         elapsed = None
         if switching:
@@ -240,6 +259,7 @@ class CvmLifecycleService:
             has_cvm=has_cvm,
             switching=switching,
             elapsed_seconds=elapsed,
+            cvm=cvm if isinstance(cvm, dict) else None,
         )
 
     # ------------------------------------------------------------------ DAH-2629: launch
@@ -362,3 +382,88 @@ class CvmLifecycleService:
     def schedule_ensure(self, host: CvmdHost, *, assessment: SwitchAssessment | None = None) -> None:
         """Fire the launch as its own task — a boot must never extend a validation cycle."""
         asyncio.create_task(self.ensure_validation_cvm(host, assessment=assessment))
+
+    # ------------------------------------------------------------------ DAH-2675: attest probe
+
+    async def probe_attest_agent(self, host: CvmdHost, assessment: SwitchAssessment) -> None:
+        """Read the renter CVM's attest-agent /health and LOG what it says. Nothing else.
+
+        Log-only by construction: this method's whole output is two Loki events, so it cannot
+        touch a score no matter what it finds. That is deliberate — the renter has root in the
+        guest and can kill or firewall the agent, so until the renter-fault attribution rules
+        (DAH-2676) decide what an unreachable agent MEANS, acting on one would let the renter
+        (or a provider running the mirror image of that attack) move a score. What this buys
+        now is the rollout data: how often the agent answers, with which identity, across the
+        fleet — the same observe-before-enforce path every other CVM flag has taken.
+
+        The nonce-bound quote (`POST /v1/attest`) is deliberately NOT called here. A quote is
+        only worth requesting when something verifies it, and quote verification against a real
+        TDX host is the hardware half of DAH-2675.
+        """
+        if not settings.ENABLE_CVM_ATTEST_PROBE:
+            return
+
+        extra = get_extra_info({
+            "executor_uuid": host.executor_uuid,
+            "miner_hotkey": host.miner_hotkey,
+        })
+        try:
+            ports = (assessment.cvm or {}).get("ports") or []
+            host_port = next(
+                (
+                    mapping.get("host_port")
+                    for mapping in ports
+                    if isinstance(mapping, dict)
+                    and mapping.get("guest_port") == settings.CVM_ATTEST_AGENT_GUEST_PORT
+                ),
+                None,
+            )
+            if not host_port:
+                # The fleet forward list does not carry the agent's port — a config gap worth
+                # a log line, not an error: the probe is optional until enforcement exists.
+                logger.info(_m(
+                    f"{CVM_ATTEST_PROBE_FAILED_EVENT} — no forward for the agent's guest port",
+                    extra={**extra, "guest_port": settings.CVM_ATTEST_AGENT_GUEST_PORT},
+                ))
+                return
+
+            result = await self.agent_relay.forward(
+                base_url=f"https://{host.address}:{host_port}",
+                method="GET",
+                path="/health",
+                body="",
+                headers={},
+                timeout_seconds=settings.CVM_ATTEST_PROBE_TIMEOUT_SECONDS,
+            )
+            if not result.ok:
+                logger.info(_m(
+                    f"{CVM_ATTEST_PROBE_FAILED_EVENT} — the agent answered an error",
+                    extra={**extra, "status": result.status, "detail": result.reason()},
+                ))
+                return
+
+            body = result.body
+            logger.info(_m(
+                CVM_ATTEST_PROBE_OK_EVENT,
+                extra={
+                    **extra,
+                    "agent_version": body.get("version"),
+                    "tls_public_key": body.get("tls_public_key"),
+                    "gpu_uuid_digest": body.get("gpu_uuid_digest"),
+                    "gpu_count": len(body.get("gpu_uuids") or []),
+                },
+            ))
+        except CvmdRelayError as exc:
+            logger.info(_m(
+                f"{CVM_ATTEST_PROBE_FAILED_EVENT} — the agent was not reached",
+                extra={**extra, "error": str(exc)},
+            ))
+        except Exception as exc:  # noqa: BLE001 - a log-only probe must never surface a failure
+            logger.warning(_m(
+                f"{CVM_ATTEST_PROBE_FAILED_EVENT} — probe error",
+                extra={**extra, "error": str(exc)},
+            ))
+
+    def schedule_attest_probe(self, host: CvmdHost, assessment: SwitchAssessment) -> None:
+        """Fire the probe as its own task — a slow agent must never extend a validation cycle."""
+        asyncio.create_task(self.probe_attest_agent(host, assessment))

--- a/neurons/validators/src/services/cvm_lifecycle.py
+++ b/neurons/validators/src/services/cvm_lifecycle.py
@@ -62,9 +62,12 @@ CVM_SWITCH_BUDGET_EXCEEDED_EVENT = "CVM_SWITCH_BUDGET_EXCEEDED"
 CVM_LAUNCH_STARTED_EVENT = "CVM_VALIDATION_LAUNCH_STARTED"
 CVM_LAUNCH_VERIFIED_EVENT = "CVM_VALIDATION_LAUNCH_VERIFIED"
 CVM_LAUNCH_FAILED_EVENT = "CVM_VALIDATION_LAUNCH_FAILED"
-# DAH-2674 — the rental forced pass and its observe-mode twin.
+# DAH-2674 — the rental forced pass, its observe-mode twin, and the two refusals: the
+# backend has no record of the rental cvmd claims, or the host reports its own guest dead.
 CVM_RENTAL_PASS_EVENT = "CVM_RENTAL_FORCED_PASS"
 CVM_RENTAL_PASS_OBSERVED_EVENT = "CVM_RENTAL_FORCED_PASS_OBSERVED"
+CVM_RENTAL_BACKEND_MISMATCH_EVENT = "CVM_RENTAL_BACKEND_MISMATCH"
+CVM_RENTAL_SUPERVISOR_DEAD_EVENT = "CVM_RENTAL_SUPERVISOR_DEAD"
 # DAH-2675 — what the log-only attest-agent probe reports.
 CVM_ATTEST_PROBE_OK_EVENT = "CVM_RENTER_ATTEST_PROBE_OK"
 CVM_ATTEST_PROBE_FAILED_EVENT = "CVM_RENTER_ATTEST_PROBE_FAILED"
@@ -166,6 +169,11 @@ class CvmLifecycleService:
         # Hosts with a launch in flight in THIS process, so one slow launch is not joined
         # by a second from the next cycle. The Redis cooldown covers everything else.
         self._launching: set[str] = set()
+        # Strong references to fire-and-forget tasks. The event loop holds only a weak
+        # reference to a task, so an unreferenced create_task can be garbage-collected
+        # mid-flight — a dropped launch or probe with no trace. The done-callback both
+        # releases the reference and surfaces an exception nothing else would await.
+        self._background_tasks: set[asyncio.Task] = set()
 
     # ------------------------------------------------------------------ registry
 
@@ -245,7 +253,13 @@ class CvmLifecycleService:
 
         body = result.body
         state = body.get("state")
+        # Normalized once, here: everything downstream — has_cvm, renter_running, and the
+        # probe's forward lookup — reads the SAME value, so an out-of-contract body (a string
+        # where the cvm object belongs) cannot make the scoring decision and its evidence
+        # disagree about whether a CVM exists.
         cvm = body.get("cvm")
+        if not isinstance(cvm, dict):
+            cvm = None
         has_cvm = cvm is not None
         switching = state in (STATE_TEARDOWN, STATE_SWITCHING)
         elapsed = None
@@ -259,7 +273,7 @@ class CvmLifecycleService:
             has_cvm=has_cvm,
             switching=switching,
             elapsed_seconds=elapsed,
-            cvm=cvm if isinstance(cvm, dict) else None,
+            cvm=cvm,
         )
 
     # ------------------------------------------------------------------ DAH-2629: launch
@@ -379,9 +393,26 @@ class CvmLifecycleService:
         finally:
             self._launching.discard(host.executor_uuid)
 
+    def _spawn_background(self, coro) -> None:
+        """create_task with a held reference and an exception drain — see `_background_tasks`."""
+        task = asyncio.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._reap_background)
+
+    def _reap_background(self, task: asyncio.Task) -> None:
+        self._background_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.warning(_m(
+                "A CVM lifecycle background task failed",
+                extra=get_extra_info({"error": repr(exc)}),
+            ))
+
     def schedule_ensure(self, host: CvmdHost, *, assessment: SwitchAssessment | None = None) -> None:
         """Fire the launch as its own task — a boot must never extend a validation cycle."""
-        asyncio.create_task(self.ensure_validation_cvm(host, assessment=assessment))
+        self._spawn_background(self.ensure_validation_cvm(host, assessment=assessment))
 
     # ------------------------------------------------------------------ DAH-2675: attest probe
 
@@ -407,63 +438,77 @@ class CvmLifecycleService:
             "executor_uuid": host.executor_uuid,
             "miner_hotkey": host.miner_hotkey,
         })
-        try:
-            ports = (assessment.cvm or {}).get("ports") or []
-            host_port = next(
-                (
-                    mapping.get("host_port")
-                    for mapping in ports
-                    if isinstance(mapping, dict)
-                    and mapping.get("guest_port") == settings.CVM_ATTEST_AGENT_GUEST_PORT
-                ),
-                None,
-            )
-            if not host_port:
-                # The fleet forward list does not carry the agent's port — a config gap worth
-                # a log line, not an error: the probe is optional until enforcement exists.
-                logger.info(_m(
-                    f"{CVM_ATTEST_PROBE_FAILED_EVENT} — no forward for the agent's guest port",
-                    extra={**extra, "guest_port": settings.CVM_ATTEST_AGENT_GUEST_PORT},
-                ))
-                return
+        ports = (assessment.cvm or {}).get("ports") or []
+        mapping = next(
+            (
+                entry
+                for entry in ports
+                if isinstance(entry, dict)
+                and entry.get("guest_port") == settings.CVM_ATTEST_AGENT_GUEST_PORT
+            ),
+            None,
+        )
+        if mapping is None or not mapping.get("host_port"):
+            # The fleet forward list does not carry the agent's port — a config gap worth
+            # a log line, not an error: the probe is optional until enforcement exists.
+            logger.info(_m(
+                f"{CVM_ATTEST_PROBE_FAILED_EVENT} — no forward for the agent's guest port",
+                extra={**extra, "guest_port": settings.CVM_ATTEST_AGENT_GUEST_PORT},
+            ))
+            return
 
+        bind_address = str(mapping.get("address") or "")
+        if bind_address.startswith("127.") or bind_address == "localhost":
+            # cvmd's port parser defaults the bind address to 127.0.0.1, and a loopback
+            # forward is reachable from the CVM host alone. Dialing the public address would
+            # time out every cycle and read, fleet-wide, as "the agent is never up" — the
+            # exact wrong rollout signal. Named as its own condition so Loki can tell a
+            # config gap from a dead agent.
+            logger.info(_m(
+                f"{CVM_ATTEST_PROBE_FAILED_EVENT} — the agent's forward is bound to loopback "
+                f"on the host, so this validator cannot reach it",
+                extra={**extra, "bind_address": bind_address, "host_port": mapping.get("host_port")},
+            ))
+            return
+
+        # Only the network call can raise, and the relay funnels every transport failure
+        # into CvmdRelayError — a wider net here would relabel code bugs as agent flakiness.
+        # Anything truly unexpected surfaces through `_reap_background`.
+        try:
             result = await self.agent_relay.forward(
-                base_url=f"https://{host.address}:{host_port}",
+                base_url=f"https://{host.address}:{mapping['host_port']}",
                 method="GET",
                 path="/health",
                 body="",
                 headers={},
                 timeout_seconds=settings.CVM_ATTEST_PROBE_TIMEOUT_SECONDS,
             )
-            if not result.ok:
-                logger.info(_m(
-                    f"{CVM_ATTEST_PROBE_FAILED_EVENT} — the agent answered an error",
-                    extra={**extra, "status": result.status, "detail": result.reason()},
-                ))
-                return
-
-            body = result.body
-            logger.info(_m(
-                CVM_ATTEST_PROBE_OK_EVENT,
-                extra={
-                    **extra,
-                    "agent_version": body.get("version"),
-                    "tls_public_key": body.get("tls_public_key"),
-                    "gpu_uuid_digest": body.get("gpu_uuid_digest"),
-                    "gpu_count": len(body.get("gpu_uuids") or []),
-                },
-            ))
         except CvmdRelayError as exc:
             logger.info(_m(
                 f"{CVM_ATTEST_PROBE_FAILED_EVENT} — the agent was not reached",
                 extra={**extra, "error": str(exc)},
             ))
-        except Exception as exc:  # noqa: BLE001 - a log-only probe must never surface a failure
-            logger.warning(_m(
-                f"{CVM_ATTEST_PROBE_FAILED_EVENT} — probe error",
-                extra={**extra, "error": str(exc)},
+            return
+
+        if not result.ok:
+            logger.info(_m(
+                f"{CVM_ATTEST_PROBE_FAILED_EVENT} — the agent answered an error",
+                extra={**extra, "status": result.status, "detail": result.reason()},
             ))
+            return
+
+        body = result.body
+        logger.info(_m(
+            CVM_ATTEST_PROBE_OK_EVENT,
+            extra={
+                **extra,
+                "agent_version": body.get("version"),
+                "tls_public_key": body.get("tls_public_key"),
+                "gpu_uuid_digest": body.get("gpu_uuid_digest"),
+                "gpu_count": len(body.get("gpu_uuids") or []),
+            },
+        ))
 
     def schedule_attest_probe(self, host: CvmdHost, assessment: SwitchAssessment) -> None:
         """Fire the probe as its own task — a slow agent must never extend a validation cycle."""
-        asyncio.create_task(self.probe_attest_agent(host, assessment))
+        self._spawn_background(self.probe_attest_agent(host, assessment))

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -366,13 +366,18 @@ class MinerService:
                             ),
                         ),
                     )
-                    if len(msg.executors) == 0 and not self._has_manual_rental_executors(
-                        payload, rented_data
+                    if (
+                        len(msg.executors) == 0
+                        and not self._has_manual_rental_executors(payload, rented_data)
+                        and not await self._has_cvmd_hosts(payload)
                     ):
                         # Zero executors is normally a miner failure. It is the *expected* shape when
                         # every executor this miner has is under a manual rental, though -- the miner
                         # drops each one because it can no longer install our key. Only fail when
                         # there is genuinely nothing to score; otherwise fall through to synthesis.
+                        # A miner whose only node is a cvmd host has the same shape while that node
+                        # is rented or switching (DAH-2674): the executor process is gone with the
+                        # validation CVM, so failing here would bypass the sweep that scores it.
                         return self._build_failed_job_result(
                             payload,
                             "Miner returned zero executors in AcceptSSHKeyRequest",
@@ -402,10 +407,13 @@ class MinerService:
                     results.extend(
                         self._build_manual_rental_results(payload, rented_data, existing=results)
                     )
-                    # DAH-2629/2630: record this cycle's cvmd hosts, grace the ones inside a
-                    # budgeted switch window, and bring empty ones back up.
+                    # DAH-2629/2630/2674: record this cycle's cvmd hosts, grace the ones inside
+                    # a budgeted switch window, score the ones a renter holds, and bring empty
+                    # ones back up.
                     results.extend(
-                        await self._record_and_grace_cvm_hosts(payload, existing=results)
+                        await self._record_and_grace_cvm_hosts(
+                            payload, existing=results, rented_data=rented_data
+                        )
                     )
 
                     logger.info(
@@ -616,6 +624,23 @@ class MinerService:
         """
         return any(self._iter_manual_rental_candidates(payload, rented_data))
 
+    async def _has_cvmd_hosts(self, payload: MinerJobRequestPayload) -> bool:
+        """Whether this miner has any registered cvmd host (DAH-2674).
+
+        The other half of the zero-executor decision: a miner whose ONLY node is a cvmd host
+        reports zero executors while that node is rented or switching — the executor process
+        left with the validation CVM — and that shape must reach the CVM sweep, not fail the
+        whole miner first. Gated on the sweep's own flag so a fleet without the lifecycle
+        keeps today's behavior exactly. Never raises: no registry means no exemption.
+        """
+        if not settings.ENABLE_CVM_LIFECYCLE:
+            return False
+        try:
+            lifecycle = self._cvm_lifecycle()
+            return bool(await lifecycle.hosts_for_miner(payload.miner_hotkey))
+        except Exception:  # noqa: BLE001 - registry trouble must not change the failure path
+            return False
+
     def _build_manual_rental_results(
         self,
         payload: MinerJobRequestPayload,
@@ -724,9 +749,10 @@ class MinerService:
         self,
         payload: MinerJobRequestPayload,
         existing: list[JobResult],
+        rented_data: RentedExecutorsResponse | None = None,
     ) -> list[JobResult]:
         """Record this cycle's attested cvmd hosts, then account for the ones that are
-        switching or empty (DAH-2629 + DAH-2630).
+        switching, rented, or empty (DAH-2629 + DAH-2630 + DAH-2674).
 
         Runs after the real results, exactly like the manual-rental synthesis: a node that
         answered normally is already scored and is skipped. Everything here is best-effort
@@ -810,6 +836,20 @@ class MinerService:
                 lifecycle.schedule_ensure(host)
                 continue
 
+            if assessment.renter_running:
+                # DAH-2674: a renter holds this node's CVM, so it cannot answer a normal
+                # validation for the whole rental. Score it from the host-side signal that
+                # just arrived (cvmd's signed state read), never from anything inside the
+                # guest — the renter has root there.
+                rental_result = await self._build_cvm_rental_result(
+                    payload, host, lifecycle, rented_data=rented_data, extra=extra
+                )
+                if rental_result is not None:
+                    graces.append(rental_result)
+                # DAH-2675, log-only: read the attest-agent's /health for rollout data.
+                lifecycle.schedule_attest_probe(host, assessment)
+                continue
+
             if not assessment.switching:
                 continue
 
@@ -889,6 +929,107 @@ class MinerService:
                 }),
             ))
         return graces
+
+    async def _build_cvm_rental_result(
+        self,
+        payload: MinerJobRequestPayload,
+        host,
+        lifecycle,
+        *,
+        rented_data: RentedExecutorsResponse | None,
+        extra: dict,
+    ) -> JobResult | None:
+        """Forced pass for a node whose CVM a renter holds (DAH-2674), or None.
+
+        The same shape and the same precedent as the special-manual-rental synthesis — a node
+        handed to a renter at root level cannot answer a validation, and the platform knows
+        exactly why. Two things differ, both deliberate:
+
+          * the evidence is HOST-side: cvmd (the daemon on the host, outside the guest) just
+            answered a signed state read saying RENTER_RUNNING. Nothing read from inside the
+            guest participates, so a renter killing the agent, firewalling ports, or wedging
+            their own workload cannot move the provider's score (the DAH-2676 rule).
+          * `spec` is None, like every synthesis here: the backend skips its executor upsert
+            on a null spec, so a scored rental cycle cannot flip the stored executor row.
+
+        The registry entry is refreshed first, score or no score. A rental can run 720 hours
+        against a 7-day registry TTL; without the refresh a long rental would age its host out
+        of the very sweep that scores it, and the node would silently fall back to zero.
+        """
+        from services.cvm_lifecycle import (
+            CVM_RENTAL_PASS_EVENT,
+            CVM_RENTAL_PASS_OBSERVED_EVENT,
+        )
+
+        try:
+            await lifecycle.record_host(
+                executor_uuid=host.executor_uuid,
+                address=host.address,
+                miner_hotkey=host.miner_hotkey,
+                gpu_model=host.gpu_model,
+                gpu_count=host.gpu_count,
+            )
+        except Exception:  # noqa: BLE001 - the refresh is best-effort, the score is the point
+            pass
+
+        if host.gpu_model not in BASE_GPU_MAP:
+            # Same guard as the manual-rental and switch-grace syntheses, same reason: an
+            # unknown model reaching the incentive layer aborts weight-setting subnet-wide.
+            logger.warning(_m(
+                "Rented CVM node's GPU model is not in BASE_GPU_MAP; skipping its forced pass",
+                extra=extra,
+            ))
+            return None
+
+        if not settings.ENABLE_CVM_RENTAL_SCORING:
+            logger.info(_m(CVM_RENTAL_PASS_OBSERVED_EVENT, extra=extra))
+            return None
+
+        # The incentive-layer gates come off rented_data exactly as the manual-rental synthesis
+        # reads them: a forced pass buys a place in the mining pool, not an exemption from the
+        # spot-tier or Discord exclusions.
+        executor_uuid = host.executor_uuid
+        is_spot = bool(rented_data and executor_uuid in (rented_data.spot_executor_ids or []))
+        discord_connected_ids = (
+            rented_data.provider_discord_connected_executor_ids if rented_data else None
+        )
+        provider_discord_connected = (
+            True if discord_connected_ids is None else executor_uuid in discord_connected_ids
+        )
+
+        log_text = _m(
+            CVM_RENTAL_PASS_EVENT,
+            extra={**extra, "gpu_count": host.gpu_count, "reason": "cvm_rental"},
+        ).to_full_string()
+        logger.info(log_text)
+        return JobResult(
+            spec=None,
+            executor_info=ExecutorSSHInfo(
+                uuid=executor_uuid,
+                address=host.address,
+                port=0,
+                ssh_username="",
+                ssh_port=0,
+                python_path="",
+                root_dir="",
+            ),
+            score=1.0,
+            job_score=1.0,
+            job_batch_id=payload.job_batch_id,
+            log_status="success",
+            log_text=log_text,
+            gpu_model=host.gpu_model,
+            gpu_count=host.gpu_count,
+            # Rented exempts the minimum-driver gate, which we cannot measure here.
+            is_rented=True,
+            # Not measurable through the guest; a false reading would silently cut the score.
+            sysbox_runtime=True,
+            is_spot=is_spot,
+            provider_discord_connected=provider_discord_connected,
+            # This is a CVM-class node: the registry entry that got us here was recorded by an
+            # attested cycle, and the sweep's own state read is the host-side continuation of it.
+            tdx_attestation_passed=True,
+        )
 
     def _build_failed_job_result(self, payload: MinerJobRequestPayload, reason: str):
         executor_info = ExecutorSSHInfo(

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -366,25 +366,6 @@ class MinerService:
                             ),
                         ),
                     )
-                    if (
-                        len(msg.executors) == 0
-                        and not self._has_manual_rental_executors(payload, rented_data)
-                        and not settings.ENABLE_CVM_LIFECYCLE
-                    ):
-                        # Zero executors is normally a miner failure. It is the *expected* shape when
-                        # every executor this miner has is under a manual rental, though -- the miner
-                        # drops each one because it can no longer install our key. Only fail when
-                        # there is genuinely nothing to score; otherwise fall through to synthesis.
-                        # A miner whose only node is a cvmd host has the same shape while that node
-                        # is rented or switching (DAH-2674), so with the lifecycle on the decision is
-                        # deferred to AFTER the sweep: if nothing could be synthesized either, the
-                        # failure record below is emitted exactly as before. Deciding late keeps the
-                        # failed-miner signal — an upfront registry-membership exemption would turn
-                        # a genuinely broken miner into no record at all.
-                        return self._build_failed_job_result(
-                            payload,
-                            "Miner returned zero executors in AcceptSSHKeyRequest",
-                        )
                     tasks = [
                         asyncio.create_task(
                             asyncio.wait_for(
@@ -419,9 +400,15 @@ class MinerService:
                         )
                     )
                     if len(msg.executors) == 0 and not results:
-                        # The deferred half of the zero-executor decision: every synthesis has
-                        # had its chance and produced nothing, so the original failure stands
-                        # and is recorded exactly as it always was.
+                        # The zero-executor decision, made AFTER every synthesis has had its
+                        # chance. Zero executors is normally a miner failure, but it is the
+                        # *expected* shape when every executor this miner has is under a manual
+                        # rental, or is a cvmd host mid-rental or mid-switch (DAH-2674) — the
+                        # miner drops each one because it can no longer install our key.
+                        # Deciding on "did anything synthesize?" rather than predicting what
+                        # could means a new synthesis source needs no gate edit here, and a
+                        # genuinely broken miner still gets its failure record exactly as
+                        # it always did.
                         return self._build_failed_job_result(
                             payload,
                             "Miner returned zero executors in AcceptSSHKeyRequest",
@@ -581,8 +568,8 @@ class MinerService:
     ):
         """Yield (executor_uuid, info, rented_executor) for this miner's force-passable rentals.
 
-        Shared by the cheap `_has_manual_rental_executors` probe and the actual synthesis so the
-        two can never disagree about which executors qualify.
+        One home for the qualification rules, so every consumer of the candidate list agrees
+        about which executors qualify.
         """
         if not rented_data or not rented_data.manual_rental_executors:
             return
@@ -623,32 +610,19 @@ class MinerService:
 
             yield executor_uuid, info, rented_executor
 
-    def _has_manual_rental_executors(
-        self,
-        payload: MinerJobRequestPayload,
-        rented_data: RentedExecutorsResponse | None,
-    ) -> bool:
-        """Whether this miner has any force-passable manual rental, without building anything.
-
-        Used to decide whether a zero-executor AcceptSSHKeyRequest is a genuine miner failure or
-        the expected shape when every executor has been handed to a renter.
-        """
-        return any(self._iter_manual_rental_candidates(payload, rented_data))
-
     @staticmethod
     def _incentive_gates(
-        rented_data: RentedExecutorsResponse | None, executor_uuid: str
+        rented_data: RentedExecutorsResponse, executor_uuid: str
     ) -> tuple[bool, bool]:
         """(is_spot, provider_discord_connected) for one executor, read off rented_data.
 
         One home for the tri-state contract every synthesis must honor: ``None`` for the
         Discord list means "the backend sent no exclusions", which passes — a re-derivation
-        that read it as "not connected" would silently cut scores fleet-wide.
+        that read it as "not connected" would silently cut scores fleet-wide. Every caller
+        has already proven the backend record exists, so ``rented_data`` is required here.
         """
-        is_spot = bool(rented_data and executor_uuid in (rented_data.spot_executor_ids or []))
-        discord_connected_ids = (
-            rented_data.provider_discord_connected_executor_ids if rented_data else None
-        )
+        is_spot = executor_uuid in (rented_data.spot_executor_ids or [])
+        discord_connected_ids = rented_data.provider_discord_connected_executor_ids
         provider_discord_connected = (
             True if discord_connected_ids is None else executor_uuid in discord_connected_ids
         )
@@ -1003,20 +977,14 @@ class MinerService:
             logger.warning(_m(CVM_RENTAL_BACKEND_MISMATCH_EVENT, extra=extra))
             return None
 
-        if (assessment.cvm or {}).get("supervisor_alive") is False:
+        if assessment.supervisor_alive is False:
             # The state document says RENTER_RUNNING but the host's own /proc read says the
             # supervisor is gone — QEMU died mid-rental and nothing relaunched it. That is a
             # host-side failure; paying it would score a rental the customer cannot reach.
             logger.warning(_m(CVM_RENTAL_SUPERVISOR_DEAD_EVENT, extra=extra))
             return None
 
-        await lifecycle.record_host(
-            executor_uuid=executor_uuid,
-            address=host.address,
-            miner_hotkey=host.miner_hotkey,
-            gpu_model=host.gpu_model,
-            gpu_count=host.gpu_count,
-        )
+        await lifecycle.touch_host(host)
 
         if host.gpu_model not in BASE_GPU_MAP:
             # Same guard as the manual-rental and switch-grace syntheses, same reason: an
@@ -2339,19 +2307,6 @@ class MinerService:
                         ),
                     ),
                 )
-                if (
-                    len(msg.executors) == 0
-                    and not self._has_manual_rental_executors(payload, rented_data)
-                    and not settings.ENABLE_CVM_LIFECYCLE
-                ):
-                    # See the WebSocket path: zero executors is the expected shape when every
-                    # executor is under a manual rental — and, with the lifecycle on, when the
-                    # miner's only node is a cvmd host mid-rental or mid-switch (DAH-2674), so
-                    # the decision is deferred until after the sweep below.
-                    return self._build_failed_job_result(
-                        payload,
-                        "Miner returned zero executors in AcceptSSHKeyRequest",
-                    )
                 tasks = [
                     asyncio.create_task(
                         asyncio.wait_for(
@@ -2378,8 +2333,8 @@ class MinerService:
                     self._build_manual_rental_results(payload, rented_data, existing=results)
                 )
                 # DAH-2629/2630/2674 — same accounting as the WebSocket path, including the
-                # deferred zero-executor decision: if no synthesis produced anything either,
-                # the failure record is emitted exactly as before.
+                # after-the-sweep zero-executor decision: if no synthesis produced anything
+                # either, the failure record is emitted exactly as before.
                 results.extend(
                     await self._record_and_grace_cvm_hosts(
                         payload, existing=results, rented_data=rented_data

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -369,15 +369,18 @@ class MinerService:
                     if (
                         len(msg.executors) == 0
                         and not self._has_manual_rental_executors(payload, rented_data)
-                        and not await self._has_cvmd_hosts(payload)
+                        and not settings.ENABLE_CVM_LIFECYCLE
                     ):
                         # Zero executors is normally a miner failure. It is the *expected* shape when
                         # every executor this miner has is under a manual rental, though -- the miner
                         # drops each one because it can no longer install our key. Only fail when
                         # there is genuinely nothing to score; otherwise fall through to synthesis.
                         # A miner whose only node is a cvmd host has the same shape while that node
-                        # is rented or switching (DAH-2674): the executor process is gone with the
-                        # validation CVM, so failing here would bypass the sweep that scores it.
+                        # is rented or switching (DAH-2674), so with the lifecycle on the decision is
+                        # deferred to AFTER the sweep: if nothing could be synthesized either, the
+                        # failure record below is emitted exactly as before. Deciding late keeps the
+                        # failed-miner signal — an upfront registry-membership exemption would turn
+                        # a genuinely broken miner into no record at all.
                         return self._build_failed_job_result(
                             payload,
                             "Miner returned zero executors in AcceptSSHKeyRequest",
@@ -415,6 +418,14 @@ class MinerService:
                             payload, existing=results, rented_data=rented_data
                         )
                     )
+                    if len(msg.executors) == 0 and not results:
+                        # The deferred half of the zero-executor decision: every synthesis has
+                        # had its chance and produced nothing, so the original failure stands
+                        # and is recorded exactly as it always was.
+                        return self._build_failed_job_result(
+                            payload,
+                            "Miner returned zero executors in AcceptSSHKeyRequest",
+                        )
 
                     logger.info(
                         _m(
@@ -624,22 +635,65 @@ class MinerService:
         """
         return any(self._iter_manual_rental_candidates(payload, rented_data))
 
-    async def _has_cvmd_hosts(self, payload: MinerJobRequestPayload) -> bool:
-        """Whether this miner has any registered cvmd host (DAH-2674).
+    @staticmethod
+    def _incentive_gates(
+        rented_data: RentedExecutorsResponse | None, executor_uuid: str
+    ) -> tuple[bool, bool]:
+        """(is_spot, provider_discord_connected) for one executor, read off rented_data.
 
-        The other half of the zero-executor decision: a miner whose ONLY node is a cvmd host
-        reports zero executors while that node is rented or switching — the executor process
-        left with the validation CVM — and that shape must reach the CVM sweep, not fail the
-        whole miner first. Gated on the sweep's own flag so a fleet without the lifecycle
-        keeps today's behavior exactly. Never raises: no registry means no exemption.
+        One home for the tri-state contract every synthesis must honor: ``None`` for the
+        Discord list means "the backend sent no exclusions", which passes — a re-derivation
+        that read it as "not connected" would silently cut scores fleet-wide.
         """
-        if not settings.ENABLE_CVM_LIFECYCLE:
-            return False
-        try:
-            lifecycle = self._cvm_lifecycle()
-            return bool(await lifecycle.hosts_for_miner(payload.miner_hotkey))
-        except Exception:  # noqa: BLE001 - registry trouble must not change the failure path
-            return False
+        is_spot = bool(rented_data and executor_uuid in (rented_data.spot_executor_ids or []))
+        discord_connected_ids = (
+            rented_data.provider_discord_connected_executor_ids if rented_data else None
+        )
+        provider_discord_connected = (
+            True if discord_connected_ids is None else executor_uuid in discord_connected_ids
+        )
+        return is_spot, provider_discord_connected
+
+    def _forced_pass_result(
+        self,
+        payload: MinerJobRequestPayload,
+        *,
+        executor_uuid: str,
+        address: str,
+        port: int,
+        gpu_model: str | None,
+        gpu_count: int,
+        log_text: str,
+        **flags,
+    ) -> JobResult:
+        """The one forced-pass shape every synthesis shares (manual rental, switch grace,
+        CVM rental): a full score with ``spec=None`` so the backend's executor upsert is
+        untouched, and a synthesized ExecutorSSHInfo because the node was never contacted.
+        Each caller states its own incentive flags explicitly — the flag sets differ by
+        design, and hiding them here is how the three copies drifted apart before this
+        helper existed."""
+        return JobResult(
+            spec=None,
+            executor_info=ExecutorSSHInfo(
+                uuid=executor_uuid,
+                address=address,
+                port=port,
+                ssh_username="",
+                ssh_port=0,
+                python_path="",
+                root_dir="",
+            ),
+            score=1.0,
+            job_score=1.0,
+            job_batch_id=payload.job_batch_id,
+            log_status="success",
+            log_text=log_text,
+            gpu_model=gpu_model,
+            gpu_count=gpu_count,
+            # Not measurable without the node; a false reading would silently cut the score.
+            sysbox_runtime=True,
+            **flags,
+        )
 
     def _build_manual_rental_results(
         self,
@@ -677,24 +731,11 @@ class MinerService:
             except (TypeError, ValueError):
                 executor_port = 0
 
-            executor_info = ExecutorSSHInfo(
-                uuid=executor_uuid,
-                address=rented_executor.executor_ip_address,
-                port=executor_port,
-                # No SSH is attempted for a manual rental; these exist only to satisfy the model.
-                ssh_username="",
-                ssh_port=0,
-                python_path="",
-                root_dir="",
-            )
-
             # Read the incentive-layer gates off rented_data exactly as ResultHandler does, rather
             # than hardcoding them: forcing score=1.0 buys a place in the mining pool, it does not
             # exempt the node from spot-tier or Discord exclusions.
-            is_spot = executor_uuid in (rented_data.spot_executor_ids or [])
-            discord_connected_ids = rented_data.provider_discord_connected_executor_ids
-            provider_discord_connected = (
-                True if discord_connected_ids is None else executor_uuid in discord_connected_ids
+            is_spot, provider_discord_connected = self._incentive_gates(
+                rented_data, executor_uuid
             )
 
             log_text = _m(
@@ -711,20 +752,16 @@ class MinerService:
             ).to_full_string()
 
             results.append(
-                JobResult(
-                    spec=None,
-                    executor_info=executor_info,
-                    score=1.0,
-                    job_score=1.0,
-                    job_batch_id=payload.job_batch_id,
-                    log_status="success",
-                    log_text=log_text,
+                self._forced_pass_result(
+                    payload,
+                    executor_uuid=executor_uuid,
+                    address=rented_executor.executor_ip_address,
+                    port=executor_port,
                     gpu_model=info.gpu_model,
                     gpu_count=info.gpu_count,
+                    log_text=log_text,
                     # Rented exempts the minimum-driver gate, which we cannot measure here.
                     is_rented=True,
-                    # Not measurable without the node; a false reading would silently cut the score.
-                    sysbox_runtime=True,
                     is_spot=is_spot,
                     provider_discord_connected=provider_discord_connected,
                 )
@@ -842,7 +879,12 @@ class MinerService:
                 # just arrived (cvmd's signed state read), never from anything inside the
                 # guest — the renter has root there.
                 rental_result = await self._build_cvm_rental_result(
-                    payload, host, lifecycle, rented_data=rented_data, extra=extra
+                    payload,
+                    host,
+                    lifecycle,
+                    assessment=assessment,
+                    rented_data=rented_data,
+                    extra=extra,
                 )
                 if rental_result is not None:
                     graces.append(rental_result)
@@ -892,28 +934,14 @@ class MinerService:
             ).to_full_string()
             logger.info(log_text)
             graces.append(
-                JobResult(
-                    # spec=None on purpose: the backend skips its executor upsert on a null
-                    # spec, so a graced cycle cannot flip the stored row.
-                    spec=None,
-                    executor_info=ExecutorSSHInfo(
-                        uuid=host.executor_uuid,
-                        address=host.address,
-                        port=0,
-                        ssh_username="",
-                        ssh_port=0,
-                        python_path="",
-                        root_dir="",
-                    ),
-                    score=1.0,
-                    job_score=1.0,
-                    job_batch_id=payload.job_batch_id,
-                    log_status="success",
-                    log_text=log_text,
+                self._forced_pass_result(
+                    payload,
+                    executor_uuid=host.executor_uuid,
+                    address=host.address,
+                    port=0,
                     gpu_model=host.gpu_model,
                     gpu_count=host.gpu_count,
-                    # Not measurable mid-switch; a false reading would silently cut the score.
-                    sysbox_runtime=True,
+                    log_text=log_text,
                     tdx_attestation_passed=True,
                 )
             )
@@ -936,41 +964,59 @@ class MinerService:
         host,
         lifecycle,
         *,
+        assessment,
         rented_data: RentedExecutorsResponse | None,
         extra: dict,
     ) -> JobResult | None:
         """Forced pass for a node whose CVM a renter holds (DAH-2674), or None.
 
-        The same shape and the same precedent as the special-manual-rental synthesis — a node
-        handed to a renter at root level cannot answer a validation, and the platform knows
-        exactly why. Two things differ, both deliberate:
+        The same shape and the same standard of proof as the special-manual-rental synthesis:
+        the pass needs TWO independent parties to agree. cvmd (host-side, outside the guest)
+        says RENTER_RUNNING, and the BACKEND's own rented-executors list says this executor
+        really is under a paid rental for this miner. Either alone is refusable — a host that
+        fabricates its state answer earns nothing without a rental the platform is billing,
+        and nothing read from inside the guest participates at all, so a root renter cannot
+        move the provider's score either (the DAH-2676 rule).
 
-          * the evidence is HOST-side: cvmd (the daemon on the host, outside the guest) just
-            answered a signed state read saying RENTER_RUNNING. Nothing read from inside the
-            guest participates, so a renter killing the agent, firewalling ports, or wedging
-            their own workload cannot move the provider's score (the DAH-2676 rule).
-          * `spec` is None, like every synthesis here: the backend skips its executor upsert
-            on a null spec, so a scored rental cycle cannot flip the stored executor row.
+        The host must also still be holding its guest: cvmd reports `supervisor_alive` from
+        its own /proc read, and a dead QEMU mid-rental is a host-side failure, not a scored
+        cycle. `spec` is None, like every synthesis here, so the backend's executor upsert is
+        untouched.
 
-        The registry entry is refreshed first, score or no score. A rental can run 720 hours
-        against a 7-day registry TTL; without the refresh a long rental would age its host out
-        of the very sweep that scores it, and the node would silently fall back to zero.
+        The registry entry is refreshed only for a backend-confirmed rental — a rental can run
+        720 hours against a 7-day registry TTL, and without the refresh the host would age out
+        of the very sweep that scores it. Gating the refresh the same way as the pass means a
+        fabricated state answer cannot keep its own registry entry alive either.
         """
         from services.cvm_lifecycle import (
+            CVM_RENTAL_BACKEND_MISMATCH_EVENT,
             CVM_RENTAL_PASS_EVENT,
             CVM_RENTAL_PASS_OBSERVED_EVENT,
+            CVM_RENTAL_SUPERVISOR_DEAD_EVENT,
         )
 
-        try:
-            await lifecycle.record_host(
-                executor_uuid=host.executor_uuid,
-                address=host.address,
-                miner_hotkey=host.miner_hotkey,
-                gpu_model=host.gpu_model,
-                gpu_count=host.gpu_count,
-            )
-        except Exception:  # noqa: BLE001 - the refresh is best-effort, the score is the point
-            pass
+        executor_uuid = host.executor_uuid
+        rented_executor = rented_data.executors.get(executor_uuid) if rented_data else None
+        if rented_executor is None or rented_executor.miner_hotkey != payload.miner_hotkey:
+            # cvmd claims a rental the platform is not billing. Nothing to score — and worth
+            # a loud event: it is either a backend/relay lag or a host inventing its state.
+            logger.warning(_m(CVM_RENTAL_BACKEND_MISMATCH_EVENT, extra=extra))
+            return None
+
+        if (assessment.cvm or {}).get("supervisor_alive") is False:
+            # The state document says RENTER_RUNNING but the host's own /proc read says the
+            # supervisor is gone — QEMU died mid-rental and nothing relaunched it. That is a
+            # host-side failure; paying it would score a rental the customer cannot reach.
+            logger.warning(_m(CVM_RENTAL_SUPERVISOR_DEAD_EVENT, extra=extra))
+            return None
+
+        await lifecycle.record_host(
+            executor_uuid=executor_uuid,
+            address=host.address,
+            miner_hotkey=host.miner_hotkey,
+            gpu_model=host.gpu_model,
+            gpu_count=host.gpu_count,
+        )
 
         if host.gpu_model not in BASE_GPU_MAP:
             # Same guard as the manual-rental and switch-grace syntheses, same reason: an
@@ -988,42 +1034,31 @@ class MinerService:
         # The incentive-layer gates come off rented_data exactly as the manual-rental synthesis
         # reads them: a forced pass buys a place in the mining pool, not an exemption from the
         # spot-tier or Discord exclusions.
-        executor_uuid = host.executor_uuid
-        is_spot = bool(rented_data and executor_uuid in (rented_data.spot_executor_ids or []))
-        discord_connected_ids = (
-            rented_data.provider_discord_connected_executor_ids if rented_data else None
-        )
-        provider_discord_connected = (
-            True if discord_connected_ids is None else executor_uuid in discord_connected_ids
-        )
+        is_spot, provider_discord_connected = self._incentive_gates(rented_data, executor_uuid)
+
+        # The rented executor's real address and port, like the manual-rental synthesis:
+        # the uptime ledger is keyed on "address:port", and a synthesized port of 0 would
+        # miss it every cycle.
+        try:
+            executor_port = int(rented_executor.executor_ip_port)
+        except (TypeError, ValueError):
+            executor_port = 0
 
         log_text = _m(
             CVM_RENTAL_PASS_EVENT,
             extra={**extra, "gpu_count": host.gpu_count, "reason": "cvm_rental"},
         ).to_full_string()
         logger.info(log_text)
-        return JobResult(
-            spec=None,
-            executor_info=ExecutorSSHInfo(
-                uuid=executor_uuid,
-                address=host.address,
-                port=0,
-                ssh_username="",
-                ssh_port=0,
-                python_path="",
-                root_dir="",
-            ),
-            score=1.0,
-            job_score=1.0,
-            job_batch_id=payload.job_batch_id,
-            log_status="success",
-            log_text=log_text,
+        return self._forced_pass_result(
+            payload,
+            executor_uuid=executor_uuid,
+            address=rented_executor.executor_ip_address,
+            port=executor_port,
             gpu_model=host.gpu_model,
             gpu_count=host.gpu_count,
+            log_text=log_text,
             # Rented exempts the minimum-driver gate, which we cannot measure here.
             is_rented=True,
-            # Not measurable through the guest; a false reading would silently cut the score.
-            sysbox_runtime=True,
             is_spot=is_spot,
             provider_discord_connected=provider_discord_connected,
             # This is a CVM-class node: the registry entry that got us here was recorded by an
@@ -2304,11 +2339,15 @@ class MinerService:
                         ),
                     ),
                 )
-                if len(msg.executors) == 0 and not self._has_manual_rental_executors(
-                    payload, rented_data
+                if (
+                    len(msg.executors) == 0
+                    and not self._has_manual_rental_executors(payload, rented_data)
+                    and not settings.ENABLE_CVM_LIFECYCLE
                 ):
                     # See the WebSocket path: zero executors is the expected shape when every
-                    # executor is under a manual rental, so only fail when nothing can be scored.
+                    # executor is under a manual rental — and, with the lifecycle on, when the
+                    # miner's only node is a cvmd host mid-rental or mid-switch (DAH-2674), so
+                    # the decision is deferred until after the sweep below.
                     return self._build_failed_job_result(
                         payload,
                         "Miner returned zero executors in AcceptSSHKeyRequest",
@@ -2338,10 +2377,19 @@ class MinerService:
                 results.extend(
                     self._build_manual_rental_results(payload, rented_data, existing=results)
                 )
-                # DAH-2629/2630 — same accounting as the WebSocket path.
+                # DAH-2629/2630/2674 — same accounting as the WebSocket path, including the
+                # deferred zero-executor decision: if no synthesis produced anything either,
+                # the failure record is emitted exactly as before.
                 results.extend(
-                    await self._record_and_grace_cvm_hosts(payload, existing=results)
+                    await self._record_and_grace_cvm_hosts(
+                        payload, existing=results, rented_data=rented_data
+                    )
                 )
+                if len(msg.executors) == 0 and not results:
+                    return self._build_failed_job_result(
+                        payload,
+                        "Miner returned zero executors in AcceptSSHKeyRequest",
+                    )
 
                 logger.info(
                     _m(

--- a/neurons/validators/tests/cvm_helpers.py
+++ b/neurons/validators/tests/cvm_helpers.py
@@ -1,0 +1,92 @@
+"""Shared builders for the CVM lifecycle suites (DAH-2630 / DAH-2674 / DAH-2678).
+
+One home for the fakes that encode `_record_and_grace_cvm_hosts`'s collaborator surface.
+A second copy of the harness would have to be taught every new lifecycle method by hand —
+and a suite that missed one would get a silently-passing MagicMock auto-attribute instead
+of a failure. Task suites import from here, never from each other.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from datura.requests.miner_requests import ExecutorSSHInfo
+
+from services.cvm_lifecycle import CvmdHost, CvmLifecycleService
+from services.miner_service import MinerService
+from services.task.models import JobResult
+
+PAYLOAD = SimpleNamespace(miner_hotkey="5Miner", miner_coldkey="5Cold", job_batch_id="batch-1")
+
+
+def cvmd_host(
+    executor_uuid="e-1",
+    address="203.0.113.7",
+    *,
+    gpu_model="NVIDIA H200",
+    gpu_count=8,
+):
+    return CvmdHost(
+        executor_uuid=executor_uuid,
+        address=address,
+        miner_hotkey="5Miner",
+        gpu_model=gpu_model,
+        gpu_count=gpu_count,
+        updated_at=0.0,
+    )
+
+
+def make_miner_service(hosts, assessments):
+    """A miner service whose lifecycle answers `assessments` (one value, or one per host)."""
+    service = MinerService.__new__(MinerService)
+    service.redis_service = MagicMock()
+    lifecycle = MagicMock(spec=CvmLifecycleService)
+    lifecycle.record_host = AsyncMock()
+    lifecycle.touch_host = AsyncMock()
+    lifecycle.hosts_for_miner = AsyncMock(return_value=hosts)
+    if isinstance(assessments, list):
+        lifecycle.assess = AsyncMock(side_effect=assessments)
+    else:
+        lifecycle.assess = AsyncMock(return_value=assessments)
+    lifecycle.schedule_ensure = MagicMock()
+    lifecycle.schedule_attest_probe = MagicMock()
+    service._cvm_lifecycle_service = lifecycle
+    return service, lifecycle
+
+
+def scored_result(executor_uuid="already-scored", tdx=False):
+    """A node that answered its validation normally — the shape a synthesis must never beat."""
+    return JobResult(
+        spec=None,
+        executor_info=ExecutorSSHInfo(
+            uuid=executor_uuid,
+            address="198.51.100.3",
+            port=1,
+            ssh_username="",
+            ssh_port=0,
+            python_path="",
+            root_dir="",
+        ),
+        score=1.0,
+        job_score=1.0,
+        job_batch_id="batch-1",
+        log_status="success",
+        log_text="ok",
+        gpu_model="NVIDIA H200",
+        gpu_count=8,
+        tdx_attestation_passed=tdx,
+    )
+
+
+def rented_data_for(executor_uuid="e-rented", *, miner_hotkey="5Miner", spot=(), discord=None):
+    """The backend's half of the two-party proof: this executor is under a paid rental."""
+    return SimpleNamespace(
+        executors={
+            executor_uuid: SimpleNamespace(
+                miner_hotkey=miner_hotkey,
+                executor_ip_address="203.0.113.7",
+                executor_ip_port="4001",
+            )
+        },
+        spot_executor_ids=list(spot),
+        provider_discord_connected_executor_ids=discord,
+    )

--- a/neurons/validators/tests/test_dah2629_cvm_lifecycle.py
+++ b/neurons/validators/tests/test_dah2629_cvm_lifecycle.py
@@ -198,7 +198,7 @@ HOST = CvmdHost(
     updated_at=0.0,
 )
 
-IDLE = SwitchAssessment(reachable=True, state="RECONCILING", has_cvm=False)
+IDLE = SwitchAssessment(reachable=True, state="RECONCILING")
 
 
 def make_lifecycle(catalog_entry, *, cooldown_active=False):
@@ -314,9 +314,11 @@ class TestEnsureValidationCvm:
         service.client.launch_validation = AsyncMock()
 
         for assessment in (
-            SwitchAssessment(reachable=True, state="RENTER_RUNNING", has_cvm=True),
-            SwitchAssessment(reachable=True, state="SWITCHING", has_cvm=True, switching=True),
-            SwitchAssessment(reachable=True, state="FAILED", has_cvm=False),
+            SwitchAssessment(reachable=True, state="RENTER_RUNNING", cvm={"instance_id": "r-1"}),
+            SwitchAssessment(
+                reachable=True, state="SWITCHING", cvm={"instance_id": "s-1"}, switching=True
+            ),
+            SwitchAssessment(reachable=True, state="FAILED"),
             SwitchAssessment(reachable=False),
         ):
             assert await service.ensure_validation_cvm(HOST, assessment=assessment) is False

--- a/neurons/validators/tests/test_dah2630_switching_grace.py
+++ b/neurons/validators/tests/test_dah2630_switching_grace.py
@@ -16,76 +16,28 @@ recognize the window instead of reading it as downtime. The claims pinned here:
 
 import json
 from datetime import UTC, datetime, timedelta
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from datura.requests.miner_requests import ExecutorSSHInfo
+from cvm_helpers import PAYLOAD, cvmd_host, make_miner_service, scored_result
 
 from core.config import settings
 from services.cvm_lifecycle import (
-    CvmdHost,
     CvmLifecycleService,
     SwitchAssessment,
 )
 from services.cvmd_relay import RelayResult
-from services.miner_service import MinerService
-from services.task.models import JobResult
 
-HOST = CvmdHost(
-    executor_uuid="e-switch",
-    address="203.0.113.7",
-    miner_hotkey="5Miner",
-    gpu_model="NVIDIA H200",
-    gpu_count=8,
-    updated_at=0.0,
-)
-
-PAYLOAD = SimpleNamespace(miner_hotkey="5Miner", miner_coldkey="5Cold", job_batch_id="batch-1")
-
-
-def make_miner_service(hosts, assessment):
-    service = MinerService.__new__(MinerService)
-    service.redis_service = MagicMock()
-    lifecycle = MagicMock(spec=CvmLifecycleService)
-    lifecycle.record_host = AsyncMock()
-    lifecycle.hosts_for_miner = AsyncMock(return_value=hosts)
-    lifecycle.assess = AsyncMock(return_value=assessment)
-    lifecycle.schedule_ensure = MagicMock()
-    service._cvm_lifecycle_service = lifecycle
-    return service, lifecycle
+HOST = cvmd_host("e-switch")
 
 
 def switching(elapsed_seconds):
     return SwitchAssessment(
         reachable=True,
         state="SWITCHING",
-        has_cvm=True,
+        cvm={"instance_id": "s-1"},
         switching=True,
         elapsed_seconds=elapsed_seconds,
-    )
-
-
-def scored_result(executor_uuid="already-scored", tdx=False):
-    return JobResult(
-        spec=None,
-        executor_info=ExecutorSSHInfo(
-            uuid=executor_uuid,
-            address="198.51.100.3",
-            port=1,
-            ssh_username="",
-            ssh_port=0,
-            python_path="",
-            root_dir="",
-        ),
-        score=1.0,
-        job_score=1.0,
-        job_batch_id="batch-1",
-        log_status="success",
-        log_text="ok",
-        gpu_model="NVIDIA H200",
-        gpu_count=8,
-        tdx_attestation_passed=tdx,
     )
 
 
@@ -155,9 +107,9 @@ class TestTheBudgetIsAHardEdge:
         monkeypatch.setattr(
             settings, "CVM_SWITCH_BUDGET_SECONDS_BY_GPU_MODEL", "not json", raising=False
         )
-        assert settings.get_cvm_switch_budget_seconds("NVIDIA H200") == 300, (
-            "bad config falls back rather than failing the cycle"
-        )
+        assert (
+            settings.get_cvm_switch_budget_seconds("NVIDIA H200") == 300
+        ), "bad config falls back rather than failing the cycle"
 
 
 class TestObserveMode:
@@ -184,7 +136,7 @@ class TestLifecycleHandoff:
     @pytest.mark.asyncio
     async def test_an_empty_idle_host_is_scheduled_for_a_launch_not_graced(self, grace_on):
         service, lifecycle = make_miner_service(
-            [HOST], SwitchAssessment(reachable=True, state="RECONCILING", has_cvm=False)
+            [HOST], SwitchAssessment(reachable=True, state="RECONCILING")
         )
 
         results = await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[])
@@ -196,14 +148,7 @@ class TestLifecycleHandoff:
     async def test_an_unknown_gpu_model_is_never_graced(self, grace_on):
         """Same guard as the manual-rental synthesis: an unknown model reaching the
         incentive layer aborts weight-setting for the whole subnet."""
-        odd_host = CvmdHost(
-            executor_uuid="e-odd",
-            address="203.0.113.9",
-            miner_hotkey="5Miner",
-            gpu_model="Prototype GPU X",
-            gpu_count=1,
-            updated_at=0.0,
-        )
+        odd_host = cvmd_host("e-odd", "203.0.113.9", gpu_model="Prototype GPU X", gpu_count=1)
         service, _ = make_miner_service([odd_host], switching(10.0))
 
         assert await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[]) == []
@@ -261,10 +206,57 @@ class TestAssessmentParsing:
         service = CvmLifecycleService(redis, whitelist, Keypair.create_from_uri("//Alice"))
         service.client = MagicMock()
         service.client.state = AsyncMock(
-            return_value=RelayResult(status=200, body={"state": "RECONCILING", "cvm": None, "last_switch": None})
+            return_value=RelayResult(
+                status=200, body={"state": "RECONCILING", "cvm": None, "last_switch": None}
+            )
         )
 
         assessment = await service.assess(HOST)
 
         assert assessment.idle_without_cvm
         assert not assessment.switching
+        assert (
+            assessment.supervisor_alive is None
+        ), "no cvm object means no supervisor fact — absent must never read as dead"
+
+    @pytest.mark.asyncio
+    async def test_the_wire_facts_are_folded_here_and_nowhere_else(self):
+        """`assess` is the only reader of cvmd's wire format: supervisor_alive and the
+        forward list come off the state answer HERE, so no other module carries the wire
+        key names or their absent-means-what conventions."""
+        redis = MagicMock()
+        whitelist = MagicMock()
+        from bittensor_wallet import Keypair
+
+        service = CvmLifecycleService(redis, whitelist, Keypair.create_from_uri("//Alice"))
+        service.client = MagicMock()
+        service.client.state = AsyncMock(
+            return_value=RelayResult(
+                status=200,
+                body={
+                    "state": "RENTER_RUNNING",
+                    "cvm": {
+                        "instance_id": "r-1",
+                        "supervisor_alive": False,
+                        "ports": [
+                            {
+                                "protocol": "tcp",
+                                "address": "0.0.0.0",
+                                "host_port": 18451,
+                                "guest_port": 8451,
+                            }
+                        ],
+                    },
+                },
+            )
+        )
+
+        assessment = await service.assess(HOST)
+
+        assert assessment.has_cvm and assessment.renter_running
+        assert assessment.supervisor_alive is False
+        forward = assessment.forward_for(8451)
+        assert forward is not None
+        assert forward.host_port == 18451
+        assert not forward.is_loopback
+        assert assessment.forward_for(9999) is None

--- a/neurons/validators/tests/test_dah2674_rental_scoring.py
+++ b/neurons/validators/tests/test_dah2674_rental_scoring.py
@@ -1,23 +1,28 @@
-"""DAH-2674: a node whose CVM a renter holds is scored, from host-side signals alone.
+"""DAH-2674: a node whose CVM a renter holds is scored — on two-party proof.
 
 During RENTER_RUNNING the executor process is gone with the validation CVM, so the node
 cannot answer a normal validation and — before this task — scored zero for the whole rental.
 The claims pinned here:
 
-  * a RENTER_RUNNING node gets the same forced-pass shape as a special manual rental:
-    score 1.0, ``spec=None`` so the backend's executor upsert is untouched, ``is_rented``;
-  * the ONLY evidence consumed is cvmd's signed state read — the synthesis takes nothing
-    from inside the guest, so a root renter cannot move the provider's score (DAH-2676's
-    rule, held by construction);
+  * the forced pass needs TWO independent parties to agree: cvmd's host-side state read says
+    RENTER_RUNNING, and the backend's rented-executors list says this executor is under a
+    paid rental for this miner. A host that fabricates its state earns nothing — and cannot
+    even keep its registry entry alive, because the refresh is gated the same way;
+  * nothing read from inside the guest participates, so a root renter cannot move the
+    provider's score (DAH-2676's rule, held by construction);
+  * a host whose own /proc read says the supervisor is dead (`supervisor_alive: false`) is a
+    host-side failure, not a scored cycle;
+  * the pass carries the rented executor's REAL address and port — the uptime ledger is
+    keyed on "address:port", and a synthesized port of 0 would miss it every cycle;
   * with ENABLE_CVM_RENTAL_SCORING off the sweep observes and contributes nothing;
   * a node that answered its validation normally is already scored and is never touched;
-  * the registry entry is refreshed on every rented sweep, scored or observed — a 720-hour
-    rental must not age out of the 7-day registry TTL and silently fall back to zero;
-  * the spot-tier and Discord gates come off rented_data exactly as the manual synthesis
-    reads them: a forced pass buys a place in the pool, not an exemption;
-  * an unknown GPU model is skipped — same weight-setting guard as every other synthesis;
-  * the zero-executor early return exempts a miner with registered cvmd hosts, so a miner
-    whose ONLY node is rented reaches this sweep instead of failing wholesale.
+  * the spot-tier and Discord gates ride rented_data exactly as the manual synthesis reads
+    them: a forced pass buys a place in the pool, not an exemption;
+  * an unknown GPU model is skipped — same weight-setting guard as every other synthesis.
+
+The zero-executor decision is deliberately NOT an upfront registry exemption: the flow
+defers it to after the sweep, so a genuinely broken miner still produces its failure record
+when no synthesis fires (see `_record_and_grace_cvm_hosts` call sites in miner_service.py).
 """
 
 from types import SimpleNamespace
@@ -47,25 +52,49 @@ HOST = CvmdHost(
 PAYLOAD = SimpleNamespace(miner_hotkey="5Miner", miner_coldkey="5Cold", job_batch_id="batch-1")
 
 
-def make_miner_service(hosts, assessment):
+def rented_data_for(executor_uuid="e-rented", *, miner_hotkey="5Miner", spot=(), discord=None):
+    """The backend's half of the proof: this executor is under a paid rental."""
+    return SimpleNamespace(
+        executors={
+            executor_uuid: SimpleNamespace(
+                miner_hotkey=miner_hotkey,
+                executor_ip_address="203.0.113.7",
+                executor_ip_port="4001",
+            )
+        },
+        spot_executor_ids=list(spot),
+        provider_discord_connected_executor_ids=discord,
+    )
+
+
+def make_miner_service(hosts, assessments):
+    """A miner service whose lifecycle answers `assessments` (one value, or one per host)."""
     service = MinerService.__new__(MinerService)
     service.redis_service = MagicMock()
     lifecycle = MagicMock(spec=CvmLifecycleService)
     lifecycle.record_host = AsyncMock()
     lifecycle.hosts_for_miner = AsyncMock(return_value=hosts)
-    lifecycle.assess = AsyncMock(return_value=assessment)
+    if isinstance(assessments, list):
+        lifecycle.assess = AsyncMock(side_effect=assessments)
+    else:
+        lifecycle.assess = AsyncMock(return_value=assessments)
     lifecycle.schedule_ensure = MagicMock()
     lifecycle.schedule_attest_probe = MagicMock()
     service._cvm_lifecycle_service = lifecycle
     return service, lifecycle
 
 
-def renter_running(ports=None):
+def renter_running(supervisor_alive=True):
     return SwitchAssessment(
         reachable=True,
         state="RENTER_RUNNING",
         has_cvm=True,
-        cvm={"instance_id": "cvm-1", "rental_id": "rental-1", "ports": ports or []},
+        cvm={
+            "instance_id": "cvm-1",
+            "rental_id": "rental-1",
+            "supervisor_alive": supervisor_alive,
+            "ports": [],
+        },
     )
 
 
@@ -102,7 +131,9 @@ class TestTheForcedPass:
     async def test_a_rented_node_scores_the_manual_rental_shape(self, rental_scoring_on):
         service, _ = make_miner_service([HOST], renter_running())
 
-        results = await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[])
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD, existing=[], rented_data=rented_data_for()
+        )
 
         assert len(results) == 1
         passed = results[0]
@@ -116,17 +147,29 @@ class TestTheForcedPass:
         assert "CVM_RENTAL_FORCED_PASS" in passed.log_text
 
     @pytest.mark.asyncio
-    async def test_the_only_evidence_is_the_host_side_state_read(self, rental_scoring_on):
-        """The synthesis must complete from the assessment alone — the whole point of the
-        design is that nothing inside the guest participates. One state read, no other call
-        that could reach the guest."""
+    async def test_the_pass_carries_the_rented_executors_real_endpoint(self, rental_scoring_on):
+        """The uptime ledger is keyed on "address:port"; a synthesized port of 0 would miss
+        it every cycle and, on a fleet enforcing the collateral uptime penalty, silently
+        multiply the mining score to zero."""
+        service, _ = make_miner_service([HOST], renter_running())
+
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD, existing=[], rented_data=rented_data_for()
+        )
+
+        assert results[0].executor_info.address == "203.0.113.7"
+        assert results[0].executor_info.port == 4001
+
+    @pytest.mark.asyncio
+    async def test_the_evidence_is_host_side_plus_backend_record_only(self, rental_scoring_on):
+        """One state read and the backend's own list — nothing that touches the guest."""
         service, lifecycle = make_miner_service([HOST], renter_running())
 
-        await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[])
+        await service._record_and_grace_cvm_hosts(
+            PAYLOAD, existing=[], rented_data=rented_data_for()
+        )
 
         lifecycle.assess.assert_awaited_once()
-        # The probe is scheduled, but it is log-only by construction (DAH-2675) — the score
-        # above was already built before it could ever run.
         lifecycle.schedule_ensure.assert_not_called()
 
     @pytest.mark.asyncio
@@ -134,7 +177,9 @@ class TestTheForcedPass:
         service, lifecycle = make_miner_service([HOST], renter_running())
 
         results = await service._record_and_grace_cvm_hosts(
-            PAYLOAD, existing=[scored_result(executor_uuid="e-rented")]
+            PAYLOAD,
+            existing=[scored_result(executor_uuid="e-rented")],
+            rented_data=rented_data_for(),
         )
 
         assert results == []
@@ -152,7 +197,48 @@ class TestTheForcedPass:
         )
         service, _ = make_miner_service([odd_host], renter_running())
 
-        assert await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[]) == []
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD, existing=[], rented_data=rented_data_for("e-odd")
+        )
+        assert results == []
+
+
+class TestTheBackendIsHalfTheProof:
+    @pytest.mark.asyncio
+    async def test_a_state_answer_with_no_backend_rental_earns_nothing(self, rental_scoring_on):
+        """A host that fabricates RENTER_RUNNING has no rental the platform is billing —
+        without this gate, any HTTPS server answering /v1/state could farm emissions."""
+        service, lifecycle = make_miner_service([HOST], renter_running())
+
+        results = await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[], rented_data=None)
+
+        assert results == []
+        # A fabricated state answer must not keep its own registry entry alive either.
+        lifecycle.record_host.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_rental_recorded_for_another_miner_earns_nothing(self, rental_scoring_on):
+        service, _ = make_miner_service([HOST], renter_running())
+
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD,
+            existing=[],
+            rented_data=rented_data_for(miner_hotkey="5SomeoneElse"),
+        )
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_a_dead_supervisor_is_a_host_failure_not_a_scored_cycle(self, rental_scoring_on):
+        """QEMU died mid-rental and nothing relaunched it: the state document still says
+        RENTER_RUNNING, but the host's own /proc read says the guest is gone."""
+        service, _ = make_miner_service([HOST], renter_running(supervisor_alive=False))
+
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD, existing=[], rented_data=rented_data_for()
+        )
+
+        assert results == []
 
 
 class TestObserveMode:
@@ -162,17 +248,24 @@ class TestObserveMode:
         monkeypatch.setattr(settings, "ENABLE_CVM_RENTAL_SCORING", False, raising=False)
         service, lifecycle = make_miner_service([HOST], renter_running())
 
-        assert await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[]) == []
-        # Observation still refreshes the registry: rollout-mode fleets have long rentals too.
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD, existing=[], rented_data=rented_data_for()
+        )
+
+        assert results == []
+        # Observation still refreshes the registry for the CONFIRMED rental: rollout-mode
+        # fleets have long rentals too, and the host must not age out mid-rental.
         lifecycle.record_host.assert_awaited()
 
 
 class TestTheRegistryOutlivesTheRental:
     @pytest.mark.asyncio
-    async def test_a_rented_sweep_refreshes_the_hosts_entry(self, rental_scoring_on):
+    async def test_a_confirmed_rental_refreshes_the_hosts_entry(self, rental_scoring_on):
         service, lifecycle = make_miner_service([HOST], renter_running())
 
-        await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[])
+        await service._record_and_grace_cvm_hosts(
+            PAYLOAD, existing=[], rented_data=rented_data_for()
+        )
 
         kwargs = lifecycle.record_host.await_args.kwargs
         assert kwargs["executor_uuid"] == "e-rented"
@@ -185,13 +278,11 @@ class TestIncentiveGates:
     @pytest.mark.asyncio
     async def test_spot_and_discord_exclusions_ride_rented_data(self, rental_scoring_on):
         service, _ = make_miner_service([HOST], renter_running())
-        rented_data = SimpleNamespace(
-            spot_executor_ids=["e-rented"],
-            provider_discord_connected_executor_ids=[],
-        )
 
         results = await service._record_and_grace_cvm_hosts(
-            PAYLOAD, existing=[], rented_data=rented_data
+            PAYLOAD,
+            existing=[],
+            rented_data=rented_data_for(spot=["e-rented"], discord=[]),
         )
 
         assert results[0].is_spot is True
@@ -200,10 +291,12 @@ class TestIncentiveGates:
         ), "a forced pass buys a place in the pool, not an exemption from the gates"
 
     @pytest.mark.asyncio
-    async def test_no_rented_data_reads_as_no_exclusions(self, rental_scoring_on):
+    async def test_no_exclusion_lists_read_as_no_exclusions(self, rental_scoring_on):
         service, _ = make_miner_service([HOST], renter_running())
 
-        results = await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[])
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD, existing=[], rented_data=rented_data_for()
+        )
 
         assert results[0].is_spot is False
         assert results[0].provider_discord_connected is True
@@ -216,35 +309,11 @@ class TestTheAttestProbeHandoff:
         agent cannot extend the cycle — and being log-only it cannot move the score."""
         service, lifecycle = make_miner_service([HOST], renter_running())
 
-        await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[])
+        await service._record_and_grace_cvm_hosts(
+            PAYLOAD, existing=[], rented_data=rented_data_for()
+        )
 
         lifecycle.schedule_attest_probe.assert_called_once()
         host, assessment = lifecycle.schedule_attest_probe.call_args.args
         assert host.executor_uuid == "e-rented"
         assert assessment.renter_running
-
-
-class TestTheZeroExecutorExemption:
-    @pytest.mark.asyncio
-    async def test_a_miner_with_cvmd_hosts_is_exempt(self, monkeypatch):
-        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
-        service, _ = make_miner_service([HOST], renter_running())
-
-        assert await service._has_cvmd_hosts(PAYLOAD) is True
-
-    @pytest.mark.asyncio
-    async def test_lifecycle_off_keeps_todays_failure_path(self, monkeypatch):
-        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", False, raising=False)
-        service, lifecycle = make_miner_service([HOST], renter_running())
-
-        assert await service._has_cvmd_hosts(PAYLOAD) is False
-        lifecycle.hosts_for_miner.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_registry_trouble_means_no_exemption(self, monkeypatch):
-        """Fail toward the stricter outcome: a broken registry must not excuse a miner."""
-        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
-        service, lifecycle = make_miner_service([], renter_running())
-        lifecycle.hosts_for_miner.side_effect = RuntimeError("redis is down")
-
-        assert await service._has_cvmd_hosts(PAYLOAD) is False

--- a/neurons/validators/tests/test_dah2674_rental_scoring.py
+++ b/neurons/validators/tests/test_dah2674_rental_scoring.py
@@ -1,0 +1,250 @@
+"""DAH-2674: a node whose CVM a renter holds is scored, from host-side signals alone.
+
+During RENTER_RUNNING the executor process is gone with the validation CVM, so the node
+cannot answer a normal validation and — before this task — scored zero for the whole rental.
+The claims pinned here:
+
+  * a RENTER_RUNNING node gets the same forced-pass shape as a special manual rental:
+    score 1.0, ``spec=None`` so the backend's executor upsert is untouched, ``is_rented``;
+  * the ONLY evidence consumed is cvmd's signed state read — the synthesis takes nothing
+    from inside the guest, so a root renter cannot move the provider's score (DAH-2676's
+    rule, held by construction);
+  * with ENABLE_CVM_RENTAL_SCORING off the sweep observes and contributes nothing;
+  * a node that answered its validation normally is already scored and is never touched;
+  * the registry entry is refreshed on every rented sweep, scored or observed — a 720-hour
+    rental must not age out of the 7-day registry TTL and silently fall back to zero;
+  * the spot-tier and Discord gates come off rented_data exactly as the manual synthesis
+    reads them: a forced pass buys a place in the pool, not an exemption;
+  * an unknown GPU model is skipped — same weight-setting guard as every other synthesis;
+  * the zero-executor early return exempts a miner with registered cvmd hosts, so a miner
+    whose ONLY node is rented reaches this sweep instead of failing wholesale.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from datura.requests.miner_requests import ExecutorSSHInfo
+
+from core.config import settings
+from services.cvm_lifecycle import (
+    CvmdHost,
+    CvmLifecycleService,
+    SwitchAssessment,
+)
+from services.miner_service import MinerService
+from services.task.models import JobResult
+
+HOST = CvmdHost(
+    executor_uuid="e-rented",
+    address="203.0.113.7",
+    miner_hotkey="5Miner",
+    gpu_model="NVIDIA H200",
+    gpu_count=8,
+    updated_at=0.0,
+)
+
+PAYLOAD = SimpleNamespace(miner_hotkey="5Miner", miner_coldkey="5Cold", job_batch_id="batch-1")
+
+
+def make_miner_service(hosts, assessment):
+    service = MinerService.__new__(MinerService)
+    service.redis_service = MagicMock()
+    lifecycle = MagicMock(spec=CvmLifecycleService)
+    lifecycle.record_host = AsyncMock()
+    lifecycle.hosts_for_miner = AsyncMock(return_value=hosts)
+    lifecycle.assess = AsyncMock(return_value=assessment)
+    lifecycle.schedule_ensure = MagicMock()
+    lifecycle.schedule_attest_probe = MagicMock()
+    service._cvm_lifecycle_service = lifecycle
+    return service, lifecycle
+
+
+def renter_running(ports=None):
+    return SwitchAssessment(
+        reachable=True,
+        state="RENTER_RUNNING",
+        has_cvm=True,
+        cvm={"instance_id": "cvm-1", "rental_id": "rental-1", "ports": ports or []},
+    )
+
+
+def scored_result(executor_uuid="already-scored"):
+    return JobResult(
+        spec=None,
+        executor_info=ExecutorSSHInfo(
+            uuid=executor_uuid,
+            address="198.51.100.3",
+            port=1,
+            ssh_username="",
+            ssh_port=0,
+            python_path="",
+            root_dir="",
+        ),
+        score=1.0,
+        job_score=1.0,
+        job_batch_id="batch-1",
+        log_status="success",
+        log_text="ok",
+        gpu_model="NVIDIA H200",
+        gpu_count=8,
+    )
+
+
+@pytest.fixture
+def rental_scoring_on(monkeypatch):
+    monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+    monkeypatch.setattr(settings, "ENABLE_CVM_RENTAL_SCORING", True, raising=False)
+
+
+class TestTheForcedPass:
+    @pytest.mark.asyncio
+    async def test_a_rented_node_scores_the_manual_rental_shape(self, rental_scoring_on):
+        service, _ = make_miner_service([HOST], renter_running())
+
+        results = await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[])
+
+        assert len(results) == 1
+        passed = results[0]
+        assert passed.score == 1.0
+        assert passed.job_score == 1.0
+        assert passed.spec is None, "a scored rental cycle must not touch the executor row"
+        assert passed.is_rented is True
+        assert passed.gpu_model == "NVIDIA H200"
+        assert passed.gpu_count == 8
+        assert str(passed.executor_info.uuid) == "e-rented"
+        assert "CVM_RENTAL_FORCED_PASS" in passed.log_text
+
+    @pytest.mark.asyncio
+    async def test_the_only_evidence_is_the_host_side_state_read(self, rental_scoring_on):
+        """The synthesis must complete from the assessment alone — the whole point of the
+        design is that nothing inside the guest participates. One state read, no other call
+        that could reach the guest."""
+        service, lifecycle = make_miner_service([HOST], renter_running())
+
+        await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[])
+
+        lifecycle.assess.assert_awaited_once()
+        # The probe is scheduled, but it is log-only by construction (DAH-2675) — the score
+        # above was already built before it could ever run.
+        lifecycle.schedule_ensure.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_node_that_answered_normally_is_untouched(self, rental_scoring_on):
+        service, lifecycle = make_miner_service([HOST], renter_running())
+
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD, existing=[scored_result(executor_uuid="e-rented")]
+        )
+
+        assert results == []
+        lifecycle.assess.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_gpu_model_is_never_passed(self, rental_scoring_on):
+        odd_host = CvmdHost(
+            executor_uuid="e-odd",
+            address="203.0.113.9",
+            miner_hotkey="5Miner",
+            gpu_model="Prototype GPU X",
+            gpu_count=1,
+            updated_at=0.0,
+        )
+        service, _ = make_miner_service([odd_host], renter_running())
+
+        assert await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[]) == []
+
+
+class TestObserveMode:
+    @pytest.mark.asyncio
+    async def test_flag_off_observes_and_contributes_nothing(self, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+        monkeypatch.setattr(settings, "ENABLE_CVM_RENTAL_SCORING", False, raising=False)
+        service, lifecycle = make_miner_service([HOST], renter_running())
+
+        assert await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[]) == []
+        # Observation still refreshes the registry: rollout-mode fleets have long rentals too.
+        lifecycle.record_host.assert_awaited()
+
+
+class TestTheRegistryOutlivesTheRental:
+    @pytest.mark.asyncio
+    async def test_a_rented_sweep_refreshes_the_hosts_entry(self, rental_scoring_on):
+        service, lifecycle = make_miner_service([HOST], renter_running())
+
+        await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[])
+
+        kwargs = lifecycle.record_host.await_args.kwargs
+        assert kwargs["executor_uuid"] == "e-rented"
+        assert kwargs["address"] == "203.0.113.7"
+        assert kwargs["gpu_model"] == "NVIDIA H200"
+        assert kwargs["gpu_count"] == 8
+
+
+class TestIncentiveGates:
+    @pytest.mark.asyncio
+    async def test_spot_and_discord_exclusions_ride_rented_data(self, rental_scoring_on):
+        service, _ = make_miner_service([HOST], renter_running())
+        rented_data = SimpleNamespace(
+            spot_executor_ids=["e-rented"],
+            provider_discord_connected_executor_ids=[],
+        )
+
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD, existing=[], rented_data=rented_data
+        )
+
+        assert results[0].is_spot is True
+        assert (
+            results[0].provider_discord_connected is False
+        ), "a forced pass buys a place in the pool, not an exemption from the gates"
+
+    @pytest.mark.asyncio
+    async def test_no_rented_data_reads_as_no_exclusions(self, rental_scoring_on):
+        service, _ = make_miner_service([HOST], renter_running())
+
+        results = await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[])
+
+        assert results[0].is_spot is False
+        assert results[0].provider_discord_connected is True
+
+
+class TestTheAttestProbeHandoff:
+    @pytest.mark.asyncio
+    async def test_the_probe_is_scheduled_never_awaited(self, rental_scoring_on):
+        """DAH-2675: the probe rides the rented branch fire-and-forget, so a slow or dead
+        agent cannot extend the cycle — and being log-only it cannot move the score."""
+        service, lifecycle = make_miner_service([HOST], renter_running())
+
+        await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[])
+
+        lifecycle.schedule_attest_probe.assert_called_once()
+        host, assessment = lifecycle.schedule_attest_probe.call_args.args
+        assert host.executor_uuid == "e-rented"
+        assert assessment.renter_running
+
+
+class TestTheZeroExecutorExemption:
+    @pytest.mark.asyncio
+    async def test_a_miner_with_cvmd_hosts_is_exempt(self, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+        service, _ = make_miner_service([HOST], renter_running())
+
+        assert await service._has_cvmd_hosts(PAYLOAD) is True
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_off_keeps_todays_failure_path(self, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", False, raising=False)
+        service, lifecycle = make_miner_service([HOST], renter_running())
+
+        assert await service._has_cvmd_hosts(PAYLOAD) is False
+        lifecycle.hosts_for_miner.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_registry_trouble_means_no_exemption(self, monkeypatch):
+        """Fail toward the stricter outcome: a broken registry must not excuse a miner."""
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+        service, lifecycle = make_miner_service([], renter_running())
+        lifecycle.hosts_for_miner.side_effect = RuntimeError("redis is down")
+
+        assert await service._has_cvmd_hosts(PAYLOAD) is False

--- a/neurons/validators/tests/test_dah2674_rental_scoring.py
+++ b/neurons/validators/tests/test_dah2674_rental_scoring.py
@@ -25,98 +25,35 @@ defers it to after the sweep, so a genuinely broken miner still produces its fai
 when no synthesis fires (see `_record_and_grace_cvm_hosts` call sites in miner_service.py).
 """
 
-from types import SimpleNamespace
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from datura.requests.miner_requests import ExecutorSSHInfo
+from cvm_helpers import PAYLOAD, cvmd_host, make_miner_service, rented_data_for, scored_result
 
 from core.config import settings
 from services.cvm_lifecycle import (
-    CvmdHost,
+    CVMD_HOSTS_KEY,
     CvmLifecycleService,
     SwitchAssessment,
 )
-from services.miner_service import MinerService
-from services.task.models import JobResult
 
-HOST = CvmdHost(
-    executor_uuid="e-rented",
-    address="203.0.113.7",
-    miner_hotkey="5Miner",
-    gpu_model="NVIDIA H200",
-    gpu_count=8,
-    updated_at=0.0,
-)
-
-PAYLOAD = SimpleNamespace(miner_hotkey="5Miner", miner_coldkey="5Cold", job_batch_id="batch-1")
-
-
-def rented_data_for(executor_uuid="e-rented", *, miner_hotkey="5Miner", spot=(), discord=None):
-    """The backend's half of the proof: this executor is under a paid rental."""
-    return SimpleNamespace(
-        executors={
-            executor_uuid: SimpleNamespace(
-                miner_hotkey=miner_hotkey,
-                executor_ip_address="203.0.113.7",
-                executor_ip_port="4001",
-            )
-        },
-        spot_executor_ids=list(spot),
-        provider_discord_connected_executor_ids=discord,
-    )
-
-
-def make_miner_service(hosts, assessments):
-    """A miner service whose lifecycle answers `assessments` (one value, or one per host)."""
-    service = MinerService.__new__(MinerService)
-    service.redis_service = MagicMock()
-    lifecycle = MagicMock(spec=CvmLifecycleService)
-    lifecycle.record_host = AsyncMock()
-    lifecycle.hosts_for_miner = AsyncMock(return_value=hosts)
-    if isinstance(assessments, list):
-        lifecycle.assess = AsyncMock(side_effect=assessments)
-    else:
-        lifecycle.assess = AsyncMock(return_value=assessments)
-    lifecycle.schedule_ensure = MagicMock()
-    lifecycle.schedule_attest_probe = MagicMock()
-    service._cvm_lifecycle_service = lifecycle
-    return service, lifecycle
+HOST = cvmd_host("e-rented")
 
 
 def renter_running(supervisor_alive=True):
     return SwitchAssessment(
         reachable=True,
         state="RENTER_RUNNING",
-        has_cvm=True,
         cvm={
             "instance_id": "cvm-1",
             "rental_id": "rental-1",
             "supervisor_alive": supervisor_alive,
             "ports": [],
         },
-    )
-
-
-def scored_result(executor_uuid="already-scored"):
-    return JobResult(
-        spec=None,
-        executor_info=ExecutorSSHInfo(
-            uuid=executor_uuid,
-            address="198.51.100.3",
-            port=1,
-            ssh_username="",
-            ssh_port=0,
-            python_path="",
-            root_dir="",
-        ),
-        score=1.0,
-        job_score=1.0,
-        job_batch_id="batch-1",
-        log_status="success",
-        log_text="ok",
-        gpu_model="NVIDIA H200",
-        gpu_count=8,
+        # What `assess` folds off the wire object above — see its parsing test in the
+        # DAH-2630 suite; the sweep reads only this field.
+        supervisor_alive=supervisor_alive,
     )
 
 
@@ -187,14 +124,7 @@ class TestTheForcedPass:
 
     @pytest.mark.asyncio
     async def test_an_unknown_gpu_model_is_never_passed(self, rental_scoring_on):
-        odd_host = CvmdHost(
-            executor_uuid="e-odd",
-            address="203.0.113.9",
-            miner_hotkey="5Miner",
-            gpu_model="Prototype GPU X",
-            gpu_count=1,
-            updated_at=0.0,
-        )
+        odd_host = cvmd_host("e-odd", "203.0.113.9", gpu_model="Prototype GPU X", gpu_count=1)
         service, _ = make_miner_service([odd_host], renter_running())
 
         results = await service._record_and_grace_cvm_hosts(
@@ -214,7 +144,7 @@ class TestTheBackendIsHalfTheProof:
 
         assert results == []
         # A fabricated state answer must not keep its own registry entry alive either.
-        lifecycle.record_host.assert_not_awaited()
+        lifecycle.touch_host.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_a_rental_recorded_for_another_miner_earns_nothing(self, rental_scoring_on):
@@ -255,7 +185,7 @@ class TestObserveMode:
         assert results == []
         # Observation still refreshes the registry for the CONFIRMED rental: rollout-mode
         # fleets have long rentals too, and the host must not age out mid-rental.
-        lifecycle.record_host.assert_awaited()
+        lifecycle.touch_host.assert_awaited()
 
 
 class TestTheRegistryOutlivesTheRental:
@@ -267,11 +197,33 @@ class TestTheRegistryOutlivesTheRental:
             PAYLOAD, existing=[], rented_data=rented_data_for()
         )
 
-        kwargs = lifecycle.record_host.await_args.kwargs
-        assert kwargs["executor_uuid"] == "e-rented"
-        assert kwargs["address"] == "203.0.113.7"
-        assert kwargs["gpu_model"] == "NVIDIA H200"
-        assert kwargs["gpu_count"] == 8
+        lifecycle.touch_host.assert_awaited_once()
+        touched = lifecycle.touch_host.await_args.args[0]
+        assert touched.executor_uuid == "e-rented"
+        assert touched.address == "203.0.113.7"
+        assert touched.gpu_model == "NVIDIA H200"
+        assert touched.gpu_count == 8
+
+    @pytest.mark.asyncio
+    async def test_touch_host_rewrites_the_record_with_a_fresh_timestamp(self):
+        """The refresh is write-only: the caller's record IS the stored record, so there is
+        nothing a re-read could merge — one hset, no hget."""
+        from bittensor_wallet import Keypair
+
+        redis = MagicMock()
+        redis.hset = AsyncMock()
+        redis.hget = AsyncMock()
+        service = CvmLifecycleService(redis, MagicMock(), Keypair.create_from_uri("//Alice"))
+
+        await service.touch_host(HOST)
+
+        redis.hget.assert_not_awaited()
+        redis.hset.assert_awaited_once()
+        key, field, payload_json = redis.hset.await_args.args
+        assert key == CVMD_HOSTS_KEY
+        assert field == "e-rented"
+        stored = json.loads(payload_json)
+        assert stored["updated_at"] > 0.0, "the TTL clock must actually restart"
 
 
 class TestIncentiveGates:

--- a/neurons/validators/tests/test_dah2675_attest_probe.py
+++ b/neurons/validators/tests/test_dah2675_attest_probe.py
@@ -113,6 +113,23 @@ class TestLogOnly:
         service.agent_relay.forward.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_a_loopback_bound_forward_is_never_dialed(self, probe_on, caplog):
+        """cvmd's port parser defaults the bind address to 127.0.0.1; dialing the public
+        address for a loopback forward would time out every cycle and read, fleet-wide, as
+        "the agent is never up" — the exact wrong rollout signal."""
+        service = make_service()
+        loopback = [
+            {"protocol": "tcp", "address": "127.0.0.1", "host_port": 18451, "guest_port": 8451}
+        ]
+
+        with caplog.at_level("INFO"):
+            await service.probe_attest_agent(HOST, assessment_with_forwards(loopback))
+
+        service.agent_relay.forward.assert_not_awaited()
+        assert "CVM_RENTER_ATTEST_PROBE_FAILED" in caplog.text
+        assert "loopback" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_no_forward_for_the_agent_port_is_a_log_line(self, probe_on, caplog):
         service = make_service()
         only_ssh = [FORWARDS[0]]

--- a/neurons/validators/tests/test_dah2675_attest_probe.py
+++ b/neurons/validators/tests/test_dah2675_attest_probe.py
@@ -1,0 +1,172 @@
+"""DAH-2675, the hardware-free half: the attest-agent probe is wired, and it is log-only.
+
+The agent (FR-E6) is the one thing the platform may talk to inside a rental. This suite pins
+the validator's side of that conversation as far as it can go without a TDX host:
+
+  * the probe resolves the agent's guest port through the launch report's forward list and
+    reads /health through it — the same transport stance as every cvmd call (self-signed
+    TLS, unauthenticated read);
+  * the flag defaults off, and off makes the probe a no-op;
+  * a missing forward, an agent error, an unreachable agent, or a malformed answer all end
+    in a LOG LINE — the probe has no other output, which is what "log-only" means here and
+    why it cannot move a score no matter what it finds;
+  * the nonce-bound quote (POST /v1/attest) is deliberately not requested — verifying a
+    quote against a real TDX host is the hardware half of this task.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from bittensor_wallet import Keypair
+
+from core.config import settings
+from services.cvm_lifecycle import (
+    CvmdHost,
+    CvmLifecycleService,
+    SwitchAssessment,
+)
+from services.cvmd_relay import CvmdRelayError, RelayResult
+
+HOST = CvmdHost(
+    executor_uuid="e-rented",
+    address="203.0.113.7",
+    miner_hotkey="5Miner",
+    gpu_model="NVIDIA H200",
+    gpu_count=8,
+    updated_at=0.0,
+)
+
+HEALTH = {
+    "version": "0.3.0",
+    "tls_public_key": "ab" * 32,
+    "gpu_uuids": ["GPU-1", "GPU-2"],
+    "gpu_uuid_digest": "cd" * 32,
+    "gpu_detail": "ok",
+}
+
+
+def assessment_with_forwards(ports):
+    return SwitchAssessment(
+        reachable=True,
+        state="RENTER_RUNNING",
+        has_cvm=True,
+        cvm={"instance_id": "cvm-1", "ports": ports},
+    )
+
+
+FORWARDS = [
+    {"protocol": "tcp", "address": "0.0.0.0", "host_port": 12200, "guest_port": 2200},
+    {"protocol": "tcp", "address": "0.0.0.0", "host_port": 18451, "guest_port": 8451},
+]
+
+
+def make_service(relay_result=None, relay_error=None):
+    service = CvmLifecycleService(MagicMock(), MagicMock(), Keypair.create_from_uri("//Alice"))
+    service.agent_relay = MagicMock()
+    if relay_error is not None:
+        service.agent_relay.forward = AsyncMock(side_effect=relay_error)
+    else:
+        service.agent_relay.forward = AsyncMock(
+            return_value=relay_result or RelayResult(status=200, body=dict(HEALTH))
+        )
+    return service
+
+
+@pytest.fixture
+def probe_on(monkeypatch):
+    monkeypatch.setattr(settings, "ENABLE_CVM_ATTEST_PROBE", True, raising=False)
+    monkeypatch.setattr(settings, "CVM_ATTEST_AGENT_GUEST_PORT", 8451, raising=False)
+    monkeypatch.setattr(settings, "CVM_ATTEST_PROBE_TIMEOUT_SECONDS", 15, raising=False)
+
+
+class TestTheHappyPath:
+    @pytest.mark.asyncio
+    async def test_health_is_read_through_the_agents_forward(self, probe_on):
+        service = make_service()
+
+        await service.probe_attest_agent(HOST, assessment_with_forwards(FORWARDS))
+
+        call = service.agent_relay.forward.await_args.kwargs
+        assert call["base_url"] == "https://203.0.113.7:18451"
+        assert call["method"] == "GET"
+        assert call["path"] == "/health"
+        assert call["timeout_seconds"] == 15
+
+    @pytest.mark.asyncio
+    async def test_what_the_agent_said_lands_in_the_log(self, probe_on, caplog):
+        service = make_service()
+
+        with caplog.at_level("INFO"):
+            await service.probe_attest_agent(HOST, assessment_with_forwards(FORWARDS))
+
+        assert "CVM_RENTER_ATTEST_PROBE_OK" in caplog.text
+
+
+class TestLogOnly:
+    @pytest.mark.asyncio
+    async def test_flag_off_is_a_no_op(self, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_CVM_ATTEST_PROBE", False, raising=False)
+        service = make_service()
+
+        await service.probe_attest_agent(HOST, assessment_with_forwards(FORWARDS))
+
+        service.agent_relay.forward.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_forward_for_the_agent_port_is_a_log_line(self, probe_on, caplog):
+        service = make_service()
+        only_ssh = [FORWARDS[0]]
+
+        with caplog.at_level("INFO"):
+            await service.probe_attest_agent(HOST, assessment_with_forwards(only_ssh))
+
+        service.agent_relay.forward.assert_not_awaited()
+        assert "CVM_RENTER_ATTEST_PROBE_FAILED" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_an_unreachable_agent_never_raises(self, probe_on, caplog):
+        """The renter has root and can firewall the agent; a probe that raised would hand
+        them a way to break the sweep that scores their provider."""
+        service = make_service(relay_error=CvmdRelayError("connection refused"))
+
+        with caplog.at_level("INFO"):
+            await service.probe_attest_agent(HOST, assessment_with_forwards(FORWARDS))
+
+        assert "CVM_RENTER_ATTEST_PROBE_FAILED" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_an_agent_error_answer_never_raises(self, probe_on, caplog):
+        service = make_service(
+            relay_result=RelayResult(status=503, body={"detail": "no quote provider"})
+        )
+
+        with caplog.at_level("INFO"):
+            await service.probe_attest_agent(HOST, assessment_with_forwards(FORWARDS))
+
+        assert "CVM_RENTER_ATTEST_PROBE_FAILED" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_state_body_never_raises(self, probe_on):
+        service = make_service()
+        mangled = SwitchAssessment(
+            reachable=True,
+            state="RENTER_RUNNING",
+            has_cvm=True,
+            cvm={"ports": [{"guest_port": "not-a-number"}, None, 42]},
+        )
+
+        await service.probe_attest_agent(HOST, mangled)
+
+        service.agent_relay.forward.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_quote_endpoint_is_never_requested(self, probe_on):
+        """POST /v1/attest is the hardware half — a quote nobody verifies is noise, and a
+        mocked verifier here would be false confidence."""
+        service = make_service()
+
+        await service.probe_attest_agent(HOST, assessment_with_forwards(FORWARDS))
+
+        for call in service.agent_relay.forward.await_args_list:
+            assert call.kwargs["path"] == "/health"
+            assert call.kwargs["method"] == "GET"

--- a/neurons/validators/tests/test_dah2675_attest_probe.py
+++ b/neurons/validators/tests/test_dah2675_attest_probe.py
@@ -18,23 +18,16 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from bittensor_wallet import Keypair
+from cvm_helpers import cvmd_host
 
 from core.config import settings
 from services.cvm_lifecycle import (
-    CvmdHost,
     CvmLifecycleService,
     SwitchAssessment,
 )
 from services.cvmd_relay import CvmdRelayError, RelayResult
 
-HOST = CvmdHost(
-    executor_uuid="e-rented",
-    address="203.0.113.7",
-    miner_hotkey="5Miner",
-    gpu_model="NVIDIA H200",
-    gpu_count=8,
-    updated_at=0.0,
-)
+HOST = cvmd_host("e-rented")
 
 HEALTH = {
     "version": "0.3.0",
@@ -49,7 +42,6 @@ def assessment_with_forwards(ports):
     return SwitchAssessment(
         reachable=True,
         state="RENTER_RUNNING",
-        has_cvm=True,
         cvm={"instance_id": "cvm-1", "ports": ports},
     )
 
@@ -112,6 +104,18 @@ class TestLogOnly:
 
         service.agent_relay.forward.assert_not_awaited()
 
+    def test_flag_off_schedules_no_task_at_all(self, monkeypatch):
+        """The scheduler checks the flag too: with it off (the shipping default) every
+        rented host per cycle would otherwise allocate a task whose first statement
+        returns — pure waste, at fleet scale."""
+        monkeypatch.setattr(settings, "ENABLE_CVM_ATTEST_PROBE", False, raising=False)
+        service = make_service()
+        service._spawn_background = MagicMock()
+
+        service.schedule_attest_probe(HOST, assessment_with_forwards(FORWARDS))
+
+        service._spawn_background.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_a_loopback_bound_forward_is_never_dialed(self, probe_on, caplog):
         """cvmd's port parser defaults the bind address to 127.0.0.1; dialing the public
@@ -165,16 +169,15 @@ class TestLogOnly:
     @pytest.mark.asyncio
     async def test_a_malformed_state_body_never_raises(self, probe_on):
         service = make_service()
-        mangled = SwitchAssessment(
-            reachable=True,
-            state="RENTER_RUNNING",
-            has_cvm=True,
-            cvm={"ports": [{"guest_port": "not-a-number"}, None, 42]},
-        )
+        for ports in (
+            [{"guest_port": "not-a-number"}, None, 42],
+            [{"guest_port": 8451, "host_port": "garbage", "address": "0.0.0.0"}],
+        ):
+            mangled = SwitchAssessment(reachable=True, state="RENTER_RUNNING", cvm={"ports": ports})
 
-        await service.probe_attest_agent(HOST, mangled)
+            await service.probe_attest_agent(HOST, mangled)
 
-        service.agent_relay.forward.assert_not_awaited()
+            service.agent_relay.forward.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_the_quote_endpoint_is_never_requested(self, probe_on):

--- a/neurons/validators/tests/test_dah2678_scoring_cycle.py
+++ b/neurons/validators/tests/test_dah2678_scoring_cycle.py
@@ -21,54 +21,46 @@ The hardware leg of DAH-2678 — the same sweep against a real cvmd on a TDX hos
 au11 via tools/cvm-local-e2e, not here.
 """
 
-from types import SimpleNamespace
-
 import pytest
+from cvm_helpers import PAYLOAD, cvmd_host, make_miner_service, rented_data_for
 from datura.requests.miner_requests import ExecutorSSHInfo
-from test_dah2674_rental_scoring import make_miner_service, rented_data_for
 
 from core.config import settings
-from services.cvm_lifecycle import CvmdHost, SwitchAssessment
+from services.cvm_lifecycle import SwitchAssessment
 from services.task.models import JobResult
 
-PAYLOAD = SimpleNamespace(miner_hotkey="5Miner", miner_coldkey="5Cold", job_batch_id="batch-1")
-
-
-def host(uuid="e-1", address="203.0.113.7"):
-    return CvmdHost(
-        executor_uuid=uuid,
-        address=address,
-        miner_hotkey="5Miner",
-        gpu_model="NVIDIA H200",
-        gpu_count=8,
-        updated_at=0.0,
-    )
-
-
 UNREACHABLE = SwitchAssessment(reachable=False)
-IDLE_EMPTY = SwitchAssessment(reachable=True, state="RECONCILING", has_cvm=False)
-LAUNCHING = SwitchAssessment(reachable=True, state="LAUNCHING", has_cvm=False)
+IDLE_EMPTY = SwitchAssessment(reachable=True, state="RECONCILING")
+LAUNCHING = SwitchAssessment(reachable=True, state="LAUNCHING")
 VALIDATION_RUNNING = SwitchAssessment(
-    reachable=True, state="VALIDATION_RUNNING", has_cvm=True, cvm={"instance_id": "v-1"}
+    reachable=True, state="VALIDATION_RUNNING", cvm={"instance_id": "v-1"}
 )
 SWITCHING_IN_BUDGET = SwitchAssessment(
-    reachable=True, state="SWITCHING", has_cvm=True, switching=True, elapsed_seconds=30.0
+    reachable=True,
+    state="SWITCHING",
+    cvm={"instance_id": "s-1"},
+    switching=True,
+    elapsed_seconds=30.0,
 )
 SWITCHING_OVER_BUDGET = SwitchAssessment(
-    reachable=True, state="SWITCHING", has_cvm=True, switching=True, elapsed_seconds=301.0
+    reachable=True,
+    state="SWITCHING",
+    cvm={"instance_id": "s-1"},
+    switching=True,
+    elapsed_seconds=301.0,
 )
 RENTER_RUNNING = SwitchAssessment(
     reachable=True,
     state="RENTER_RUNNING",
-    has_cvm=True,
     cvm={
         "instance_id": "r-1",
         "rental_id": "rental-1",
         "supervisor_alive": True,
         "ports": [],
     },
+    supervisor_alive=True,
 )
-FAILED = SwitchAssessment(reachable=True, state="FAILED", has_cvm=False)
+FAILED = SwitchAssessment(reachable=True, state="FAILED")
 
 
 @pytest.fixture
@@ -98,7 +90,7 @@ class TestEveryStateInOneTable:
     async def test_what_one_state_earns(
         self, full_lifecycle_on, assessment, synthesized, launch_scheduled
     ):
-        service, lifecycle = make_miner_service([host()], [assessment])
+        service, lifecycle = make_miner_service([cvmd_host()], [assessment])
 
         results = await service._record_and_grace_cvm_hosts(
             PAYLOAD, existing=[], rented_data=rented_data_for("e-1")
@@ -120,11 +112,11 @@ class TestOneCycleAcrossAMixedFleet:
         the rented node synthesize a pass; the empty host gets its launch scheduled; the rest
         contribute nothing. The per-state table above says each row; this says they compose."""
         fleet = [
-            host("e-idle", "203.0.113.1"),
-            host("e-validating", "203.0.113.2"),
-            host("e-switching", "203.0.113.3"),
-            host("e-rented", "203.0.113.4"),
-            host("e-failed", "203.0.113.5"),
+            cvmd_host("e-idle", "203.0.113.1"),
+            cvmd_host("e-validating", "203.0.113.2"),
+            cvmd_host("e-switching", "203.0.113.3"),
+            cvmd_host("e-rented", "203.0.113.4"),
+            cvmd_host("e-failed", "203.0.113.5"),
         ]
         service, lifecycle = make_miner_service(
             fleet,
@@ -167,7 +159,7 @@ class TestOneCycleAcrossAMixedFleet:
             gpu_model="NVIDIA H200",
             gpu_count=8,
         )
-        service, lifecycle = make_miner_service([host("e-rented")], [RENTER_RUNNING])
+        service, lifecycle = make_miner_service([cvmd_host("e-rented")], [RENTER_RUNNING])
 
         results = await service._record_and_grace_cvm_hosts(
             PAYLOAD, existing=[answered], rented_data=rented_data_for("e-rented")
@@ -189,7 +181,7 @@ class TestEverythingOffIsToday:
         monkeypatch.setattr(settings, "CVM_SWITCH_BUDGET_SECONDS_BY_GPU_MODEL", "", raising=False)
 
         for assessment in (SWITCHING_IN_BUDGET, RENTER_RUNNING):
-            service, _ = make_miner_service([host()], [assessment])
+            service, _ = make_miner_service([cvmd_host()], [assessment])
             results = await service._record_and_grace_cvm_hosts(
                 PAYLOAD, existing=[], rented_data=rented_data_for("e-1")
             )

--- a/neurons/validators/tests/test_dah2678_scoring_cycle.py
+++ b/neurons/validators/tests/test_dah2678_scoring_cycle.py
@@ -22,18 +22,13 @@ au11 via tools/cvm-local-e2e, not here.
 """
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from datura.requests.miner_requests import ExecutorSSHInfo
+from test_dah2674_rental_scoring import make_miner_service, rented_data_for
 
 from core.config import settings
-from services.cvm_lifecycle import (
-    CvmdHost,
-    CvmLifecycleService,
-    SwitchAssessment,
-)
-from services.miner_service import MinerService
+from services.cvm_lifecycle import CvmdHost, SwitchAssessment
 from services.task.models import JobResult
 
 PAYLOAD = SimpleNamespace(miner_hotkey="5Miner", miner_coldkey="5Cold", job_batch_id="batch-1")
@@ -48,20 +43,6 @@ def host(uuid="e-1", address="203.0.113.7"):
         gpu_count=8,
         updated_at=0.0,
     )
-
-
-def make_miner_service(hosts, assessments):
-    """A miner service whose lifecycle answers `assessments` in order, one per host."""
-    service = MinerService.__new__(MinerService)
-    service.redis_service = MagicMock()
-    lifecycle = MagicMock(spec=CvmLifecycleService)
-    lifecycle.record_host = AsyncMock()
-    lifecycle.hosts_for_miner = AsyncMock(return_value=hosts)
-    lifecycle.assess = AsyncMock(side_effect=assessments)
-    lifecycle.schedule_ensure = MagicMock()
-    lifecycle.schedule_attest_probe = MagicMock()
-    service._cvm_lifecycle_service = lifecycle
-    return service, lifecycle
 
 
 UNREACHABLE = SwitchAssessment(reachable=False)
@@ -80,7 +61,12 @@ RENTER_RUNNING = SwitchAssessment(
     reachable=True,
     state="RENTER_RUNNING",
     has_cvm=True,
-    cvm={"instance_id": "r-1", "rental_id": "rental-1", "ports": []},
+    cvm={
+        "instance_id": "r-1",
+        "rental_id": "rental-1",
+        "supervisor_alive": True,
+        "ports": [],
+    },
 )
 FAILED = SwitchAssessment(reachable=True, state="FAILED", has_cvm=False)
 
@@ -114,7 +100,9 @@ class TestEveryStateInOneTable:
     ):
         service, lifecycle = make_miner_service([host()], [assessment])
 
-        results = await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[])
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD, existing=[], rented_data=rented_data_for("e-1")
+        )
 
         assert len(results) == synthesized
         for result in results:
@@ -143,7 +131,9 @@ class TestOneCycleAcrossAMixedFleet:
             [IDLE_EMPTY, VALIDATION_RUNNING, SWITCHING_IN_BUDGET, RENTER_RUNNING, FAILED],
         )
 
-        results = await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[])
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD, existing=[], rented_data=rented_data_for("e-rented")
+        )
 
         scored = {str(result.executor_info.uuid) for result in results}
         assert scored == {"e-switching", "e-rented"}
@@ -179,7 +169,9 @@ class TestOneCycleAcrossAMixedFleet:
         )
         service, lifecycle = make_miner_service([host("e-rented")], [RENTER_RUNNING])
 
-        results = await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[answered])
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD, existing=[answered], rented_data=rented_data_for("e-rented")
+        )
 
         assert results == []
         lifecycle.assess.assert_not_awaited()
@@ -198,4 +190,7 @@ class TestEverythingOffIsToday:
 
         for assessment in (SWITCHING_IN_BUDGET, RENTER_RUNNING):
             service, _ = make_miner_service([host()], [assessment])
-            assert await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[]) == []
+            results = await service._record_and_grace_cvm_hosts(
+                PAYLOAD, existing=[], rented_data=rented_data_for("e-1")
+            )
+            assert results == []

--- a/neurons/validators/tests/test_dah2678_scoring_cycle.py
+++ b/neurons/validators/tests/test_dah2678_scoring_cycle.py
@@ -1,0 +1,201 @@
+"""DAH-2678, the local leg: one validation cycle against every cvmd lifecycle state.
+
+Every validation cycle ends in the same sweep (`_record_and_grace_cvm_hosts`), and this suite
+drives that sweep against a faked cvmd answer for each state a CVM v2 host can be in, pinning
+what the provider scores in each. This is the regression net the flag flips lean on: each row
+below is a claim about CURRENT behavior, so a change that moves one is a change someone must
+have meant.
+
+  state cvmd reports          what the sweep contributes
+  ------------------------    -------------------------------------------------------------
+  unreachable daemon          nothing — an unreachable cvmd says nothing about switching
+  RECONCILING, no CVM         nothing this cycle; a validation-CVM launch is scheduled
+  LAUNCHING                   nothing — the launch itself is the cycle's evidence
+  VALIDATION_RUNNING          nothing — the real validation scored it (or failed it)
+  SWITCHING inside budget     a grace: 1.0, spec=None
+  SWITCHING beyond budget     nothing — the budget is a hard edge, flagged not extended
+  RENTER_RUNNING              a rental forced pass: 1.0, spec=None, is_rented
+  FAILED                      nothing — a failed node scores what a failed node scores
+
+The hardware leg of DAH-2678 — the same sweep against a real cvmd on a TDX host — runs on
+au11 via tools/cvm-local-e2e, not here.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from datura.requests.miner_requests import ExecutorSSHInfo
+
+from core.config import settings
+from services.cvm_lifecycle import (
+    CvmdHost,
+    CvmLifecycleService,
+    SwitchAssessment,
+)
+from services.miner_service import MinerService
+from services.task.models import JobResult
+
+PAYLOAD = SimpleNamespace(miner_hotkey="5Miner", miner_coldkey="5Cold", job_batch_id="batch-1")
+
+
+def host(uuid="e-1", address="203.0.113.7"):
+    return CvmdHost(
+        executor_uuid=uuid,
+        address=address,
+        miner_hotkey="5Miner",
+        gpu_model="NVIDIA H200",
+        gpu_count=8,
+        updated_at=0.0,
+    )
+
+
+def make_miner_service(hosts, assessments):
+    """A miner service whose lifecycle answers `assessments` in order, one per host."""
+    service = MinerService.__new__(MinerService)
+    service.redis_service = MagicMock()
+    lifecycle = MagicMock(spec=CvmLifecycleService)
+    lifecycle.record_host = AsyncMock()
+    lifecycle.hosts_for_miner = AsyncMock(return_value=hosts)
+    lifecycle.assess = AsyncMock(side_effect=assessments)
+    lifecycle.schedule_ensure = MagicMock()
+    lifecycle.schedule_attest_probe = MagicMock()
+    service._cvm_lifecycle_service = lifecycle
+    return service, lifecycle
+
+
+UNREACHABLE = SwitchAssessment(reachable=False)
+IDLE_EMPTY = SwitchAssessment(reachable=True, state="RECONCILING", has_cvm=False)
+LAUNCHING = SwitchAssessment(reachable=True, state="LAUNCHING", has_cvm=False)
+VALIDATION_RUNNING = SwitchAssessment(
+    reachable=True, state="VALIDATION_RUNNING", has_cvm=True, cvm={"instance_id": "v-1"}
+)
+SWITCHING_IN_BUDGET = SwitchAssessment(
+    reachable=True, state="SWITCHING", has_cvm=True, switching=True, elapsed_seconds=30.0
+)
+SWITCHING_OVER_BUDGET = SwitchAssessment(
+    reachable=True, state="SWITCHING", has_cvm=True, switching=True, elapsed_seconds=301.0
+)
+RENTER_RUNNING = SwitchAssessment(
+    reachable=True,
+    state="RENTER_RUNNING",
+    has_cvm=True,
+    cvm={"instance_id": "r-1", "rental_id": "rental-1", "ports": []},
+)
+FAILED = SwitchAssessment(reachable=True, state="FAILED", has_cvm=False)
+
+
+@pytest.fixture
+def full_lifecycle_on(monkeypatch):
+    monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+    monkeypatch.setattr(settings, "ENABLE_SWITCHING_GRACE", True, raising=False)
+    monkeypatch.setattr(settings, "ENABLE_CVM_RENTAL_SCORING", True, raising=False)
+    monkeypatch.setattr(settings, "CVM_SWITCH_BUDGET_SECONDS_DEFAULT", 300, raising=False)
+    monkeypatch.setattr(settings, "CVM_SWITCH_BUDGET_SECONDS_BY_GPU_MODEL", "", raising=False)
+
+
+class TestEveryStateInOneTable:
+    @pytest.mark.parametrize(
+        ("assessment", "synthesized", "launch_scheduled"),
+        [
+            pytest.param(UNREACHABLE, 0, False, id="unreachable"),
+            pytest.param(IDLE_EMPTY, 0, True, id="idle-empty"),
+            pytest.param(LAUNCHING, 0, False, id="launching"),
+            pytest.param(VALIDATION_RUNNING, 0, False, id="validation-running"),
+            pytest.param(SWITCHING_IN_BUDGET, 1, False, id="switching-in-budget"),
+            pytest.param(SWITCHING_OVER_BUDGET, 0, False, id="switching-over-budget"),
+            pytest.param(RENTER_RUNNING, 1, False, id="renter-running"),
+            pytest.param(FAILED, 0, False, id="failed"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_what_one_state_earns(
+        self, full_lifecycle_on, assessment, synthesized, launch_scheduled
+    ):
+        service, lifecycle = make_miner_service([host()], [assessment])
+
+        results = await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[])
+
+        assert len(results) == synthesized
+        for result in results:
+            assert result.score == 1.0
+            assert result.spec is None
+        assert lifecycle.schedule_ensure.called is launch_scheduled
+
+
+class TestOneCycleAcrossAMixedFleet:
+    @pytest.mark.asyncio
+    async def test_a_miner_with_every_state_at_once_scores_exactly_the_right_nodes(
+        self, full_lifecycle_on
+    ):
+        """One miner, five cvmd hosts, one cycle: only the switching node inside budget and
+        the rented node synthesize a pass; the empty host gets its launch scheduled; the rest
+        contribute nothing. The per-state table above says each row; this says they compose."""
+        fleet = [
+            host("e-idle", "203.0.113.1"),
+            host("e-validating", "203.0.113.2"),
+            host("e-switching", "203.0.113.3"),
+            host("e-rented", "203.0.113.4"),
+            host("e-failed", "203.0.113.5"),
+        ]
+        service, lifecycle = make_miner_service(
+            fleet,
+            [IDLE_EMPTY, VALIDATION_RUNNING, SWITCHING_IN_BUDGET, RENTER_RUNNING, FAILED],
+        )
+
+        results = await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[])
+
+        scored = {str(result.executor_info.uuid) for result in results}
+        assert scored == {"e-switching", "e-rented"}
+        assert all(result.score == 1.0 and result.spec is None for result in results)
+        rented = next(r for r in results if str(r.executor_info.uuid) == "e-rented")
+        assert rented.is_rented is True
+        graced = next(r for r in results if str(r.executor_info.uuid) == "e-switching")
+        assert graced.is_rented is False
+        lifecycle.schedule_ensure.assert_called_once()
+        lifecycle.schedule_attest_probe.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_a_normally_answered_node_is_never_double_scored(self, full_lifecycle_on):
+        """A real result always beats a synthesized one, whatever state cvmd reports."""
+        answered = JobResult(
+            spec={"gpu": "real"},
+            executor_info=ExecutorSSHInfo(
+                uuid="e-rented",
+                address="203.0.113.4",
+                port=1,
+                ssh_username="",
+                ssh_port=0,
+                python_path="",
+                root_dir="",
+            ),
+            score=1.0,
+            job_score=1.0,
+            job_batch_id="batch-1",
+            log_status="success",
+            log_text="ok",
+            gpu_model="NVIDIA H200",
+            gpu_count=8,
+        )
+        service, lifecycle = make_miner_service([host("e-rented")], [RENTER_RUNNING])
+
+        results = await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[answered])
+
+        assert results == []
+        lifecycle.assess.assert_not_awaited()
+
+
+class TestEverythingOffIsToday:
+    @pytest.mark.asyncio
+    async def test_all_flags_off_synthesizes_nothing_anywhere(self, monkeypatch):
+        """The pre-CVM-v2 posture: whatever cvmd reports, the sweep contributes nothing.
+        This is the row a production fleet sits on until each flag is deliberately flipped."""
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+        monkeypatch.setattr(settings, "ENABLE_SWITCHING_GRACE", False, raising=False)
+        monkeypatch.setattr(settings, "ENABLE_CVM_RENTAL_SCORING", False, raising=False)
+        monkeypatch.setattr(settings, "CVM_SWITCH_BUDGET_SECONDS_DEFAULT", 300, raising=False)
+        monkeypatch.setattr(settings, "CVM_SWITCH_BUDGET_SECONDS_BY_GPU_MODEL", "", raising=False)
+
+        for assessment in (SWITCHING_IN_BUDGET, RENTER_RUNNING):
+            service, _ = make_miner_service([host()], [assessment])
+            assert await service._record_and_grace_cvm_hosts(PAYLOAD, existing=[]) == []


### PR DESCRIPTION
## Describe your changes

Four CVM v2 gap tasks from the scoring/root-access analysis, in one branch against the `feature/2462-cvm-v2` umbrella. All behavior is behind default-off flags; with every flag off, each path is pinned by tests to today's behavior.

**DAH-2674 — provider scoring while a renter holds the node (validator).**
During `RENTER_RUNNING` the executor process is gone with the validation CVM, so the node scored zero for the whole rental (up to 720 h). The cycle-end sweep now synthesizes the special-manual-rental forced-pass shape — score 1.0, `spec=None` (backend upsert untouched), `is_rented` — but only on **two-party proof**: cvmd's signed `/v1/state` read says `RENTER_RUNNING` **and** the backend's rented-executors record confirms this executor is under a paid rental for this miner. Either alone is refused, because cvmd's state endpoint is unauthenticated — without the backend cross-check any HTTPS server answering `/v1/state` could farm emissions indefinitely. The host must also still hold its guest: cvmd reports `supervisor_alive` from its own `/proc` read, and a dead QEMU mid-rental is a host failure, not a scored cycle. Nothing read from inside the guest participates, so a root renter cannot move the provider's score. The pass carries the rented executor's **real** address and port, because the uptime ledger is keyed on `"address:port"` and a synthesized port of `0` would miss it every cycle. The registry entry is refreshed only for a backend-confirmed rental, so a long rental cannot age out of the 7-day TTL and a fabricated state answer cannot keep its own entry alive. Flag: `ENABLE_CVM_RENTAL_SCORING` (default off = observe-and-log). The score value (1.0, the manual-rental precedent) is deliberately a constant behind the flag — the open scoring-economics question (self-rental gaming) changes a constant, not the design.

The zero-executor failure decision moved to **after** the sweep on both transports (WebSocket and REST). Zero executors is normally a miner failure, but it is the expected shape when every node is under a manual rental or is a cvmd host mid-rental or mid-switch, and a single-CVM-node miner previously failed wholesale before the sweep could run. Deciding on what actually synthesized, rather than predicting what could, means a future synthesis source needs no gate edit — and a genuinely broken miner still produces the identical failure record.

**DAH-2675 — attest-agent wired into the validator (PARTIAL — the task stays open).**
This PR delivers only the hardware-free slice: the sweep's rented branch schedules a fire-and-forget, log-only `GET /health` probe of the in-guest attest-agent (guest port 8451, resolved through the launch report's forward list). By construction the probe only logs (`CVM_RENTER_ATTEST_PROBE_OK/FAILED`), so it cannot move a score, and the nonce-bound quote (`POST /v1/attest`) is deliberately **not** requested — verifying a quote needs a TDX host, and a mocked verifier would be false confidence. Flag: `ENABLE_CVM_ATTEST_PROBE` (default off).

**The substance of DAH-2675 is not in this PR.** Quote verification, an authenticated cvmd route to reach the agent, and sourcing CVM facts from the backend remain unbuilt; the task has been rewritten with that scope and must not be closed when this merges.

**DAH-2679 — relaunch a renter CVM over its surviving directory (cvmd).**
The shape a host reboot leaves — instance record + VM directory with `hda.img` on disk, supervisor gone — was a hard FAILED, stranding the renter's data. Reconciliation can now re-spawn the supervisor over the SAME directory and land back on `RENTER_RUNNING`. Safe to attempt because the disk is encrypted and the key provider releases its key only to a guest measuring as the same triple — a tampered directory fails to unlock rather than booting into something else. Renter CVMs only (a validation CVM's disk is deliberately not durable), opt-in per host (`cvm_relaunch_renter`, default off), bounded by a cumulative 3-attempt cap so a dying guest becomes FAILED, not a crash loop. An interrupted teardown is never resurrected: `destroy` persists `TEARDOWN`/`SWITCHING` before it kills anything, so only a state that is still `RENTER_RUNNING` relaunches. The hardware half — proving the sealing key actually unlocks the same disk after a real reboot — needs a TDX host and stays on the task.

**DAH-2678 — scoring-cycle E2E, the local leg.**
One suite drives the cycle-end sweep against a faked cvmd answer for every lifecycle state (unreachable, idle-empty, LAUNCHING, VALIDATION_RUNNING, SWITCHING in/over budget, RENTER_RUNNING, FAILED) and pins what the provider scores in each — singly, composed across a mixed five-node fleet in one cycle, and with all flags off. This is the regression net for the flag flips. The hardware leg (same sweep against a real cvmd on au11 via `tools/cvm-local-e2e`) stays on the task.

**Design notes from the review and cleanup passes.**
`SwitchAssessment` is now the single reader of cvmd's wire format: `has_cvm` is derived from the `cvm` object, `supervisor_alive` is folded once in `assess`, and the probe resolves its port through a typed `forward_for()` accessor, so no other module carries the state answer's key names. A forward bound to loopback is refused with a named log line, because cvmd's port parser defaults a three-part spec to `127.0.0.1` and dialling the public address would time out every cycle — reading fleet-wide as "the agent is never up". The registry refresh uses a write-only `touch_host` rather than the merge re-read of `record_host`, and the stale pid-file cleanup lives in `supervisor.spawn`, which owns that file end to end, rather than at the one call site that first needed it.

**Verified assumption.** The two-party proof depends on CVM rentals appearing in the backend's rented-executors response. Confirmed in the backend: the CVM rental flow creates a real `Pod` row, and the query behind that endpoint filters only on pod status (excluding `BROKEN`/`DELETING`), with no CVM exclusion.

**Known follow-up (not addressed here).** The cvmd-host registry this PR feeds lives in the validator's Redis, which conflicts with the rule that the validator stays stateless — the backend is the system of record for node data. The rewritten DAH-2675 specifies retiring both this registry and the older `TDX_ATTESTED_EXECUTOR_SET` ratchet in favour of facts carried on the rented-executors response. One gap must be settled first: that response is keyed only by executors that have pods, so an **idle** CVM host never appears in it, and the DAH-2629 validation-CVM launch path needs exactly those idle hosts.

**Verification.** CI does not run on PRs into the umbrella (`test.yml` fires only on PRs into `main`/`dev`), so local suites are the gate:
- cvmd: full suite, **370 passed** (includes the new `test_relaunch.py` and the stale-pid-file case added to `test_supervisor.py`)
- validators: `test_dah2674_rental_scoring.py`, `test_dah2675_attest_probe.py`, `test_dah2678_scoring_cycle.py` + the existing `test_dah2629`/`test_dah2630`/`test_manual_rental_results` — **77 passed**
- ruff v0.5.1 (repo pin): zero new findings vs the umbrella baseline; new files formatted with `ruff format`

## Issue ticket number and link

- [DAH-2674 — provider scoring for RENTER_RUNNING nodes](https://www.notion.so/3bbb8bfdbde981dab4acf4bcc8f69ec8)
- [DAH-2675 — live attestation for rented CVMs](https://www.notion.so/3bbb8bfdbde98159ad05c9aa554eaf62) — **partially delivered (log-only probe only); keep open**
- [DAH-2678 — CVM v2 scoring-cycle E2E](https://www.notion.so/3bbb8bfdbde981ccacbbed8532887762) — local leg; hardware leg stays on the task
- [DAH-2679 — reboot survival and data durability](https://www.notion.so/3bbb8bfdbde981958894cf2e809d8994) — local leg; sealing-key proof stays on the task

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?
