### PR TITLE
DAH-2671: shadow spec-truth checks — kernel GPU verdict, CPU truth, rental CPU limit, all-cards matmul

### DIFF
--- a/neurons/validators/src/clients/backend_client.py
+++ b/neurons/validators/src/clients/backend_client.py
@@ -292,6 +292,7 @@ class BackendClient:
         executor_id: str | None = None,
         rental_in_progress: bool = False,
         gpu_uuids: list[str] | None = None,
+        cpu_count: int | None = None,
     ) -> ExecutorHealthCheckResponse | None:
         """Check executor health via backend API.
 
@@ -307,6 +308,10 @@ class BackendClient:
             gpu_uuids: GPU UUIDs from the scrape this cycle. The backend's probe asks the container
                 runtime to resolve exactly these instead of `--gpus all`, which never names a card
                 and so let a host advertising GPUs it cannot hand over pass the check (DAH-2614).
+            cpu_count: Advertised CPU-core count from the scrape this cycle. The backend creates the
+                probe with `--cpus=<cpu_count>`, so a host claiming more cores than it physically has
+                is rejected by its own Docker daemon (CPU_QUOTA_EXCEEDS_HOST) rather than only in a
+                paying customer's rent (DAH-2671). None omits the flag.
 
         Returns:
             ExecutorHealthCheckResponse if successful, None otherwise
@@ -325,6 +330,11 @@ class BackendClient:
             # where a fabricated GPU matters most.
             "gpu_uuids": gpu_uuids or [],
         }
+
+        # Same rationale as gpu_uuids: send the count this cycle's scrape produced, not the backend's
+        # stored specs. Omitted when unset so an unchanged backend keeps the pre-DAH-2671 behaviour.
+        if cpu_count is not None:
+            json_data["cpu_count"] = cpu_count
 
         if executor_id:
             json_data["executor_id"] = executor_id

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -209,6 +209,26 @@ class Settings(BaseSettings):
     # filler container. Rollout: shadow first, flip enforcement after the shadow data is clean.
     FILLER_LIVENESS_CHECK_ENABLED: bool = Field(env="FILLER_LIVENESS_CHECK_ENABLED", default=True)
     FILLER_LIVENESS_ENFORCEMENT_ENABLED: bool = Field(env="FILLER_LIVENESS_ENFORCEMENT_ENABLED", default=False)
+    # DAH-2671 spec-truth checks. Each pair mirrors the FILLER_LIVENESS precedent above:
+    # CHECK_ENABLED is the master switch — shadow mode computes the signal and emits the event/log
+    # but returns passed=True and never changes score; ENFORCEMENT (only effective while
+    # CHECK_ENABLED is on) additionally lets the signal fail closed / fail the check. No enforcement
+    # flag defaults to True: a false positive on a scoring path zeroes an honest miner's emission,
+    # so we shadow first and flip enforcement from clean fleet data (operator decision, not a commit).
+    #
+    # Item 1 — surface the kernel (procfs) GPU verdict the validator already computes and throws
+    # away, and refuse the spoofable nvidia-smi XML fallback when it disagrees with the kernel map.
+    KERNEL_GPU_VERDICT_CHECK_ENABLED: bool = Field(env="KERNEL_GPU_VERDICT_CHECK_ENABLED", default=True)
+    KERNEL_GPU_VERDICT_ENFORCEMENT_ENABLED: bool = Field(env="KERNEL_GPU_VERDICT_ENFORCEMENT_ENABLED", default=False)
+    # Item 2a — corroborate the advertised CPU(s) count against sources the lscpu wrapper does not
+    # author (/proc/cpuinfo, /sys present population, docker NCPU).
+    CPU_TRUTH_CHECK_ENABLED: bool = Field(env="CPU_TRUTH_CHECK_ENABLED", default=True)
+    CPU_TRUTH_ENFORCEMENT_ENABLED: bool = Field(env="CPU_TRUTH_ENFORCEMENT_ENABLED", default=False)
+    # Item 3 — run the GPU work-proof on every claimed card concurrently (own challenge per card,
+    # sized from the registry SKU) and time the aggregate on the validator, so a count lie either
+    # fails device selection or serialises past a wide wall-clock threshold.
+    MATMUL_ALLCARDS_CHECK_ENABLED: bool = Field(env="MATMUL_ALLCARDS_CHECK_ENABLED", default=True)
+    MATMUL_ALLCARDS_ENFORCEMENT_ENABLED: bool = Field(env="MATMUL_ALLCARDS_ENFORCEMENT_ENABLED", default=False)
     SKIP_COLLATERAL_PENALTY: bool = Field(env="SKIP_COLLATERAL_PENALTY", default=True)
     DRY_RUN: bool = Field(env="DRY_RUN", default=False, description="Run validation without publishing scores/weights")
     CONTAINER_CLEANUP_DRY_RUN: bool = Field(env="CONTAINER_CLEANUP_DRY_RUN", default=False, description="Dry run mode for stale container cleanup")

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -227,7 +227,11 @@ class Settings(BaseSettings):
     # Item 3 — run the GPU work-proof on every claimed card concurrently (own challenge per card,
     # sized from the registry SKU) and time the aggregate on the validator, so a count lie either
     # fails device selection or serialises past a wide wall-clock threshold.
-    MATMUL_ALLCARDS_CHECK_ENABLED: bool = Field(env="MATMUL_ALLCARDS_CHECK_ENABLED", default=True)
+    # Defaults to False like RENTAL_CPU_LIMIT_CHECK_ENABLED: "shadow" here only means the verdict is
+    # not scored — the GPU work itself is real, so an 8-card host would run 8 near-full-VRAM matmuls
+    # on top of the legacy single-card one every cycle. Flip it on once elapsed/VRAM/host-RSS numbers
+    # from a real 8-GPU box show what that costs an honest miner.
+    MATMUL_ALLCARDS_CHECK_ENABLED: bool = Field(env="MATMUL_ALLCARDS_CHECK_ENABLED", default=False)
     MATMUL_ALLCARDS_ENFORCEMENT_ENABLED: bool = Field(env="MATMUL_ALLCARDS_ENFORCEMENT_ENABLED", default=False)
     # Item 2b — send the advertised CPU-core count in the rental-verification health check so the
     # host's Docker daemon creates the probe with `--cpus=<advertised>` and rejects a count that

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -234,7 +234,11 @@ class Settings(BaseSettings):
     # exceeds the machine's physical cores (a signal the lscpu wrapper cannot forge, since dockerd
     # reads the kernel directly). CHECK_ENABLED sends the count and observes the verdict; ENFORCEMENT
     # additionally zeroes the score on CPU_QUOTA_EXCEEDS_HOST.
-    RENTAL_CPU_LIMIT_CHECK_ENABLED: bool = Field(env="RENTAL_CPU_LIMIT_CHECK_ENABLED", default=True)
+    # Defaults to False, unlike the other CHECK_ENABLED flags: this one is the only item that
+    # changes what the backend does (the probe is created with `--cpus`), so a rejection the backend
+    # does not yet tag CPU_QUOTA_EXCEEDS_HOST lands in the fatal branch of the check. Flip it on once
+    # the daemon-to-classification chain is confirmed on staging against the backend side (#918).
+    RENTAL_CPU_LIMIT_CHECK_ENABLED: bool = Field(env="RENTAL_CPU_LIMIT_CHECK_ENABLED", default=False)
     RENTAL_CPU_LIMIT_ENFORCEMENT_ENABLED: bool = Field(env="RENTAL_CPU_LIMIT_ENFORCEMENT_ENABLED", default=False)
     SKIP_COLLATERAL_PENALTY: bool = Field(env="SKIP_COLLATERAL_PENALTY", default=True)
     DRY_RUN: bool = Field(env="DRY_RUN", default=False, description="Run validation without publishing scores/weights")

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -229,6 +229,13 @@ class Settings(BaseSettings):
     # fails device selection or serialises past a wide wall-clock threshold.
     MATMUL_ALLCARDS_CHECK_ENABLED: bool = Field(env="MATMUL_ALLCARDS_CHECK_ENABLED", default=True)
     MATMUL_ALLCARDS_ENFORCEMENT_ENABLED: bool = Field(env="MATMUL_ALLCARDS_ENFORCEMENT_ENABLED", default=False)
+    # Item 2b — send the advertised CPU-core count in the rental-verification health check so the
+    # host's Docker daemon creates the probe with `--cpus=<advertised>` and rejects a count that
+    # exceeds the machine's physical cores (a signal the lscpu wrapper cannot forge, since dockerd
+    # reads the kernel directly). CHECK_ENABLED sends the count and observes the verdict; ENFORCEMENT
+    # additionally zeroes the score on CPU_QUOTA_EXCEEDS_HOST.
+    RENTAL_CPU_LIMIT_CHECK_ENABLED: bool = Field(env="RENTAL_CPU_LIMIT_CHECK_ENABLED", default=True)
+    RENTAL_CPU_LIMIT_ENFORCEMENT_ENABLED: bool = Field(env="RENTAL_CPU_LIMIT_ENFORCEMENT_ENABLED", default=False)
     SKIP_COLLATERAL_PENALTY: bool = Field(env="SKIP_COLLATERAL_PENALTY", default=True)
     DRY_RUN: bool = Field(env="DRY_RUN", default=False, description="Run validation without publishing scores/weights")
     CONTAINER_CLEANUP_DRY_RUN: bool = Field(env="CONTAINER_CLEANUP_DRY_RUN", default=False, description="Dry run mode for stale container cleanup")

--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -9,6 +9,11 @@ GPU_RUNTIME_NVML_MISMATCH_REASON = "GPU_RUNTIME_NVML_MISMATCH"
 # The GPU itself is gone until a host reset (post-Xid): "gpu requires reset", "unknown device",
 # "NVML unknown". Same quarantine as the mismatch above — the host cannot serve a rental either way.
 GPU_RUNTIME_DEVICE_FAULT_REASON = "GPU_RUNTIME_DEVICE_FAULT"
+# DAH-2671: the rental-verification container was created with `--cpus=<advertised>` and the host's
+# Docker daemon rejected the count — the machine has fewer physical cores than the miner reported.
+# Unlike the two GPU faults above this is spec fraud, not a broken runtime, and it is rolled out
+# shadow-first (see RENTAL_CPU_LIMIT_* in core/config.py).
+CPU_QUOTA_EXCEEDS_HOST_REASON = "CPU_QUOTA_EXCEEDS_HOST"
 
 
 class Error(BaseModel, extra="allow"):

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -4444,6 +4444,8 @@ class DockerService:
                 gpu_config = await build_gpu_docker_config_for_executor(
                     ssh_client,
                     payload.gpu_uuids,
+                    executor_id=payload.executor_id,
+                    default_extra=default_extra,
                 )
 
                 if payload.cluster_membership is not None:

--- a/neurons/validators/src/services/gpu_spec_table.py
+++ b/neurons/validators/src/services/gpu_spec_table.py
@@ -215,19 +215,23 @@ def vram_window_for_size(nominal_mb: int) -> tuple[int, int]:
     return (round(nominal_mb * VRAM_FLOOR_RATIO), round(nominal_mb * VRAM_CEIL_RATIO))
 
 
-def smallest_nominal_vram_mb(model: str | None) -> int | None:
-    """Smallest nominal VRAM size (MB) for an advertised GPU model, via the registry SKU table.
+def matmul_probe_vram_mb(model: str | None) -> int | None:
+    """VRAM (MB) to size the all-cards work-proof from — registry-derived and floored to usable.
 
-    Normalizes the CUDA-reported name, then returns the SMALLEST nominal size when the model is
-    multi-variant (e.g. RTX 3060 8/12 GB -> 8192) so a work-proof sized from this never OOMs an
-    honest smaller-variant card. Returns None for unknown models — the caller sizes off host
-    self-report or skips, never guesses. Keeps all registry sizing in this one module (DAH-2671).
+    Normalizes the CUDA-reported name, takes the SMALLEST nominal size for a multi-variant model
+    (e.g. RTX 3060 8/12 GB -> 8192), then applies VRAM_FLOOR_RATIO (0.90) — the same floor
+    GpuVramPrecheck uses. NVML `.total` is physical VRAM minus vendor/ECC/driver-reserved regions,
+    observed up to ~6.7% below the marketing nominal (e.g. B200 reports 183359 on a 192 GB card,
+    L40S 46068 on 48 GB); sizing the matmul from the raw nominal would ask an honest B200/B300/L40S
+    to allocate past its usable VRAM and OOM (DAH-2671). The floor is registry-derived, NOT host
+    self-report, so a spoofing host still cannot shrink its own challenge. Returns None for unknown
+    models — the caller then skips rather than guessing. Keeps registry sizing in this one module.
     """
     canonical = normalize_gpu_model(model)
     sizes = GPU_VRAM_SIZES_MB.get(canonical)
     if not sizes:
         return None
-    return min(sizes)
+    return round(min(sizes) * VRAM_FLOOR_RATIO)
 
 
 def get_expected_vram_windows(canonical_model: str) -> list[tuple[int, int]] | None:

--- a/neurons/validators/src/services/gpu_spec_table.py
+++ b/neurons/validators/src/services/gpu_spec_table.py
@@ -47,7 +47,6 @@ Pre-check policy:
     - Models in neither -> raises UnsupportedGpuModelError.
 """
 from __future__ import annotations
-from typing import Dict, List, Optional, Set, Tuple
 
 # Per-window bounds are nominal × [VRAM_FLOOR_RATIO, VRAM_CEIL_RATIO].
 # See the module docstring for why 0.90 / 1.05 (NVML under-reporting + vendor drift).
@@ -60,7 +59,7 @@ VRAM_CEIL_RATIO = 1.05
 #   `observed: X` notes the prod NVML-reported value(s) we've seen for that
 #   model (most-common first). Used to verify the computed window covers reality.
 #   Multi-variant cards list one nominal size per real SKU (flagged `# multi-variant`).
-GPU_VRAM_SIZES_MB: Dict[str, List[int]] = {
+GPU_VRAM_SIZES_MB: dict[str, list[int]] = {
     # Blackwell data-center
     "NVIDIA B300 SXM6 AC":                                [294912],        # 288 GB; observed: 275040
     "NVIDIA B200":                                        [196608],        # 192 GB; observed: 183359 (49140 ~48GB outlier rejected)
@@ -168,7 +167,7 @@ GPU_VRAM_SIZES_MB: Dict[str, List[int]] = {
 # Models that are in GPU_MODEL_RATES but for which we intentionally do not
 # enforce a VRAM range (e.g., legacy data, awaiting spec confirmation).
 # Pre-check returns None for these.
-KNOWN_UNRANGED: Set[str] = set()
+KNOWN_UNRANGED: set[str] = set()
 
 
 # --- Normalization (CUDA deviceProp.name -> canonical key) -------------------
@@ -177,7 +176,7 @@ KNOWN_UNRANGED: Set[str] = set()
 # keys directly. Add entries as new mismatches are observed in production
 # logs. Unmapped names pass through unchanged (and will likely produce
 # UnsupportedGpuModelError until added here).
-NORMALIZATION_MAP: Dict[str, str] = {
+NORMALIZATION_MAP: dict[str, str] = {
     # Tesla V100 family — CUDA reports "Tesla V100-..." in some driver versions
     "Tesla V100-SXM2-16GB":                 "NVIDIA Tesla V100 Tensor Core GPU",
     "Tesla V100-SXM2-32GB":                 "NVIDIA Tesla V100 Tensor Core GPU",
@@ -193,7 +192,7 @@ NORMALIZATION_MAP: Dict[str, str] = {
 }
 
 
-def normalize_gpu_model(name: Optional[str]) -> str:
+def normalize_gpu_model(name: str | None) -> str:
     """Map a CUDA-reported GPU name to a canonical GPU_MODEL_RATES key.
 
     Returns:
@@ -207,7 +206,7 @@ def normalize_gpu_model(name: Optional[str]) -> str:
     return NORMALIZATION_MAP.get(stripped, stripped)
 
 
-def vram_window_for_size(nominal_mb: int) -> Tuple[int, int]:
+def vram_window_for_size(nominal_mb: int) -> tuple[int, int]:
     """Compute the (vram_mb_min, vram_mb_max) acceptance window for one nominal size.
 
     Bounds are nominal × [VRAM_FLOOR_RATIO, VRAM_CEIL_RATIO], rounded to int. This
@@ -216,7 +215,22 @@ def vram_window_for_size(nominal_mb: int) -> Tuple[int, int]:
     return (round(nominal_mb * VRAM_FLOOR_RATIO), round(nominal_mb * VRAM_CEIL_RATIO))
 
 
-def get_expected_vram_windows(canonical_model: str) -> Optional[List[Tuple[int, int]]]:
+def smallest_nominal_vram_mb(model: str | None) -> int | None:
+    """Smallest nominal VRAM size (MB) for an advertised GPU model, via the registry SKU table.
+
+    Normalizes the CUDA-reported name, then returns the SMALLEST nominal size when the model is
+    multi-variant (e.g. RTX 3060 8/12 GB -> 8192) so a work-proof sized from this never OOMs an
+    honest smaller-variant card. Returns None for unknown models — the caller sizes off host
+    self-report or skips, never guesses. Keeps all registry sizing in this one module (DAH-2671).
+    """
+    canonical = normalize_gpu_model(model)
+    sizes = GPU_VRAM_SIZES_MB.get(canonical)
+    if not sizes:
+        return None
+    return min(sizes)
+
+
+def get_expected_vram_windows(canonical_model: str) -> list[tuple[int, int]] | None:
     """Return the list of (vram_mb_min, vram_mb_max) windows for `canonical_model`.
 
     Windows are computed from the model's nominal VRAM size(s) via

--- a/neurons/validators/src/services/matrix_validation_service.py
+++ b/neurons/validators/src/services/matrix_validation_service.py
@@ -30,6 +30,11 @@ MATRIX_VERIFY_TIMEOUT_SECONDS = 120
 # each keep the MATRIX_VERIFY_TIMEOUT_SECONDS cap, so this only fails clear serialisation.
 MATMUL_ALLCARDS_WALL_CLOCK_SECONDS = 90
 
+# Cards probed at once. Each card takes an SSH channel on one connection and MAX_GPU_COUNT is 14,
+# while OpenSSH defaults to MaxSessions 10 — 8 keeps the concurrency signal (a count lie still
+# serialises) and stays clear of that ceiling on the widest honest hosts.
+MATMUL_ALLCARDS_MAX_CONCURRENT_CARDS = 8
+
 
 class DMCompVerifyWrapper:
     def __init__(self, lib_name: str):
@@ -295,12 +300,20 @@ class ValidationService:
             params.cipher_text = self._generate_card_cipher(machine_info, params)
             challenges.append(params)
 
+        # One SSH channel per card on a single connection, so the fan-out has to stay under the
+        # executor's sshd MaxSessions (OpenSSH defaults to 10). A 12-14 card host would otherwise
+        # push the tail channels into the ssh_error branch and read as a failed work-proof.
+        gate = asyncio.Semaphore(MATMUL_ALLCARDS_MAX_CONCURRENT_CARDS)
+
+        async def run_gated(index: int, params: VerifierParams) -> dict:
+            async with gate:
+                return await self._run_one_card(
+                    ssh_client, executor_info, script_path, index, params
+                )
+
         start = time.perf_counter()
         per_card = await asyncio.gather(
-            *(
-                self._run_one_card(ssh_client, executor_info, script_path, index, params)
-                for index, params in enumerate(challenges)
-            )
+            *(run_gated(index, params) for index, params in enumerate(challenges))
         )
         elapsed = time.perf_counter() - start
 

--- a/neurons/validators/src/services/matrix_validation_service.py
+++ b/neurons/validators/src/services/matrix_validation_service.py
@@ -298,6 +298,17 @@ class ValidationService:
             params.generate()
             params.dim_k = int(self.get_max_matrix_dimensions(sized_vram_mb, params.dim_n))
             params.cipher_text = self._generate_card_cipher(machine_info, params)
+            # A native error yields an empty cipher, which would go out as a bare `--cipher_text `
+            # and read as a failed work-proof on every card. Our own fault, not the host's: skip
+            # the probe and let the caller's single-card path decide, as the legacy path does.
+            if not params.cipher_text:
+                logger.warning(
+                    _m(
+                        "All-cards matmul skipped: cipher text generation failed (native error)",
+                        extra=get_extra_info(default_extra),
+                    )
+                )
+                return None
             challenges.append(params)
 
         # One SSH channel per card on a single connection, so the fan-out has to stay under the

--- a/neurons/validators/src/services/matrix_validation_service.py
+++ b/neurons/validators/src/services/matrix_validation_service.py
@@ -386,10 +386,15 @@ class ValidationService:
             return {"card_index": index, "ok": False, "reason": f"exit_status={exit_status}"}
         if not stdout.strip():
             return {"card_index": index, "ok": False, "reason": "empty_output"}
-        # Record whether the executor's decrypt recovered THIS card's challenge uuid. Emitted for
-        # observability, NOT yet gated on (verdict stays exit-status + non-empty): it lets the shadow
-        # data show per-card decrypt efficacy — chiefly that machine_info reconstructs correctly under
-        # CUDA_VISIBLE_DEVICES on a real multi-GPU host. Gate on it before enforcement (DAH-2671).
+        # Observability only — do NOT gate the verdict on this. Confirmed on a staging 2xA6000
+        # (DAH-2671): under CUDA_VISIBLE_DEVICES the .so's getGPUInfo() reconstructs machine_info from
+        # the masked (single) card, so its AES key diverges from the validator's full-N machine_info
+        # key and decrypt recovers no uuid — uuid_match is expected False on EVERY honest multi-GPU
+        # host (the same box's no-CVD legacy CapabilityCheck verified fine). Item 3 therefore proves
+        # card COUNT via device-selection failure (an index past the real cards -> CUDA_ERROR_NO_DEVICE
+        # -> non-zero exit -> ok False) plus the aggregate wall-clock, NOT per-card crypto; the per-card
+        # cryptographic seal that survives CVD is the named follow-on ticket. The field is kept so the
+        # shadow data records this, and so a future seal-aware .so would flip it True.
         returned_uuid = _extract_result_uuid(stdout)
         return {
             "card_index": index,

--- a/neurons/validators/src/services/matrix_validation_service.py
+++ b/neurons/validators/src/services/matrix_validation_service.py
@@ -13,7 +13,7 @@ import asyncssh
 
 from core.config import settings
 from core.utils import _m, get_extra_info
-from services.gpu_spec_table import smallest_nominal_vram_mb
+from services.gpu_spec_table import matmul_probe_vram_mb
 
 logger = logging.getLogger(__name__)
 
@@ -178,6 +178,19 @@ class AllCardsProbe:
     per_card: list[dict]
 
 
+def _extract_result_uuid(stdout: str) -> str:
+    # uuid from the last RESULT_JSON marker, else the legacy "UUID:" line; "" if neither parses
+    lines = stdout.splitlines()
+    for line in reversed(lines):
+        if line.startswith("RESULT_JSON:"):
+            try:
+                return str(json.loads(line[len("RESULT_JSON:"):].strip()).get("uuid", "") or "")
+            except (ValueError, TypeError, AttributeError):
+                break
+    uuid_line = next((line for line in lines if line.startswith("UUID:")), None)
+    return uuid_line.split("UUID:")[1].strip() if uuid_line else ""
+
+
 class ValidationService:
     def __init__(self):
         """
@@ -262,7 +275,7 @@ class ValidationService:
             return None
 
         gpu_model = details[0].get("name", "") or ""
-        sized_vram_mb = smallest_nominal_vram_mb(gpu_model)
+        sized_vram_mb = matmul_probe_vram_mb(gpu_model)
         if not sized_vram_mb:
             return None
 
@@ -318,6 +331,13 @@ class ValidationService:
         }
         log = logger.info if passed else logger.warning
         log(_m("All-cards GPU work-proof", extra=get_extra_info(log_extra)))
+
+        if any(outcome.get("reason") == "timeout" for outcome in per_card):
+            # asyncssh's timeout only abandons the local wait; a timed-out remote matmul keeps
+            # running and holding VRAM. The fatal single-card capability matmul runs next in this
+            # same call, so sweep the orphans first or it OOMs on device 0 — mirrors the legacy path.
+            await self._kill_remote_matmul(ssh_client, script_path, log_extra)
+
         return AllCardsProbe(
             passed=passed,
             failure_reason=failure_reason,
@@ -366,7 +386,18 @@ class ValidationService:
             return {"card_index": index, "ok": False, "reason": f"exit_status={exit_status}"}
         if not stdout.strip():
             return {"card_index": index, "ok": False, "reason": "empty_output"}
-        return {"card_index": index, "ok": True, "reason": ""}
+        # Record whether the executor's decrypt recovered THIS card's challenge uuid. Emitted for
+        # observability, NOT yet gated on (verdict stays exit-status + non-empty): it lets the shadow
+        # data show per-card decrypt efficacy — chiefly that machine_info reconstructs correctly under
+        # CUDA_VISIBLE_DEVICES on a real multi-GPU host. Gate on it before enforcement (DAH-2671).
+        returned_uuid = _extract_result_uuid(stdout)
+        return {
+            "card_index": index,
+            "ok": True,
+            "reason": "",
+            "returned_uuid": returned_uuid,
+            "uuid_match": bool(returned_uuid) and returned_uuid == params.uuid,
+        }
 
     async def validate_gpu_model_and_process_job(
         self,

--- a/neurons/validators/src/services/matrix_validation_service.py
+++ b/neurons/validators/src/services/matrix_validation_service.py
@@ -343,7 +343,7 @@ class ValidationService:
         log = logger.info if passed else logger.warning
         log(_m("All-cards GPU work-proof", extra=get_extra_info(log_extra)))
 
-        if any(outcome.get("reason") == "timeout" for outcome in per_card):
+        if any(self._leaves_matmul_running(outcome) for outcome in per_card):
             # asyncssh's timeout only abandons the local wait; a timed-out remote matmul keeps
             # running and holding VRAM. The fatal single-card capability matmul runs next in this
             # same call, so sweep the orphans first or it OOMs on device 0 — mirrors the legacy path.
@@ -356,6 +356,13 @@ class ValidationService:
             over_wall_clock=over_wall_clock,
             per_card=per_card,
         )
+
+    @staticmethod
+    def _leaves_matmul_running(outcome: dict) -> bool:
+        # the per-card failures where the remote matmul may still hold VRAM: a timeout abandons only
+        # the local wait, and a channel that dies mid-run (ssh_error) leaves the process untouched
+        reason = outcome.get("reason") or ""
+        return reason == "timeout" or reason.startswith("ssh_error")
 
     def _generate_card_cipher(self, machine_info: str, params: "VerifierParams") -> str:
         # generate one card's challenge on a dedicated object; no per-card seal is verified (a

--- a/neurons/validators/src/services/matrix_validation_service.py
+++ b/neurons/validators/src/services/matrix_validation_service.py
@@ -183,19 +183,6 @@ class AllCardsProbe:
     per_card: list[dict]
 
 
-def _extract_result_uuid(stdout: str) -> str:
-    # uuid from the last RESULT_JSON marker, else the legacy "UUID:" line; "" if neither parses
-    lines = stdout.splitlines()
-    for line in reversed(lines):
-        if line.startswith("RESULT_JSON:"):
-            try:
-                return str(json.loads(line[len("RESULT_JSON:"):].strip()).get("uuid", "") or "")
-            except (ValueError, TypeError, AttributeError):
-                break
-    uuid_line = next((line for line in lines if line.startswith("UUID:")), None)
-    return uuid_line.split("UUID:")[1].strip() if uuid_line else ""
-
-
 class ValidationService:
     def __init__(self):
         """
@@ -410,23 +397,9 @@ class ValidationService:
             return {"card_index": index, "ok": False, "reason": f"exit_status={exit_status}"}
         if not stdout.strip():
             return {"card_index": index, "ok": False, "reason": "empty_output"}
-        # Observability only — do NOT gate the verdict on this. Confirmed on a staging 2xA6000
-        # (DAH-2671): under CUDA_VISIBLE_DEVICES the .so's getGPUInfo() reconstructs machine_info from
-        # the masked (single) card, so its AES key diverges from the validator's full-N machine_info
-        # key and decrypt recovers no uuid — uuid_match is expected False on EVERY honest multi-GPU
-        # host (the same box's no-CVD legacy CapabilityCheck verified fine). Item 3 therefore proves
-        # card COUNT via device-selection failure (an index past the real cards -> CUDA_ERROR_NO_DEVICE
-        # -> non-zero exit -> ok False) plus the aggregate wall-clock, NOT per-card crypto; the per-card
-        # cryptographic seal that survives CVD is the named follow-on ticket. The field is kept so the
-        # shadow data records this, and so a future seal-aware .so would flip it True.
-        returned_uuid = _extract_result_uuid(stdout)
-        return {
-            "card_index": index,
-            "ok": True,
-            "reason": "",
-            "returned_uuid": returned_uuid,
-            "uuid_match": bool(returned_uuid) and returned_uuid == params.uuid,
-        }
+        # No per-card cryptographic seal yet (follow-on ticket): the .so's AES key diverges under
+        # CUDA_VISIBLE_DEVICES, so per-card crypto cannot gate today.
+        return {"card_index": index, "ok": True, "reason": ""}
 
     async def validate_gpu_model_and_process_job(
         self,

--- a/neurons/validators/src/services/matrix_validation_service.py
+++ b/neurons/validators/src/services/matrix_validation_service.py
@@ -1,17 +1,19 @@
 import asyncio
-import time
-import random
-import logging
 import json
+import logging
 import os
+import random
 import shlex
+import time
 import uuid as uuid4
+from ctypes import CDLL, POINTER, c_char_p, c_longlong, c_void_p
 from dataclasses import dataclass
 
 import asyncssh
 
+from core.config import settings
 from core.utils import _m, get_extra_info
-from ctypes import CDLL, c_longlong, POINTER, c_void_p, c_char_p
+from services.gpu_spec_table import smallest_nominal_vram_mb
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +21,14 @@ logger = logging.getLogger(__name__)
 # GPU (e.g. VRAM held by an orphaned container, DAH-2364) hangs the whole pipeline until
 # the outer JOB_TIME_OUT cancellation, which dies silently without a reason_code (DAH-2365).
 MATRIX_VERIFY_TIMEOUT_SECONDS = 120
+
+# DAH-2671 item 3 — wide aggregate wall-clock (seconds) for the all-claimed-cards work-proof.
+# N honest cards run concurrently in ~single-card time (4-27s); a count lie that serialises onto one
+# real card blows out to ~N*single-card. This threshold is deliberately WIDE so honest slowdowns
+# (disabled P2P/IOMMU/ACS, 10-20% thermal throttle, a card already busy with a filler) do not trip
+# it; the emitted RAW timing lets ops recalibrate before flipping enforcement. The per-card SSH runs
+# each keep the MATRIX_VERIFY_TIMEOUT_SECONDS cap, so this only fails clear serialisation.
+MATMUL_ALLCARDS_WALL_CLOCK_SECONDS = 90
 
 
 class DMCompVerifyWrapper:
@@ -150,7 +160,23 @@ class ValidationResult:
     def __bool__(self) -> bool:
         """Allow using ValidationResult in boolean context for backward compatibility."""
         return self.success
-    
+
+
+@dataclass
+class AllCardsProbe:
+    """Outcome of the all-claimed-cards work-proof (DAH-2671 item 3).
+
+    Honesty (validator-side only, never sent to the host): this proves N cards' worth of capacity
+    existed in the window, NOT that the cards share one chassis — a relay to a genuine 8-GPU host
+    still passes. Chassis-binding (NCCL) and the per-card cryptographic seal are follow-on tickets.
+    """
+
+    passed: bool
+    failure_reason: str
+    elapsed_seconds: float
+    over_wall_clock: bool
+    per_card: list[dict]
+
 
 class ValidationService:
     def __init__(self):
@@ -221,6 +247,127 @@ class ValidationService:
                 )
             )
 
+    async def _probe_all_claimed_cards(
+        self, ssh_client, executor_info, default_extra: dict, machine_spec: dict
+    ) -> AllCardsProbe | None:
+        # concurrent per-card work-proof: one independent challenge per claimed card (own seed + own
+        # uuid + own cipher), each pinned with CUDA_VISIBLE_DEVICES=<index>, sized from the registry
+        # SKU (not host self-report), aggregate timed on the validator. Returns None when it does not
+        # apply — a single claimed card (legacy/whole-single-GPU path) or a model with no known
+        # registry VRAM size (cannot size safely) — so the caller's single-card path stays authoritative.
+        gpu = machine_spec.get("gpu", {}) or {}
+        gpu_count = gpu.get("count", 0) or 0
+        details = gpu.get("details", []) or []
+        if gpu_count <= 1 or not details:
+            return None
+
+        gpu_model = details[0].get("name", "") or ""
+        sized_vram_mb = smallest_nominal_vram_mb(gpu_model)
+        if not sized_vram_mb:
+            return None
+
+        gpu_uuids = ",".join(detail.get("uuid", "") for detail in details)
+        # machine_info is identical across cards — the executor's .so reconstructs it locally from
+        # getGPUInfo(); only seed+uuid (and thus the cipher) differ per card.
+        machine_info = json.dumps(
+            {"uuids": gpu_uuids, "gpu_count": gpu_count, "gpu_model": gpu_model}, sort_keys=True
+        )
+        script_path = f"{executor_info.root_dir}/src/decrypt_challenge.py"
+
+        challenges: list[VerifierParams] = []
+        for _ in range(gpu_count):
+            params = VerifierParams()
+            params.generate()
+            params.dim_k = int(self.get_max_matrix_dimensions(sized_vram_mb, params.dim_n))
+            params.cipher_text = self._generate_card_cipher(machine_info, params)
+            challenges.append(params)
+
+        start = time.perf_counter()
+        per_card = await asyncio.gather(
+            *(
+                self._run_one_card(ssh_client, executor_info, script_path, index, params)
+                for index, params in enumerate(challenges)
+            )
+        )
+        elapsed = time.perf_counter() - start
+
+        failed_cards = [outcome for outcome in per_card if not outcome["ok"]]
+        over_wall_clock = elapsed > MATMUL_ALLCARDS_WALL_CLOCK_SECONDS
+        passed = not failed_cards and not over_wall_clock
+        if failed_cards:
+            failure_reason = f"{len(failed_cards)}/{gpu_count} card(s) failed device work-proof"
+        elif over_wall_clock:
+            failure_reason = (
+                f"aggregate wall-clock {elapsed:.1f}s over {MATMUL_ALLCARDS_WALL_CLOCK_SECONDS}s "
+                f"(serialisation on fewer real cards than claimed)"
+            )
+        else:
+            failure_reason = ""
+
+        log_extra = {
+            **default_extra,
+            "gpu_count_claimed": gpu_count,
+            "gpu_model": gpu_model,
+            "sized_vram_mb": sized_vram_mb,
+            "elapsed_seconds": round(elapsed, 3),
+            "wall_clock_threshold_seconds": MATMUL_ALLCARDS_WALL_CLOCK_SECONDS,
+            "over_wall_clock": over_wall_clock,
+            "per_card": per_card,
+            "passed": passed,
+            "enforced": settings.MATMUL_ALLCARDS_ENFORCEMENT_ENABLED,
+        }
+        log = logger.info if passed else logger.warning
+        log(_m("All-cards GPU work-proof", extra=get_extra_info(log_extra)))
+        return AllCardsProbe(
+            passed=passed,
+            failure_reason=failure_reason,
+            elapsed_seconds=elapsed,
+            over_wall_clock=over_wall_clock,
+            per_card=per_card,
+        )
+
+    def _generate_card_cipher(self, machine_info: str, params: "VerifierParams") -> str:
+        # generate one card's challenge on a dedicated object; no per-card seal is verified (a
+        # follow-on ticket), so the key is not retained past cipher generation.
+        gen_ptr = None
+        try:
+            gen_ptr = self.wrapper.DMCompVerify_new(10, 10)
+            self.wrapper.setDimension(gen_ptr, params.dim_n, params.dim_k)
+            self.wrapper.generateChallenge(gen_ptr, params.seed, machine_info, params.uuid)
+            return self.wrapper.getCipherText(gen_ptr) or ""
+        except Exception as e:
+            logger.error("Failed encrypt challenge request (all-cards): %s", str(e))
+            return ""
+        finally:
+            if gen_ptr is not None:
+                try:
+                    self.wrapper.free(gen_ptr)
+                except Exception:
+                    pass
+
+    async def _run_one_card(
+        self, ssh_client, executor_info, script_path: str, index: int, params: "VerifierParams"
+    ) -> dict:
+        # run the challenge pinned to one CUDA device index; a count lie fails device selection here
+        # (invalid ordinal) or serialises onto the one real card, caught by the aggregate wall-clock.
+        # The command sent to the executor is unchanged except the CUDA_VISIBLE_DEVICES env prefix,
+        # and never reveals which card/signal disagreed (anti-treadmill).
+        command = f"CUDA_VISIBLE_DEVICES={index} {executor_info.python_path} {script_path} {params}"
+        try:
+            result = await ssh_client.run(command, timeout=MATRIX_VERIFY_TIMEOUT_SECONDS)
+        except (TimeoutError, asyncssh.TimeoutError):
+            return {"card_index": index, "ok": False, "reason": "timeout"}
+        except Exception as e:
+            return {"card_index": index, "ok": False, "reason": f"ssh_error: {e}"}
+
+        exit_status = getattr(result, "exit_status", 0)
+        stdout = getattr(result, "stdout", "") or ""
+        if exit_status != 0:
+            return {"card_index": index, "ok": False, "reason": f"exit_status={exit_status}"}
+        if not stdout.strip():
+            return {"card_index": index, "ok": False, "reason": "empty_output"}
+        return {"card_index": index, "ok": True, "reason": ""}
+
     async def validate_gpu_model_and_process_job(
         self,
         ssh_client,
@@ -228,6 +375,25 @@ class ValidationService:
         default_extra: dict,
         machine_spec: dict,
     ) -> ValidationResult:
+        # DAH-2671 item 3: all-claimed-cards work-proof. Shadow (MATMUL_ALLCARDS_CHECK_ENABLED
+        # without enforcement) logs timing + per-card outcome and NEVER changes the returned result;
+        # enforcement fails a count lie (device-selection error / OOM / serialised aggregate
+        # wall-clock). Single-card / unknown-model hosts skip it (probe returns None), which also
+        # keeps a not-yet-relevant fleet — and the legacy single-card path below — unchanged.
+        if settings.MATMUL_ALLCARDS_CHECK_ENABLED:
+            all_cards = await self._probe_all_claimed_cards(
+                ssh_client, executor_info, default_extra, machine_spec
+            )
+            if (
+                settings.MATMUL_ALLCARDS_ENFORCEMENT_ENABLED
+                and all_cards is not None
+                and not all_cards.passed
+            ):
+                return ValidationResult(
+                    success=False,
+                    error_message=f"All-cards GPU work-proof failed: {all_cards.failure_reason}",
+                )
+
         # Per-call verifier object: its key MUST survive the SSH round-trip so we can
         # unseal the executor's authenticated response. A shared object would be clobbered
         # by concurrent validations across the `await` below. Freed in `finally`.
@@ -309,7 +475,7 @@ class ValidationService:
             # Run the script
             try:
                 result = await ssh_client.run(command, timeout=MATRIX_VERIFY_TIMEOUT_SECONDS)
-            except (asyncssh.TimeoutError, asyncio.TimeoutError):
+            except (TimeoutError, asyncssh.TimeoutError):
                 # asyncssh's timeout only abandons the local wait — the remote process keeps
                 # running and holding GPU memory, so it must be killed explicitly.
                 error_msg = (
@@ -346,7 +512,7 @@ class ValidationService:
             try:
                 stdout = result.stdout.strip()
                 stderr = result.stderr.strip() if hasattr(result, 'stderr') else ""
-            except AttributeError as e:
+            except AttributeError:
                 error_msg = "Result object missing stdout attribute"
                 logger.error(_m(error_msg, extra=get_extra_info(log_extra)))
                 return ValidationResult(

--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -37,7 +37,6 @@ executor-side issues.
 """
 from __future__ import annotations
 
-import inspect
 import logging
 import shlex
 import xml.etree.ElementTree as ET
@@ -88,9 +87,6 @@ def _ssh_peer(ssh: asyncssh.SSHClientConnection) -> str | None:
         return None
     if isinstance(peer, tuple | list) and len(peer) >= 2:
         return f"{peer[0]}:{peer[1]}"
-    # A mocked (AsyncMock) connection can hand back a coroutine here; drop it without awaiting.
-    if inspect.iscoroutine(peer):
-        peer.close()
     return None
 
 

--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -268,13 +268,15 @@ async def _query_gpu_nodes_for_uuids(
     total lets the caller decide whether this is a partial-host rental.
     """
     errors: list[str] = []
-    proc_unreadable = False
     try:
         uuid_to_minor = await _query_gpu_minor_map_from_proc(ssh)
     except RuntimeError as exc:
         errors.append(str(exc))
         uuid_to_minor = {}
-        proc_unreadable = True
+    # An empty map is the real signal, not the exception: _PROC_GPU_INFO_CMD swallows an
+    # unreadable procfs (unexpanded glob, `|| continue`, stderr discarded) and exits 0, so an
+    # honest host with no readable procfs would otherwise log identically to a spoof.
+    proc_unreadable = not uuid_to_minor
 
     if not uuid_to_minor or _missing_gpu_uuids(gpu_uuids, uuid_to_minor):
         # The kernel (procfs) map cannot satisfy the request; today we consult the NVML-backed

--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -35,6 +35,7 @@ executor-side issues.
 """
 from __future__ import annotations
 
+import inspect
 import logging
 import shlex
 import xml.etree.ElementTree as ET
@@ -46,6 +47,100 @@ from core.config import settings
 from services.rental_docker_sdk import GpuDockerConfig, build_gpu_docker_config
 
 logger = logging.getLogger(__name__)
+
+# Distinctive, stable log-message strings so ops can hang a Loki alert on them (DAH-2671, item 1).
+# There is no separate alert service in the validator — the structured log line IS the alert.
+_KERNEL_GPU_VERDICT_MISSING_MSG = "kernel_gpu_verdict: rented GPU absent from kernel procfs list"
+_KERNEL_GPU_VERDICT_DISAGREE_MSG = "kernel_gpu_verdict: kernel procfs vs nvidia-smi XML GPU disagreement"
+
+
+class MissingRentedGpuError(RuntimeError):
+    """A tenant-requested GPU UUID is absent from the kernel (procfs) GPU list.
+
+    The kernel `/proc/driver/nvidia/gpus/*/information` list is the one GPU inventory the NVML
+    shim does not author, so this is the truth verdict. Carries the full requested/visible/missing
+    UUID lists so the caught event can report counts and both lists without re-parsing the message.
+    """
+
+    def __init__(
+        self,
+        *,
+        requested_uuids: Sequence[str],
+        visible_uuids: Sequence[str],
+        missing_uuids: Sequence[str],
+    ):
+        self.requested_uuids = list(requested_uuids)
+        self.visible_uuids = list(visible_uuids)
+        self.missing_uuids = list(missing_uuids)
+        super().__init__(
+            f"GPU {self.missing_uuids[0]!r} requested by tenant not present on executor; "
+            f"visible: {sorted(self.visible_uuids)}"
+        )
+
+
+def _ssh_peer(ssh: asyncssh.SSHClientConnection) -> str | None:
+    # host:port of the executor, a usable Loki key even when the caller passes no executor_id
+    try:
+        peer = ssh.get_extra_info("peername")
+    except Exception:
+        return None
+    if isinstance(peer, tuple | list) and len(peer) >= 2:
+        return f"{peer[0]}:{peer[1]}"
+    # A mocked (AsyncMock) connection can hand back a coroutine here; drop it without awaiting.
+    if inspect.iscoroutine(peer):
+        peer.close()
+    return None
+
+
+def _emit_missing_rented_gpu(
+    ssh: asyncssh.SSHClientConnection,
+    exc: MissingRentedGpuError,
+    *,
+    executor_id: str | None,
+    default_extra: dict | None,
+) -> None:
+    logger.warning(
+        _KERNEL_GPU_VERDICT_MISSING_MSG,
+        extra={
+            **(default_extra or {}),
+            "kernel_gpu_verdict": "missing_rented_gpu",
+            "executor_id": executor_id,
+            "executor_peer": _ssh_peer(ssh),
+            "requested_gpu_count": len(exc.requested_uuids),
+            "visible_gpu_count": len(exc.visible_uuids),
+            "requested_uuids": exc.requested_uuids,
+            "visible_uuids": exc.visible_uuids,
+            "missing_uuids": exc.missing_uuids,
+        },
+    )
+
+
+def _emit_kernel_xml_disagreement(
+    ssh: asyncssh.SSHClientConnection,
+    gpu_uuids: Sequence[str],
+    proc_map: dict[str, int],
+    xml_map: dict[str, int],
+    *,
+    proc_unreadable: bool,
+    enforce: bool,
+) -> None:
+    logger.warning(
+        _KERNEL_GPU_VERDICT_DISAGREE_MSG,
+        extra={
+            "kernel_gpu_verdict": "kernel_xml_disagreement",
+            "executor_peer": _ssh_peer(ssh),
+            # proc_unreadable distinguishes the honest case (an unreadable /proc map, which
+            # enforcement also refuses) from a real spoof (proc readable but missing a card the
+            # spoofable XML claims). Under shadow, placement is unchanged; only this line is emitted.
+            "proc_unreadable": proc_unreadable,
+            "enforced": enforce,
+            "requested_uuids": list(gpu_uuids),
+            "kernel_visible_uuids": sorted(proc_map),
+            "xml_visible_uuids": sorted(xml_map),
+            "xml_would_add_uuids": [u for u in gpu_uuids if u not in proc_map and u in xml_map],
+        },
+    )
+
 
 _PROC_GPU_INFO_CMD = (
     "for f in /proc/driver/nvidia/gpus/*/information; do "
@@ -65,6 +160,9 @@ _PROC_GPU_INFO_CMD = (
 async def build_gpu_flags(
     ssh_client: asyncssh.SSHClientConnection,
     gpu_uuids: Sequence[str] | None,
+    *,
+    executor_id: str | None = None,
+    default_extra: dict | None = None,
 ) -> str:
     """Assemble the full GPU flag block for `docker run`.
 
@@ -79,7 +177,9 @@ async def build_gpu_flags(
     at WARNING). The pod will still be created in the legacy path; it just
     won't survive `systemctl daemon-reload` on the executor host.
     """
-    gpu_config = await build_gpu_docker_config_for_executor(ssh_client, gpu_uuids)
+    gpu_config = await build_gpu_docker_config_for_executor(
+        ssh_client, gpu_uuids, executor_id=executor_id, default_extra=default_extra
+    )
     device_flags = _device_flags(
         tuple(device.path_on_host for device in gpu_config.device_mounts)
     )
@@ -89,6 +189,9 @@ async def build_gpu_flags(
 async def build_gpu_docker_config_for_executor(
     ssh_client: asyncssh.SSHClientConnection,
     gpu_uuids: Sequence[str] | None,
+    *,
+    executor_id: str | None = None,
+    default_extra: dict | None = None,
 ) -> GpuDockerConfig:
     """Resolve structured GPU Docker options for SDK container creation."""
     try:
@@ -106,7 +209,14 @@ async def build_gpu_docker_config_for_executor(
         # under partial rental closes the leak before either ever ships.
         shared = await _query_shared_nodes(ssh_client, is_whole_host_rental=not is_partial_rental)
         return build_gpu_docker_config(gpu_uuids, device_nodes=(*per_gpu, *shared))
-    except Exception:
+    except Exception as exc:
+        # 1a: the kernel-truth verdict (a rented UUID absent from procfs) otherwise dies as a bare
+        # WARNING. Surface it as a stable structured event so ops can alert on it; behavior is
+        # unchanged — we still fall back to the legacy --gpus string below.
+        if isinstance(exc, MissingRentedGpuError) and settings.KERNEL_GPU_VERDICT_CHECK_ENABLED:
+            _emit_missing_rented_gpu(
+                ssh_client, exc, executor_id=executor_id, default_extra=default_extra
+            )
         logger.warning(
             "nvidia_devices: probe failed, falling back to legacy --gpus only "
             "(pod will not survive systemd daemon-reload on the executor)",
@@ -142,20 +252,45 @@ async def _query_gpu_nodes_for_uuids(
     total lets the caller decide whether this is a partial-host rental.
     """
     errors: list[str] = []
+    proc_unreadable = False
     try:
         uuid_to_minor = await _query_gpu_minor_map_from_proc(ssh)
     except RuntimeError as exc:
         errors.append(str(exc))
         uuid_to_minor = {}
+        proc_unreadable = True
 
     if not uuid_to_minor or _missing_gpu_uuids(gpu_uuids, uuid_to_minor):
+        # The kernel (procfs) map cannot satisfy the request; today we consult the NVML-backed
+        # nvidia-smi XML, which the shim can spoof, and let it replace the kernel truth. 1b: treat a
+        # kernel-vs-XML disagreement (XML supplies a UUID the kernel lacks) as the finding. Under
+        # enforcement, refuse the overwrite — the kernel truth stands and the missing-GPU verdict
+        # below fires (fail closed). Under shadow, emit and preserve today's overwrite exactly.
         try:
             xml_uuid_to_minor = await _query_gpu_minor_map_from_nvidia_smi_xml(ssh)
         except RuntimeError as exc:
             errors.append(str(exc))
-        else:
-            if xml_uuid_to_minor:
-                uuid_to_minor = xml_uuid_to_minor
+            xml_uuid_to_minor = {}
+
+        overwrite_with_xml = bool(xml_uuid_to_minor)
+        if xml_uuid_to_minor and settings.KERNEL_GPU_VERDICT_CHECK_ENABLED:
+            xml_would_add = [
+                u for u in gpu_uuids if u not in uuid_to_minor and u in xml_uuid_to_minor
+            ]
+            if xml_would_add:
+                enforce = settings.KERNEL_GPU_VERDICT_ENFORCEMENT_ENABLED
+                _emit_kernel_xml_disagreement(
+                    ssh,
+                    gpu_uuids,
+                    uuid_to_minor,
+                    xml_uuid_to_minor,
+                    proc_unreadable=proc_unreadable,
+                    enforce=enforce,
+                )
+                if enforce:
+                    overwrite_with_xml = False
+        if overwrite_with_xml:
+            uuid_to_minor = xml_uuid_to_minor
 
     if not uuid_to_minor:
         details = f": {'; '.join(errors)}" if errors else ""
@@ -163,9 +298,10 @@ async def _query_gpu_nodes_for_uuids(
 
     missing = _missing_gpu_uuids(gpu_uuids, uuid_to_minor)
     if missing:
-        raise RuntimeError(
-            f"GPU {missing[0]!r} requested by tenant not present on executor; "
-            f"visible: {sorted(uuid_to_minor)}"
+        raise MissingRentedGpuError(
+            requested_uuids=gpu_uuids,
+            visible_uuids=list(uuid_to_minor),
+            missing_uuids=missing,
         )
 
     # Deduplicated, request order kept: the caller compares this length against the host GPU count

--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -26,8 +26,10 @@ Public surface
 
 Failure handling
 ----------------
-`build_gpu_flags` never raises: any probe failure (SSH error, missing
-nvidia-smi, unknown UUID, etc.) is logged at WARNING and the function falls
+`build_gpu_flags` raises only one thing: `MissingRentedGpuError`, and only under
+KERNEL_GPU_VERDICT_ENFORCEMENT_ENABLED — a rented UUID the kernel cannot see must not become a
+container (DAH-2671, item 1). Every other probe failure (SSH error, missing
+nvidia-smi, etc.) is logged at WARNING and the function falls
 back to the legacy `--gpus`-only string. The pod still gets created — it
 just doesn't get the daemon-reload protection. This trades a known
 regression (back to today's behaviour) for resilience against unforeseen
@@ -217,6 +219,11 @@ async def build_gpu_docker_config_for_executor(
             _emit_missing_rented_gpu(
                 ssh_client, exc, executor_id=executor_id, default_extra=default_extra
             )
+            if settings.KERNEL_GPU_VERDICT_ENFORCEMENT_ENABLED:
+                # Fail closed: falling through to the legacy --gpus string would still create the
+                # container on a host that cannot hand over a rented card, only without the --device
+                # entries. The caller records this create FAILED, the same way gpu_power_cap does.
+                raise
         logger.warning(
             "nvidia_devices: probe failed, falling back to legacy --gpus only "
             "(pod will not survive systemd daemon-reload on the executor)",

--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -125,11 +125,15 @@ def _emit_kernel_xml_disagreement(
     *,
     proc_unreadable: bool,
     enforce: bool,
+    executor_id: str | None,
+    default_extra: dict | None,
 ) -> None:
     logger.warning(
         _KERNEL_GPU_VERDICT_DISAGREE_MSG,
         extra={
+            **(default_extra or {}),
             "kernel_gpu_verdict": "kernel_xml_disagreement",
+            "executor_id": executor_id,
             "executor_peer": _ssh_peer(ssh),
             # proc_unreadable distinguishes the honest case (an unreadable /proc map, which
             # enforcement also refuses) from a real spoof (proc readable but missing a card the
@@ -198,7 +202,9 @@ async def build_gpu_docker_config_for_executor(
     """Resolve structured GPU Docker options for SDK container creation."""
     try:
         if gpu_uuids:
-            per_gpu, host_total = await _query_gpu_nodes_for_uuids(ssh_client, gpu_uuids)
+            per_gpu, host_total = await _query_gpu_nodes_for_uuids(
+                ssh_client, gpu_uuids, executor_id=executor_id, default_extra=default_extra
+            )
             is_partial_rental = len(per_gpu) < host_total
         else:
             per_gpu = await _query_all_gpu_nodes(ssh_client)
@@ -252,6 +258,9 @@ async def _query_all_gpu_nodes(ssh: asyncssh.SSHClientConnection) -> tuple[str, 
 async def _query_gpu_nodes_for_uuids(
     ssh: asyncssh.SSHClientConnection,
     gpu_uuids: Sequence[str],
+    *,
+    executor_id: str | None = None,
+    default_extra: dict | None = None,
 ) -> tuple[tuple[str, ...], int]:
     """Resolve requested UUIDs to /dev/nvidiaN nodes, plus return host GPU count.
 
@@ -293,6 +302,8 @@ async def _query_gpu_nodes_for_uuids(
                     xml_uuid_to_minor,
                     proc_unreadable=proc_unreadable,
                     enforce=enforce,
+                    executor_id=executor_id,
+                    default_extra=default_extra,
                 )
                 if enforce:
                     overwrite_with_xml = False

--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -273,6 +273,7 @@ async def _query_gpu_nodes_for_uuids(
     # unreadable procfs (unexpanded glob, `|| continue`, stderr discarded) and exits 0, so an
     # honest host with no readable procfs would otherwise log identically to a spoof.
     proc_unreadable = not uuid_to_minor
+    refused_xml_overwrite = False
 
     if not uuid_to_minor or _missing_gpu_uuids(gpu_uuids, uuid_to_minor):
         # The kernel (procfs) map cannot satisfy the request; today we consult the NVML-backed
@@ -305,10 +306,21 @@ async def _query_gpu_nodes_for_uuids(
                 )
                 if enforce:
                     overwrite_with_xml = False
+                    refused_xml_overwrite = True
         if overwrite_with_xml:
             uuid_to_minor = xml_uuid_to_minor
 
     if not uuid_to_minor:
+        if refused_xml_overwrite:
+            # Enforcement just refused the XML overwrite on an unreadable procfs, so the kernel
+            # knows none of the rented cards. A plain RuntimeError here would land in the caller's
+            # generic branch and fall back to the legacy --gpus string — the container gets created
+            # anyway and fail-closed would not hold. Name the verdict instead.
+            raise MissingRentedGpuError(
+                requested_uuids=gpu_uuids,
+                visible_uuids=[],
+                missing_uuids=list(gpu_uuids),
+            )
         details = f": {'; '.join(errors)}" if errors else ""
         raise RuntimeError(f"GPU minor discovery returned no UUID/minor rows{details}")
 

--- a/neurons/validators/src/services/task/checks/__init__.py
+++ b/neurons/validators/src/services/task/checks/__init__.py
@@ -3,6 +3,7 @@ from .banned_provider import BannedProviderCheck
 from .cached_template_verification import CachedTemplateVerificationCheck
 from .capability import CapabilityCheck
 from .collateral import CollateralCheck
+from .cpu_truth import CpuTruthCheck
 from .custom_build_orphan_sweep import CustomBuildOrphanSweepCheck
 from .duplicate_executor import DuplicateExecutorCheck
 from .finalize import FinalizeCheck
@@ -34,6 +35,7 @@ __all__ = [
     "CachedTemplateVerificationCheck",
     "CapabilityCheck",
     "CollateralCheck",
+    "CpuTruthCheck",
     "CustomBuildOrphanSweepCheck",
     "DuplicateExecutorCheck",
     "FinalizeCheck",

--- a/neurons/validators/src/services/task/checks/cpu_truth.py
+++ b/neurons/validators/src/services/task/checks/cpu_truth.py
@@ -27,7 +27,7 @@ class CpuTruthCheck:
     the host too (bind-mount / PATH-wrap reachable) so they are recorded as corroborating only.
 
     Non-fatal and observe-only: shadow always passes, and only CPU_TRUTH_ENFORCEMENT_ENABLED lets a
-    genuine mismatch fail. Never fails on an inability to measure (SSH error, unreadable population,
+    genuine mismatch fail and zero the score. Never fails on an inability to measure (SSH error, unreadable population,
     missing advertised count) — those return passed=True with a distinct *_unknown reason.
     """
 
@@ -76,7 +76,20 @@ class CpuTruthCheck:
                 impact=None if enforce else "Shadow observation only: score was NOT changed",
                 what=what,
             )
-            return CheckResult(passed=not enforce, event=event)
+            # The check is non-fatal, so passed=False alone changes nothing in the pipeline: under
+            # enforcement the score has to be zeroed explicitly, the same quarantine the CPU-quota
+            # verdict applies.
+            updates = (
+                {
+                    "score": 0.0,
+                    "job_score": 0.0,
+                    "score_warning": "Advertised CPU cores exceed the host's physical cores",
+                    "clear_verified_job_info": True,
+                }
+                if enforce
+                else {}
+            )
+            return CheckResult(passed=not enforce, event=event, updates=updates)
 
         event = render_message(Msg.CPU_OK, ctx=ctx, check_id=self.check_id, what=what)
         return CheckResult(passed=True, event=event)

--- a/neurons/validators/src/services/task/checks/cpu_truth.py
+++ b/neurons/validators/src/services/task/checks/cpu_truth.py
@@ -15,6 +15,10 @@ from ..pipeline import CheckResult, Context
 # vs 44), far outside any slack, so the margin never masks a real lie. The predicate is provisional:
 # the emitted RAW counts let ops recalibrate from a week of fleet data before flipping enforcement.
 CPU_TRUTH_MARGIN_CORES = 4
+# Reading one sysfs file is instant on a live host; without a bound a wedged host would hold the
+# check open for the executor's whole validation budget. A timeout lands in the *_unknown path
+# (asyncssh raises the builtin TimeoutError, itself an OSError), so the host is never failed for it.
+CPU_TRUTH_READ_TIMEOUT_SECONDS = 15
 
 
 class CpuTruthCheck:
@@ -38,7 +42,7 @@ class CpuTruthCheck:
             event = render_message(Msg.SKIPPED, ctx=ctx, check_id=self.check_id)
             return CheckResult(passed=True, event=event)
 
-        advertised = self._advertised_count(ctx)
+        advertised = advertised_cpu_count(ctx)
         if advertised is None:
             return self._unknown(ctx, reason="advertised CPU count missing from specs")
 
@@ -86,17 +90,11 @@ class CpuTruthCheck:
         event = render_message(Msg.CPU_OK, ctx=ctx, check_id=self.check_id, what=what)
         return CheckResult(passed=True, event=event)
 
-    def _advertised_count(self, ctx: Context) -> int | None:
-        cpu = (ctx.state.specs or {}).get("cpu") or {}
-        try:
-            count = int(cpu.get("count"))
-        except (TypeError, ValueError):
-            return None
-        return count if count > 0 else None
-
     async def _read_present(self, ssh) -> int | None:
         # kernel-present CPU population — the authoritative like-with-like comparison
-        res = await ssh.run("cat /sys/devices/system/cpu/present")
+        res = await ssh.run(
+            "cat /sys/devices/system/cpu/present", timeout=CPU_TRUTH_READ_TIMEOUT_SECONDS
+        )
         if getattr(res, "exit_status", 1) != 0:
             return None
         return _count_cpu_list((getattr(res, "stdout", "") or "").strip())
@@ -111,6 +109,16 @@ class CpuTruthCheck:
             what={"executor_uuid": ctx.executor.uuid, "reason": reason, **(details or {})},
         )
         return CheckResult(passed=True, event=event)
+
+
+def advertised_cpu_count(ctx: Context) -> int | None:
+    # the core count the miner reported this cycle, or None when the scrape produced no usable value
+    cpu = (ctx.state.specs or {}).get("cpu") or {}
+    try:
+        count = int(cpu.get("count"))
+    except (TypeError, ValueError):
+        return None
+    return count if count > 0 else None
 
 
 def _count_cpu_list(spec: str) -> int | None:

--- a/neurons/validators/src/services/task/checks/cpu_truth.py
+++ b/neurons/validators/src/services/task/checks/cpu_truth.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import asyncssh
+
+from core.config import settings
+
+from ..messages import CpuTruthMessages as Msg
+from ..messages import render_message
+from ..pipeline import CheckResult, Context
+
+# Advertised cores may exceed the kernel-present population by this many before it is called a spoof.
+# `present` (== the population lscpu counts in `CPU(s):`) and the advertised count are the SAME
+# population, so an honest host — even one with cores offlined — matches exactly; this slack only
+# absorbs a benign hotplug/measurement race. Observed spoofs advertise 4-8x their real cores (176
+# vs 44), far outside any slack, so the margin never masks a real lie. The predicate is provisional:
+# the emitted RAW counts let ops recalibrate from a week of fleet data before flipping enforcement.
+CPU_TRUTH_MARGIN_CORES = 4
+
+
+class CpuTruthCheck:
+    """Corroborate the advertised CPU(s) count against sources the lscpu wrapper does not author.
+
+    The scrape reports `CPU(s):` from a `lscpu` a userspace wrapper can rewrite. This check reads,
+    over ``ctx.ssh``, the kernel-present CPU population (`/sys/devices/system/cpu/present`, the same
+    population lscpu counts), the online logical CPUs (`/proc/cpuinfo`), and docker's NCPU. The
+    present count is the like-with-like comparison; `/proc/cpuinfo` and docker NCPU resolve through
+    the host too (bind-mount / PATH-wrap reachable) so they are recorded as corroborating only.
+
+    Non-fatal and observe-only: shadow always passes, and only CPU_TRUTH_ENFORCEMENT_ENABLED lets a
+    genuine mismatch fail. Never fails on an inability to measure (SSH error, unreadable population,
+    missing advertised count) — those return passed=True with a distinct *_unknown reason.
+    """
+
+    check_id = "host.validate.cpu_truth"
+    fatal = False
+
+    async def run(self, ctx: Context) -> CheckResult:
+        # compare advertised CPU(s) against the kernel-present population and docker NCPU over ssh
+        if not settings.CPU_TRUTH_CHECK_ENABLED:
+            event = render_message(Msg.SKIPPED, ctx=ctx, check_id=self.check_id)
+            return CheckResult(passed=True, event=event)
+
+        advertised = self._advertised_count(ctx)
+        if advertised is None:
+            return self._unknown(ctx, reason="advertised CPU count missing from specs")
+
+        try:
+            online = await self._read_online(ctx.ssh)
+            present = await self._read_present(ctx.ssh)
+            ncpu = await self._read_ncpu(ctx.ssh)
+        except (asyncssh.Error, OSError) as exc:
+            return self._unknown(ctx, reason="ssh transport error", details={"error": repr(exc)})
+
+        if present is None:
+            return self._unknown(
+                ctx,
+                reason="kernel-present CPU population unreadable",
+                details={"advertised": advertised, "online": online, "ncpu": ncpu},
+            )
+
+        what = {
+            "executor_uuid": ctx.executor.uuid,
+            "advertised": advertised,
+            "online": online,
+            "present": present,
+            "ncpu": ncpu,
+            "margin_cores": CPU_TRUTH_MARGIN_CORES,
+        }
+        enforce = settings.CPU_TRUTH_ENFORCEMENT_ENABLED
+        if advertised - present > CPU_TRUTH_MARGIN_CORES:
+            event = render_message(
+                Msg.CPU_MISMATCH,
+                ctx=ctx,
+                check_id=self.check_id,
+                severity=None if enforce else "warning",
+                impact=None if enforce else "Shadow observation only: score was NOT changed",
+                what=what,
+            )
+            return CheckResult(passed=not enforce, event=event)
+
+        event = render_message(Msg.CPU_OK, ctx=ctx, check_id=self.check_id, what=what)
+        return CheckResult(passed=True, event=event)
+
+    def _advertised_count(self, ctx: Context) -> int | None:
+        cpu = (ctx.state.specs or {}).get("cpu") or {}
+        try:
+            count = int(cpu.get("count"))
+        except (TypeError, ValueError):
+            return None
+        return count if count > 0 else None
+
+    async def _read_online(self, ssh) -> int | None:
+        # online logical CPUs — corroborating, resolves through the host like the wrapper does
+        return _parse_int(await ssh.run("grep -c ^processor /proc/cpuinfo"))
+
+    async def _read_present(self, ssh) -> int | None:
+        # kernel-present CPU population — the authoritative like-with-like comparison
+        res = await ssh.run("cat /sys/devices/system/cpu/present")
+        if getattr(res, "exit_status", 1) != 0:
+            return None
+        return _count_cpu_list((getattr(res, "stdout", "") or "").strip())
+
+    async def _read_ncpu(self, ssh) -> int | None:
+        # docker's view of host CPUs by ABSOLUTE path (matches the scrape's docker invocation)
+        return _parse_int(await ssh.run("/usr/bin/docker info --format '{{.NCPU}}'"))
+
+    def _unknown(
+        self, ctx: Context, *, reason: str, details: dict | None = None
+    ) -> CheckResult:
+        event = render_message(
+            Msg.CPU_UNKNOWN,
+            ctx=ctx,
+            check_id=self.check_id,
+            what={"executor_uuid": ctx.executor.uuid, "reason": reason, **(details or {})},
+        )
+        return CheckResult(passed=True, event=event)
+
+
+def _parse_int(res) -> int | None:
+    if getattr(res, "exit_status", 1) != 0:
+        return None
+    try:
+        return int((getattr(res, "stdout", "") or "").strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _count_cpu_list(spec: str) -> int | None:
+    # count entries in a Linux CPU-list string, e.g. "0-127" -> 128, "0-19,40-59" -> 40, "0" -> 1
+    if not spec:
+        return None
+    total = 0
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            low, _, high = part.partition("-")
+            try:
+                total += int(high) - int(low) + 1
+            except ValueError:
+                return None
+        else:
+            try:
+                int(part)
+            except ValueError:
+                return None
+            total += 1
+    return total or None

--- a/neurons/validators/src/services/task/checks/cpu_truth.py
+++ b/neurons/validators/src/services/task/checks/cpu_truth.py
@@ -76,14 +76,12 @@ class CpuTruthCheck:
                 impact=None if enforce else "Shadow observation only: score was NOT changed",
                 what=what,
             )
-            # The check is non-fatal, so passed=False alone changes nothing in the pipeline: under
-            # enforcement the score has to be zeroed explicitly, the same quarantine the CPU-quota
-            # verdict applies.
+            # The check is non-fatal, so passed=False alone changes nothing in the pipeline, and
+            # zeroing `score` here would be overwritten by ScoreCheck further down. The verdict
+            # travels as a context flag that calculate_scores gates on, like the TDX one.
             updates = (
                 {
-                    "score": 0.0,
-                    "job_score": 0.0,
-                    "score_warning": "Advertised CPU cores exceed the host's physical cores",
+                    "cpu_truth_passed": False,
                     "clear_verified_job_info": True,
                 }
                 if enforce

--- a/neurons/validators/src/services/task/checks/cpu_truth.py
+++ b/neurons/validators/src/services/task/checks/cpu_truth.py
@@ -18,13 +18,11 @@ CPU_TRUTH_MARGIN_CORES = 4
 
 
 class CpuTruthCheck:
-    """Corroborate the advertised CPU(s) count against sources the lscpu wrapper does not author.
+    """Compare the advertised CPU(s) count against the kernel-present population.
 
     The scrape reports `CPU(s):` from a `lscpu` a userspace wrapper can rewrite. This check reads,
     over ``ctx.ssh``, the kernel-present CPU population (`/sys/devices/system/cpu/present`, the same
-    population lscpu counts), the online logical CPUs (`/proc/cpuinfo`), and docker's NCPU. The
-    present count is the like-with-like comparison; `/proc/cpuinfo` and docker NCPU resolve through
-    the host too (bind-mount / PATH-wrap reachable) so they are recorded as corroborating only.
+    population lscpu counts) — one SSH read, the like-with-like comparison.
 
     Non-fatal and observe-only: shadow always passes, and only CPU_TRUTH_ENFORCEMENT_ENABLED lets a
     genuine mismatch fail and zero the score. Never fails on an inability to measure (SSH error, unreadable population,
@@ -35,7 +33,7 @@ class CpuTruthCheck:
     fatal = False
 
     async def run(self, ctx: Context) -> CheckResult:
-        # compare advertised CPU(s) against the kernel-present population and docker NCPU over ssh
+        # compare advertised CPU(s) against the kernel-present population over ssh
         if not settings.CPU_TRUTH_CHECK_ENABLED:
             event = render_message(Msg.SKIPPED, ctx=ctx, check_id=self.check_id)
             return CheckResult(passed=True, event=event)
@@ -45,9 +43,7 @@ class CpuTruthCheck:
             return self._unknown(ctx, reason="advertised CPU count missing from specs")
 
         try:
-            online = await self._read_online(ctx.ssh)
             present = await self._read_present(ctx.ssh)
-            ncpu = await self._read_ncpu(ctx.ssh)
         except (asyncssh.Error, OSError) as exc:
             return self._unknown(ctx, reason="ssh transport error", details={"error": repr(exc)})
 
@@ -55,15 +51,13 @@ class CpuTruthCheck:
             return self._unknown(
                 ctx,
                 reason="kernel-present CPU population unreadable",
-                details={"advertised": advertised, "online": online, "ncpu": ncpu},
+                details={"advertised": advertised},
             )
 
         what = {
             "executor_uuid": ctx.executor.uuid,
             "advertised": advertised,
-            "online": online,
             "present": present,
-            "ncpu": ncpu,
             "margin_cores": CPU_TRUTH_MARGIN_CORES,
         }
         enforce = settings.CPU_TRUTH_ENFORCEMENT_ENABLED
@@ -100,20 +94,12 @@ class CpuTruthCheck:
             return None
         return count if count > 0 else None
 
-    async def _read_online(self, ssh) -> int | None:
-        # online logical CPUs — corroborating, resolves through the host like the wrapper does
-        return _parse_int(await ssh.run("grep -c ^processor /proc/cpuinfo"))
-
     async def _read_present(self, ssh) -> int | None:
         # kernel-present CPU population — the authoritative like-with-like comparison
         res = await ssh.run("cat /sys/devices/system/cpu/present")
         if getattr(res, "exit_status", 1) != 0:
             return None
         return _count_cpu_list((getattr(res, "stdout", "") or "").strip())
-
-    async def _read_ncpu(self, ssh) -> int | None:
-        # docker's view of host CPUs by ABSOLUTE path (matches the scrape's docker invocation)
-        return _parse_int(await ssh.run("/usr/bin/docker info --format '{{.NCPU}}'"))
 
     def _unknown(
         self, ctx: Context, *, reason: str, details: dict | None = None
@@ -125,15 +111,6 @@ class CpuTruthCheck:
             what={"executor_uuid": ctx.executor.uuid, "reason": reason, **(details or {})},
         )
         return CheckResult(passed=True, event=event)
-
-
-def _parse_int(res) -> int | None:
-    if getattr(res, "exit_status", 1) != 0:
-        return None
-    try:
-        return int((getattr(res, "stdout", "") or "").strip())
-    except (TypeError, ValueError):
-        return None
 
 
 def _count_cpu_list(spec: str) -> int | None:

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 import asyncssh
 from core.docker_utils import DockerCommand, collect_container_death_diagnostics
 from protocol.vc_protocol.compute_requests import (
+    CPU_QUOTA_EXCEEDS_HOST_REASON,
     GPU_RUNTIME_DEVICE_FAULT_REASON,
     GPU_RUNTIME_NVML_MISMATCH_REASON,
     FillerRunActiveResponse,
@@ -152,6 +153,15 @@ class RentalVerificationCheck:
         gpu_details = ctx.state.gpu_details or (ctx.state.specs or {}).get("gpu", {}).get("details", [])
         gpu_uuids = [detail["uuid"] for detail in gpu_details if isinstance(detail, dict) and detail.get("uuid")]
 
+        # DAH-2671 item 2b: hand the backend the advertised core count so the probe is created with
+        # `--cpus=<advertised>`. The daemon rejects a count above the host's physical cores — a lie
+        # the lscpu wrapper cannot cover, because dockerd reads the kernel directly. Skipped on TDX
+        # hosts (a real rent skips `--cpus` there too) and when the count is unreadable, so shadow
+        # only ever sends a number we could actually stand behind.
+        cpu_count = None
+        if settings.RENTAL_CPU_LIMIT_CHECK_ENABLED and not ctx.executor.tdx_quote:
+            cpu_count = self._advertised_cpu_count(ctx)
+
         try:
             # Call backend API to verify executor health. Pass the rental hint: when this validator
             # already sees an active customer rental, the backend skips the container-creating check
@@ -164,6 +174,7 @@ class RentalVerificationCheck:
                 executor_id=executor.uuid,
                 rental_in_progress=has_customer_rental,
                 gpu_uuids=gpu_uuids,
+                cpu_count=cpu_count,
             )
 
             # Handle API failure (None response) - fail this executor
@@ -200,6 +211,8 @@ class RentalVerificationCheck:
                     event=event,
                     updates={},
                 )
+            elif response.reason_code == CPU_QUOTA_EXCEEDS_HOST_REASON:
+                return self._cpu_quota_verdict(ctx, response)
             elif response.reason_code in _GPU_RUNTIME_QUARANTINE:
                 quarantine = _GPU_RUNTIME_QUARANTINE[response.reason_code]
                 details = response.details or {}
@@ -270,6 +283,55 @@ class RentalVerificationCheck:
             await ctx.services.container_cleanup.force_remove_health_checks(
                 ctx.ssh, ctx.executor.uuid
             )
+
+    @staticmethod
+    def _advertised_cpu_count(ctx: Context) -> int | None:
+        """The core count the miner reported this cycle, or None when the scrape produced no usable value."""
+        cpu = (ctx.state.specs or {}).get("cpu") or {}
+        try:
+            count = int(cpu.get("count"))
+        except (TypeError, ValueError):
+            return None
+        return count if count > 0 else None
+
+    def _cpu_quota_verdict(self, ctx: Context, response) -> CheckResult:
+        """Render the CPU-quota verdict: the host's daemon refused `--cpus=<advertised>` at create.
+
+        Shadow (enforcement off) logs the verdict as a warning and keeps passed=True so scoring is
+        unchanged; enforcement zeroes the score and clears the verified job, the same quarantine the
+        GPU runtime faults use.
+        """
+        enforce = settings.RENTAL_CPU_LIMIT_ENFORCEMENT_ENABLED
+        details = response.details or {}
+        stderr = details.get("docker_stderr") or response.error
+        event = render_message(
+            Msg.CPU_QUOTA_EXCEEDS_HOST,
+            ctx=ctx,
+            check_id=self.check_id,
+            severity=None if enforce else "warning",
+            impact=None if enforce else "Shadow observation only: score was NOT changed",
+            what={
+                "verified": False,
+                "executor_uuid": ctx.executor.uuid,
+                "source": "rental_verification",
+                "reason_code": response.reason_code,
+                "advertised_cpu_count": self._advertised_cpu_count(ctx),
+                "stderr": stderr,
+                "enforced": enforce,
+                "details": details,
+            },
+        )
+        updates = (
+            {
+                "score": 0.0,
+                "job_score": 0.0,
+                "score_warning": "Advertised CPU cores exceed the host's physical cores",
+                "clear_verified_job_info": True,
+            }
+            if enforce
+            else {}
+        )
+        return CheckResult(passed=not enforce, event=event, updates=updates)
 
     async def _verify_every_filler_alive(
         self, ctx: Context, filler_containers: list[str], *, enforce: bool

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 import asyncssh
+
+from core.config import settings
 from core.docker_utils import DockerCommand, collect_container_death_diagnostics
 from protocol.vc_protocol.compute_requests import (
     CPU_QUOTA_EXCEEDS_HOST_REASON,
@@ -12,13 +14,10 @@ from protocol.vc_protocol.compute_requests import (
     FillerRunActiveResponse,
 )
 
-from core.config import settings
-
 from ...const import FILLER_CONTAINER_PREFIX, FILLER_LIVENESS_GRACE_MINUTES
 from ..messages import MessageTemplate, render_message
 from ..messages import RentalVerificationMessages as Msg
 from ..pipeline import CheckResult, Context
-from .cpu_truth import CPU_TRUTH_MARGIN_CORES, _count_cpu_list
 
 
 @dataclass(frozen=True)
@@ -154,14 +153,16 @@ class RentalVerificationCheck:
         gpu_details = ctx.state.gpu_details or (ctx.state.specs or {}).get("gpu", {}).get("details", [])
         gpu_uuids = [detail["uuid"] for detail in gpu_details if isinstance(detail, dict) and detail.get("uuid")]
 
-        # DAH-2671 item 2b: hand the backend the advertised core count so the probe is created with
-        # `--cpus=<advertised>`. The daemon rejects a count above the host's physical cores — a lie
-        # the lscpu wrapper cannot cover, because dockerd reads the kernel directly. Skipped on TDX
-        # hosts (a real rent skips `--cpus` there too) and when the count is unreadable, so shadow
-        # only ever sends a number we could actually stand behind.
-        cpu_count = None
-        if settings.RENTAL_CPU_LIMIT_CHECK_ENABLED and not ctx.executor.tdx_quote:
-            cpu_count = await self._probe_cpu_limit(ctx)
+        # DAH-2671 item 2b: hand the backend the advertised core count AS-IS so the probe is created
+        # with `--cpus=<advertised>`. The backend classifier compares it against the daemon's own N
+        # from the refusal message and only classifies CPU_QUOTA_EXCEEDS_HOST when
+        # advertised > 2*N + 4 (honest max divergence is 2x — SMT off; observed spoofs 4-8x), so an
+        # honest SMT-off host falls into the backend's retry-without-flag path. No host-read capping:
+        # any source read from the judged host (sysfs/procfs) is spoofable, and a cap computed from
+        # it would let a spoofer neutralise the daemon check (fake `present` == advertised while
+        # `/proc/cpuinfo` stays real → cap = online → daemon accepts). Skipped on TDX hosts (a real
+        # rent skips `--cpus` there too) and when the count is unreadable.
+        cpu_count = self._advertised_cpu_count(ctx) if settings.RENTAL_CPU_LIMIT_CHECK_ENABLED and not ctx.executor.tdx_quote else None
 
         try:
             # Call backend API to verify executor health. Pass the rental hint: when this validator
@@ -284,33 +285,6 @@ class RentalVerificationCheck:
             await ctx.services.container_cleanup.force_remove_health_checks(
                 ctx.ssh, ctx.executor.uuid
             )
-
-    async def _probe_cpu_limit(self, ctx: Context) -> int | None:
-        """The `--cpus` value to probe with: the advertised count, capped by ONLINE CPUs only on an
-        already-honest host.
-
-        Docker's `--cpus` ceiling is the online population, while CpuTruthCheck (item 2a) calls a
-        host honest against the kernel-PRESENT one. A host with cores offlined (present 128, online
-        64) is honest there and would be refused here on a quota it never claimed to serve, so cap
-        instead. But the cap reads /proc/cpuinfo, which item 2a itself treats as spoofable: a host
-        that fakes lscpu and leaves /proc/cpuinfo real would have the lie capped away and could never
-        trip CPU_QUOTA_EXCEEDS_HOST. So cap only where the advertised count already matches the
-        kernel-present population; otherwise send the advertised count and let the daemon refuse it.
-        """
-        advertised = self._advertised_cpu_count(ctx)
-        if advertised is None or ctx.ssh is None:
-            return advertised
-        try:
-            present = _count_cpu_list(
-                (await ctx.ssh.run("cat /sys/devices/system/cpu/present")).stdout
-            )
-            if present is None or advertised - present > CPU_TRUTH_MARGIN_CORES:
-                return advertised
-            res = await ctx.ssh.run("grep -c ^processor /proc/cpuinfo")
-            online = int((res.stdout or "").strip()) if res.exit_status == 0 else None
-        except (asyncssh.Error, OSError, AttributeError, TypeError, ValueError):
-            return advertised
-        return min(advertised, online) if online else advertised
 
     @staticmethod
     def _advertised_cpu_count(ctx: Context) -> int | None:

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -18,6 +18,7 @@ from ...const import FILLER_CONTAINER_PREFIX, FILLER_LIVENESS_GRACE_MINUTES
 from ..messages import MessageTemplate, render_message
 from ..messages import RentalVerificationMessages as Msg
 from ..pipeline import CheckResult, Context
+from .cpu_truth import advertised_cpu_count
 
 
 @dataclass(frozen=True)
@@ -162,7 +163,7 @@ class RentalVerificationCheck:
         # it would let a spoofer neutralise the daemon check (fake `present` == advertised while
         # `/proc/cpuinfo` stays real → cap = online → daemon accepts). Skipped on TDX hosts (a real
         # rent skips `--cpus` there too) and when the count is unreadable.
-        cpu_count = self._advertised_cpu_count(ctx) if settings.RENTAL_CPU_LIMIT_CHECK_ENABLED and not ctx.executor.tdx_quote else None
+        cpu_count = advertised_cpu_count(ctx) if settings.RENTAL_CPU_LIMIT_CHECK_ENABLED and not ctx.executor.tdx_quote else None
 
         try:
             # Call backend API to verify executor health. Pass the rental hint: when this validator
@@ -286,16 +287,6 @@ class RentalVerificationCheck:
                 ctx.ssh, ctx.executor.uuid
             )
 
-    @staticmethod
-    def _advertised_cpu_count(ctx: Context) -> int | None:
-        """The core count the miner reported this cycle, or None when the scrape produced no usable value."""
-        cpu = (ctx.state.specs or {}).get("cpu") or {}
-        try:
-            count = int(cpu.get("count"))
-        except (TypeError, ValueError):
-            return None
-        return count if count > 0 else None
-
     def _cpu_quota_verdict(self, ctx: Context, response) -> CheckResult:
         """Render the CPU-quota verdict: the host's daemon refused `--cpus=<advertised>` at create.
 
@@ -317,7 +308,7 @@ class RentalVerificationCheck:
                 "executor_uuid": ctx.executor.uuid,
                 "source": "rental_verification",
                 "reason_code": response.reason_code,
-                "advertised_cpu_count": self._advertised_cpu_count(ctx),
+                "advertised_cpu_count": advertised_cpu_count(ctx),
                 "stderr": stderr,
                 "enforced": enforce,
                 "details": details,

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -18,6 +18,7 @@ from ...const import FILLER_CONTAINER_PREFIX, FILLER_LIVENESS_GRACE_MINUTES
 from ..messages import MessageTemplate, render_message
 from ..messages import RentalVerificationMessages as Msg
 from ..pipeline import CheckResult, Context
+from .cpu_truth import CPU_TRUTH_MARGIN_CORES, _count_cpu_list
 
 
 @dataclass(frozen=True)
@@ -285,21 +286,30 @@ class RentalVerificationCheck:
             )
 
     async def _probe_cpu_limit(self, ctx: Context) -> int | None:
-        """The `--cpus` value to probe with: the advertised count, capped by the host's ONLINE CPUs.
+        """The `--cpus` value to probe with: the advertised count, capped by ONLINE CPUs only on an
+        already-honest host.
 
         Docker's `--cpus` ceiling is the online population, while CpuTruthCheck (item 2a) calls a
         host honest against the kernel-PRESENT one. A host with cores offlined (present 128, online
         64) is honest there and would be refused here on a quota it never claimed to serve, so cap
-        instead. A spoofed count is still refused: the lie inflates the online population too.
+        instead. But the cap reads /proc/cpuinfo, which item 2a itself treats as spoofable: a host
+        that fakes lscpu and leaves /proc/cpuinfo real would have the lie capped away and could never
+        trip CPU_QUOTA_EXCEEDS_HOST. So cap only where the advertised count already matches the
+        kernel-present population; otherwise send the advertised count and let the daemon refuse it.
         """
         advertised = self._advertised_cpu_count(ctx)
         if advertised is None or ctx.ssh is None:
             return advertised
         try:
+            present = _count_cpu_list(
+                (await ctx.ssh.run("cat /sys/devices/system/cpu/present")).stdout
+            )
+            if present is None or advertised - present > CPU_TRUTH_MARGIN_CORES:
+                return advertised
             res = await ctx.ssh.run("grep -c ^processor /proc/cpuinfo")
             online = int((res.stdout or "").strip()) if res.exit_status == 0 else None
-        except (asyncssh.Error, OSError, TypeError, ValueError):
-            online = None
+        except (asyncssh.Error, OSError, AttributeError, TypeError, ValueError):
+            return advertised
         return min(advertised, online) if online else advertised
 
     @staticmethod

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -160,7 +160,7 @@ class RentalVerificationCheck:
         # only ever sends a number we could actually stand behind.
         cpu_count = None
         if settings.RENTAL_CPU_LIMIT_CHECK_ENABLED and not ctx.executor.tdx_quote:
-            cpu_count = self._advertised_cpu_count(ctx)
+            cpu_count = await self._probe_cpu_limit(ctx)
 
         try:
             # Call backend API to verify executor health. Pass the rental hint: when this validator
@@ -283,6 +283,24 @@ class RentalVerificationCheck:
             await ctx.services.container_cleanup.force_remove_health_checks(
                 ctx.ssh, ctx.executor.uuid
             )
+
+    async def _probe_cpu_limit(self, ctx: Context) -> int | None:
+        """The `--cpus` value to probe with: the advertised count, capped by the host's ONLINE CPUs.
+
+        Docker's `--cpus` ceiling is the online population, while CpuTruthCheck (item 2a) calls a
+        host honest against the kernel-PRESENT one. A host with cores offlined (present 128, online
+        64) is honest there and would be refused here on a quota it never claimed to serve, so cap
+        instead. A spoofed count is still refused: the lie inflates the online population too.
+        """
+        advertised = self._advertised_cpu_count(ctx)
+        if advertised is None or ctx.ssh is None:
+            return advertised
+        try:
+            res = await ctx.ssh.run("grep -c ^processor /proc/cpuinfo")
+            online = int((res.stdout or "").strip()) if res.exit_status == 0 else None
+        except (asyncssh.Error, OSError, TypeError, ValueError):
+            online = None
+        return min(advertised, online) if online else advertised
 
     @staticmethod
     def _advertised_cpu_count(ctx: Context) -> int | None:

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -1058,6 +1058,45 @@ class RentalVerificationMessages:
     )
 
 
+class CpuTruthMessages:
+    """DAH-2671 item 2a — corroborate advertised CPU(s) against sources the lscpu wrapper does not
+    author. Shadow (CPU_TRUTH_CHECK_ENABLED without enforcement) emits CPU_MISMATCH as a warning and
+    keeps passed=True; only CPU_TRUTH_ENFORCEMENT_ENABLED renders it error/score-zeroing."""
+
+    CPU_OK = MessageTemplate(
+        event="CPU core count corroborated",
+        reason="CPU_TRUTH_OK",
+        severity="info",
+        category="env",
+        impact="Proceed",
+    )
+    CPU_MISMATCH = MessageTemplate(
+        event="Advertised CPU cores exceed the kernel-present CPU population",
+        reason="CPU_TRUTH_MISMATCH",
+        severity="error",
+        category="env",
+        impact="Score set to 0",
+        remediation=(
+            "Advertise the real CPU(s) count. The kernel-present CPU population "
+            "(/sys/devices/system/cpu/present) is far below the reported core count."
+        ),
+    )
+    CPU_UNKNOWN = MessageTemplate(
+        event="CPU core count could not be corroborated",
+        reason="CPU_TRUTH_UNKNOWN",
+        severity="info",
+        category="env",
+        impact="Proceed without penalty",
+    )
+    SKIPPED = MessageTemplate(
+        event="CPU truth check disabled",
+        reason="CPU_TRUTH_DISABLED",
+        severity="info",
+        category="env",
+        impact="Proceed",
+    )
+
+
 class FinalizeMessages:
     COMPLETED = MessageTemplate(
         event="Validation task completed",

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -1014,6 +1014,17 @@ class RentalVerificationMessages:
             "`sudo reboot`, then check `nvidia-smi` and `dmesg` for Xid errors."
         ),
     )
+    CPU_QUOTA_EXCEEDS_HOST = MessageTemplate(
+        event="Advertised CPU cores exceed the host's physical cores",
+        reason="CPU_QUOTA_EXCEEDS_HOST",
+        severity="error",
+        category="runtime",
+        impact="Score set to 0: the rental-verification container demanded the advertised cores and the host's Docker daemon rejected the count.",
+        remediation=(
+            "Advertise the real CPU(s) count. The host's Docker daemon refused `--cpus=<advertised>` "
+            "because the machine has fewer physical cores than reported."
+        ),
+    )
     API_ERROR = MessageTemplate(
         event="Rental verification API error",
         reason="RENTAL_CHECK_API_ERROR",

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -161,6 +161,9 @@ class Context(BaseModel):
     success: bool = False
     is_provider_banned: bool = False
     tdx_attestation_passed: bool = False
+    # False only once CpuTruthCheck sees a mismatch under enforcement; the score gate lives in
+    # calculate_scores because the check is non-fatal and ScoreCheck runs after it.
+    cpu_truth_passed: bool = True
     # G1 — NVIDIA CC GPU attestation outcome: True/False when verified, None when
     # not performed (non-CVM node, no evidence supplied, or NRAS undeterminable).
     gpu_attestation_passed: bool | None = None

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -9,9 +9,11 @@ import uuid
 from typing import cast
 
 import bittensor
-from clients.backend_client import BackendClient
 from datura.requests.miner_requests import ExecutorSSHInfo
 from payload_models.payloads import MinerJobEnryptedFiles, MinerJobRequestPayload
+
+from clients.backend_client import BackendClient
+from core.config import settings, shared_client
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.collateral_contract_service import CollateralContractService
 from services.const import GPU_MODEL_RATES, LIB_NVIDIA_ML_DIGESTS, MAX_GPU_COUNT
@@ -21,10 +23,8 @@ from services.inspector_validation_service import InspectorValidationService
 from services.interactive_shell_service import InteractiveShellService
 from services.matrix_validation_service import ValidationService
 from services.redis_service import RENTAL_SUCCEED_MACHINE_SET, RedisService
-from services.verifyx_validation_service import VerifyXValidationService
-
-from core.config import settings, shared_client
 from services.ssh_service import SSHService
+from services.verifyx_validation_service import VerifyXValidationService
 
 from .checks import (
     BannedGpuCheck,
@@ -32,6 +32,7 @@ from .checks import (
     CachedTemplateVerificationCheck,
     CapabilityCheck,
     CollateralCheck,
+    CpuTruthCheck,
     CustomBuildOrphanSweepCheck,
     DuplicateExecutorCheck,
     FinalizeCheck,
@@ -254,6 +255,11 @@ class PipelineFactory:
                 # here — before the rented short-circuit (TenantEnforcementCheck)
                 # — to gate rented and idle executors alike.
                 GpuVramPrecheck(),
+                # DAH-2671 item 2a: non-fatal, observe-only CPU-count corroboration. Placed right
+                # after the GPU spec-check group (and before the rented short-circuit) so it reads
+                # advertised specs already populated by the scrape; it only reads over SSH, mutates
+                # no executor state, and never zeroes score outside CPU_TRUTH_ENFORCEMENT_ENABLED.
+                CpuTruthCheck(),
                 GpuPowerLimitCheck(),
                 NvmlDigestCheck(),
                 SpecChangeCheck(),
@@ -321,6 +327,8 @@ class PipelineFactory:
                 GpuCountCheck(),
                 GpuModelValidCheck(),
                 GpuVramPrecheck(),
+                # DAH-2671 item 2a: read-only SSH corroboration, safe in dry run (mutates nothing).
+                CpuTruthCheck(),
                 # restore_stale_caps=False: dry run must not run nvidia-smi -pl on the executor or
                 # consume the shared gpu_power_restore:* records the production pipeline relies on.
                 GpuPowerLimitCheck(restore_stale_caps=False),

--- a/neurons/validators/src/services/task/score_calculator.py
+++ b/neurons/validators/src/services/task/score_calculator.py
@@ -61,6 +61,14 @@ def calculate_scores(
         job_score = 0.0
         warning_messages.append("CVM attestation not passed (TDX/GPU attestation required)")
 
+    # CPU-truth gate: the advertised CPU(s) count is contradicted by the kernel-present
+    # population. CpuTruthCheck is non-fatal and runs before this, so passed=False alone would
+    # not survive — only this gate actually zeroes the score. Shadow leaves the flag True.
+    if not ctx.cpu_truth_passed:
+        actual_score = 0.0
+        job_score = 0.0
+        warning_messages.append("Advertised CPU cores exceed the host's physical cores")
+
     # EMA verifyx download speed check — threshold enforced upstream in VerifyXCheck
     ema_verifyx_download = ((ctx.state.specs or {}).get("network") or {}).get(
         "ema_verifyx_download_speed"

--- a/neurons/validators/tests/test_attestation_gaps_g1_g4.py
+++ b/neurons/validators/tests/test_attestation_gaps_g1_g4.py
@@ -523,6 +523,7 @@ def _score_ctx(tdx_quote, attestation_passed):
         contract_version=None,
         executor=executor,
         tdx_attestation_passed=attestation_passed,
+        cpu_truth_passed=True,
     )
 
 

--- a/neurons/validators/tests/test_cpu_truth_check.py
+++ b/neurons/validators/tests/test_cpu_truth_check.py
@@ -99,10 +99,52 @@ async def test_mismatch_fails_under_enforcement(context_factory):
 
     assert result.passed is False
     assert result.event.reason_code == Msg.CPU_MISMATCH.reason
-    # The check is non-fatal, so the zeroing has to travel in `updates`, not in passed=False.
-    assert result.updates["score"] == 0.0
-    assert result.updates["job_score"] == 0.0
+    # The check is non-fatal and ScoreCheck runs after it, so the verdict travels as a context
+    # flag calculate_scores gates on — see test_mismatch_zeroes_the_final_score.
+    assert result.updates["cpu_truth_passed"] is False
     assert result.updates["clear_verified_job_info"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("enforce, expected_score", [(True, 0.0), (False, 1.0)])
+async def test_mismatch_zeroes_the_final_score(context_factory, enforce, expected_score):
+    # End-to-end through the pipeline: CpuTruthCheck is non-fatal and ScoreCheck recomputes the
+    # score from scratch afterwards, so only a context flag calculate_scores reads survives.
+    from neurons.validators.src.services.task.checks.score import ScoreCheck
+    from neurons.validators.src.services.task.pipeline import Pipeline
+    from neurons.validators.src.services.task.score_calculator import calculate_scores
+
+    from tests.helpers import build_services, build_state, default_executor
+
+    class _NullSink:
+        async def emit(self, event):
+            pass
+
+    # ema_verifyx_download_speed present so the CPU-truth verdict is the only gate that can fire.
+    state = build_state(
+        specs={"cpu": {"count": 176}, "network": {"ema_verifyx_download_speed": 120.0}}
+    )
+    ctx = context_factory(
+        state=state,
+        ssh=_fake_ssh(present="0-43", cpuinfo="44"),
+        services=build_services(score_calculator=calculate_scores),
+        collateral_deposited=True,
+        executor=default_executor().model_copy(update={"price_per_gpu": None}),
+    )
+    with (
+        patch("neurons.validators.src.services.task.checks.cpu_truth.settings") as s,
+        patch("neurons.validators.src.services.task.score_calculator.settings") as score_s,
+    ):
+        s.CPU_TRUTH_CHECK_ENABLED = True
+        s.CPU_TRUTH_ENFORCEMENT_ENABLED = enforce
+        score_s.ENABLE_TDX_ATTESTATION = False
+        score_s.COLLATERAL_EXCLUDED_GPU_TYPES = []
+        score_s.ENABLE_NO_COLLATERAL = True
+        pipeline = Pipeline([CpuTruthCheck(), ScoreCheck()], _NullSink())
+        _, _, final_ctx = await pipeline.run(ctx)
+
+    assert final_ctx.score == expected_score
+    assert final_ctx.job_score == expected_score
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_cpu_truth_check.py
+++ b/neurons/validators/tests/test_cpu_truth_check.py
@@ -18,16 +18,12 @@ from neurons.validators.src.services.task.checks.cpu_truth import (
 from neurons.validators.src.services.task.messages import CpuTruthMessages as Msg
 
 
-def _fake_ssh(*, cpuinfo="128", present="0-127", ncpu="128", raise_exc=None):
+def _fake_ssh(*, present="0-127", raise_exc=None):
     async def run(cmd, *args, **kwargs):
         if raise_exc is not None:
             raise raise_exc
-        if "/proc/cpuinfo" in cmd:
-            return SimpleNamespace(exit_status=0, stdout=cpuinfo, stderr="")
         if "/sys/devices/system/cpu/present" in cmd:
             return SimpleNamespace(exit_status=0, stdout=present, stderr="")
-        if "docker info" in cmd:
-            return SimpleNamespace(exit_status=0, stdout=ncpu, stderr="")
         return SimpleNamespace(exit_status=1, stdout="", stderr="")
 
     return SimpleNamespace(run=run)
@@ -76,7 +72,7 @@ async def test_match_passes(context_factory):
 @pytest.mark.asyncio
 async def test_mismatch_emits_under_shadow_and_still_passes(context_factory):
     # advertised 176 over a 44-core present population — the spoof signature.
-    ctx = context_factory(state=_state(176), ssh=_fake_ssh(present="0-43", cpuinfo="44"))
+    ctx = context_factory(state=_state(176), ssh=_fake_ssh(present="0-43"))
     with patch("neurons.validators.src.services.task.checks.cpu_truth.settings") as s:
         s.CPU_TRUTH_CHECK_ENABLED = True
         s.CPU_TRUTH_ENFORCEMENT_ENABLED = False
@@ -91,7 +87,7 @@ async def test_mismatch_emits_under_shadow_and_still_passes(context_factory):
 
 @pytest.mark.asyncio
 async def test_mismatch_fails_under_enforcement(context_factory):
-    ctx = context_factory(state=_state(176), ssh=_fake_ssh(present="0-43", cpuinfo="44"))
+    ctx = context_factory(state=_state(176), ssh=_fake_ssh(present="0-43"))
     with patch("neurons.validators.src.services.task.checks.cpu_truth.settings") as s:
         s.CPU_TRUTH_CHECK_ENABLED = True
         s.CPU_TRUTH_ENFORCEMENT_ENABLED = True
@@ -126,7 +122,7 @@ async def test_mismatch_zeroes_the_final_score(context_factory, enforce, expecte
     )
     ctx = context_factory(
         state=state,
-        ssh=_fake_ssh(present="0-43", cpuinfo="44"),
+        ssh=_fake_ssh(present="0-43"),
         services=build_services(score_calculator=calculate_scores),
         collateral_deposited=True,
         executor=default_executor().model_copy(update={"price_per_gpu": None}),
@@ -161,8 +157,8 @@ async def test_ssh_error_passes_with_unknown_reason(context_factory):
 
 @pytest.mark.asyncio
 async def test_offlined_cores_not_a_spoof(context_factory):
-    # honest host with cores offlined: present (== lscpu CPU(s)) equals advertised; online is lower.
-    ctx = context_factory(state=_state(128), ssh=_fake_ssh(present="0-127", cpuinfo="64"))
+    # honest host with cores offlined: present (== lscpu CPU(s)) equals advertised.
+    ctx = context_factory(state=_state(128), ssh=_fake_ssh(present="0-127"))
     with patch("neurons.validators.src.services.task.checks.cpu_truth.settings") as s:
         s.CPU_TRUTH_CHECK_ENABLED = True
         s.CPU_TRUTH_ENFORCEMENT_ENABLED = True

--- a/neurons/validators/tests/test_cpu_truth_check.py
+++ b/neurons/validators/tests/test_cpu_truth_check.py
@@ -83,6 +83,7 @@ async def test_mismatch_emits_under_shadow_and_still_passes(context_factory):
         result = await CpuTruthCheck().run(ctx)
 
     assert result.passed is True  # shadow: never changes score
+    assert result.updates == {}
     assert result.event.reason_code == Msg.CPU_MISMATCH.reason
     assert result.event.what_we_saw["advertised"] == 176
     assert result.event.what_we_saw["present"] == 44
@@ -98,6 +99,10 @@ async def test_mismatch_fails_under_enforcement(context_factory):
 
     assert result.passed is False
     assert result.event.reason_code == Msg.CPU_MISMATCH.reason
+    # The check is non-fatal, so the zeroing has to travel in `updates`, not in passed=False.
+    assert result.updates["score"] == 0.0
+    assert result.updates["job_score"] == 0.0
+    assert result.updates["clear_verified_job_info"] is True
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_cpu_truth_check.py
+++ b/neurons/validators/tests/test_cpu_truth_check.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 import pytest
 from neurons.validators.src.services.task.checks.cpu_truth import (
+    CPU_TRUTH_READ_TIMEOUT_SECONDS,
     CpuTruthCheck,
     _count_cpu_list,
 )
@@ -53,6 +54,25 @@ def test_count_cpu_list(spec, expected):
 
 
 # ---------------------------- behavior ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_sysfs_read_is_bounded(context_factory):
+    # An unbounded read on a wedged host would hold this check open for the executor's whole
+    # validation budget; the timeout turns that into the *_unknown path instead.
+    seen: dict = {}
+
+    async def run(cmd, *args, **kwargs):
+        seen.update(kwargs)
+        return SimpleNamespace(exit_status=0, stdout="0-127", stderr="")
+
+    ctx = context_factory(state=_state(128), ssh=SimpleNamespace(run=run))
+    with patch("neurons.validators.src.services.task.checks.cpu_truth.settings") as s:
+        s.CPU_TRUTH_CHECK_ENABLED = True
+        s.CPU_TRUTH_ENFORCEMENT_ENABLED = False
+        await CpuTruthCheck().run(ctx)
+
+    assert seen.get("timeout") == CPU_TRUTH_READ_TIMEOUT_SECONDS
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_cpu_truth_check.py
+++ b/neurons/validators/tests/test_cpu_truth_check.py
@@ -1,0 +1,151 @@
+"""DAH-2671 item 2a — CpuTruthCheck.
+
+RED→GREEN: before the check existed, nothing compared the advertised CPU(s) count against the
+kernel-present population, so a host advertising 176 cores over 44 real ones passed unnoticed. The
+mismatch test fails closed only under CPU_TRUTH_ENFORCEMENT_ENABLED; shadow observes and passes; an
+inability to measure never fails.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from neurons.validators.src.services.task.checks.cpu_truth import (
+    CpuTruthCheck,
+    _count_cpu_list,
+)
+from neurons.validators.src.services.task.messages import CpuTruthMessages as Msg
+
+
+def _fake_ssh(*, cpuinfo="128", present="0-127", ncpu="128", raise_exc=None):
+    async def run(cmd, *args, **kwargs):
+        if raise_exc is not None:
+            raise raise_exc
+        if "/proc/cpuinfo" in cmd:
+            return SimpleNamespace(exit_status=0, stdout=cpuinfo, stderr="")
+        if "/sys/devices/system/cpu/present" in cmd:
+            return SimpleNamespace(exit_status=0, stdout=present, stderr="")
+        if "docker info" in cmd:
+            return SimpleNamespace(exit_status=0, stdout=ncpu, stderr="")
+        return SimpleNamespace(exit_status=1, stdout="", stderr="")
+
+    return SimpleNamespace(run=run)
+
+
+def _state(advertised):
+    from tests.helpers import build_state
+
+    return build_state(specs={"cpu": {"count": advertised}})
+
+
+# ---------------------------- _count_cpu_list (pure) ----------------------------
+
+
+@pytest.mark.parametrize(
+    "spec,expected",
+    [
+        ("0-127", 128),
+        ("0-19,40-59", 40),
+        ("0", 1),
+        ("", None),
+        ("garbage", None),
+    ],
+)
+def test_count_cpu_list(spec, expected):
+    assert _count_cpu_list(spec) == expected
+
+
+# ---------------------------- behavior ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_match_passes(context_factory):
+    ctx = context_factory(state=_state(128), ssh=_fake_ssh(present="0-127"))
+    with patch("neurons.validators.src.services.task.checks.cpu_truth.settings") as s:
+        s.CPU_TRUTH_CHECK_ENABLED = True
+        s.CPU_TRUTH_ENFORCEMENT_ENABLED = False
+        result = await CpuTruthCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.CPU_OK.reason
+    assert result.event.what_we_saw["advertised"] == 128
+    assert result.event.what_we_saw["present"] == 128
+
+
+@pytest.mark.asyncio
+async def test_mismatch_emits_under_shadow_and_still_passes(context_factory):
+    # advertised 176 over a 44-core present population — the spoof signature.
+    ctx = context_factory(state=_state(176), ssh=_fake_ssh(present="0-43", cpuinfo="44"))
+    with patch("neurons.validators.src.services.task.checks.cpu_truth.settings") as s:
+        s.CPU_TRUTH_CHECK_ENABLED = True
+        s.CPU_TRUTH_ENFORCEMENT_ENABLED = False
+        result = await CpuTruthCheck().run(ctx)
+
+    assert result.passed is True  # shadow: never changes score
+    assert result.event.reason_code == Msg.CPU_MISMATCH.reason
+    assert result.event.what_we_saw["advertised"] == 176
+    assert result.event.what_we_saw["present"] == 44
+
+
+@pytest.mark.asyncio
+async def test_mismatch_fails_under_enforcement(context_factory):
+    ctx = context_factory(state=_state(176), ssh=_fake_ssh(present="0-43", cpuinfo="44"))
+    with patch("neurons.validators.src.services.task.checks.cpu_truth.settings") as s:
+        s.CPU_TRUTH_CHECK_ENABLED = True
+        s.CPU_TRUTH_ENFORCEMENT_ENABLED = True
+        result = await CpuTruthCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.CPU_MISMATCH.reason
+
+
+@pytest.mark.asyncio
+async def test_ssh_error_passes_with_unknown_reason(context_factory):
+    ctx = context_factory(state=_state(176), ssh=_fake_ssh(raise_exc=OSError("ssh down")))
+    with patch("neurons.validators.src.services.task.checks.cpu_truth.settings") as s:
+        s.CPU_TRUTH_CHECK_ENABLED = True
+        s.CPU_TRUTH_ENFORCEMENT_ENABLED = True  # even under enforcement, cannot-measure never fails
+        result = await CpuTruthCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.CPU_UNKNOWN.reason
+
+
+@pytest.mark.asyncio
+async def test_offlined_cores_not_a_spoof(context_factory):
+    # honest host with cores offlined: present (== lscpu CPU(s)) equals advertised; online is lower.
+    ctx = context_factory(state=_state(128), ssh=_fake_ssh(present="0-127", cpuinfo="64"))
+    with patch("neurons.validators.src.services.task.checks.cpu_truth.settings") as s:
+        s.CPU_TRUTH_CHECK_ENABLED = True
+        s.CPU_TRUTH_ENFORCEMENT_ENABLED = True
+        result = await CpuTruthCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.CPU_OK.reason
+
+
+@pytest.mark.asyncio
+async def test_missing_advertised_count_is_unknown(context_factory):
+    from tests.helpers import build_state
+
+    ctx = context_factory(state=build_state(specs={"cpu": {}}), ssh=_fake_ssh())
+    with patch("neurons.validators.src.services.task.checks.cpu_truth.settings") as s:
+        s.CPU_TRUTH_CHECK_ENABLED = True
+        s.CPU_TRUTH_ENFORCEMENT_ENABLED = True
+        result = await CpuTruthCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.CPU_UNKNOWN.reason
+
+
+@pytest.mark.asyncio
+async def test_disabled_master_switch_skips(context_factory):
+    ctx = context_factory(state=_state(176), ssh=_fake_ssh(present="0-43"))
+    with patch("neurons.validators.src.services.task.checks.cpu_truth.settings") as s:
+        s.CPU_TRUTH_CHECK_ENABLED = False
+        s.CPU_TRUTH_ENFORCEMENT_ENABLED = True
+        result = await CpuTruthCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.SKIPPED.reason

--- a/neurons/validators/tests/test_matmul_allcards.py
+++ b/neurons/validators/tests/test_matmul_allcards.py
@@ -1,0 +1,136 @@
+"""DAH-2671 item 3 — full-matmul-all-cards work-proof.
+
+RED→GREEN: before this change the work-proof ran ONE process with no device selection, so cards
+1..N-1 were never touched and a 1-GPU host advertising 8 passed. Now every claimed card gets its
+own challenge, pinned with CUDA_VISIBLE_DEVICES=<index>, timed in aggregate on the validator:
+  - a 1-real-card host under an 8-GPU claim fails device selection → fails under enforcement;
+  - an honest 8-card host passes;
+  - an aggregate wall-clock over threshold fails under enforcement, only emits under shadow;
+  - a single-card (legacy) executor is never judged by the all-cards path (probe returns None).
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import services.matrix_validation_service as mvs
+
+
+@pytest.fixture
+def svc(monkeypatch):
+    """Real ValidationService with a fully mocked native wrapper (no .so on the test host)."""
+    wrapper = MagicMock(name="DMCompVerifyWrapper")
+    wrapper.DMCompVerify_new.return_value = "ptr"
+    wrapper.getCipherText.return_value = "deadbeef"
+    monkeypatch.setattr(mvs, "DMCompVerifyWrapper", lambda *a, **k: wrapper)
+    return mvs.ValidationService()
+
+
+def _executor():
+    return SimpleNamespace(root_dir="/root/app", python_path="/usr/bin/python")
+
+
+def _spec(count, model="NVIDIA H100 80GB HBM3"):
+    return {
+        "gpu": {
+            "count": count,
+            "details": [
+                {"name": model, "uuid": f"GPU-{i}", "capacity": 81920} for i in range(count)
+            ],
+        }
+    }
+
+
+def _card_index(cmd: str) -> int:
+    return int(cmd.split("CUDA_VISIBLE_DEVICES=")[1].split(" ")[0])
+
+
+def _ssh(real_cards: int):
+    # a host with `real_cards` genuine GPUs: indices past that fail device selection (invalid ordinal)
+    async def run(cmd, *args, **kwargs):
+        if "CUDA_VISIBLE_DEVICES=" in cmd:
+            if _card_index(cmd) < real_cards:
+                return SimpleNamespace(exit_status=0, stdout="RESULT_JSON: {}", stderr="")
+            return SimpleNamespace(exit_status=1, stdout="", stderr="invalid device ordinal")
+        # single-card fallback path (no device prefix) — benign output.
+        return SimpleNamespace(exit_status=0, stdout="UUID: x", stderr="")
+
+    return SimpleNamespace(run=run)
+
+
+def _flags(monkeypatch, *, enforce):
+    monkeypatch.setattr(mvs.settings, "MATMUL_ALLCARDS_CHECK_ENABLED", True, raising=False)
+    monkeypatch.setattr(
+        mvs.settings, "MATMUL_ALLCARDS_ENFORCEMENT_ENABLED", enforce, raising=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_spoof_one_card_under_eight_claim_fails_under_enforcement(svc, monkeypatch):
+    _flags(monkeypatch, enforce=True)
+    result = await svc.validate_gpu_model_and_process_job(
+        ssh_client=_ssh(real_cards=1),
+        executor_info=_executor(),
+        default_extra={},
+        machine_spec=_spec(8),
+    )
+    assert result.success is False
+    assert result.error_message.startswith("All-cards GPU work-proof failed")
+
+
+@pytest.mark.asyncio
+async def test_honest_eight_cards_probe_passes(svc):
+    probe = await svc._probe_all_claimed_cards(_ssh(real_cards=8), _executor(), {}, _spec(8))
+    assert probe is not None
+    assert probe.passed is True
+    assert len(probe.per_card) == 8
+    assert all(card["ok"] for card in probe.per_card)
+
+
+@pytest.mark.asyncio
+async def test_wall_clock_over_threshold_fails_under_enforcement(svc, monkeypatch):
+    _flags(monkeypatch, enforce=True)
+    # -1s threshold: any real elapsed trips it even though every card ran fine (models serialisation).
+    monkeypatch.setattr(mvs, "MATMUL_ALLCARDS_WALL_CLOCK_SECONDS", -1, raising=False)
+    result = await svc.validate_gpu_model_and_process_job(
+        ssh_client=_ssh(real_cards=8),
+        executor_info=_executor(),
+        default_extra={},
+        machine_spec=_spec(8),
+    )
+    assert result.success is False
+    assert "wall-clock" in result.error_message
+
+
+@pytest.mark.asyncio
+async def test_wall_clock_over_threshold_only_emits_under_shadow(svc, monkeypatch, caplog):
+    _flags(monkeypatch, enforce=False)
+    monkeypatch.setattr(mvs, "MATMUL_ALLCARDS_WALL_CLOCK_SECONDS", -1, raising=False)
+    with caplog.at_level("WARNING"):
+        result = await svc.validate_gpu_model_and_process_job(
+            ssh_client=_ssh(real_cards=8),
+            executor_info=_executor(),
+            default_extra={},
+            machine_spec=_spec(8),
+        )
+    # shadow: the probe never turns into a returned all-cards failure.
+    assert not result.error_message.startswith("All-cards GPU work-proof failed")
+    # but the observation is emitted.
+    assert any("All-cards GPU work-proof" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_legacy_single_card_is_not_judged_by_all_cards(svc):
+    # gpu_count <= 1 → probe returns None, so the executor is judged only by the unchanged
+    # single-card path and a not-yet-upgraded / single-GPU fleet is never zeroed by this check.
+    probe = await svc._probe_all_claimed_cards(_ssh(real_cards=1), _executor(), {}, _spec(1))
+    assert probe is None
+
+
+@pytest.mark.asyncio
+async def test_unknown_model_skips_probe(svc):
+    # a model with no registry VRAM size cannot be sized safely → probe returns None (fail-open).
+    probe = await svc._probe_all_claimed_cards(
+        _ssh(real_cards=8), _executor(), {}, _spec(8, model="NVIDIA MADE-UP 9000")
+    )
+    assert probe is None

--- a/neurons/validators/tests/test_matmul_allcards.py
+++ b/neurons/validators/tests/test_matmul_allcards.py
@@ -9,11 +9,12 @@ own challenge, pinned with CUDA_VISIBLE_DEVICES=<index>, timed in aggregate on t
   - a single-card (legacy) executor is never judged by the all-cards path (probe returns None).
 """
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 import services.matrix_validation_service as mvs
+from services.gpu_spec_table import GPU_VRAM_SIZES_MB, VRAM_FLOOR_RATIO, matmul_probe_vram_mb
 
 
 @pytest.fixture
@@ -134,3 +135,33 @@ async def test_unknown_model_skips_probe(svc):
         _ssh(real_cards=8), _executor(), {}, _spec(8, model="NVIDIA MADE-UP 9000")
     )
     assert probe is None
+
+
+def test_matmul_probe_vram_mb_floors_below_observed():
+    # Finding 1: size each card's challenge from the 0.90 floor, NOT the raw nominal, so an honest
+    # B200/L40S is never asked to allocate past its usable (NVML-reported) VRAM and OOM.
+    b200 = matmul_probe_vram_mb("NVIDIA B200")
+    assert b200 == round(196608 * VRAM_FLOOR_RATIO)
+    assert b200 < 183359                                   # below observed usable total (registry note)
+    assert b200 < GPU_VRAM_SIZES_MB["NVIDIA B200"][0]      # strictly below the raw nominal
+    # multi-variant: smallest nominal, then floored
+    assert matmul_probe_vram_mb("NVIDIA GeForce RTX 3060") == round(8192 * VRAM_FLOOR_RATIO)
+    assert matmul_probe_vram_mb("NVIDIA MADE-UP 9000") is None
+
+
+@pytest.mark.asyncio
+async def test_timeout_sweeps_orphan_matmul(svc, monkeypatch):
+    # Finding 2: a timed-out per-card run must trigger _kill_remote_matmul, or the orphaned remote
+    # process keeps holding VRAM into the fatal single-card matmul that runs next in the same call.
+    _flags(monkeypatch, enforce=False)
+    killed = AsyncMock()
+    monkeypatch.setattr(svc, "_kill_remote_matmul", killed)
+
+    async def run(cmd, *a, **k):
+        if "CUDA_VISIBLE_DEVICES=0" in cmd:
+            raise TimeoutError
+        return SimpleNamespace(exit_status=0, stdout="RESULT_JSON: {}", stderr="")
+
+    probe = await svc._probe_all_claimed_cards(SimpleNamespace(run=run), _executor(), {}, _spec(2))
+    assert probe is not None and probe.passed is False
+    killed.assert_awaited_once()

--- a/neurons/validators/tests/test_matmul_allcards.py
+++ b/neurons/validators/tests/test_matmul_allcards.py
@@ -8,6 +8,7 @@ own challenge, pinned with CUDA_VISIBLE_DEVICES=<index>, timed in aggregate on t
   - an aggregate wall-clock over threshold fails under enforcement, only emits under shadow;
   - a single-card (legacy) executor is never judged by the all-cards path (probe returns None).
 """
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -147,6 +148,26 @@ def test_matmul_probe_vram_mb_floors_below_observed():
     # multi-variant: smallest nominal, then floored
     assert matmul_probe_vram_mb("NVIDIA GeForce RTX 3060") == round(8192 * VRAM_FLOOR_RATIO)
     assert matmul_probe_vram_mb("NVIDIA MADE-UP 9000") is None
+
+
+@pytest.mark.asyncio
+async def test_card_fan_out_stays_under_sshd_max_sessions(svc):
+    # Finding: one SSH channel per card on a single connection; OpenSSH defaults to MaxSessions 10,
+    # so a 14-card host must not open 14 at once or the tail channels read as failed work-proofs.
+    in_flight = 0
+    peak = 0
+
+    async def run(cmd, *a, **k):
+        nonlocal in_flight, peak
+        in_flight += 1
+        peak = max(peak, in_flight)
+        await asyncio.sleep(0)
+        in_flight -= 1
+        return SimpleNamespace(exit_status=0, stdout="RESULT_JSON: {}", stderr="")
+
+    probe = await svc._probe_all_claimed_cards(SimpleNamespace(run=run), _executor(), {}, _spec(14))
+    assert probe is not None and probe.passed is True
+    assert peak <= mvs.MATMUL_ALLCARDS_MAX_CONCURRENT_CARDS < 10
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_matmul_allcards.py
+++ b/neurons/validators/tests/test_matmul_allcards.py
@@ -197,3 +197,39 @@ async def test_timeout_sweeps_orphan_matmul(svc, monkeypatch):
     probe = await svc._probe_all_claimed_cards(SimpleNamespace(run=run), _executor(), {}, _spec(2))
     assert probe is not None and probe.passed is False
     killed.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ssh_error_sweeps_orphan_matmul(svc, monkeypatch):
+    # A channel that dies mid-run leaves the remote matmul untouched, exactly like a timeout — and
+    # the fatal single-card matmul that follows lands on device 0 and OOMs against it.
+    _flags(monkeypatch, enforce=False)
+    killed = AsyncMock()
+    monkeypatch.setattr(svc, "_kill_remote_matmul", killed)
+
+    async def run(cmd, *a, **k):
+        if "CUDA_VISIBLE_DEVICES=0" in cmd:
+            raise OSError("channel closed")
+        return SimpleNamespace(exit_status=0, stdout="RESULT_JSON: {}", stderr="")
+
+    probe = await svc._probe_all_claimed_cards(SimpleNamespace(run=run), _executor(), {}, _spec(2))
+    assert probe is not None and probe.passed is False
+    killed.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_a_plain_card_failure_does_not_sweep(svc, monkeypatch):
+    # A card that answered (non-zero exit) has no process left to kill; sweeping there would pkill
+    # the fatal single-card matmul of a concurrent validator run on the same host for nothing.
+    _flags(monkeypatch, enforce=False)
+    killed = AsyncMock()
+    monkeypatch.setattr(svc, "_kill_remote_matmul", killed)
+
+    async def run(cmd, *a, **k):
+        if "CUDA_VISIBLE_DEVICES=0" in cmd:
+            return SimpleNamespace(exit_status=1, stdout="", stderr="invalid device ordinal")
+        return SimpleNamespace(exit_status=0, stdout="RESULT_JSON: {}", stderr="")
+
+    probe = await svc._probe_all_claimed_cards(SimpleNamespace(run=run), _executor(), {}, _spec(2))
+    assert probe is not None and probe.passed is False
+    killed.assert_not_awaited()

--- a/neurons/validators/tests/test_matmul_allcards.py
+++ b/neurons/validators/tests/test_matmul_allcards.py
@@ -138,6 +138,17 @@ async def test_unknown_model_skips_probe(svc):
     assert probe is None
 
 
+@pytest.mark.asyncio
+async def test_native_cipher_failure_skips_probe(svc, monkeypatch):
+    # Our own .so failing must not read as the host failing: an empty cipher would go out as a bare
+    # `--cipher_text ` and every card would come back ok=False. Skip the probe instead.
+    monkeypatch.setattr(
+        svc, "_generate_card_cipher", lambda machine_info, params: "", raising=False
+    )
+    probe = await svc._probe_all_claimed_cards(_ssh(real_cards=8), _executor(), {}, _spec(8))
+    assert probe is None
+
+
 def test_matmul_probe_vram_mb_floors_below_observed():
     # Finding 1: size each card's challenge from the 0.90 floor, NOT the raw nominal, so an honest
     # B200/L40S is never asked to allocate past its usable (NVML-reported) VRAM and OOM.

--- a/neurons/validators/tests/test_nvidia_devices_kernel_verdict.py
+++ b/neurons/validators/tests/test_nvidia_devices_kernel_verdict.py
@@ -1,0 +1,136 @@
+"""DAH-2671 item 1 — surface the kernel (procfs) GPU verdict + refuse the spoofable XML fallback.
+
+RED→GREEN:
+  1a — before this change the missing-GPU verdict died as a bare WARNING; now it emits a stable,
+       greppable structured event carrying requested/visible counts and both full UUID lists.
+  1b — before this change the NVML-backed nvidia-smi XML always replaced the kernel map; now a
+       kernel-vs-XML disagreement is emitted, and under enforcement the overwrite is refused
+       (fail closed) so the kernel truth stands.
+"""
+from unittest.mock import AsyncMock
+
+import pytest
+from neurons.validators.src.services.nvidia_devices import (
+    MissingRentedGpuError,
+    _query_gpu_nodes_for_uuids,
+    build_gpu_docker_config_for_executor,
+)
+
+import services.nvidia_devices as nd
+
+_XML_BOTH = """\
+<?xml version="1.0" ?>
+<nvidia_smi_log>
+    <gpu id="00000000:02:00.0"><uuid>GPU-aaa</uuid><minor_number>0</minor_number></gpu>
+    <gpu id="00000000:03:00.0"><uuid>GPU-bbb</uuid><minor_number>1</minor_number></gpu>
+</nvidia_smi_log>
+"""
+
+
+class FakeRun:
+    def __init__(self, stdout="", stderr="", exit_status=0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_status = exit_status
+
+
+def _fake_ssh(*responses):
+    ssh = AsyncMock()
+    ssh.run.side_effect = responses
+    ssh.get_extra_info = lambda *a, **k: ("1.2.3.4", 22)
+    return ssh
+
+
+@pytest.fixture(autouse=True)
+def _shadow_flags(monkeypatch):
+    # default posture for every test: master on, enforcement off; tests flip enforcement explicitly.
+    monkeypatch.setattr(nd.settings, "KERNEL_GPU_VERDICT_CHECK_ENABLED", True, raising=False)
+    monkeypatch.setattr(nd.settings, "KERNEL_GPU_VERDICT_ENFORCEMENT_ENABLED", False, raising=False)
+
+
+# ---------------------------- 1a: missing-GPU verdict emits ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_rented_gpu_emits_structured_event(caplog):
+    # proc lists only GPU-aaa; XML empty → GPU-bbb absent everywhere → MissingRentedGpuError.
+    ssh = _fake_ssh(FakeRun("GPU-aaa, 0\n"), FakeRun(""))
+
+    with caplog.at_level("WARNING"):
+        config = await build_gpu_docker_config_for_executor(
+            ssh, ["GPU-bbb"], executor_id="exec-9", default_extra={"executor_uuid": "exec-9"}
+        )
+
+    # Behavior unchanged: still falls back to the legacy --gpus config (no device mounts).
+    assert config.device_mounts == ()
+
+    rec = next(r for r in caplog.records if r.message == nd._KERNEL_GPU_VERDICT_MISSING_MSG)
+    assert rec.requested_gpu_count == 1
+    assert rec.visible_gpu_count == 1
+    assert rec.requested_uuids == ["GPU-bbb"]
+    assert rec.visible_uuids == ["GPU-aaa"]
+    assert rec.missing_uuids == ["GPU-bbb"]
+    assert rec.executor_id == "exec-9"
+
+
+# ---------------------------- 1b: kernel-vs-XML disagreement ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_disagreement_shadow_preserves_behavior_and_emits(caplog):
+    # proc readable but missing GPU-bbb; XML supplies it. Shadow keeps today's behavior: XML wins.
+    ssh = _fake_ssh(FakeRun("GPU-aaa, 0\n"), FakeRun(_XML_BOTH))
+
+    with caplog.at_level("WARNING"):
+        nodes, host_total = await _query_gpu_nodes_for_uuids(ssh, ["GPU-bbb"])
+
+    assert nodes == ("/dev/nvidia1",)  # XML overwrote the kernel map — placement unchanged
+    assert host_total == 2
+
+    rec = next(r for r in caplog.records if r.message == nd._KERNEL_GPU_VERDICT_DISAGREE_MSG)
+    assert rec.proc_unreadable is False
+    assert rec.enforced is False
+    assert rec.xml_would_add_uuids == ["GPU-bbb"]
+
+
+@pytest.mark.asyncio
+async def test_disagreement_enforcement_fails_closed(monkeypatch, caplog):
+    monkeypatch.setattr(nd.settings, "KERNEL_GPU_VERDICT_ENFORCEMENT_ENABLED", True, raising=False)
+    ssh = _fake_ssh(FakeRun("GPU-aaa, 0\n"), FakeRun(_XML_BOTH))
+
+    with caplog.at_level("WARNING"):
+        # kernel truth stands (XML not allowed to overwrite) → the missing verdict fires.
+        with pytest.raises(MissingRentedGpuError):
+            await _query_gpu_nodes_for_uuids(ssh, ["GPU-bbb"])
+
+    rec = next(r for r in caplog.records if r.message == nd._KERNEL_GPU_VERDICT_DISAGREE_MSG)
+    assert rec.enforced is True
+
+
+@pytest.mark.asyncio
+async def test_unreadable_proc_recorded_distinctly(monkeypatch, caplog):
+    # honest casualty: /proc map unreadable (non-zero exit) while XML answers. Enforcement refuses
+    # the overwrite and records proc_unreadable=True so ops can tell it apart from a real spoof.
+    monkeypatch.setattr(nd.settings, "KERNEL_GPU_VERDICT_ENFORCEMENT_ENABLED", True, raising=False)
+    ssh = _fake_ssh(FakeRun("proc boom", "err", exit_status=1), FakeRun(_XML_BOTH))
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RuntimeError):
+            await _query_gpu_nodes_for_uuids(ssh, ["GPU-bbb"])
+
+    rec = next(r for r in caplog.records if r.message == nd._KERNEL_GPU_VERDICT_DISAGREE_MSG)
+    assert rec.proc_unreadable is True
+    assert rec.enforced is True
+
+
+@pytest.mark.asyncio
+async def test_check_disabled_preserves_legacy_behavior(monkeypatch, caplog):
+    # master switch off → no emit, XML overwrites exactly as before the change.
+    monkeypatch.setattr(nd.settings, "KERNEL_GPU_VERDICT_CHECK_ENABLED", False, raising=False)
+    ssh = _fake_ssh(FakeRun("GPU-aaa, 0\n"), FakeRun(_XML_BOTH))
+
+    with caplog.at_level("WARNING"):
+        nodes, _ = await _query_gpu_nodes_for_uuids(ssh, ["GPU-bbb"])
+
+    assert nodes == ("/dev/nvidia1",)
+    assert not any(r.message == nd._KERNEL_GPU_VERDICT_DISAGREE_MSG for r in caplog.records)

--- a/neurons/validators/tests/test_nvidia_devices_kernel_verdict.py
+++ b/neurons/validators/tests/test_nvidia_devices_kernel_verdict.py
@@ -96,7 +96,9 @@ async def test_disagreement_shadow_preserves_behavior_and_emits(caplog):
     ssh = _fake_ssh(FakeRun("GPU-aaa, 0\n"), FakeRun(_XML_BOTH))
 
     with caplog.at_level("WARNING"):
-        nodes, host_total = await _query_gpu_nodes_for_uuids(ssh, ["GPU-bbb"])
+        nodes, host_total = await _query_gpu_nodes_for_uuids(
+            ssh, ["GPU-bbb"], executor_id="exec-9", default_extra={"miner_hotkey": "hk-1"}
+        )
 
     assert nodes == ("/dev/nvidia1",)  # XML overwrote the kernel map — placement unchanged
     assert host_total == 2
@@ -105,6 +107,9 @@ async def test_disagreement_shadow_preserves_behavior_and_emits(caplog):
     assert rec.proc_unreadable is False
     assert rec.enforced is False
     assert rec.xml_would_add_uuids == ["GPU-bbb"]
+    # the event has to be correlatable by miner/batch, not just by host:port
+    assert rec.executor_id == "exec-9"
+    assert rec.miner_hotkey == "hk-1"
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_nvidia_devices_kernel_verdict.py
+++ b/neurons/validators/tests/test_nvidia_devices_kernel_verdict.py
@@ -143,6 +143,22 @@ async def test_unreadable_proc_recorded_distinctly(monkeypatch, caplog):
 
 
 @pytest.mark.asyncio
+async def test_silently_empty_proc_still_records_unreadable(monkeypatch, caplog):
+    # The usual shape of the honest casualty: _PROC_GPU_INFO_CMD exits 0 with no rows (unexpanded
+    # glob, `|| continue`, stderr discarded), so no RuntimeError is raised. The map is still empty,
+    # and without proc_unreadable=True this host would log identically to a real spoof.
+    monkeypatch.setattr(nd.settings, "KERNEL_GPU_VERDICT_ENFORCEMENT_ENABLED", True, raising=False)
+    ssh = _fake_ssh(FakeRun(""), FakeRun(_XML_BOTH))
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RuntimeError):
+            await _query_gpu_nodes_for_uuids(ssh, ["GPU-bbb"])
+
+    rec = next(r for r in caplog.records if r.message == nd._KERNEL_GPU_VERDICT_DISAGREE_MSG)
+    assert rec.proc_unreadable is True
+
+
+@pytest.mark.asyncio
 async def test_check_disabled_preserves_legacy_behavior(monkeypatch, caplog):
     # master switch off → no emit, XML overwrites exactly as before the change.
     monkeypatch.setattr(nd.settings, "KERNEL_GPU_VERDICT_CHECK_ENABLED", False, raising=False)

--- a/neurons/validators/tests/test_nvidia_devices_kernel_verdict.py
+++ b/neurons/validators/tests/test_nvidia_devices_kernel_verdict.py
@@ -134,7 +134,9 @@ async def test_unreadable_proc_recorded_distinctly(monkeypatch, caplog):
     ssh = _fake_ssh(FakeRun("proc boom", "err", exit_status=1), FakeRun(_XML_BOTH))
 
     with caplog.at_level("WARNING"):
-        with pytest.raises(RuntimeError):
+        # MissingRentedGpuError, not a bare RuntimeError: only the named verdict survives the
+        # caller's legacy fallback, so fail-closed holds here too.
+        with pytest.raises(MissingRentedGpuError):
             await _query_gpu_nodes_for_uuids(ssh, ["GPU-bbb"])
 
     rec = next(r for r in caplog.records if r.message == nd._KERNEL_GPU_VERDICT_DISAGREE_MSG)
@@ -151,11 +153,36 @@ async def test_silently_empty_proc_still_records_unreadable(monkeypatch, caplog)
     ssh = _fake_ssh(FakeRun(""), FakeRun(_XML_BOTH))
 
     with caplog.at_level("WARNING"):
-        with pytest.raises(RuntimeError):
+        with pytest.raises(MissingRentedGpuError):
             await _query_gpu_nodes_for_uuids(ssh, ["GPU-bbb"])
 
     rec = next(r for r in caplog.records if r.message == nd._KERNEL_GPU_VERDICT_DISAGREE_MSG)
     assert rec.proc_unreadable is True
+
+
+@pytest.mark.asyncio
+async def test_empty_kernel_map_under_enforcement_refuses_the_container(monkeypatch, caplog):
+    # The bypass this closes: with an empty kernel map the refused XML overwrite left nothing to
+    # raise but a plain RuntimeError, which the caller catches and downgrades to the legacy --gpus
+    # string — the container is created anyway on NVML's spoofable word. Enforcement must refuse it.
+    monkeypatch.setattr(nd.settings, "KERNEL_GPU_VERDICT_ENFORCEMENT_ENABLED", True, raising=False)
+    ssh = _fake_ssh(FakeRun(""), FakeRun(_XML_BOTH))
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(MissingRentedGpuError):
+            await build_gpu_docker_config_for_executor(ssh, ["GPU-bbb"], executor_id="exec-9")
+
+
+@pytest.mark.asyncio
+async def test_empty_kernel_map_in_shadow_still_creates_the_container():
+    # Shadow is the fleet-wide default: the XML overwrite stands, so an honest host with an
+    # unreadable procfs keeps its device mounts and nothing about placement changes.
+    # Three responses: empty procfs, the XML fallback, then the shared-node query.
+    ssh = _fake_ssh(FakeRun(""), FakeRun(_XML_BOTH), FakeRun(""))
+
+    config = await build_gpu_docker_config_for_executor(ssh, ["GPU-bbb"], executor_id="exec-9")
+
+    assert [device.path_on_host for device in config.device_mounts] == ["/dev/nvidia1"]
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_nvidia_devices_kernel_verdict.py
+++ b/neurons/validators/tests/test_nvidia_devices_kernel_verdict.py
@@ -73,6 +73,20 @@ async def test_missing_rented_gpu_emits_structured_event(caplog):
     assert rec.executor_id == "exec-9"
 
 
+@pytest.mark.asyncio
+async def test_missing_rented_gpu_under_enforcement_refuses_the_container(monkeypatch, caplog):
+    # The verdict must reach the caller, not be swallowed into the legacy --gpus fallback: otherwise
+    # enforcement only drops the --device mounts and the container is still created.
+    monkeypatch.setattr(nd.settings, "KERNEL_GPU_VERDICT_ENFORCEMENT_ENABLED", True, raising=False)
+    ssh = _fake_ssh(FakeRun("GPU-aaa, 0\n"), FakeRun(""))
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(MissingRentedGpuError):
+            await build_gpu_docker_config_for_executor(ssh, ["GPU-bbb"], executor_id="exec-9")
+
+    assert any(r.message == nd._KERNEL_GPU_VERDICT_MISSING_MSG for r in caplog.records)
+
+
 # ---------------------------- 1b: kernel-vs-XML disagreement ----------------------------
 
 

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -14,8 +14,8 @@ from neurons.validators.src.services.container_cleanup import ContainerCleanup
 from neurons.validators.src.services.task.checks.rental_verification import RentalVerificationCheck
 from neurons.validators.src.services.task.messages import RentalVerificationMessages as Msg
 from neurons.validators.src.services.task.pipeline import CheckResult, Context
-from protocol.vc_protocol.compute_requests import RentedExecutor, RentedExecutorsResponse, RentedPod
 
+from protocol.vc_protocol.compute_requests import RentedExecutor, RentedExecutorsResponse, RentedPod
 from tests.helpers import build_services, build_state
 
 
@@ -1003,10 +1003,7 @@ async def test_cpu_quota_verdict_is_observe_only_in_shadow():
     state = build_state(specs={"verified_ports": [8080], "cpu": {"count": 176}})
 
     from tests.helpers import make_context
-    # A spoofed host: 44 real cores in both /proc/cpuinfo and sysfs, 176 advertised. The cap only
-    # applies to hosts already honest against the kernel-present population, so 176 goes out intact
-    # and the daemon refuses it.
-    ctx = make_context(services=services, state=state, ssh=_OnlineCpuSSH(44))
+    ctx = make_context(services=services, state=state, ssh=_RecordingSSH())
 
     with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
         mock_settings.SKIP_RENTAL_VERIFICATION = False
@@ -1028,10 +1025,7 @@ async def test_cpu_quota_verdict_zeroes_score_under_enforcement():
     state = build_state(specs={"verified_ports": [8080], "cpu": {"count": 176}})
 
     from tests.helpers import make_context
-    # A spoofed host: 44 real cores in both /proc/cpuinfo and sysfs, 176 advertised. The cap only
-    # applies to hosts already honest against the kernel-present population, so 176 goes out intact
-    # and the daemon refuses it.
-    ctx = make_context(services=services, state=state, ssh=_OnlineCpuSSH(44))
+    ctx = make_context(services=services, state=state, ssh=_RecordingSSH())
 
     with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
         mock_settings.SKIP_RENTAL_VERIFICATION = False
@@ -1055,7 +1049,7 @@ async def test_advertised_cpu_count_is_sent_to_the_backend():
     state = build_state(specs={"verified_ports": [8080], "cpu": {"count": 44}})
 
     from tests.helpers import make_context
-    ctx = make_context(services=services, state=state, ssh=_OnlineCpuSSH(44))
+    ctx = make_context(services=services, state=state, ssh=_RecordingSSH())
 
     with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
         mock_settings.SKIP_RENTAL_VERIFICATION = False
@@ -1066,32 +1060,11 @@ async def test_advertised_cpu_count_is_sent_to_the_backend():
 
 
 @pytest.mark.asyncio
-async def test_cpu_count_sent_is_capped_by_the_hosts_online_cpus():
-    """An honest host with cores offlined: CpuTruthCheck compares against the kernel-PRESENT
-    population and passes it, so the probe must not ask for a `--cpus` quota above the ONLINE
-    count dockerd actually enforces."""
-    backend_client = DummyBackendClient(
-        response=ExecutorHealthCheckResponse(success=True, error=None, details={})
-    )
-    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
-    state = build_state(specs={"verified_ports": [8080], "cpu": {"count": 128}})
-
-    from tests.helpers import make_context
-    ctx = make_context(services=services, state=state, ssh=_OnlineCpuSSH(64, present=128))
-
-    with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
-        mock_settings.SKIP_RENTAL_VERIFICATION = False
-        mock_settings.RENTAL_CPU_LIMIT_CHECK_ENABLED = True
-        await RentalVerificationCheck().run(ctx)
-
-    assert backend_client.called_with["cpu_count"] == 64
-
-
-@pytest.mark.asyncio
-async def test_cpu_count_is_not_capped_on_a_host_that_lies_about_its_cores():
-    """A spoofed host whose /proc/cpuinfo stayed honest (44 real cores, 176 advertised): capping by
-    the online count would ask for a quota the daemon happily grants, so the lie must go out
-    uncapped and be refused."""
+async def test_fake_present_population_does_not_cap_the_advertised_count():
+    """Bypass regression: a spoofer faking `present` == advertised (176) while /proc/cpuinfo stays
+    real (44) must NOT get the advertised count capped to the online population — a host-read cap
+    would turn the lie into a quota the daemon happily grants. The count goes out AS-IS and the
+    daemon/backend classifier judges it."""
     backend_client = DummyBackendClient(
         response=ExecutorHealthCheckResponse(success=True, error=None, details={})
     )
@@ -1099,7 +1072,7 @@ async def test_cpu_count_is_not_capped_on_a_host_that_lies_about_its_cores():
     state = build_state(specs={"verified_ports": [8080], "cpu": {"count": 176}})
 
     from tests.helpers import make_context
-    ctx = make_context(services=services, state=state, ssh=_OnlineCpuSSH(44))
+    ctx = make_context(services=services, state=state, ssh=_OnlineCpuSSH(44, present=176))
 
     with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
         mock_settings.SKIP_RENTAL_VERIFICATION = False

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -969,16 +969,20 @@ _CPU_QUOTA_STDERR = (
 
 
 class _OnlineCpuSSH(_RecordingSSH):
-    """An executor whose `/proc/cpuinfo` reports `online` logical CPUs; every other command is a no-op."""
+    """An executor reporting `online` logical CPUs in `/proc/cpuinfo` and `present` kernel-present
+    cores in sysfs; every other command is a no-op. `present` defaults to `online`."""
 
-    def __init__(self, online: int):
+    def __init__(self, online: int, present: int | None = None):
         super().__init__()
         self.online = online
+        self.present = online if present is None else present
 
     async def run(self, cmd):
         res = await super().run(cmd)
         if "processor /proc/cpuinfo" in cmd:
             res.stdout = f"{self.online}\n"
+        if "/sys/devices/system/cpu/present" in cmd:
+            res.stdout = f"0-{self.present - 1}\n"
         return res
 
 
@@ -999,9 +1003,10 @@ async def test_cpu_quota_verdict_is_observe_only_in_shadow():
     state = build_state(specs={"verified_ports": [8080], "cpu": {"count": 176}})
 
     from tests.helpers import make_context
-    # A spoofing wrapper inflates /proc/cpuinfo alongside lscpu, so the online cap leaves 176 intact
-    # and the daemon still refuses it.
-    ctx = make_context(services=services, state=state, ssh=_OnlineCpuSSH(176))
+    # A spoofed host: 44 real cores in both /proc/cpuinfo and sysfs, 176 advertised. The cap only
+    # applies to hosts already honest against the kernel-present population, so 176 goes out intact
+    # and the daemon refuses it.
+    ctx = make_context(services=services, state=state, ssh=_OnlineCpuSSH(44))
 
     with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
         mock_settings.SKIP_RENTAL_VERIFICATION = False
@@ -1023,9 +1028,10 @@ async def test_cpu_quota_verdict_zeroes_score_under_enforcement():
     state = build_state(specs={"verified_ports": [8080], "cpu": {"count": 176}})
 
     from tests.helpers import make_context
-    # A spoofing wrapper inflates /proc/cpuinfo alongside lscpu, so the online cap leaves 176 intact
-    # and the daemon still refuses it.
-    ctx = make_context(services=services, state=state, ssh=_OnlineCpuSSH(176))
+    # A spoofed host: 44 real cores in both /proc/cpuinfo and sysfs, 176 advertised. The cap only
+    # applies to hosts already honest against the kernel-present population, so 176 goes out intact
+    # and the daemon refuses it.
+    ctx = make_context(services=services, state=state, ssh=_OnlineCpuSSH(44))
 
     with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
         mock_settings.SKIP_RENTAL_VERIFICATION = False
@@ -1071,7 +1077,7 @@ async def test_cpu_count_sent_is_capped_by_the_hosts_online_cpus():
     state = build_state(specs={"verified_ports": [8080], "cpu": {"count": 128}})
 
     from tests.helpers import make_context
-    ctx = make_context(services=services, state=state, ssh=_OnlineCpuSSH(64))
+    ctx = make_context(services=services, state=state, ssh=_OnlineCpuSSH(64, present=128))
 
     with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
         mock_settings.SKIP_RENTAL_VERIFICATION = False
@@ -1079,6 +1085,28 @@ async def test_cpu_count_sent_is_capped_by_the_hosts_online_cpus():
         await RentalVerificationCheck().run(ctx)
 
     assert backend_client.called_with["cpu_count"] == 64
+
+
+@pytest.mark.asyncio
+async def test_cpu_count_is_not_capped_on_a_host_that_lies_about_its_cores():
+    """A spoofed host whose /proc/cpuinfo stayed honest (44 real cores, 176 advertised): capping by
+    the online count would ask for a quota the daemon happily grants, so the lie must go out
+    uncapped and be refused."""
+    backend_client = DummyBackendClient(
+        response=ExecutorHealthCheckResponse(success=True, error=None, details={})
+    )
+    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
+    state = build_state(specs={"verified_ports": [8080], "cpu": {"count": 176}})
+
+    from tests.helpers import make_context
+    ctx = make_context(services=services, state=state, ssh=_OnlineCpuSSH(44))
+
+    with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
+        mock_settings.SKIP_RENTAL_VERIFICATION = False
+        mock_settings.RENTAL_CPU_LIMIT_CHECK_ENABLED = True
+        await RentalVerificationCheck().run(ctx)
+
+    assert backend_client.called_with["cpu_count"] == 176
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 import asyncssh
 import pytest
 from neurons.validators.src.protocol.vc_protocol.compute_requests import (
+    CPU_QUOTA_EXCEEDS_HOST_REASON,
     GPU_RUNTIME_DEVICE_FAULT_REASON,
     GPU_RUNTIME_NVML_MISMATCH_REASON,
     ExecutorHealthCheckResponse,
@@ -47,6 +48,7 @@ class DummyBackendClient:
         executor_id: str | None = None,
         rental_in_progress: bool = False,
         gpu_uuids: list[str] | None = None,
+        cpu_count: int | None = None,
     ):
         self.called_with = {
             "miner_address": miner_address,
@@ -56,6 +58,7 @@ class DummyBackendClient:
             "executor_id": executor_id,
             "rental_in_progress": rental_in_progress,
             "gpu_uuids": gpu_uuids,
+            "cpu_count": cpu_count,
         }
         return self.response
 
@@ -155,6 +158,7 @@ async def test_rental_verification_success():
         "executor_id": "executor-123",
         "rental_in_progress": False,  # no customer rental in this state
         "gpu_uuids": [],  # this state carries no scraped gpu details
+        "cpu_count": None,  # this state carries no scraped cpu count
     }
 
 
@@ -954,3 +958,125 @@ async def test_rental_verification_skips_gpu_details_without_a_uuid():
 
     assert result.passed is True
     assert backend_client.called_with["gpu_uuids"] == ["GPU-f2bfa67f-5281-aabc-aa90-c91764f90d17"]
+
+
+# --- DAH-2671 item 2b: send the advertised CPU count, quarantine a daemon-rejected count ---
+
+_CPU_QUOTA_STDERR = (
+    "docker: Error response from daemon: Range of CPUs is from 0.01 to 20.00, "
+    "as there are only 20 CPUs available."
+)
+
+
+def _cpu_quota_response() -> ExecutorHealthCheckResponse:
+    return ExecutorHealthCheckResponse(
+        success=False,
+        error=_CPU_QUOTA_STDERR,
+        details={"docker_stderr": _CPU_QUOTA_STDERR},
+        reason_code=CPU_QUOTA_EXCEEDS_HOST_REASON,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cpu_quota_verdict_is_observe_only_in_shadow():
+    """CHECK on, ENFORCEMENT off: the daemon-rejected count is logged but the score is untouched."""
+    backend_client = DummyBackendClient(response=_cpu_quota_response())
+    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
+    state = build_state(specs={"verified_ports": [8080], "cpu": {"count": 176}})
+
+    from tests.helpers import make_context
+    ctx = make_context(services=services, state=state)
+
+    with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
+        mock_settings.SKIP_RENTAL_VERIFICATION = False
+        mock_settings.RENTAL_CPU_LIMIT_CHECK_ENABLED = True
+        mock_settings.RENTAL_CPU_LIMIT_ENFORCEMENT_ENABLED = False
+        result = await RentalVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == CPU_QUOTA_EXCEEDS_HOST_REASON
+    assert result.updates == {}
+    assert result.event.what_we_saw["advertised_cpu_count"] == 176
+    assert "Range of CPUs is from" in result.event.what_we_saw["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_cpu_quota_verdict_zeroes_score_under_enforcement():
+    backend_client = DummyBackendClient(response=_cpu_quota_response())
+    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
+    state = build_state(specs={"verified_ports": [8080], "cpu": {"count": 176}})
+
+    from tests.helpers import make_context
+    ctx = make_context(services=services, state=state)
+
+    with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
+        mock_settings.SKIP_RENTAL_VERIFICATION = False
+        mock_settings.RENTAL_CPU_LIMIT_CHECK_ENABLED = True
+        mock_settings.RENTAL_CPU_LIMIT_ENFORCEMENT_ENABLED = True
+        result = await RentalVerificationCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == CPU_QUOTA_EXCEEDS_HOST_REASON
+    assert result.updates["score"] == 0.0
+    assert result.updates["job_score"] == 0.0
+    assert result.updates["clear_verified_job_info"] is True
+
+
+@pytest.mark.asyncio
+async def test_advertised_cpu_count_is_sent_to_the_backend():
+    backend_client = DummyBackendClient(
+        response=ExecutorHealthCheckResponse(success=True, error=None, details={})
+    )
+    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
+    state = build_state(specs={"verified_ports": [8080], "cpu": {"count": 44}})
+
+    from tests.helpers import make_context
+    ctx = make_context(services=services, state=state)
+
+    with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
+        mock_settings.SKIP_RENTAL_VERIFICATION = False
+        mock_settings.RENTAL_CPU_LIMIT_CHECK_ENABLED = True
+        await RentalVerificationCheck().run(ctx)
+
+    assert backend_client.called_with["cpu_count"] == 44
+
+
+@pytest.mark.asyncio
+async def test_cpu_count_is_not_sent_when_the_check_is_disabled():
+    backend_client = DummyBackendClient(
+        response=ExecutorHealthCheckResponse(success=True, error=None, details={})
+    )
+    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
+    state = build_state(specs={"verified_ports": [8080], "cpu": {"count": 44}})
+
+    from tests.helpers import make_context
+    ctx = make_context(services=services, state=state)
+
+    with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
+        mock_settings.SKIP_RENTAL_VERIFICATION = False
+        mock_settings.RENTAL_CPU_LIMIT_CHECK_ENABLED = False
+        await RentalVerificationCheck().run(ctx)
+
+    assert backend_client.called_with["cpu_count"] is None
+
+
+@pytest.mark.asyncio
+async def test_cpu_count_is_not_sent_for_a_tdx_host():
+    """A real rent skips `--cpus` on a confidential VM (docker_service.py), so verification does too."""
+    backend_client = DummyBackendClient(
+        response=ExecutorHealthCheckResponse(success=True, error=None, details={})
+    )
+    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
+    state = build_state(specs={"verified_ports": [8080], "cpu": {"count": 44}})
+
+    from tests.helpers import default_executor, make_context
+    executor = default_executor()
+    executor.tdx_quote = '{"quote": "..."}'
+    ctx = make_context(executor=executor, services=services, state=state)
+
+    with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
+        mock_settings.SKIP_RENTAL_VERIFICATION = False
+        mock_settings.RENTAL_CPU_LIMIT_CHECK_ENABLED = True
+        await RentalVerificationCheck().run(ctx)
+
+    assert backend_client.called_with["cpu_count"] is None

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -968,6 +968,20 @@ _CPU_QUOTA_STDERR = (
 )
 
 
+class _OnlineCpuSSH(_RecordingSSH):
+    """An executor whose `/proc/cpuinfo` reports `online` logical CPUs; every other command is a no-op."""
+
+    def __init__(self, online: int):
+        super().__init__()
+        self.online = online
+
+    async def run(self, cmd):
+        res = await super().run(cmd)
+        if "processor /proc/cpuinfo" in cmd:
+            res.stdout = f"{self.online}\n"
+        return res
+
+
 def _cpu_quota_response() -> ExecutorHealthCheckResponse:
     return ExecutorHealthCheckResponse(
         success=False,
@@ -985,7 +999,9 @@ async def test_cpu_quota_verdict_is_observe_only_in_shadow():
     state = build_state(specs={"verified_ports": [8080], "cpu": {"count": 176}})
 
     from tests.helpers import make_context
-    ctx = make_context(services=services, state=state)
+    # A spoofing wrapper inflates /proc/cpuinfo alongside lscpu, so the online cap leaves 176 intact
+    # and the daemon still refuses it.
+    ctx = make_context(services=services, state=state, ssh=_OnlineCpuSSH(176))
 
     with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
         mock_settings.SKIP_RENTAL_VERIFICATION = False
@@ -1007,7 +1023,9 @@ async def test_cpu_quota_verdict_zeroes_score_under_enforcement():
     state = build_state(specs={"verified_ports": [8080], "cpu": {"count": 176}})
 
     from tests.helpers import make_context
-    ctx = make_context(services=services, state=state)
+    # A spoofing wrapper inflates /proc/cpuinfo alongside lscpu, so the online cap leaves 176 intact
+    # and the daemon still refuses it.
+    ctx = make_context(services=services, state=state, ssh=_OnlineCpuSSH(176))
 
     with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
         mock_settings.SKIP_RENTAL_VERIFICATION = False
@@ -1031,7 +1049,7 @@ async def test_advertised_cpu_count_is_sent_to_the_backend():
     state = build_state(specs={"verified_ports": [8080], "cpu": {"count": 44}})
 
     from tests.helpers import make_context
-    ctx = make_context(services=services, state=state)
+    ctx = make_context(services=services, state=state, ssh=_OnlineCpuSSH(44))
 
     with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
         mock_settings.SKIP_RENTAL_VERIFICATION = False
@@ -1039,6 +1057,28 @@ async def test_advertised_cpu_count_is_sent_to_the_backend():
         await RentalVerificationCheck().run(ctx)
 
     assert backend_client.called_with["cpu_count"] == 44
+
+
+@pytest.mark.asyncio
+async def test_cpu_count_sent_is_capped_by_the_hosts_online_cpus():
+    """An honest host with cores offlined: CpuTruthCheck compares against the kernel-PRESENT
+    population and passes it, so the probe must not ask for a `--cpus` quota above the ONLINE
+    count dockerd actually enforces."""
+    backend_client = DummyBackendClient(
+        response=ExecutorHealthCheckResponse(success=True, error=None, details={})
+    )
+    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
+    state = build_state(specs={"verified_ports": [8080], "cpu": {"count": 128}})
+
+    from tests.helpers import make_context
+    ctx = make_context(services=services, state=state, ssh=_OnlineCpuSSH(64))
+
+    with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
+        mock_settings.SKIP_RENTAL_VERIFICATION = False
+        mock_settings.RENTAL_CPU_LIMIT_CHECK_ENABLED = True
+        await RentalVerificationCheck().run(ctx)
+
+    assert backend_client.called_with["cpu_count"] == 64
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes the class where an executor advertises 8 GPUs / 176–240 CPU cores while really having one GPU and 20–44 cores and still passes rental verification. Every verification surface reads the same tampered NVML on the judged host; the fix is built on **a lie is exposed by what you demand, not by what you enumerate** — verification asks for access, rental asks for resources.

**All four checks ship shadow-first.** Each pair mirrors `FILLER_LIVENESS_*`: `*_CHECK_ENABLED` defaults `True` (compute + emit, but `passed=True`, no score change), `*_ENFORCEMENT_ENABLED` defaults `False`. Nothing reduces an honest miner's score until enforcement is flipped from a week of fleet data — an operator decision at a halt, not a follow-up commit.

### What changed
- **1 · surface-kernel-verdict** (`nvidia_devices.py`) — the validator already computes a truth verdict from the kernel's own `/proc/driver/nvidia/gpus/` list (a source the NVML shim does not author) and throws it away (243×/7d in prod). Emit it as a stable, greppable structured event, and treat a kernel-vs-nvidia-smi-XML disagreement as the finding: under enforcement refuse the spoofable XML overwrite so the kernel truth stands (fail closed); the unreadable-`/proc` honest case is recorded distinctly.
- **2a · rental-cpu-truth** (new non-fatal `CpuTruthCheck`) — compares the advertised `CPU(s)` count against the kernel-present population (`/sys/devices/system/cpu/present`, like-for-like with `lscpu`), `/proc/cpuinfo` and docker `NCPU`, over SSH. Emits the RAW counts so the enforcement predicate is chosen from data. Any inability to measure passes with a distinct `*_unknown` reason.
- **2b · rental-cpu-limit** (`rental_verification.py`, `backend_client.py`) — send the advertised core count in the rental-verification health check so the backend creates the probe with `--cpus=<advertised>`. The host's **own Docker daemon** rejects a count above its physical cores (`CPU_QUOTA_EXCEEDS_HOST`) — a lie the lscpu wrapper cannot cover, because dockerd reads the kernel directly. Shadow observes the verdict; enforcement zeroes the score. Skipped on TDX hosts (a real rent skips `--cpus` there too). **Requires the backend half first:** Datura-ai/lium-io-backend#918.
- **3 · full-matmul-all-cards** (`matrix_validation_service.py`) — runs the GPU work-proof on **every** claimed card concurrently, each pinned `CUDA_VISIBLE_DEVICES=<index>`, each with its own challenge, sized from the registry SKU table (`gpu_spec_table`) instead of host self-report, timed in aggregate by the validator. A count lie fails device selection or serialises past a wide wall-clock. Only reaches idle executors (customer rentals halt at `TenantEnforcement`; filler-only nodes skip in `CapabilityCheck`). No `.so` rebuild — the change is validator-side command construction only. Legacy single-card / unknown-model hosts skip the probe.

### Companion PR
Backend half of 2b (declare + apply `cpu_count`, classify the daemon's CPU-400): Datura-ai/lium-io-backend#918 — **merge that first**, then this.

### Out of scope (own tickets)
The per-card cryptographic seal in `libdmcompverify.so` (staging proved `CUDA_VISIBLE_DEVICES` breaks per-card decrypt, so item 3 is a count-check, not per-card crypto), NCCL/NVLink chassis-binding, and collateral/clawback.

### Testing
`pdm run pytest tests/` → 1543 passed, 28 new (`test_cpu_truth_check.py`, `test_nvidia_devices_kernel_verdict.py`, `test_matmul_allcards.py`, +5 in `test_rental_verification_check.py` for 2b). The 3 `test_sshd_bootstrap_script.py` failures are pre-existing (fail identically on `main`). Items 1/2a live on staging; item 3 ran live on a real 2×A6000 (passes honest, no false positive). 2b: honest-box no-false-positive + the daemon→classify→shadow chain to be exercised on staging.
