### PR TITLE
DAH-2675 - Verify a rented CVM's TDX quote through cvmd and score on it

### DIFF
--- a/neurons/executor/attest-agent/Dockerfile
+++ b/neurons/executor/attest-agent/Dockerfile
@@ -5,9 +5,11 @@
 # re-approving it fleet-wide, and the customer can read exactly what runs beside their
 # workload, because it is a service in the compose they submitted.
 #
-# The image is deliberately thin. Everything this container can reach is something a trust
-# check needs — there is no shell tooling to pivot with, no docker client, and the compose
-# block that runs it grants no socket and no volume into the workload.
+# Everything this container can reach is something a trust check needs — there is no shell
+# tooling to pivot with, no docker client, and the compose block that runs it grants no socket
+# and no volume into the workload. The NVIDIA attestation stack below is the one bulky thing
+# here, and it is not optional: without it the agent has no GPU evidence to return, and the
+# GPUs a renter paid for cannot be proven to exist.
 
 FROM python:3.12-slim
 
@@ -21,12 +23,29 @@ COPY pyproject.toml README.md ./
 COPY src ./src
 
 RUN pip install --no-cache-dir . \
-    # The two CVM-only dependencies, added here rather than declared in pyproject.toml so
-    # the package stays installable (and testable) outside a CVM. See the comment there.
-    && pip install --no-cache-dir "dstack-sdk>=0.5.0" "nvidia-ml-py>=12.560.30" \
+    # The CVM-only dependencies, added here rather than declared in pyproject.toml so the
+    # package stays installable (and testable) outside a CVM. See the comment there.
+    #
+    # nv-ppcie-verifier is the NVIDIA attestation stack — the same package and version the
+    # executor image installs under INSTALL_GPU_ATTESTATION, so both collectors produce
+    # evidence NRAS is known to accept on this fleet. Without it the agent answers every
+    # trust check with no GPU evidence, and the GPU set of a rented CVM stays a guest-made
+    # claim that nothing can confirm.
+    #
+    # It brings its own pinned nvidia-ml-py (== 12.550.52, which is pynvml). Do not ask for a
+    # newer one alongside it: the two constraints are unsatisfiable and the build fails.
+    && pip install --no-cache-dir "dstack-sdk>=0.5.0" "nv-ppcie-verifier==1.5.0" \
     && mkdir -p /var/lib/lium-attest-agent \
     && chown -R attest:attest /var/lib/lium-attest-agent
 
 USER attest
+
+# Not /opt/attest-agent. The NVIDIA verifier package opens a log file in the working
+# directory as it is imported, and this container runs unprivileged with a read-only rootfs
+# (the compose block sets `read_only: true`), so every other path raises PermissionError or
+# EROFS before a single piece of GPU evidence is collected. The state volume is the one
+# writable place the agent has, and it is where that log belongs anyway.
+WORKDIR /var/lib/lium-attest-agent
+
 EXPOSE 8451
 ENTRYPOINT ["attest-agent"]

--- a/neurons/executor/attest-agent/README.md
+++ b/neurons/executor/attest-agent/README.md
@@ -34,21 +34,33 @@ The answer carries a fresh TDX quote and NVIDIA CC evidence, both bound to the c
 nonce:
 
 ```
-report_data = sha256(agent_tls_public_key ‖ gpu_uuid_digest) ‖ nonce
-              |________________ 32 bytes _________________|  |_ 32 _|
-                      identity                                freshness
+report_data = sha256("LIUM_RENTER_ATTEST_TLS_V1\0" ‖ tls_spki_der ‖ gpu_uuid_digest) ‖ nonce
+              |_______________________ 32 bytes ______________________________|  |_ 32 _|
+                                 identity                                         freshness
 ```
+
+**The tag is versioned and NUL-terminated** so these 32 bytes state their purpose. Without
+it the digest is just "a hash over a TLS key", indistinguishable from any other use of the
+same key material, and a later recipe would be the same bytes read a second way instead of
+a new construction a verifier can accept or refuse by name.
 
 **The TLS key is in there because the quote and the channel have to be the same thing.**
 The validator's only way into a renter CVM is this agent's TLS endpoint. A quote that did
 not name the key proves some TDX guest exists somewhere; an attacker who can terminate TLS
 relays a genuine quote from a CVM it does not own, and the verifier cannot tell. The key is
 generated *inside* the guest on first boot, so its private half exists only in encrypted
-CVM memory and on the CVM's encrypted disk.
+CVM memory and on the CVM's encrypted disk. It is hashed as its SubjectPublicKeyInfo DER —
+the bytes a client sees on the wire, since that is all a verifier holds.
 
-**The GPU UUIDs are in there because of FR-G6.** Today those identifiers travel on a
-channel no proof covers, so a node can claim GPUs it does not hold. Folding their digest
-into the same 32 bytes makes the GPU set hardware-attested rather than software-asserted.
+**The GPU UUIDs are in there because of FR-G6** — so the GPU claim travels inside the
+hardware's signature instead of beside it, where the host could rewrite it or move it onto
+another quote.
+
+**What that does not do is authenticate the GPUs.** NVML UUIDs are read by the guest and
+vouched for by nobody. Whether those GPUs exist, are genuine, are in CC mode, and are not
+also answering for another node is decided on the per-GPU `ueid` claims in the NVIDIA
+evidence returned beside the quote — the one GPU identifier here a node cannot choose. The
+validator counts ueids, and refuses a response with a missing or repeated one.
 
 ## Idempotent, not amnesiac
 
@@ -69,6 +81,10 @@ A CVM with no GPUs, or a build without the NVIDIA verifier stack, returns `null`
 evidence **with a stated reason** — never an empty list. "This CVM holds no GPUs" and "this
 agent could not tell" lead to opposite decisions on the validator's side, so they do not
 share an encoding.
+
+When evidence is produced it is returned as the payload NRAS accepts —
+`{"nonce", "evidence_list", "arch"}` — not a bare evidence list, which NRAS will not judge.
+The collection flow mirrors the executor's own collector, single-GPU branch included.
 
 The dstack SDK and the NVIDIA stack are not declared in `pyproject.toml`: both exist only
 inside a CVM and both drag fragile native trees, so declaring them would make the agent

--- a/neurons/executor/attest-agent/src/attest_agent/app.py
+++ b/neurons/executor/attest-agent/src/attest_agent/app.py
@@ -147,16 +147,21 @@ def create_app(config: Config) -> FastAPI:
             logger.error("no quote: %s", exc)
             return JSONResponse(status_code=503, content={"detail": NO_QUOTE_DETAIL})
 
-        gpu = collect_gpu_evidence(uuids, request.nonce)
+        gpu = collect_gpu_evidence(uuids, request.nonce, arch=config.gpu_arch)
         answer = {
             "version": __version__,
             "report_data": data.hex(),
+            # The TLS SubjectPublicKeyInfo DER, hex — the exact bytes the quote's identity
+            # half is taken over, so a verifier reproduces the digest without re-encoding.
             "tls_public_key": identity.public_key_hex,
+            # What NVML reported, bound into the quote. An observation, not an attested
+            # identity: the ueids inside `gpu_evidence` are what decide the GPU set.
             "gpu_uuids": gpu.uuids,
             "gpu_uuid_digest": gpu_uuid_digest(uuids).hex(),
             "gpu_detail": gpu_detail,
             "quote": quote,
-            "gpu_evidence": gpu.evidence,
+            # Ready to submit to NRAS as-is: {"nonce", "evidence_list", "arch"}.
+            "gpu_evidence": gpu.payload,
             "gpu_evidence_detail": gpu.detail,
         }
         app.state.ledger.put(request.nonce, answer)

--- a/neurons/executor/attest-agent/src/attest_agent/config.py
+++ b/neurons/executor/attest-agent/src/attest_agent/config.py
@@ -10,6 +10,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from attest_agent.evidence import DEFAULT_GPU_ARCH
 from attest_agent.tls import TlsIdentity, load_or_create
 
 DEFAULT_PORT = 8451
@@ -33,6 +34,10 @@ class Config:
     state_dir: Path = DEFAULT_STATE_DIR
     quote_timeout_seconds: int = DEFAULT_QUOTE_TIMEOUT_SECONDS
     nonce_cache_size: int = DEFAULT_NONCE_CACHE_SIZE
+    # Which architecture NRAS is asked to verify this CVM's GPU evidence as. A fact about the
+    # cards the order passed in, so the platform sets it per rental where it differs from the
+    # fleet default; the agent has no way to read it off the devices.
+    gpu_arch: str = DEFAULT_GPU_ARCH
 
     @property
     def cert_path(self) -> Path:
@@ -63,6 +68,7 @@ def load_config() -> Config:
         state_dir=Path(os.environ.get("ATTEST_AGENT_STATE_DIR", str(DEFAULT_STATE_DIR))),
         quote_timeout_seconds=_int("ATTEST_AGENT_QUOTE_TIMEOUT", DEFAULT_QUOTE_TIMEOUT_SECONDS),
         nonce_cache_size=_int("ATTEST_AGENT_NONCE_CACHE", DEFAULT_NONCE_CACHE_SIZE),
+        gpu_arch=os.environ.get("ATTEST_AGENT_GPU_ARCH", "").strip() or DEFAULT_GPU_ARCH,
     )
     if config.port <= 0 or config.port > 65535:
         raise ValueError(f"ATTEST_AGENT_PORT must be in 1-65535, got {config.port}")

--- a/neurons/executor/attest-agent/src/attest_agent/evidence.py
+++ b/neurons/executor/attest-agent/src/attest_agent/evidence.py
@@ -26,14 +26,19 @@ from dataclasses import dataclass
 logger = logging.getLogger(__name__)
 
 
+# The architecture NRAS is asked to verify this CVM's evidence as. A property of the cards
+# passed into the guest rather than of this agent, so it is configurable — with the fleet's
+# current default, which is what the executor's own collector uses.
+DEFAULT_GPU_ARCH = "HOPPER"
+
+
 @dataclass(frozen=True)
 class GpuEvidence:
     uuids: list[str]
-    evidence: list | None
+    # The NRAS request payload — {"nonce", "evidence_list", "arch"} — not the bare evidence
+    # list. See `collect_gpu_evidence`.
+    payload: dict | None
     detail: str
-
-    def report(self) -> dict:
-        return {"gpu_uuids": self.uuids, "evidence": self.evidence, "detail": self.detail}
 
 
 class EvidenceError(Exception):
@@ -75,32 +80,78 @@ def gpu_uuids() -> tuple[list[str], str]:
             pass
 
 
-def collect_gpu_evidence(uuids: list[str], nonce_hex: str) -> GpuEvidence:
+def collect_gpu_evidence(
+    uuids: list[str], nonce_hex: str, *, arch: str = DEFAULT_GPU_ARCH
+) -> GpuEvidence:
     """NVIDIA CC evidence for this CVM's GPUs, bound to the caller's nonce.
+
+    Returned as the payload NRAS takes — `{"nonce", "evidence_list", "arch"}` — rather than
+    the bare evidence list. This is the half that carries the per-GPU `ueid` claims, and the
+    ueids are what actually settle how many GPUs this CVM holds and whether they are genuine;
+    the NVML UUIDs in the quote's identity half cannot settle either (see `identity.py`). A
+    list with no nonce and no arch beside it is not submittable, so an agent returning one
+    would leave that question permanently open.
 
     The same nonce as the TDX quote's, so the two halves of one trust check cannot be
     assembled from two different moments — which is the whole shape of a replay.
+
+    The collection flow mirrors `executor/src/services/gpu_attestation_service.py`, single-GPU
+    branch included: that flow is the one NRAS is known to accept on this fleet, and a second
+    dialect of the same call is a second thing that can silently stop being accepted.
     """
     if not uuids:
         return GpuEvidence([], None, "this CVM holds no GPUs that NVML could identify")
 
     try:
         from nv_attestation_sdk import attestation
+        from verifier import cc_admin
     except ImportError:
-        return GpuEvidence(uuids, None, "the NVIDIA attestation SDK is not installed in this build")
+        return GpuEvidence(
+            uuids, None, "the NVIDIA attestation stack is not installed in this build"
+        )
+    except Exception as exc:  # noqa: BLE001 - importing it does real work, see below
+        # The verifier package opens its own log file in the process's working directory the
+        # moment it is imported, so an unwritable CWD raises here rather than at collection —
+        # and this agent runs unprivileged on a read-only rootfs, where most directories are.
+        # The Dockerfile therefore starts it in the one writable path it has. Degraded rather
+        # than raised: an exception out of this route reads to the validator as a broken
+        # agent, when what is broken is one half of one answer.
+        logger.warning("the NVIDIA attestation stack could not be loaded: %s", exc)
+        return GpuEvidence(uuids, None, "the NVIDIA attestation stack could not be loaded")
 
     try:
-        client = attestation.Attestation()
-        client.set_name("lium-attest-agent")
-        client.set_nonce(nonce_hex)
-        client.add_verifier(attestation.Devices.GPU, attestation.Environment.REMOTE, "", "", "")
-        return GpuEvidence(uuids, client.get_evidence(), f"evidence for {len(uuids)} GPU(s)")
+        if len(uuids) == 1:
+            # The count comes from the NVML read above rather than a second nvmlInit: one
+            # enumeration per request, so the two halves cannot disagree about it.
+            evidence_list = cc_admin.collect_gpu_evidence_remote(nonce_hex)
+        else:
+            attester = attestation.Attestation()
+            attester.set_name(arch)
+            attester.set_nonce(nonce_hex)
+            attester.set_claims_version("2.0")
+            attester.set_ocsp_nonce_disabled(True)
+            attester.add_verifier(
+                dev=attestation.Devices.GPU,
+                env=attestation.Environment["REMOTE"],
+                url=None,
+                evidence="",
+            )
+            evidence_list = attester.get_evidence(options={"ppcie_mode": False})
     except Exception as exc:  # noqa: BLE001 - the SDK raises broadly
         # Not fatal here. The validator decides what a missing half means; an agent that
         # refused to answer at all would leave it unable to tell "no evidence" from
         # "no agent".
         logger.warning("GPU evidence collection failed: %s", exc)
         return GpuEvidence(uuids, None, "GPU evidence collection failed")
+
+    if not evidence_list:
+        return GpuEvidence(uuids, None, "GPU evidence collection returned nothing")
+
+    return GpuEvidence(
+        uuids,
+        {"nonce": nonce_hex, "evidence_list": evidence_list, "arch": arch},
+        f"evidence for {len(uuids)} GPU(s)",
+    )
 
 
 def tdx_quote(report_data: bytes, *, timeout: int) -> str:

--- a/neurons/executor/attest-agent/src/attest_agent/identity.py
+++ b/neurons/executor/attest-agent/src/attest_agent/identity.py
@@ -1,32 +1,54 @@
-"""What a renter CVM proves it is, and which GPUs it is holding while it proves it.
+"""What a renter CVM proves it is, and which GPUs it says it is holding while it proves it.
 
 A TDX quote carries 64 bytes of caller-supplied `report_data`, and those 64 bytes are the
 only thing binding the hardware's signature to anything outside the hardware. DAH-2579
 spends them like this:
 
-    report_data = sha256(agent_tls_public_key ‖ gpu_uuid_digest) ‖ nonce
-                  |________________ 32 bytes _________________|  |_ 32 _|
-                          identity                                freshness
+    report_data = sha256("LIUM_RENTER_ATTEST_TLS_V1\\0" ‖ tls_spki_der ‖ gpu_uuid_digest) ‖ nonce
+                  |_____________________________ 32 bytes ____________________________|  |_ 32 _|
+                                        identity                                          freshness
 
-**Why the TLS key.** The validator's only channel into a renter CVM is this agent's TLS
-endpoint (FR-F3). Without the key in the quote, a quote proves that *some* TDX guest exists
-and says nothing about whether it is the one on the other end of the connection — an
-attacker who can terminate TLS relays a genuine quote from a genuine CVM it does not own.
-Hashing the key in makes the proof and the channel the same thing. It is the renter-side
-counterpart of the validation CVM's `SSH_HOST_KEY:` binding in
-`executor/src/services/tdx_service.py`, and it exists for the same reason.
+**Why a versioned domain tag.** A bare `sha256(key ‖ digest)` states no purpose, so nothing
+distinguishes it from any other hash anyone ever takes over the same key material — and this
+key is a TLS key, which lives to be hashed by other protocols. The tag gives these 32 bytes
+one meaning, and carries the version *inside* the hashed bytes: a future recipe is a new tag
+rather than a silent reinterpretation of the old one, so a verifier accepts the constructions
+it knows and cannot be talked into reading one as another. The trailing NUL terminates the
+tag — without it, a tag that is a prefix of a longer future tag could be made to collide by
+shifting bytes across the boundary. The validator mirrors the constant in
+`validators/src/services/attestation_service.py`; the two must agree byte for byte.
 
-**Why the GPU UUIDs.** FR-G6: "every trust check must state which physical GPUs the CVM
-holds", because today those identifiers travel on a channel no proof covers and a node can
-claim GPUs it does not have. Folding their digest into the same 32 bytes means the GPU set
-is attested by the hardware rather than asserted by software the host controls.
+**Why the TLS key, and in which encoding.** The validator's only channel into a renter CVM is
+this agent's TLS endpoint (FR-F3). Without the key in the quote, a quote proves that *some*
+TDX guest exists and says nothing about whether it is the one on the other end of the
+connection — an attacker who can terminate TLS relays a genuine quote from a genuine CVM it
+does not own. Hashing the key in makes the proof and the channel the same thing. The key is
+hashed as its **SubjectPublicKeyInfo DER**, which is what `tls.py` reads back out of the
+certificate and therefore what a client sees on the wire; the encoding is part of the recipe
+because two encodings of one key are two different identities to a verifier that only holds
+the wire bytes. It is the renter-side counterpart of the validation CVM's `SSH_HOST_KEY:`
+binding in `executor/src/services/tdx_service.py`, and it exists for the same reason.
+
+**Why the GPU UUIDs — and what they are not.** FR-G6: "every trust check must state which
+physical GPUs the CVM holds", because those identifiers otherwise travel on a channel no
+proof covers. Folding their digest in means the *host* cannot swap the GPU claim in flight
+and the claim cannot be lifted onto another quote: what the measured guest read is what the
+hardware signed.
+
+That is the whole of it. NVML UUIDs are read by the guest; they are not authenticated by
+NVIDIA's attestation evidence, so this binding does not establish that those GPUs exist, are
+genuine, are in confidential-compute mode, or are not also answering for another node. The
+identifier that does is the per-GPU `ueid` claim in the NRAS-verified evidence this agent
+returns alongside the quote — the one GPU identifier here that a node cannot choose. Existence,
+authenticity, counting and cross-node uniqueness are decided on the ueids, on the validator's
+side; the digest below is an observation, bound so that it cannot be tampered with in transit.
 
 **Why a nonce in the other half.** FR-G1: old proofs cannot be replayed. dstack zero-pads
 `report_data` when it is short, so the second half is free and is exactly 32 bytes wide.
 
-The three inputs are ordered and length-fixed — a 32-byte digest and a 32-byte nonce — so
-the encoding is unambiguous without length prefixes. `gpu_uuid_digest` folds a variable
-number of identifiers into a fixed width before it gets here.
+The inputs are ordered and length-fixed — a constant tag, one DER blob, a 32-byte digest, a
+32-byte nonce — so the encoding is unambiguous without length prefixes. `gpu_uuid_digest`
+folds a variable number of identifiers into a fixed width before it gets here.
 """
 
 import hashlib
@@ -34,6 +56,11 @@ import hashlib
 NONCE_BYTES = 32
 DIGEST_BYTES = 32
 REPORT_DATA_BYTES = NONCE_BYTES + DIGEST_BYTES
+
+# The domain-separation tag for the renter recipe, hashed ahead of everything else. See
+# "Why a versioned domain tag" above. Mirrored by the validator; changing either side alone
+# fails every honest node.
+RENTER_IDENTITY_DOMAIN_V1 = b"LIUM_RENTER_ATTEST_TLS_V1\x00"
 
 # The separator between UUIDs inside the digest. A character that cannot occur in an NVIDIA
 # GPU UUID, so no two different GPU sets can produce the same joined string — with a
@@ -47,7 +74,10 @@ class IdentityError(Exception):
 
 
 def gpu_uuid_digest(uuids: list[str]) -> bytes:
-    """A fixed-width digest of the GPU set this CVM holds.
+    """A fixed-width digest of the GPU set this CVM *observes* through NVML.
+
+    Observes, not proves — see the module docstring. Binding it makes the observation
+    tamper-evident in transit; it does not make it an attested identity.
 
     Sorted, so the digest depends on which GPUs are present and not on the order NVML
     happened to enumerate them in — an ordering that varies with PCI topology and would
@@ -67,18 +97,26 @@ def gpu_uuid_digest(uuids: list[str]) -> bytes:
     return hashlib.sha256(joined.encode()).digest()
 
 
-def identity_digest(tls_public_key: bytes, uuids: list[str]) -> bytes:
-    """The 32-byte identity half: this agent's TLS key bound to this CVM's GPUs."""
-    if not tls_public_key:
+def identity_digest(tls_public_key_der: bytes, uuids: list[str]) -> bytes:
+    """The 32-byte identity half: this agent's TLS channel, and the GPU set it observes.
+
+    `tls_public_key_der` is the SubjectPublicKeyInfo DER — the encoding `tls.py` reads out
+    of the certificate, and the one a client sees on the wire. Not "some encoding of the
+    key": the recipe fixes it, because a verifier holding the wire bytes can only reproduce
+    this digest if it hashes them the same way.
+    """
+    if not tls_public_key_der:
         raise IdentityError("the agent has no TLS public key, so it can prove nothing")
-    return hashlib.sha256(tls_public_key + gpu_uuid_digest(uuids)).digest()
+    return hashlib.sha256(
+        RENTER_IDENTITY_DOMAIN_V1 + tls_public_key_der + gpu_uuid_digest(uuids)
+    ).digest()
 
 
-def report_data(tls_public_key: bytes, uuids: list[str], nonce: bytes) -> bytes:
+def report_data(tls_public_key_der: bytes, uuids: list[str], nonce: bytes) -> bytes:
     """The full 64 bytes handed to the TDX quote."""
     if len(nonce) != NONCE_BYTES:
         raise IdentityError(f"the nonce must be exactly {NONCE_BYTES} bytes, got {len(nonce)}")
-    return identity_digest(tls_public_key, uuids) + nonce
+    return identity_digest(tls_public_key_der, uuids) + nonce
 
 
 def parse_nonce(value: str) -> bytes:

--- a/neurons/executor/attest-agent/tests/test_agent.py
+++ b/neurons/executor/attest-agent/tests/test_agent.py
@@ -13,6 +13,7 @@ properties of this code, and both are where a bug would be silent on hardware.
 
 import hashlib
 import json
+from types import SimpleNamespace
 
 import pytest
 from attest_agent import evidence
@@ -24,6 +25,7 @@ from attest_agent.app import (
 )
 from attest_agent.config import Config
 from attest_agent.identity import (
+    RENTER_IDENTITY_DOMAIN_V1,
     IdentityError,
     gpu_uuid_digest,
     identity_digest,
@@ -63,7 +65,11 @@ def gpus(monkeypatch):
     )
     monkeypatch.setattr(
         "attest_agent.app.collect_gpu_evidence",
-        lambda uuids, nonce: evidence.GpuEvidence(uuids, [{"nonce": nonce}], "stub evidence"),
+        lambda uuids, nonce, *, arch: evidence.GpuEvidence(
+            uuids,
+            {"nonce": nonce, "evidence_list": [{"gpu": 0}, {"gpu": 1}], "arch": arch},
+            "stub evidence",
+        ),
     )
 
 
@@ -92,8 +98,34 @@ class TestReportData:
         assert identity_digest(b"key-a", UUIDS) != identity_digest(b"key-b", UUIDS)
 
     def test_the_identity_half_binds_the_gpus(self):
-        """FR-G6: a node must not be able to claim GPUs it does not hold."""
+        """FR-G6: the GPU claim travels inside the signature, so the host cannot rewrite it.
+        (What it does NOT do is authenticate the GPUs — that is the ueids' job.)"""
         assert identity_digest(b"key", UUIDS) != identity_digest(b"key", UUIDS[:1])
+
+    def test_the_identity_half_is_domain_separated_and_versioned(self):
+        """The exact bytes, spelled out. A verifier reproduces this digest from the wire and
+        nothing else, so the tag, the key encoding and the order are the wire contract — and
+        the version lives INSIDE the hash, which is what makes a future recipe a new tag
+        rather than the same 32 bytes read a second way."""
+        key = b"\x01" * 91
+
+        assert identity_digest(key, UUIDS) == hashlib.sha256(
+            b"LIUM_RENTER_ATTEST_TLS_V1\x00" + key + gpu_uuid_digest(UUIDS)
+        ).digest()
+
+    def test_the_domain_tag_is_terminated(self):
+        """Without the NUL, a longer future tag starting with this one could be made to
+        collide by shifting bytes across the boundary between tag and key."""
+        assert RENTER_IDENTITY_DOMAIN_V1.endswith(b"\x00")
+
+    def test_an_untagged_digest_is_not_accepted_as_this_one(self):
+        """The whole point of the tag: the same key material hashed without a stated purpose
+        is a different value, so nothing hashed for another purpose can be read as this."""
+        key = b"\x01" * 91
+
+        assert identity_digest(key, UUIDS) != hashlib.sha256(
+            key + gpu_uuid_digest(UUIDS)
+        ).digest()
 
     def test_the_gpu_digest_does_not_depend_on_enumeration_order(self):
         """NVML's order varies with PCI topology; the same node must not attest differently
@@ -170,7 +202,16 @@ class TestAttesting:
         the shape of a replay."""
         answer = client.post("/v1/attest", json={"nonce": NONCE}).json()
 
-        assert answer["gpu_evidence"][0]["nonce"] == NONCE
+        assert answer["gpu_evidence"]["nonce"] == NONCE
+
+    def test_the_gpu_evidence_is_submittable_to_nras_as_returned(self, client):
+        """The ueids inside NRAS's answer are what decide the GPU set, and NRAS will not
+        answer a bare evidence list. An agent that returned one would leave the validator
+        holding evidence it cannot get judged."""
+        answer = client.post("/v1/attest", json={"nonce": NONCE}).json()
+
+        assert set(answer["gpu_evidence"]) == {"nonce", "evidence_list", "arch"}
+        assert answer["gpu_evidence"]["evidence_list"]
 
     def test_a_different_nonce_gets_a_different_quote(self, client, quoted):
         client.post("/v1/attest", json={"nonce": NONCE})
@@ -307,15 +348,70 @@ class TestDegradingHonestly:
         decisions on the validator's side, so they must not share an encoding."""
         result = evidence.collect_gpu_evidence([], "aa" * 32)
 
-        assert result.evidence is None
+        assert result.payload is None
         assert "no GPUs" in result.detail
 
     def test_a_build_without_the_nvidia_stack_says_so(self, monkeypatch):
         monkeypatch.setitem(__import__("sys").modules, "nv_attestation_sdk", None)
         result = evidence.collect_gpu_evidence(UUIDS, "aa" * 32)
 
-        assert result.evidence is None
+        assert result.payload is None
         assert result.uuids == UUIDS
+
+    def test_a_stack_that_fails_while_loading_degrades_instead_of_raising(self, monkeypatch):
+        """Importing the NVIDIA stack does real work — it opens a log file in the working
+        directory — so it can fail on a read-only rootfs for reasons that are not ImportError.
+        An exception escaping here would 500 the route, which the validator reads as a broken
+        agent rather than as one half of one answer being unavailable."""
+
+        class Exploding:
+            def __getattr__(self, name):
+                raise PermissionError("verifier.log")
+
+        monkeypatch.setitem(__import__("sys").modules, "nv_attestation_sdk", Exploding())
+        result = evidence.collect_gpu_evidence(UUIDS, "aa" * 32)
+
+        assert result.payload is None
+        assert "could not be loaded" in result.detail
+
+    def test_a_collector_that_returns_nothing_is_no_evidence_not_empty_evidence(
+        self, monkeypatch
+    ):
+        """An empty evidence_list submitted to NRAS would come back describing zero GPUs,
+        which reads as "this CVM holds none" — the opposite of "the collector came up
+        empty"."""
+
+        class FakeAttester:
+            def set_name(self, name): ...
+            def set_nonce(self, nonce): ...
+            def set_claims_version(self, version): ...
+            def set_ocsp_nonce_disabled(self, disabled): ...
+            def add_verifier(self, **kwargs): ...
+
+            def get_evidence(self, options=None):
+                return []
+
+        modules = __import__("sys").modules
+        monkeypatch.setitem(
+            modules,
+            "nv_attestation_sdk",
+            SimpleNamespace(
+                attestation=SimpleNamespace(
+                    Attestation=FakeAttester,
+                    Devices=SimpleNamespace(GPU="gpu"),
+                    Environment={"REMOTE": "remote"},
+                )
+            ),
+        )
+        monkeypatch.setitem(
+            modules,
+            "verifier",
+            SimpleNamespace(cc_admin=SimpleNamespace(collect_gpu_evidence_remote=lambda n: [])),
+        )
+        result = evidence.collect_gpu_evidence(UUIDS, "aa" * 32)
+
+        assert result.payload is None
+        assert "returned nothing" in result.detail
 
     def test_no_nvml_is_not_a_crash(self, monkeypatch):
         monkeypatch.setitem(__import__("sys").modules, "pynvml", None)

--- a/neurons/executor/cvmd/src/cvmd/agent_relay.py
+++ b/neurons/executor/cvmd/src/cvmd/agent_relay.py
@@ -1,0 +1,87 @@
+"""Dial the in-guest attest-agent through its host-side forward (DAH-2675).
+
+cvmd is the only party that can reach the agent when its forward is bound to loopback — the
+default `ports.py` gives a three-part spec — and that binding is wanted: it keeps the agent off
+the public internet without publishing a per-node port. So the validator asks cvmd, cvmd asks
+the agent, and the answer goes back verbatim.
+
+Relaying adds no trust. The agent's answer is a TDX quote whose `report_data` binds the agent's
+TLS key, the GPU set and the caller's nonce (attest-agent/identity.py), so this host can
+withhold the answer but cannot forge or replay one — the verifier on the validator's side checks
+the binding against the nonce it issued. That is also why TLS verification is off here: the
+certificate is the agent's self-signed one, and the quote binding — not a CA — is what
+authenticates the exchange, the same stance the validator's own relay takes toward cvmd.
+"""
+
+import json
+import logging
+import ssl
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+ATTEST_PATH = "/v1/attest"
+
+
+class AgentRelayError(Exception):
+    """The agent was not reached, or answered something that is not a JSON object."""
+
+
+def dial_address(bind_address: str) -> str:
+    """Where to dial for a forward bound at `bind_address`, from this host itself.
+
+    A loopback or wildcard bind is reachable at 127.0.0.1 from here; an explicit address is
+    dialed as written. An empty address is a record predating the address field — treat it as
+    the loopback default the port parser would have applied.
+    """
+    if not bind_address or bind_address == "0.0.0.0":
+        return "127.0.0.1"
+    return bind_address
+
+
+def relay_attest(
+    *,
+    address: str,
+    host_port: int,
+    nonce: str,
+    timeout_seconds: float,
+) -> tuple[int, dict]:
+    """POST the caller's nonce to the agent and return (status, body) exactly as answered.
+
+    HTTP error statuses are answers, not failures: a 422 or 503 from the agent carries the
+    distinction the validator acts on, so it is passed through rather than flattened into one
+    relay error. Only "no usable answer at all" raises.
+    """
+    url = f"https://{dial_address(address)}:{host_port}{ATTEST_PATH}"
+    body = json.dumps({"nonce": nonce}).encode()
+
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+
+    request = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds, context=context) as answer:
+            return answer.status, _decode(answer.read())
+    except urllib.error.HTTPError as exc:
+        return exc.code, _decode(exc.read())
+    except (urllib.error.URLError, OSError, TimeoutError) as exc:
+        raise AgentRelayError(f"the attest-agent at {url} could not be reached: {exc}") from exc
+
+
+def _decode(raw: bytes) -> dict:
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise AgentRelayError("the attest-agent answered with something that is not JSON") from exc
+    if not isinstance(parsed, dict):
+        raise AgentRelayError(
+            f"the attest-agent answered with a {type(parsed).__name__}, not an object"
+        )
+    return parsed

--- a/neurons/executor/cvmd/src/cvmd/auth/clients.py
+++ b/neurons/executor/cvmd/src/cvmd/auth/clients.py
@@ -14,10 +14,18 @@ from bittensor.sp_core import Keypair
 
 
 class Scope(StrEnum):
-    """What a key is allowed to do. The two scopes are disjoint by design."""
+    """What a key is allowed to do. The scopes are disjoint by design.
+
+    ATTEST holds no launch or teardown right at all: a key in this scope can make the reads
+    open to any authorized key, plus `POST /v1/attest` — which is itself open to any
+    authorized key, so the scope GRANTS nothing the other two lack. It exists for the
+    opposite direction: an operator can authorize a key that can request a renter CVM's
+    quote and nothing else (DAH-2675).
+    """
 
     VALIDATION = "validation"
     RENTER = "renter"
+    ATTEST = "attest"
 
 
 class AuthorizedClientsError(Exception):

--- a/neurons/executor/cvmd/src/cvmd/auth/scope.py
+++ b/neurons/executor/cvmd/src/cvmd/auth/scope.py
@@ -17,8 +17,13 @@ from cvmd.auth.clients import Scope
 CVM_PATH = "/v1/cvm"
 STATE_PATH = "/v1/state"
 HEALTH_PATH = "/health"
+# DAH-2675: open to any authorized key via the default below, like the other non-mutating
+# routes. Requesting a quote grants nothing — the agent's answer is hardware-bound to the
+# caller's nonce — and the narrow ATTEST scope exists so a key can be authorized for exactly
+# this and hold no launch or teardown right.
+ATTEST_PATH = "/v1/attest"
 
-# Routes readable by either authorized key.
+# Routes open to any authorized key.
 EITHER_KEY = None
 
 # `kind` values accepted by POST /v1/cvm, and the scope each one demands.

--- a/neurons/executor/cvmd/src/cvmd/routes/cvm.py
+++ b/neurons/executor/cvmd/src/cvmd/routes/cvm.py
@@ -23,6 +23,10 @@ naming the conditions that did not.
 The two `/v1/catalog` routes are DAH-2578's. Both are open to either authorized key, because
 neither decides what this host may run — the platform's signature does, and it is checked on
 every read of the cached manifest.
+
+`POST /v1/attest` is DAH-2675's: it relays one nonce-bound trust-check to the renter CVM's
+in-guest attest-agent and returns the answer verbatim. Open to any authorized key, because the
+answer authenticates itself — the quote binds the caller's nonce.
 """
 
 import asyncio
@@ -32,10 +36,11 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, ValidationError
 
-from cvmd import __version__
+from cvmd import __version__, agent_relay
 from cvmd.catalog import HEX64, CatalogStore, refresh_once
 from cvmd.cvm.manager import KIND_RENTER, KIND_VALIDATION, CvmManager, LaunchFailure, Triple
 from cvmd.cvm.renter import RenterOrder
+from cvmd.state.machine import NodeState
 from cvmd.state.store import StateStore
 
 logger = logging.getLogger(__name__)
@@ -51,6 +56,20 @@ MAX_COMPOSE_CHARS = 32 * 1024
 
 # Scripts run before the workload and are folded into the same measured file. Same reasoning.
 MAX_SCRIPT_CHARS = 8 * 1024
+
+# DAH-2675 — the attest relay. The guest port matches the attest-agent's own default; a caller
+# whose order injected the agent elsewhere names the port in the request. The timeout bounds a
+# fresh quote plus GPU evidence, both collected inside the guest; callers budget above it so the
+# reason that reaches them is this host's, which names what actually failed.
+DEFAULT_AGENT_GUEST_PORT = 8451
+AGENT_RELAY_TIMEOUT_SECONDS = 120
+
+# Fixed refusal texts, authored here rather than derived from any caught exception — the full
+# exception goes to the journal, and a relayed error's text is a view of this host's internals
+# (CodeQL `py/stack-trace-exposure`).
+NO_RENTER_CVM_DETAIL = "no renter CVM is running on this node, so there is no agent to attest"
+NO_AGENT_FORWARD_DETAIL = "the renter CVM carries no port forward for the agent's guest port"
+AGENT_UNREACHABLE_DETAIL = "the renter CVM's attest-agent could not be reached from this host"
 
 
 class CreateCvmRequest(BaseModel):
@@ -221,6 +240,74 @@ async def _create_renter(request: Request, body: dict) -> JSONResponse:
 @router.delete("/v1/cvm")
 async def destroy_cvm(request: Request) -> JSONResponse:
     return await _exclusively(request, _manager(request).destroy, success=200)
+
+
+class AttestRelayRequest(BaseModel):
+    """One trust-check challenge for the renter CVM's in-guest agent.
+
+    The nonce is the VERIFIER'S challenge — the agent folds it into the hardware-signed
+    `report_data`, so it is pinned to the agent's contract (64 hex chars) rather than
+    reshaped here. It has nothing to do with the auth header's replay nonce.
+
+    `extra="forbid"` for the same reason as the renter order: an unknown field means the
+    sender speaks a version of this contract this host does not implement.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    nonce: str = Field(min_length=64, max_length=64, pattern=r"^[0-9a-fA-F]{64}$")
+    agent_port: int = Field(default=DEFAULT_AGENT_GUEST_PORT, ge=1, le=65535)
+
+
+@router.post("/v1/attest")
+async def attest_renter_cvm(request: Request) -> JSONResponse:
+    """Relay one nonce-bound attestation request to the in-guest agent (DAH-2675).
+
+    cvmd is transport here, not authority: the agent's answer is returned verbatim, status
+    and all, because the quote inside it is self-authenticating — it binds the agent's TLS
+    key, the GPU set and the caller's nonce, so this host can refuse to relay but cannot
+    substitute an answer that verifies. Open to any authorized key (see `auth/scope`): the
+    call grants nothing, and the agent-side ledger makes a repeat of the same nonce
+    idempotent rather than a fresh quote.
+
+    On a worker thread like every other slow handler — a quote takes seconds and
+    `/v1/state` must stay answerable while it is produced.
+    """
+    try:
+        parsed = AttestRelayRequest.model_validate(request.state.parsed_body)
+    except ValidationError as exc:
+        return JSONResponse(status_code=422, content={"detail": exc.errors(include_url=False)})
+
+    instance = request.app.state.instances.current
+    if (
+        _store(request).state is not NodeState.RENTER_RUNNING
+        or instance is None
+        or instance.kind != KIND_RENTER
+    ):
+        return JSONResponse(status_code=409, content={"detail": NO_RENTER_CVM_DETAIL})
+
+    forward = next((port for port in instance.ports if port.guest_port == parsed.agent_port), None)
+    if forward is None:
+        logger.warning(
+            "attest relay refused: no forward for guest port %d on CVM %s",
+            parsed.agent_port,
+            instance.instance_id,
+        )
+        return JSONResponse(status_code=502, content={"detail": NO_AGENT_FORWARD_DETAIL})
+
+    try:
+        status, answer = await asyncio.to_thread(
+            agent_relay.relay_attest,
+            address=forward.address,
+            host_port=forward.host_port,
+            nonce=parsed.nonce,
+            timeout_seconds=AGENT_RELAY_TIMEOUT_SECONDS,
+        )
+    except agent_relay.AgentRelayError as exc:
+        logger.warning("attest relay failed: %s", exc)
+        return JSONResponse(status_code=502, content={"detail": AGENT_UNREACHABLE_DETAIL})
+
+    return JSONResponse(status_code=status, content=answer)
 
 
 @router.get("/v1/catalog")

--- a/neurons/executor/cvmd/tests/test_attest_relay.py
+++ b/neurons/executor/cvmd/tests/test_attest_relay.py
@@ -1,0 +1,280 @@
+"""DAH-2675 — the attest relay route and its scope.
+
+What is pinned here:
+
+- the route is open to any authorized key and closed to strangers;
+- a key in the new `attest` scope can request a quote and NOTHING else that mutates;
+- the relay refuses by name (wrong state, no forward, agent unreachable) and otherwise
+  passes the agent's answer through verbatim, status and all;
+- the dial-address rule that makes a loopback-bound forward reachable from the host.
+
+The agent itself is faked at the `agent_relay.relay_attest` seam: these tests are about the
+route's decisions, and the real dial function is three lines of urllib whose behavior is
+pinned by `dial_address` and `_decode` tests below.
+"""
+
+import json
+
+import pytest
+from bittensor.sp_core import Keypair
+from cvmd import agent_relay
+from cvmd.agent_relay import AgentRelayError, dial_address
+from cvmd.app import create_app
+from cvmd.auth.clients import AuthorizedClientsError, Scope, load_authorized_clients
+from cvmd.config import Config
+from cvmd.cvm.instance import Instance, PortReport
+from cvmd.cvm.manager import KIND_RENTER
+from cvmd.state.machine import NodeState
+from fastapi.testclient import TestClient
+from tests.conftest import signed_request
+
+ATTEST_URI = "//Ferdie"
+NONCE = "ab" * 32
+AGENT_ANSWER = {
+    "version": "0.1.0",
+    "report_data": "cd" * 64,
+    "tls_public_key": "ee" * 32,
+    "gpu_uuids": ["GPU-1"],
+    "gpu_uuid_digest": "ff" * 32,
+    "quote": '{"quote": "raw"}',
+}
+
+
+@pytest.fixture
+def attest_key() -> Keypair:
+    return Keypair.create_from_uri(ATTEST_URI)
+
+
+@pytest.fixture
+def clients_file_with_attest(tmp_path, validator_key, platform_key, attest_key):
+    path = tmp_path / "authorized_clients.json"
+    path.write_text(
+        json.dumps(
+            [
+                {"hotkey": validator_key.ss58_address, "scope": "validation"},
+                {"hotkey": platform_key.ss58_address, "scope": "renter"},
+                {"hotkey": attest_key.ss58_address, "scope": "attest"},
+            ]
+        )
+    )
+    return path
+
+
+@pytest.fixture
+def app(clients_file_with_attest, state_dir):
+    config = Config(authorized_clients=clients_file_with_attest, state_dir=state_dir)
+    return create_app(config)
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app)
+
+
+def make_renter(app, *, ports: list[PortReport] | None = None) -> Instance:
+    """Put the app under a renter CVM, the shape reconciliation would have adopted."""
+    default_ports = [
+        PortReport(protocol="tcp", address="127.0.0.1", host_port=18451, guest_port=8451)
+    ]
+    instance = Instance(
+        instance_id="cvm-renter-1",
+        kind=KIND_RENTER,
+        artifact_id="renter-abc",
+        vm_dir="/nonexistent/vm",
+        supervisor_pid=1,
+        created_at="2026-08-13T00:00:00+00:00",
+        qemu="10.1.0",
+        os_image_hash="a" * 64,
+        compose_hash="b" * 64,
+        ports=default_ports if ports is None else ports,
+    )
+    app.state.instances.set(instance)
+    app.state.store.transition(NodeState.RENTER_RUNNING)
+    return instance
+
+
+def attest(client, keypair, payload: dict):
+    return signed_request(client, keypair, "POST", "/v1/attest", body=json.dumps(payload).encode())
+
+
+class TestScope:
+    def test_a_stranger_is_refused_before_anything_else(self, client, stranger_key, app):
+        make_renter(app)
+        assert attest(client, stranger_key, {"nonce": NONCE}).status_code == 401
+
+    def test_every_authorized_scope_may_ask(
+        self, client, app, validator_key, platform_key, attest_key, monkeypatch
+    ):
+        make_renter(app)
+        monkeypatch.setattr(agent_relay, "relay_attest", lambda **kwargs: (200, AGENT_ANSWER))
+        for keypair in (validator_key, platform_key, attest_key):
+            assert attest(client, keypair, {"nonce": NONCE}).status_code == 200
+
+    def test_the_attest_scope_holds_no_launch_or_teardown_right(self, client, app, attest_key):
+        launch = signed_request(
+            client,
+            attest_key,
+            "POST",
+            "/v1/cvm",
+            body=json.dumps(
+                {
+                    "kind": "validation",
+                    "qemu": "10.1.0",
+                    "os_image_hash": "a" * 64,
+                    "compose_hash": "b" * 64,
+                }
+            ).encode(),
+        )
+        assert launch.status_code == 403
+
+        teardown = signed_request(client, attest_key, "DELETE", "/v1/cvm")
+        assert teardown.status_code == 403
+
+    def test_the_attest_scope_still_reads_state(self, client, attest_key):
+        assert signed_request(client, attest_key, "GET", "/v1/state").status_code == 200
+
+    def test_the_clients_file_accepts_the_new_scope(self, clients_file_with_attest):
+        clients = load_authorized_clients(clients_file_with_attest)
+        assert len(clients) == 3
+
+    def test_an_unknown_scope_still_refuses_startup(self, tmp_path, validator_key):
+        path = tmp_path / "authorized_clients.json"
+        path.write_text(json.dumps([{"hotkey": validator_key.ss58_address, "scope": "observer"}]))
+        with pytest.raises(AuthorizedClientsError, match="unknown scope"):
+            load_authorized_clients(path)
+
+    def test_attest_is_a_scope_value(self):
+        assert Scope("attest") is Scope.ATTEST
+
+
+class TestRefusals:
+    def test_a_malformed_nonce_is_422(self, client, app, validator_key):
+        make_renter(app)
+        answer = attest(client, validator_key, {"nonce": "not-hex"})
+        assert answer.status_code == 422
+
+    def test_an_unknown_field_is_422(self, client, app, validator_key):
+        make_renter(app)
+        answer = attest(client, validator_key, {"nonce": NONCE, "verify_tls": False})
+        assert answer.status_code == 422
+
+    def test_an_idle_node_has_no_agent_to_attest(self, client, validator_key):
+        answer = attest(client, validator_key, {"nonce": NONCE})
+        assert answer.status_code == 409
+        assert "no renter CVM" in answer.json()["detail"]
+
+    def test_a_validation_cvm_is_not_a_renter(self, client, app, validator_key):
+        instance = Instance(
+            instance_id="cvm-validation-1",
+            kind="validation",
+            artifact_id="validation-abc",
+            vm_dir="/nonexistent/vm",
+            supervisor_pid=1,
+            created_at="2026-08-13T00:00:00+00:00",
+            qemu="10.1.0",
+            os_image_hash="a" * 64,
+            compose_hash="b" * 64,
+        )
+        app.state.instances.set(instance)
+        app.state.store.transition(NodeState.VALIDATION_RUNNING)
+        answer = attest(client, validator_key, {"nonce": NONCE})
+        assert answer.status_code == 409
+
+    def test_a_cvm_without_the_agent_forward_is_502_by_name(self, client, app, validator_key):
+        make_renter(
+            app,
+            ports=[PortReport(protocol="tcp", address="0.0.0.0", host_port=2201, guest_port=2200)],
+        )
+        answer = attest(client, validator_key, {"nonce": NONCE})
+        assert answer.status_code == 502
+        assert "no port forward" in answer.json()["detail"]
+
+    def test_an_unreachable_agent_is_502_with_a_fixed_detail(
+        self, client, app, validator_key, monkeypatch
+    ):
+        make_renter(app)
+
+        def refuse(**kwargs):
+            raise AgentRelayError("connection refused: secret internals")
+
+        monkeypatch.setattr(agent_relay, "relay_attest", refuse)
+        answer = attest(client, validator_key, {"nonce": NONCE})
+        assert answer.status_code == 502
+        # The caller's copy is the authored constant, never the exception's text.
+        assert "secret internals" not in answer.json()["detail"]
+        assert "could not be reached" in answer.json()["detail"]
+
+
+class TestRelay:
+    def test_the_agent_answer_passes_through_verbatim(
+        self, client, app, validator_key, monkeypatch
+    ):
+        make_renter(app)
+        seen = {}
+
+        def fake_relay(**kwargs):
+            seen.update(kwargs)
+            return 200, AGENT_ANSWER
+
+        monkeypatch.setattr(agent_relay, "relay_attest", fake_relay)
+        answer = attest(client, validator_key, {"nonce": NONCE})
+        assert answer.status_code == 200
+        assert answer.json() == AGENT_ANSWER
+        assert seen["nonce"] == NONCE
+        assert seen["host_port"] == 18451
+        assert seen["address"] == "127.0.0.1"
+
+    def test_the_caller_may_name_a_different_agent_port(
+        self, client, app, validator_key, monkeypatch
+    ):
+        make_renter(
+            app,
+            ports=[
+                PortReport(protocol="tcp", address="127.0.0.1", host_port=19000, guest_port=9000)
+            ],
+        )
+        seen = {}
+
+        def fake_relay(**kwargs):
+            seen.update(kwargs)
+            return 200, AGENT_ANSWER
+
+        monkeypatch.setattr(agent_relay, "relay_attest", fake_relay)
+        answer = attest(client, validator_key, {"nonce": NONCE, "agent_port": 9000})
+        assert answer.status_code == 200
+        assert seen["host_port"] == 19000
+
+    def test_an_agent_error_status_is_an_answer_not_a_relay_failure(
+        self, client, app, validator_key, monkeypatch
+    ):
+        make_renter(app)
+        monkeypatch.setattr(
+            agent_relay,
+            "relay_attest",
+            lambda **kwargs: (503, {"detail": "no quote from the guest agent"}),
+        )
+        answer = attest(client, validator_key, {"nonce": NONCE})
+        assert answer.status_code == 503
+        assert answer.json()["detail"] == "no quote from the guest agent"
+
+
+class TestDialRules:
+    def test_a_loopback_bind_is_dialed_at_loopback(self):
+        assert dial_address("127.0.0.1") == "127.0.0.1"
+
+    def test_a_wildcard_bind_is_dialed_at_loopback(self):
+        assert dial_address("0.0.0.0") == "127.0.0.1"
+
+    def test_an_empty_bind_defaults_like_the_port_parser(self):
+        assert dial_address("") == "127.0.0.1"
+
+    def test_an_explicit_bind_is_dialed_as_written(self):
+        assert dial_address("10.0.0.7") == "10.0.0.7"
+
+    def test_a_non_object_agent_answer_is_a_relay_error(self):
+        with pytest.raises(AgentRelayError, match="not an object"):
+            agent_relay._decode(b"[1, 2]")
+
+    def test_a_non_json_agent_answer_is_a_relay_error(self):
+        with pytest.raises(AgentRelayError, match="not JSON"):
+            agent_relay._decode(b"<html>gateway timeout</html>")

--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -109,6 +109,10 @@ class CvmExpectations(BaseModel):
     compose_hash: str | None = None
     gpu_model: str | None = None
     gpu_count: int | None = None
+    # DAH-2675 — the guest port the order injected the attest-agent on, so the live quote
+    # check asks cvmd for the right forward. None (an older backend) leaves cvmd's default
+    # in force.
+    agent_port: int | None = None
 
 
 class RentedExecutorsResponse(BaseModel):

--- a/neurons/validators/src/services/attestation_service.py
+++ b/neurons/validators/src/services/attestation_service.py
@@ -39,6 +39,14 @@ TDX_LAST_ATTESTATION_EVENT_PREFIX = "tdx_last_attestation_event"
 # contract, so a copy that drifts must fail a test rather than silently accept a wrong set.
 GPU_UUID_SEPARATOR = ","
 
+# The domain-separation tag the renter agent hashes ahead of its identity material
+# (attest-agent/identity.py:RENTER_IDENTITY_DOMAIN_V1). It gives those 32 bytes one stated
+# purpose, so nothing else ever taken over the same TLS key can be read as this binding, and
+# it carries the version inside the hashed bytes: a later recipe is a new tag this validator
+# either knows or refuses, never an old digest reinterpreted. Reproduced here for the same
+# reason as the separator above — separate package, wire contract, drift must fail a test.
+RENTER_IDENTITY_DOMAIN_V1 = b"LIUM_RENTER_ATTEST_TLS_V1\x00"
+
 # DAH-2675 — the three verdicts on a rented CVM's live quote. Three, not two, because two of
 # the outcomes lead to opposite decisions and must not share an encoding: REJECTED means the
 # evidence was examined and failed (earns nothing), while UNAVAILABLE means nothing could be
@@ -261,8 +269,30 @@ class AttestationService:
 
         This mirrors `attest-agent/identity.py:gpu_uuid_digest`. The two must agree exactly or a
         correct node fails verification, which is why the separator is pinned as a constant.
+
+        What it is NOT is proof of the GPU set. NVML identifiers are read by the guest; binding
+        them keeps the host from swapping the claim in flight, and stops there. Which GPUs are
+        really present is settled by the per-GPU ueids in the NVIDIA evidence — see
+        `_rented_gpu_identity`.
         """
         return hashlib.sha256(GPU_UUID_SEPARATOR.join(sorted(uuids)).encode()).digest()
+
+    @staticmethod
+    def renter_identity_digest(tls_public_key_der: bytes, uuids: list[str]) -> bytes:
+        """The identity half of a renter CVM's report_data.
+
+            sha256("LIUM_RENTER_ATTEST_TLS_V1\\0" ‖ tls_spki_der ‖ gpu_uuid_digest(uuids))
+
+        The key is hashed as its SubjectPublicKeyInfo DER — the encoding a TLS client reads off
+        the wire, and the one the agent takes out of its own certificate. The encoding is part
+        of the recipe, not an implementation detail: this validator only ever holds wire bytes,
+        so any other encoding reproduces a different digest and fails an honest node.
+        """
+        return hashlib.sha256(
+            RENTER_IDENTITY_DOMAIN_V1
+            + tls_public_key_der
+            + AttestationService.gpu_uuid_digest(uuids)
+        ).digest()
 
     def _bound_gpu_digest(self, executor: ExecutorSSHInfo) -> bytes | None:
         """The GPU digest to fold into the v2 identity, or None if it cannot be established.
@@ -273,10 +303,9 @@ class AttestationService:
         What the value is *for* is telling the validator which set to expect; what makes it
         evidence is that the hardware signed it.
 
-        `scraped_uuids` is the independent check, applied when this validator has already
-        collected the node's GPU UUIDs. A mismatch means the claim and the machine disagree,
-        which is refused rather than papered over — the whole point of FR-G6 is that a node
-        cannot claim GPUs it does not have.
+        That is an integrity argument and nothing more: it pins the guest to one claim about
+        its NVML devices. Whether those devices are real, genuine, and this many is answered by
+        the per-GPU ueids in the NVIDIA evidence (`_check_gpu_claims`), never here.
         """
         claimed = (executor.gpu_uuid_digest or "").strip().lower()
         if not claimed:
@@ -307,10 +336,14 @@ class AttestationService:
             v1  sha256("SSH_HOST_KEY:" | host_key)
             v2  sha256("SSH_HOST_KEY:" | host_key | gpu_uuid_digest)
 
-        v2 is the same identity material with the GPU set folded in, which is what makes "which
-        GPUs is this CVM holding" a hardware-signed claim instead of an asserted one. The renter
-        form substitutes the agent's TLS public key for the SSH host key, on the same shape, and
-        is produced by `attest-agent/identity.py`.
+        v2 is the same identity material with the guest's observed GPU set folded in, so that
+        set travels inside the hardware's signature instead of beside it — the host cannot
+        rewrite it, and it cannot be lifted onto another quote. It does not make those NVML
+        identifiers attested; that is what the ueids in the NVIDIA evidence are for.
+
+        The renter form is the same idea over the agent's TLS key rather than the SSH host key,
+        and carries an explicit versioned domain tag (RENTER_IDENTITY_DOMAIN_V1) where these two
+        rely on the `SSH_HOST_KEY:` prefix. See `renter_identity_digest`.
         """
         material = self.REPORT_PREFIX + (executor.ssh_host_key or "").encode("utf-8")
         digests: list[tuple[str, bytes]] = []
@@ -663,6 +696,12 @@ class AttestationService:
             ueid = claims.get("ueid")
             if isinstance(ueid, str) and ueid:
                 self._last_gpu_ueids.append(ueid)
+            else:
+                # A per-GPU token with no ueid is a GPU this response cannot identify. Left
+                # silent it would simply shrink the attested set, and every decision taken on
+                # that set — how many GPUs are here, whether one of them is also answering for
+                # another node — would quietly narrow to the GPUs that did identify themselves.
+                failures.append(f"gpu_att_failed:{gpu_name}:ueid_missing")
             if claims.get("measres") not in (None, "success"):
                 failures.append(f"gpu_att_failed:{gpu_name}:measres")
             if expected_nonce_hex:
@@ -679,6 +718,14 @@ class AttestationService:
             if allowed_hwmodels and isinstance(hwmodel, str):
                 if not any(hwmodel.startswith(allowed) for allowed in allowed_hwmodels):
                     failures.append(f"gpu_att_failed:{gpu_name}:hwmodel={hwmodel}")
+
+        # One ueid answering twice is one GPU counted twice. It has to fail here rather than be
+        # deduplicated, because either reading is a lie: if the response really describes two
+        # devices then one of them is impersonating the other, and if it describes one then the
+        # count is inflated.
+        duplicates = sorted({u for u in self._last_gpu_ueids if self._last_gpu_ueids.count(u) > 1})
+        if duplicates:
+            failures.append(f"gpu_att_failed:ueid_duplicate:{len(duplicates)}")
 
         return not failures, failures
 
@@ -945,6 +992,78 @@ class AttestationService:
             )
         logger.warning(_m("Renter CVM mismatch (not enforced)", extra=extra))
 
+    async def _rented_gpu_identity(
+        self,
+        answer: dict,
+        nonce: AttestationNonce,
+        origin: _QuoteOrigin,
+    ) -> tuple[list[str] | None, str | None, str]:
+        """What the NVIDIA evidence in a rented CVM's answer proves about its GPUs.
+
+        Returns (ueids, verdict, detail). A verdict that is not None settles the whole trust
+        check and the caller returns it as-is; otherwise `ueids` is the attested GPU set, or
+        None when there is no evidence to judge.
+
+        This is where the GPU set is actually established. The `gpu_uuids` bound into the
+        quote cannot do it: NVML identifiers are read by the guest and vouched for by nobody,
+        so binding them proves only that the host did not alter what the guest read. A `ueid`
+        comes out of evidence NVIDIA signed and is the one GPU identifier in this answer the
+        node cannot choose.
+
+        The three outcomes are the three this module already keeps apart. Evidence NRAS
+        examined and refused is REJECTED — a measured false claim earns nothing. NRAS being
+        unreachable is UNAVAILABLE, exactly as the TDX verifier being down is: this
+        validator's condition, not the node's. Evidence the agent never supplied is
+        observe-only unless GPU-attestation enforcement is on — the same posture and the same
+        flag as `_verify_gpu`, because when to fail a fleet on missing GPU evidence is one
+        decision, taken once.
+        """
+        payload = answer.get("gpu_evidence")
+        detail = str(answer.get("gpu_evidence_detail") or "no GPU evidence in the answer")
+        log_extra = {"executor": f"{origin.address}:{origin.port}", "detail": detail}
+
+        if not isinstance(payload, dict) or not payload.get("evidence_list"):
+            if settings.ENABLE_GPU_ATTESTATION_ENFORCEMENT:
+                return None, RENTAL_QUOTE_REJECTED, f"no attested GPU identity: {detail}"
+            logger.warning(_m(
+                "Rented CVM answered with no submittable GPU evidence: its GPU set is unattested",
+                extra=get_extra_info(log_extra),
+            ))
+            return None, None, f"GPU set unattested ({detail})"
+
+        # Both halves must answer THIS challenge. A quote and an evidence set assembled from
+        # two different moments is a replay however well each half verifies on its own.
+        if payload.get("nonce") != nonce.value_hex:
+            return None, RENTAL_QUOTE_REJECTED, "the GPU evidence is not bound to the issued nonce"
+
+        try:
+            nras_response = await self._post_nras(payload, origin)
+        except AttestationError as exc:
+            # Includes an HTTP error status from NRAS, which could be a malformed submission
+            # rather than an outage. Classed as unavailable anyway: this validator cannot tell
+            # the two apart from a status code, and the conservative reading of "cannot tell"
+            # is the one that does not punish. A node gains nothing by it — refusing to answer
+            # reaches the same fallback more cheaply, and what absence MEANS is DAH-2676's.
+            logger.warning(_m(
+                "NRAS could not judge a rented CVM's GPU evidence",
+                extra=get_extra_info({**log_extra, "error": str(exc)}),
+            ))
+            return None, RENTAL_QUOTE_UNAVAILABLE, f"NRAS could not be reached: {exc}"
+
+        # Read back before any await: `_last_gpu_ueids` is per-service, and this is the only
+        # point at which it is known to belong to this answer.
+        passed, failures = self._check_gpu_claims(nras_response, nonce.value_hex, origin)
+        ueids = list(self._last_gpu_ueids)
+        if not passed:
+            return (
+                None,
+                RENTAL_QUOTE_REJECTED,
+                "NVIDIA refused this CVM's GPU evidence — " + "; ".join(failures),
+            )
+        if not ueids:
+            return None, RENTAL_QUOTE_REJECTED, "the GPU evidence identified no GPU"
+        return ueids, None, f"{len(ueids)} GPU(s) attested by ueid"
+
     async def verify_rented_cvm_quote(
         self,
         answer: dict,
@@ -961,7 +1080,8 @@ class AttestationService:
 
         The identity binding is the renter recipe from attest-agent/identity.py:
 
-            report_data[:32]   == sha256(agent TLS public key ‖ gpu_uuid_digest(gpu_uuids))
+            report_data[:32]   == sha256(RENTER_IDENTITY_DOMAIN_V1 ‖ tls_spki_der
+                                         ‖ gpu_uuid_digest(gpu_uuids))
             report_data[32:64] == this call's nonce
 
         The TLS key and the GPU list come from the agent's own answer. Self-supplied, and
@@ -969,6 +1089,10 @@ class AttestationService:
         holds another produces a quote whose identity half this check will not match. What
         the values are FOR is telling this validator what to expect; what makes them
         evidence is the quote.
+
+        That argument covers tampering, not authenticity: it makes the GPU UUIDs the guest's
+        own unaltered claim, never NVIDIA's. The GPU set itself is settled separately, on the
+        per-GPU ueids in the evidence — see `_rented_gpu_identity`.
 
         A VERIFIED verdict is full evidence with no feature flag behind it. The order checks
         (compose, OS image, GPU count vs `expectations`) are enforced here unconditionally,
@@ -1017,7 +1141,7 @@ class AttestationService:
         if returned is None or len(returned) < 64:
             return RENTAL_QUOTE_REJECTED, "the quote carries no usable report_data"
 
-        expected_identity = hashlib.sha256(tls_key + self.gpu_uuid_digest(uuids)).digest()
+        expected_identity = self.renter_identity_digest(tls_key, uuids)
         if returned[:32] != expected_identity:
             return (
                 RENTAL_QUOTE_REJECTED,
@@ -1059,16 +1183,49 @@ class AttestationService:
                 mismatches.append(
                     f"{field_name}: sold {expected}, measured {app_info.get(field_name)}"
                 )
+
+        # The GPU set arrives as two different claims, and they are not interchangeable:
+        #
+        #   gpu_uuids   what the guest READ from NVML, bound into report_data. The binding
+        #               stops the host altering it in flight and stops it being lifted onto
+        #               another quote. It does not make NVIDIA vouch for those identifiers.
+        #   ueid        each GPU's own attested identity, out of NRAS-verified evidence — the
+        #               one identifier here the node cannot choose.
+        #
+        # So the UUIDs are held to the weaker job they can actually do: they may CONTRADICT
+        # the order, since a signed claim that disagrees with what was sold is a false claim
+        # whoever made it. What the hardware IS — that these GPUs exist, that they are
+        # genuine, that there are this many of them — rests on the ueids.
         expected_count = getattr(expectations, "gpu_count", None) if expectations else None
-        if expected_count is not None and len(uuids) != expected_count:
-            mismatches.append(f"gpu_count: sold {expected_count}, attested {len(uuids)}")
+        ueids, gpu_verdict, gpu_detail = await self._rented_gpu_identity(answer, nonce, origin)
+        if gpu_verdict is not None:
+            return gpu_verdict, gpu_detail
+
+        if ueids is not None:
+            if len(ueids) != len(uuids):
+                mismatches.append(
+                    f"gpu_set: the guest reported {len(uuids)}, NVIDIA attested {len(ueids)}"
+                )
+            if expected_count is not None and len(ueids) != expected_count:
+                mismatches.append(f"gpu_count: sold {expected_count}, attested {len(ueids)}")
+        elif expected_count is not None and len(uuids) != expected_count:
+            # No attested set to count. The quote's own claim still has to agree with the
+            # order — it cannot prove the GPUs are there, but it can prove the node said
+            # something else than it sold.
+            mismatches.append(
+                f"gpu_count: sold {expected_count}, guest reported {len(uuids)} (unattested)"
+            )
+
         if mismatches:
             return (
                 RENTAL_QUOTE_REJECTED,
                 "the CVM does not match what was sold — " + "; ".join(mismatches),
             )
 
-        return RENTAL_QUOTE_VERIFIED, "hardware-signed quote bound to this cycle's nonce"
+        return (
+            RENTAL_QUOTE_VERIFIED,
+            f"hardware-signed quote bound to this cycle's nonce; {gpu_detail}",
+        )
 
     async def _record_attested_executor(self, executor: ExecutorSSHInfo) -> None:
         """Ratchet: remember that this executor is a CVM (minimal-G5)."""

--- a/neurons/validators/src/services/attestation_service.py
+++ b/neurons/validators/src/services/attestation_service.py
@@ -39,9 +39,28 @@ TDX_LAST_ATTESTATION_EVENT_PREFIX = "tdx_last_attestation_event"
 # contract, so a copy that drifts must fail a test rather than silently accept a wrong set.
 GPU_UUID_SEPARATOR = ","
 
+# DAH-2675 — the three verdicts on a rented CVM's live quote. Three, not two, because two of
+# the outcomes lead to opposite decisions and must not share an encoding: REJECTED means the
+# evidence was examined and failed (earns nothing), while UNAVAILABLE means nothing could be
+# examined (what that means is DAH-2676's question, so the caller falls back).
+RENTAL_QUOTE_VERIFIED = "verified"
+RENTAL_QUOTE_REJECTED = "rejected"
+RENTAL_QUOTE_UNAVAILABLE = "unavailable"
+
 
 class AttestationError(RuntimeError):
     """Raised when attestation or host verification fails."""
+
+
+@dataclass(frozen=True)
+class _QuoteOrigin:
+    """Where a relayed quote came from — just enough of an executor for the verifier call's
+    log labels. A rented CVM's quote arrives through cvmd (DAH-2675), so there is no
+    ExecutorSSHInfo to hand `_call_verifier`, and building a fake one would imply an SSH
+    session that never existed."""
+
+    address: str
+    port: int | str
 
 
 @dataclass
@@ -925,6 +944,131 @@ class AttestationService:
                 f"order it is serving — " + "; ".join(mismatches)
             )
         logger.warning(_m("Renter CVM mismatch (not enforced)", extra=extra))
+
+    async def verify_rented_cvm_quote(
+        self,
+        answer: dict,
+        *,
+        nonce: AttestationNonce,
+        expectations,
+        address: str,
+        port: int | str,
+    ) -> tuple[str, str]:
+        """Judge one agent answer for a rented CVM. Returns (verdict, reason).
+
+        The verdicts are the module constants RENTAL_QUOTE_VERIFIED / _REJECTED /
+        _UNAVAILABLE — see their comment for why three.
+
+        The identity binding is the renter recipe from attest-agent/identity.py:
+
+            report_data[:32]   == sha256(agent TLS public key ‖ gpu_uuid_digest(gpu_uuids))
+            report_data[32:64] == this call's nonce
+
+        The TLS key and the GPU list come from the agent's own answer. Self-supplied, and
+        that is fine — the hardware signed their digest, so an agent that states one set and
+        holds another produces a quote whose identity half this check will not match. What
+        the values are FOR is telling this validator what to expect; what makes them
+        evidence is the quote.
+
+        A VERIFIED verdict is full evidence with no feature flag behind it. The order checks
+        (compose, OS image, GPU count vs `expectations`) are enforced here unconditionally,
+        unlike `_assert_renter_expectations`'s flag-gated path: this path only ever runs for
+        the new rental-scoring decision, so there is no fleet to stage it across — a quote
+        that verifies but contradicts the order is a measured false claim, and it earns
+        nothing.
+        """
+        if not self.enabled:
+            return RENTAL_QUOTE_UNAVAILABLE, "TDX attestation is not enabled on this validator"
+
+        quote = answer.get("quote")
+        if not isinstance(quote, str) or not quote.strip():
+            return RENTAL_QUOTE_REJECTED, "the agent answered without a quote"
+
+        tls_key_hex = answer.get("tls_public_key")
+        gpu_uuids = answer.get("gpu_uuids")
+        if not isinstance(tls_key_hex, str) or not isinstance(gpu_uuids, list):
+            return RENTAL_QUOTE_REJECTED, "the agent answered without its identity material"
+        try:
+            tls_key = bytes.fromhex(tls_key_hex)
+        except ValueError:
+            return RENTAL_QUOTE_REJECTED, "the agent's TLS public key is not hex"
+        if not tls_key:
+            return RENTAL_QUOTE_REJECTED, "the agent's TLS public key is empty"
+        uuids = [str(uuid) for uuid in gpu_uuids]
+
+        origin = _QuoteOrigin(address=address, port=port)
+        try:
+            verifier_payload = await self._call_verifier(quote.strip(), origin)
+        except AttestationError as exc:
+            # Covers "no verifier URL", an HTTP error status, and a non-JSON answer — every
+            # one a condition of the verifier, not a judgement on the quote.
+            return RENTAL_QUOTE_UNAVAILABLE, str(exc)
+        except (aiohttp.ClientError, TimeoutError, OSError) as exc:
+            return RENTAL_QUOTE_UNAVAILABLE, f"the verifier could not be reached: {exc}"
+
+        details = verifier_payload.get("details")
+        if not isinstance(details, dict):
+            return RENTAL_QUOTE_UNAVAILABLE, "the verifier's answer carried no details section"
+
+        if not (bool(verifier_payload.get("is_valid")) and bool(details.get("quote_verified"))):
+            return RENTAL_QUOTE_REJECTED, "the verifier refused the quote"
+
+        returned = self._normalise_report_data(details.get("report_data"))
+        if returned is None or len(returned) < 64:
+            return RENTAL_QUOTE_REJECTED, "the quote carries no usable report_data"
+
+        expected_identity = hashlib.sha256(tls_key + self.gpu_uuid_digest(uuids)).digest()
+        if returned[:32] != expected_identity:
+            return (
+                RENTAL_QUOTE_REJECTED,
+                "the quote's identity half does not bind the agent's TLS key and GPU set",
+            )
+
+        if nonce.is_expired(settings.ATTESTATION_NONCE_TTL_SECONDS):
+            # This validator's own slowness, not the node's evidence — never REJECTED.
+            return RENTAL_QUOTE_UNAVAILABLE, "the issued nonce expired before verification"
+        if returned[32:64] != nonce.value_bytes:
+            return (
+                RENTAL_QUOTE_REJECTED,
+                "the quote does not echo the issued nonce (stale or replayed)",
+            )
+
+        violations = self._collect_tcb_violations(details)
+        if violations:
+            # Same posture as every other quote path: warn-only telemetry until the fleet-wide
+            # TCB flag is taken, then enforced. Not a new flag — the same one.
+            logger.warning(_m(
+                "TCB posture violations on a rented CVM quote",
+                extra=get_extra_info({
+                    "executor": f"{address}:{port}",
+                    "violations": [
+                        {"reason": reason, "value": value} for reason, value in violations
+                    ],
+                    "enforced": settings.ENABLE_TCB_ENFORCEMENT,
+                }),
+            ))
+            if settings.ENABLE_TCB_ENFORCEMENT:
+                reason, value = violations[0]
+                return RENTAL_QUOTE_REJECTED, f"TCB enforcement failed: {reason}={value!r}"
+
+        app_info = details.get("app_info", {}) or {}
+        mismatches: list[str] = []
+        for field_name in ("compose_hash", "os_image_hash"):
+            expected = getattr(expectations, field_name, None) if expectations else None
+            if expected and app_info.get(field_name) != expected:
+                mismatches.append(
+                    f"{field_name}: sold {expected}, measured {app_info.get(field_name)}"
+                )
+        expected_count = getattr(expectations, "gpu_count", None) if expectations else None
+        if expected_count is not None and len(uuids) != expected_count:
+            mismatches.append(f"gpu_count: sold {expected_count}, attested {len(uuids)}")
+        if mismatches:
+            return (
+                RENTAL_QUOTE_REJECTED,
+                "the CVM does not match what was sold — " + "; ".join(mismatches),
+            )
+
+        return RENTAL_QUOTE_VERIFIED, "hardware-signed quote bound to this cycle's nonce"
 
     async def _record_attested_executor(self, executor: ExecutorSSHInfo) -> None:
         """Ratchet: remember that this executor is a CVM (minimal-G5)."""

--- a/neurons/validators/src/services/cvm_lifecycle.py
+++ b/neurons/validators/src/services/cvm_lifecycle.py
@@ -31,7 +31,7 @@ import asyncio
 import json
 import logging
 import time
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from core.config import settings
@@ -71,6 +71,13 @@ CVM_RENTAL_SUPERVISOR_DEAD_EVENT = "CVM_RENTAL_SUPERVISOR_DEAD"
 # DAH-2675 — what the log-only attest-agent probe reports.
 CVM_ATTEST_PROBE_OK_EVENT = "CVM_RENTER_ATTEST_PROBE_OK"
 CVM_ATTEST_PROBE_FAILED_EVENT = "CVM_RENTER_ATTEST_PROBE_FAILED"
+# DAH-2675 — the live quote check on a rented CVM. VERIFIED scores on hardware evidence;
+# REJECTED is a quote (or an answer) the verifier examined and refused, which earns nothing;
+# UNAVAILABLE means no quote could be examined at all — what THAT means is DAH-2676's
+# question, so the node falls back to the flag-gated host-side pass.
+CVM_RENTAL_QUOTE_VERIFIED_EVENT = "CVM_RENTAL_QUOTE_VERIFIED"
+CVM_RENTAL_QUOTE_REJECTED_EVENT = "CVM_RENTAL_QUOTE_REJECTED"
+CVM_RENTAL_QUOTE_UNAVAILABLE_EVENT = "CVM_RENTAL_QUOTE_UNAVAILABLE"
 
 
 @dataclass(frozen=True)
@@ -254,26 +261,6 @@ class CvmLifecycleService:
             logger.warning(_m(
                 "Could not record a cvmd host",
                 extra=get_extra_info({"executor_uuid": executor_uuid, "error": str(exc)}),
-            ))
-
-    async def touch_host(self, host: CvmdHost) -> None:
-        """Refresh one host's registry TTL from a record the caller just read out of it.
-
-        Write-only on purpose: `record_host`'s merge re-read exists for callers holding
-        fresh payload data, and this caller's fields ARE the stored record, so a re-read
-        could never contribute anything. A rental can run 720 hours against a 7-day TTL;
-        without the refresh the host would age out of the very sweep that scores it.
-        """
-        try:
-            await self.redis_service.hset(
-                CVMD_HOSTS_KEY,
-                host.executor_uuid,
-                replace(host, updated_at=time.time()).to_json(),
-            )
-        except Exception as exc:  # noqa: BLE001 - registry writes must never break a cycle
-            logger.warning(_m(
-                "Could not refresh a cvmd host's registry entry",
-                extra=get_extra_info({"executor_uuid": host.executor_uuid, "error": str(exc)}),
             ))
 
     async def hosts_for_miner(self, miner_hotkey: str) -> list[CvmdHost]:
@@ -572,3 +559,38 @@ class CvmLifecycleService:
             # the default-off configuration from allocating a task just to throw it away.
             return
         self._spawn_background(self.probe_attest_agent(host, assessment))
+
+    # ------------------------------------------------------------------ DAH-2675: live quote
+
+    async def request_renter_quote(
+        self, host: CvmdHost, *, nonce_hex: str, agent_port: int | None = None
+    ) -> dict | None:
+        """One nonce-bound quote from the renter CVM's agent, relayed through cvmd, or None.
+
+        Through cvmd rather than dialed directly, because the agent's forward is loopback-bound
+        by default — only the host itself can reach it, and cvmd IS the host. The relay adds no
+        trust: the quote binds this call's nonce, so cvmd can withhold an answer but cannot
+        substitute one that verifies. Every no-answer outcome is None here; what None MEANS for
+        the score is the caller's decision, not this transport's.
+        """
+        extra = get_extra_info({
+            "executor_uuid": host.executor_uuid,
+            "miner_hotkey": host.miner_hotkey,
+        })
+        try:
+            result = await self.client.attest_renter(
+                host.cvmd_url(), nonce_hex=nonce_hex, agent_port=agent_port
+            )
+        except CvmdRelayError as exc:
+            logger.info(_m(
+                f"{CVM_RENTAL_QUOTE_UNAVAILABLE_EVENT} — cvmd was not reached",
+                extra={**extra, "error": str(exc)},
+            ))
+            return None
+        if not result.ok:
+            logger.info(_m(
+                f"{CVM_RENTAL_QUOTE_UNAVAILABLE_EVENT} — no quote came back",
+                extra={**extra, "status": result.status, "detail": result.reason()},
+            ))
+            return None
+        return result.body

--- a/neurons/validators/src/services/cvmd_client.py
+++ b/neurons/validators/src/services/cvmd_client.py
@@ -14,6 +14,7 @@ What this client can and cannot do is decided by cvmd, not here:
 
     POST /v1/cvm {kind: validation}   allowed — the validator's own scope
     GET  /v1/state, /v1/catalog       allowed — reads are open to either authorized key
+    POST /v1/attest                   allowed — open to any authorized key (DAH-2675)
     POST /v1/cvm {kind: renter}       403 — platform scope, this key is refused
     DELETE /v1/cvm                    403 — teardown is the platform's alone
 
@@ -52,11 +53,17 @@ NONCE_BYTES = 16
 
 CVM_PATH = "/v1/cvm"
 STATE_PATH = "/v1/state"
+ATTEST_PATH = "/v1/attest"
 
 KIND_VALIDATION = "validation"
 
 # A state read answers from memory; only the network is being waited on.
 DEFAULT_STATE_TIMEOUT_SECONDS = 30
+
+# An attest relay holds while the in-guest agent produces a fresh quote plus GPU evidence.
+# cvmd bounds its own dial at 120 s; this budget sits above it so the host's timeout is the
+# one that decides, and its reason is the one that reaches this validator.
+DEFAULT_ATTEST_TIMEOUT_SECONDS = 150
 
 
 def _lp(value: bytes) -> bytes:
@@ -162,8 +169,33 @@ class CvmdClient:
             timeout_seconds=DEFAULT_PROVISION_TIMEOUT_SECONDS,
         )
 
+    async def attest_renter(
+        self, base_url: str, *, nonce_hex: str, agent_port: int | None = None
+    ) -> RelayResult:
+        """Signed ``POST /v1/attest``: one nonce-bound trust check of the renter CVM's agent.
+
+        The nonce is this validator's challenge — the agent folds it into the hardware-signed
+        report_data, which is what makes the answer impossible for the relaying host to forge
+        or replay. ``agent_port`` names the guest port the order injected the agent on; None
+        leaves cvmd's default in force.
+        """
+        payload: dict = {"nonce": nonce_hex}
+        if agent_port:
+            payload["agent_port"] = agent_port
+        body = canonical_body(payload)
+        signed = sign_request(self._keypair, method="POST", path=ATTEST_PATH, body=body)
+        return await self._relay.forward(
+            base_url=base_url,
+            method=signed.method,
+            path=signed.path,
+            body=signed.body,
+            headers=signed.headers,
+            timeout_seconds=DEFAULT_ATTEST_TIMEOUT_SECONDS,
+        )
+
 
 __all__ = [
+    "ATTEST_PATH",
     "CVM_PATH",
     "STATE_PATH",
     "KIND_VALIDATION",

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -61,7 +61,14 @@ from tenacity import RetryError
 from core.config import settings
 from core.utils import _m, _StructuredMessage, get_extra_info
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
-from services.attestation_service import TDX_ATTESTED_EXECUTOR_SET, AttestationService
+from services.attestation_service import (
+    RENTAL_QUOTE_REJECTED,
+    RENTAL_QUOTE_UNAVAILABLE,
+    RENTAL_QUOTE_VERIFIED,
+    TDX_ATTESTED_EXECUTOR_SET,
+    AttestationNonce,
+    AttestationService,
+)
 from services.docker_service import DockerService
 from services.redis_service import MACHINE_SPEC_CHANNEL, RedisService
 from services.ssh_service import SSHService
@@ -774,6 +781,7 @@ class MinerService:
             CVM_SWITCH_BUDGET_EXCEEDED_EVENT,
             CVM_SWITCH_GRACE_EVENT,
             CVM_SWITCH_GRACE_OBSERVED_EVENT,
+            CvmdHost,
         )
 
         # getattr, not attribute access: results in this pipeline are duck-typed (tests and
@@ -822,6 +830,30 @@ class MinerService:
         }
         graces: list[JobResult] = []
         hosts = await lifecycle.hosts_for_miner(payload.miner_hotkey)
+
+        # DAH-2675: the backend's response is the authoritative list of rented CVM nodes, so a
+        # rental is swept even when this validator's registry has no entry for it — the
+        # registry is a cache here, never a dependency (the validator-stays-stateless rule).
+        # The GPU shape comes from the order the customer paid for, which is also what the
+        # quote check verifies against.
+        known = {host.executor_uuid for host in hosts}
+        # getattr like the rest of this pipeline: reduced shapes must read as "no CVM
+        # rentals", never as a failed batch.
+        rented_expectations = getattr(rented_data, "cvm_expectations", None) or {}
+        for executor_uuid, expectations in rented_expectations.items():
+            if executor_uuid in known:
+                continue
+            rented_executor = rented_data.executors.get(executor_uuid)
+            if rented_executor is None or rented_executor.miner_hotkey != payload.miner_hotkey:
+                continue
+            hosts.append(CvmdHost(
+                executor_uuid=executor_uuid,
+                address=rented_executor.executor_ip_address,
+                miner_hotkey=payload.miner_hotkey,
+                gpu_model=expectations.gpu_model,
+                gpu_count=expectations.gpu_count or 0,
+            ))
+
         for host in hosts:
             if host.executor_uuid in already_scored:
                 continue
@@ -942,30 +974,38 @@ class MinerService:
         rented_data: RentedExecutorsResponse | None,
         extra: dict,
     ) -> JobResult | None:
-        """Forced pass for a node whose CVM a renter holds (DAH-2674), or None.
+        """Score for a node whose CVM a renter holds (DAH-2674 + DAH-2675), or None.
 
-        The same shape and the same standard of proof as the special-manual-rental synthesis:
-        the pass needs TWO independent parties to agree. cvmd (host-side, outside the guest)
-        says RENTER_RUNNING, and the BACKEND's own rented-executors list says this executor
-        really is under a paid rental for this miner. Either alone is refusable — a host that
-        fabricates its state answer earns nothing without a rental the platform is billing,
-        and nothing read from inside the guest participates at all, so a root renter cannot
-        move the provider's score either (the DAH-2676 rule).
+        The gates come first, and both are the DAH-2674 two-party proof: cvmd (host-side,
+        outside the guest) says RENTER_RUNNING, and the BACKEND's own rented-executors list
+        says this executor really is under a paid rental for this miner. Either alone is
+        refusable — a host that fabricates its state answer earns nothing without a rental
+        the platform is billing. The host must also still hold its guest: cvmd reports
+        `supervisor_alive` from its own /proc read, and a dead QEMU mid-rental is a host
+        failure, not a scored cycle.
 
-        The host must also still be holding its guest: cvmd reports `supervisor_alive` from
-        its own /proc read, and a dead QEMU mid-rental is a host-side failure, not a scored
-        cycle. `spec` is None, like every synthesis here, so the backend's executor upsert is
-        untouched.
+        Then the live quote decides (DAH-2675). A quote relayed through cvmd, bound to this
+        cycle's fresh nonce and accepted by the verifier against the agent recipe AND the
+        order's expectations, is full evidence — the node scores on it with no feature flag.
+        A quote the verifier examined and refused (or one that contradicts what was sold)
+        earns nothing, flag or no flag: a measured false claim outranks the host-side
+        signals. Only when NO quote could be examined does the node fall back to the
+        DAH-2674 host-side pass, still behind `ENABLE_CVM_RENTAL_SCORING`, because what a
+        missing quote means (renter sabotage vs provider fault) is DAH-2676's question.
 
-        The registry entry is refreshed only for a backend-confirmed rental — a rental can run
-        720 hours against a 7-day registry TTL, and without the refresh the host would age out
-        of the very sweep that scores it. Gating the refresh the same way as the pass means a
-        fabricated state answer cannot keep its own registry entry alive either.
+        Nothing here reads validator-side state: the rental facts (address, GPU shape,
+        expectations) ride the backend's response each cycle. The registry entry is
+        re-recorded from those backend facts purely for the post-rental launch path
+        (DAH-2629 must find the host once it is idle again), gated behind the backend
+        cross-check so a fabricated state answer cannot keep its own entry alive. `spec` is
+        None, like every synthesis here, so the backend's executor upsert is untouched.
         """
         from services.cvm_lifecycle import (
             CVM_RENTAL_BACKEND_MISMATCH_EVENT,
             CVM_RENTAL_PASS_EVENT,
             CVM_RENTAL_PASS_OBSERVED_EVENT,
+            CVM_RENTAL_QUOTE_REJECTED_EVENT,
+            CVM_RENTAL_QUOTE_VERIFIED_EVENT,
             CVM_RENTAL_SUPERVISOR_DEAD_EVENT,
         )
 
@@ -984,9 +1024,29 @@ class MinerService:
             logger.warning(_m(CVM_RENTAL_SUPERVISOR_DEAD_EVENT, extra=extra))
             return None
 
-        await lifecycle.touch_host(host)
+        # The backend's copy of the node's facts outranks the registry's: the expectations
+        # rode in on THIS cycle's response, while a registry entry is whatever some earlier
+        # cycle recorded.
+        expectations = (getattr(rented_data, "cvm_expectations", None) or {}).get(executor_uuid)
+        gpu_model = (
+            expectations.gpu_model if expectations and expectations.gpu_model else host.gpu_model
+        )
+        gpu_count = (
+            expectations.gpu_count if expectations and expectations.gpu_count else host.gpu_count
+        )
 
-        if host.gpu_model not in BASE_GPU_MAP:
+        # Re-record rather than merely refresh: the backend facts are authoritative, and a
+        # rental can run 720 hours against the registry's 7-day TTL — without this the host
+        # would age out of the launch path that must find it once the rental ends.
+        await lifecycle.record_host(
+            executor_uuid=executor_uuid,
+            address=rented_executor.executor_ip_address,
+            miner_hotkey=payload.miner_hotkey,
+            gpu_model=gpu_model,
+            gpu_count=gpu_count or 0,
+        )
+
+        if gpu_model not in BASE_GPU_MAP:
             # Same guard as the manual-rental and switch-grace syntheses, same reason: an
             # unknown model reaching the incentive layer aborts weight-setting subnet-wide.
             logger.warning(_m(
@@ -995,8 +1055,19 @@ class MinerService:
             ))
             return None
 
-        if not settings.ENABLE_CVM_RENTAL_SCORING:
-            logger.info(_m(CVM_RENTAL_PASS_OBSERVED_EVENT, extra=extra))
+        verdict, quote_reason = await self._judge_rental_quote(
+            host, lifecycle, expectations, extra
+        )
+        if verdict == RENTAL_QUOTE_REJECTED:
+            # Examined and failed. Never scored — and never softened by the fallback below,
+            # which exists for absence of evidence, not for evidence of absence.
+            logger.warning(_m(
+                CVM_RENTAL_QUOTE_REJECTED_EVENT, extra={**extra, "reason": quote_reason}
+            ))
+            return None
+
+        if verdict != RENTAL_QUOTE_VERIFIED and not settings.ENABLE_CVM_RENTAL_SCORING:
+            logger.info(_m(CVM_RENTAL_PASS_OBSERVED_EVENT, extra={**extra, "quote": quote_reason}))
             return None
 
         # The incentive-layer gates come off rented_data exactly as the manual-rental synthesis
@@ -1012,9 +1083,13 @@ class MinerService:
         except (TypeError, ValueError):
             executor_port = 0
 
+        if verdict == RENTAL_QUOTE_VERIFIED:
+            event, reason = CVM_RENTAL_QUOTE_VERIFIED_EVENT, "cvm_rental_quote"
+        else:
+            event, reason = CVM_RENTAL_PASS_EVENT, "cvm_rental"
         log_text = _m(
-            CVM_RENTAL_PASS_EVENT,
-            extra={**extra, "gpu_count": host.gpu_count, "reason": "cvm_rental"},
+            event,
+            extra={**extra, "gpu_count": gpu_count, "reason": reason, "quote": quote_reason},
         ).to_full_string()
         logger.info(log_text)
         return self._forced_pass_result(
@@ -1022,17 +1097,56 @@ class MinerService:
             executor_uuid=executor_uuid,
             address=rented_executor.executor_ip_address,
             port=executor_port,
-            gpu_model=host.gpu_model,
-            gpu_count=host.gpu_count,
+            gpu_model=gpu_model,
+            gpu_count=gpu_count,
             log_text=log_text,
             # Rented exempts the minimum-driver gate, which we cannot measure here.
             is_rented=True,
             is_spot=is_spot,
             provider_discord_connected=provider_discord_connected,
-            # This is a CVM-class node: the registry entry that got us here was recorded by an
-            # attested cycle, and the sweep's own state read is the host-side continuation of it.
+            # On a verified quote this is a measurement made THIS cycle; on the fallback it is
+            # the DAH-2674 host-side continuation of the attested cycle that recorded the host.
             tdx_attestation_passed=True,
         )
+
+    async def _judge_rental_quote(
+        self, host, lifecycle, expectations, extra: dict
+    ) -> tuple[str, str]:
+        """One live trust check of a rented CVM: request through cvmd, verify here.
+
+        Never raises; every outcome is one of the three RENTAL_QUOTE_* verdicts. The nonce is
+        minted fresh per check, so no cache anywhere — the agent's ledger included — can
+        satisfy it with an old quote. The agent's guest port comes from the order's
+        expectations when the backend carries it; None leaves cvmd's default in force.
+        """
+        from services.cvm_lifecycle import CVM_RENTAL_QUOTE_UNAVAILABLE_EVENT
+
+        if not getattr(self.attestation_service, "enabled", False):
+            # No verifier to examine a quote — don't make the guest produce one that
+            # nothing will ever read. Same verdict the verification step would return.
+            return RENTAL_QUOTE_UNAVAILABLE, "TDX attestation is not enabled on this validator"
+
+        nonce = AttestationNonce.issue()
+        agent_port = getattr(expectations, "agent_port", None) if expectations else None
+        answer = await lifecycle.request_renter_quote(
+            host, nonce_hex=nonce.value_hex, agent_port=agent_port
+        )
+        if answer is None:
+            # The transport already logged its own UNAVAILABLE event with the failing leg.
+            return RENTAL_QUOTE_UNAVAILABLE, "no answer came back through cvmd"
+
+        verdict, reason = await self.attestation_service.verify_rented_cvm_quote(
+            answer,
+            nonce=nonce,
+            expectations=expectations,
+            address=host.address,
+            port=settings.CVMD_PORT,
+        )
+        if verdict == RENTAL_QUOTE_UNAVAILABLE:
+            logger.info(_m(
+                CVM_RENTAL_QUOTE_UNAVAILABLE_EVENT, extra={**extra, "reason": reason}
+            ))
+        return verdict, reason
 
     def _build_failed_job_result(self, payload: MinerJobRequestPayload, reason: str):
         executor_info = ExecutorSSHInfo(

--- a/neurons/validators/tests/cvm_helpers.py
+++ b/neurons/validators/tests/cvm_helpers.py
@@ -36,12 +36,20 @@ def cvmd_host(
 
 
 def make_miner_service(hosts, assessments):
-    """A miner service whose lifecycle answers `assessments` (one value, or one per host)."""
+    """A miner service whose lifecycle answers `assessments` (one value, or one per host).
+
+    The quote leg defaults to "nothing came back" (`request_renter_quote` -> None), which is
+    the verdict that preserves the DAH-2674 flag-gated behavior — a suite exercising the
+    live-quote path overrides the mock and the attestation service's verdict explicitly.
+    """
     service = MinerService.__new__(MinerService)
     service.redis_service = MagicMock()
+    service.attestation_service = MagicMock()
+    service.attestation_service.verify_rented_cvm_quote = AsyncMock(
+        return_value=("unavailable", "no verifier in this test")
+    )
     lifecycle = MagicMock(spec=CvmLifecycleService)
     lifecycle.record_host = AsyncMock()
-    lifecycle.touch_host = AsyncMock()
     lifecycle.hosts_for_miner = AsyncMock(return_value=hosts)
     if isinstance(assessments, list):
         lifecycle.assess = AsyncMock(side_effect=assessments)
@@ -49,6 +57,7 @@ def make_miner_service(hosts, assessments):
         lifecycle.assess = AsyncMock(return_value=assessments)
     lifecycle.schedule_ensure = MagicMock()
     lifecycle.schedule_attest_probe = MagicMock()
+    lifecycle.request_renter_quote = AsyncMock(return_value=None)
     service._cvm_lifecycle_service = lifecycle
     return service, lifecycle
 
@@ -77,8 +86,19 @@ def scored_result(executor_uuid="already-scored", tdx=False):
     )
 
 
-def rented_data_for(executor_uuid="e-rented", *, miner_hotkey="5Miner", spot=(), discord=None):
-    """The backend's half of the two-party proof: this executor is under a paid rental."""
+def rented_data_for(
+    executor_uuid="e-rented",
+    *,
+    miner_hotkey="5Miner",
+    spot=(),
+    discord=None,
+    expectations=None,
+):
+    """The backend's half of the two-party proof: this executor is under a paid rental.
+
+    `expectations` is the per-executor CvmExpectations side-map entry (any object with the
+    right attributes); None models a backend that carries no CVM facts for this node.
+    """
     return SimpleNamespace(
         executors={
             executor_uuid: SimpleNamespace(
@@ -87,6 +107,7 @@ def rented_data_for(executor_uuid="e-rented", *, miner_hotkey="5Miner", spot=(),
                 executor_ip_port="4001",
             )
         },
+        cvm_expectations={executor_uuid: expectations} if expectations is not None else {},
         spot_executor_ids=list(spot),
         provider_discord_connected_executor_ids=discord,
     )

--- a/neurons/validators/tests/test_attestation_gaps_g1_g4.py
+++ b/neurons/validators/tests/test_attestation_gaps_g1_g4.py
@@ -412,8 +412,10 @@ async def test_g1_per_gpu_claims_checked(service, monkeypatch):
         return _nras_response(
             overall=True,
             nonce=nonce.value_hex,
-            per_gpu={"GPU-0": {"measres": "success", "eat_nonce": nonce.value_hex},
-                     "GPU-1": {"measres": "fail", "eat_nonce": nonce.value_hex}},
+            per_gpu={"GPU-0": {"measres": "success", "eat_nonce": nonce.value_hex,
+                               "ueid": "ueid-0"},
+                     "GPU-1": {"measres": "fail", "eat_nonce": nonce.value_hex,
+                               "ueid": "ueid-1"}},
         )
 
     monkeypatch.setattr(service, "_post_nras", fake_post)
@@ -434,13 +436,58 @@ async def test_g1_nras_pass_returns_true(service, monkeypatch):
             overall=True,
             nonce=nonce.value_hex,
             per_gpu={"GPU-0": {"measres": "success", "eat_nonce": nonce.value_hex,
-                               "dbgstat": "disabled", "secboot": True}},
+                               "dbgstat": "disabled", "secboot": True, "ueid": "ueid-0"}},
         )
 
     monkeypatch.setattr(service, "_post_nras", fake_post)
 
     # Act / Assert
     assert await service._verify_gpu(executor, nonce) is True
+    assert service._last_gpu_ueids == ["ueid-0"]
+
+
+async def test_g1_a_gpu_that_does_not_identify_itself_fails(service, monkeypatch):
+    """The ueid is the only GPU identifier the node cannot choose, so a per-GPU token
+    without one is a GPU this response cannot identify. Left silent it would just shrink the
+    attested set, and every count taken on that set would quietly agree."""
+    monkeypatch.setattr(settings, "ENABLE_GPU_ATTESTATION_ENFORCEMENT", True)
+    nonce = AttestationNonce.issue()
+    executor = _make_executor(nvidia_payload=_gpu_payload(nonce.value_hex))
+
+    async def fake_post(payload, executor_):
+        return _nras_response(
+            overall=True,
+            nonce=nonce.value_hex,
+            per_gpu={"GPU-0": {"measres": "success", "ueid": "ueid-0"},
+                     "GPU-1": {"measres": "success"}},
+        )
+
+    monkeypatch.setattr(service, "_post_nras", fake_post)
+
+    with pytest.raises(AttestationError, match="GPU-1:ueid_missing"):
+        await service._verify_gpu(executor, nonce)
+
+
+async def test_g1_two_gpus_with_one_identity_fail(service, monkeypatch):
+    """One ueid answering twice is one GPU counted twice. Deduplicating would hide it:
+    either the response describes two devices and one is impersonating the other, or it
+    describes one and the count is inflated."""
+    monkeypatch.setattr(settings, "ENABLE_GPU_ATTESTATION_ENFORCEMENT", True)
+    nonce = AttestationNonce.issue()
+    executor = _make_executor(nvidia_payload=_gpu_payload(nonce.value_hex))
+
+    async def fake_post(payload, executor_):
+        return _nras_response(
+            overall=True,
+            nonce=nonce.value_hex,
+            per_gpu={"GPU-0": {"measres": "success", "ueid": "same-ueid"},
+                     "GPU-1": {"measres": "success", "ueid": "same-ueid"}},
+        )
+
+    monkeypatch.setattr(service, "_post_nras", fake_post)
+
+    with pytest.raises(AttestationError, match="ueid_duplicate"):
+        await service._verify_gpu(executor, nonce)
 
 
 async def test_g1_nras_unreachable_fail_closed_when_enforced(service, monkeypatch):

--- a/neurons/validators/tests/test_dah2674_rental_scoring.py
+++ b/neurons/validators/tests/test_dah2674_rental_scoring.py
@@ -25,18 +25,11 @@ defers it to after the sweep, so a genuinely broken miner still produces its fai
 when no synthesis fires (see `_record_and_grace_cvm_hosts` call sites in miner_service.py).
 """
 
-import json
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 from cvm_helpers import PAYLOAD, cvmd_host, make_miner_service, rented_data_for, scored_result
 
 from core.config import settings
-from services.cvm_lifecycle import (
-    CVMD_HOSTS_KEY,
-    CvmLifecycleService,
-    SwitchAssessment,
-)
+from services.cvm_lifecycle import SwitchAssessment
 
 HOST = cvmd_host("e-rented")
 
@@ -144,7 +137,7 @@ class TestTheBackendIsHalfTheProof:
 
         assert results == []
         # A fabricated state answer must not keep its own registry entry alive either.
-        lifecycle.touch_host.assert_not_awaited()
+        lifecycle.record_host.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_a_rental_recorded_for_another_miner_earns_nothing(self, rental_scoring_on):
@@ -185,45 +178,30 @@ class TestObserveMode:
         assert results == []
         # Observation still refreshes the registry for the CONFIRMED rental: rollout-mode
         # fleets have long rentals too, and the host must not age out mid-rental.
-        lifecycle.touch_host.assert_awaited()
+        lifecycle.record_host.assert_awaited()
 
 
 class TestTheRegistryOutlivesTheRental:
     @pytest.mark.asyncio
-    async def test_a_confirmed_rental_refreshes_the_hosts_entry(self, rental_scoring_on):
+    async def test_a_confirmed_rental_rerecords_the_host_from_backend_facts(
+        self, rental_scoring_on
+    ):
+        """Re-recorded, not merely refreshed: the address and GPU shape written back are the
+        BACKEND's copy from this cycle's response, so the registry entry that the DAH-2629
+        launch path will need after the rental cannot drift from the system of record."""
         service, lifecycle = make_miner_service([HOST], renter_running())
 
         await service._record_and_grace_cvm_hosts(
             PAYLOAD, existing=[], rented_data=rented_data_for()
         )
 
-        lifecycle.touch_host.assert_awaited_once()
-        touched = lifecycle.touch_host.await_args.args[0]
-        assert touched.executor_uuid == "e-rented"
-        assert touched.address == "203.0.113.7"
-        assert touched.gpu_model == "NVIDIA H200"
-        assert touched.gpu_count == 8
-
-    @pytest.mark.asyncio
-    async def test_touch_host_rewrites_the_record_with_a_fresh_timestamp(self):
-        """The refresh is write-only: the caller's record IS the stored record, so there is
-        nothing a re-read could merge — one hset, no hget."""
-        from bittensor_wallet import Keypair
-
-        redis = MagicMock()
-        redis.hset = AsyncMock()
-        redis.hget = AsyncMock()
-        service = CvmLifecycleService(redis, MagicMock(), Keypair.create_from_uri("//Alice"))
-
-        await service.touch_host(HOST)
-
-        redis.hget.assert_not_awaited()
-        redis.hset.assert_awaited_once()
-        key, field, payload_json = redis.hset.await_args.args
-        assert key == CVMD_HOSTS_KEY
-        assert field == "e-rented"
-        stored = json.loads(payload_json)
-        assert stored["updated_at"] > 0.0, "the TTL clock must actually restart"
+        lifecycle.record_host.assert_awaited_once()
+        recorded = lifecycle.record_host.await_args.kwargs
+        assert recorded["executor_uuid"] == "e-rented"
+        assert recorded["address"] == "203.0.113.7"
+        assert recorded["miner_hotkey"] == "5Miner"
+        assert recorded["gpu_model"] == "NVIDIA H200"
+        assert recorded["gpu_count"] == 8
 
 
 class TestIncentiveGates:

--- a/neurons/validators/tests/test_dah2675_quote_verify.py
+++ b/neurons/validators/tests/test_dah2675_quote_verify.py
@@ -1,0 +1,446 @@
+"""DAH-2675: a rented CVM's live quote decides its score.
+
+The claims pinned here:
+
+  * a quote relayed through cvmd, bound to THIS cycle's fresh nonce and accepted by the
+    verifier against the agent recipe (sha256(TLS key ‖ gpu_uuid_digest) ‖ nonce) AND the
+    order's expectations, scores the node with NO feature flag — a verified quote is full
+    evidence, not a rollout experiment;
+  * a quote the verifier examined and refused — bad identity binding, wrong nonce, or a
+    measurement that contradicts what was sold — earns nothing, even with the DAH-2674
+    fallback flag on: evidence of a false claim outranks the host-side signals;
+  * only when NO quote could be examined (agent unreachable, verifier down, attestation
+    disabled) does the node fall back to the flag-gated host-side pass — what a missing
+    quote MEANS is DAH-2676's question, so absence must never be judged here;
+  * the rented sweep is driven by the BACKEND's response, not by validator-side state: a
+    rental with no registry entry is still found, and the backend's GPU facts outrank the
+    registry's (the validator-stays-stateless rule);
+  * the verification math itself: identity binding, nonce echo, expectations comparison,
+    and the three-way verdict encoding.
+"""
+
+import hashlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cvm_helpers import PAYLOAD, cvmd_host, make_miner_service, rented_data_for
+
+from core.config import settings
+from services.attestation_service import (
+    RENTAL_QUOTE_REJECTED,
+    RENTAL_QUOTE_UNAVAILABLE,
+    RENTAL_QUOTE_VERIFIED,
+    AttestationError,
+    AttestationNonce,
+    AttestationService,
+)
+from services.cvm_lifecycle import CvmLifecycleService, SwitchAssessment
+from services.cvmd_client import ATTEST_PATH, CvmdClient
+from services.cvmd_relay import CvmdRelayError, RelayResult
+
+TLS_KEY = bytes.fromhex("aa" * 32)
+GPU_UUIDS = ["GPU-bbb", "GPU-aaa"]
+COMPOSE_HASH = "c" * 64
+OS_IMAGE_HASH = "d" * 64
+
+
+def expectations_for(**overrides):
+    base = {
+        "qemu": "10.1.0",
+        "os_image_hash": OS_IMAGE_HASH,
+        "compose_hash": COMPOSE_HASH,
+        "gpu_model": "NVIDIA H200",
+        "gpu_count": 2,
+        "agent_port": 8451,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def identity_half(tls_key: bytes = TLS_KEY, uuids: list[str] | None = None) -> bytes:
+    gpu_digest = hashlib.sha256(",".join(sorted(uuids or GPU_UUIDS)).encode()).digest()
+    return hashlib.sha256(tls_key + gpu_digest).digest()
+
+
+def agent_answer(**overrides) -> dict:
+    answer = {
+        "version": "0.1.0",
+        "tls_public_key": TLS_KEY.hex(),
+        "gpu_uuids": list(GPU_UUIDS),
+        "quote": '{"quote": "raw-bytes"}',
+    }
+    answer.update(overrides)
+    return answer
+
+
+def verifier_payload(
+    nonce: AttestationNonce, *, identity: bytes | None = None, **details_overrides
+) -> dict:
+    allowed_tcb = next(iter(settings.get_allowed_tcb_statuses()))
+    details = {
+        "quote_verified": True,
+        "report_data": "0x" + ((identity or identity_half()) + nonce.value_bytes).hex(),
+        "tcb_status": allowed_tcb,
+        "advisory_ids": [],
+        "event_log_verified": True,
+        "os_image_hash_verified": True,
+        "app_info": {"compose_hash": COMPOSE_HASH, "os_image_hash": OS_IMAGE_HASH},
+    }
+    details.update(details_overrides)
+    return {"is_valid": True, "details": details}
+
+
+@pytest.fixture
+def attestation(monkeypatch) -> AttestationService:
+    monkeypatch.setattr(settings, "ENABLE_TDX_ATTESTATION", True, raising=False)
+    monkeypatch.setattr(settings, "TDX_VERIFIER_URL", "http://verifier.test", raising=False)
+    return AttestationService(redis_service=None)
+
+
+async def judge(attestation, answer, payload, *, nonce=None, expectations=None):
+    nonce = nonce or AttestationNonce.issue()
+    if isinstance(payload, Exception):
+        attestation._call_verifier = AsyncMock(side_effect=payload)
+    else:
+        attestation._call_verifier = AsyncMock(return_value=payload)
+    return await attestation.verify_rented_cvm_quote(
+        answer,
+        nonce=nonce,
+        expectations=expectations if expectations is not None else expectations_for(),
+        address="203.0.113.7",
+        port=8443,
+    )
+
+
+class TestTheVerificationMath:
+    @pytest.mark.asyncio
+    async def test_a_bound_fresh_matching_quote_verifies(self, attestation):
+        nonce = AttestationNonce.issue()
+        verdict, reason = await judge(
+            attestation, agent_answer(), verifier_payload(nonce), nonce=nonce
+        )
+        assert verdict == RENTAL_QUOTE_VERIFIED, reason
+
+    @pytest.mark.asyncio
+    async def test_an_identity_that_binds_a_different_key_is_rejected(self, attestation):
+        """The recipe makes the proof and the channel the same thing: a quote relayed from
+        some OTHER genuine CVM carries that CVM's TLS key in its identity half, and the
+        answer's self-stated key cannot repair the mismatch."""
+        nonce = AttestationNonce.issue()
+        other_identity = identity_half(tls_key=bytes.fromhex("bb" * 32))
+        verdict, reason = await judge(
+            attestation,
+            agent_answer(),
+            verifier_payload(nonce, identity=other_identity),
+            nonce=nonce,
+        )
+        assert verdict == RENTAL_QUOTE_REJECTED
+        assert "identity" in reason
+
+    @pytest.mark.asyncio
+    async def test_a_gpu_set_the_hardware_did_not_sign_is_rejected(self, attestation):
+        """An agent stating GPUs it does not hold produces an identity half this validator
+        will not reproduce — FR-G6 held by arithmetic, not by trust."""
+        nonce = AttestationNonce.issue()
+        verdict, reason = await judge(
+            attestation,
+            agent_answer(gpu_uuids=["GPU-claimed-1", "GPU-claimed-2"]),
+            verifier_payload(nonce),  # hardware signed the REAL set
+            nonce=nonce,
+        )
+        assert verdict == RENTAL_QUOTE_REJECTED
+        assert "identity" in reason
+
+    @pytest.mark.asyncio
+    async def test_a_quote_for_someone_elses_nonce_is_rejected(self, attestation):
+        nonce = AttestationNonce.issue()
+        stale = AttestationNonce.issue()
+        verdict, reason = await judge(
+            attestation, agent_answer(), verifier_payload(stale), nonce=nonce
+        )
+        assert verdict == RENTAL_QUOTE_REJECTED
+        assert "nonce" in reason
+
+    @pytest.mark.asyncio
+    async def test_a_quote_the_verifier_refused_is_rejected(self, attestation):
+        nonce = AttestationNonce.issue()
+        payload = verifier_payload(nonce)
+        payload["is_valid"] = False
+        verdict, _ = await judge(attestation, agent_answer(), payload, nonce=nonce)
+        assert verdict == RENTAL_QUOTE_REJECTED
+
+    @pytest.mark.asyncio
+    async def test_an_answer_without_a_quote_is_rejected_not_unavailable(self, attestation):
+        """The agent ANSWERED — with nothing checkable. Treating that as unavailable would
+        hand the fallback path to any guest that strips the quote field."""
+        verdict, _ = await judge(
+            attestation, agent_answer(quote=""), verifier_payload(AttestationNonce.issue())
+        )
+        assert verdict == RENTAL_QUOTE_REJECTED
+
+
+class TestTheOrderChecks:
+    @pytest.mark.asyncio
+    async def test_a_measured_compose_that_disagrees_with_the_order_is_rejected(self, attestation):
+        nonce = AttestationNonce.issue()
+        payload = verifier_payload(
+            nonce, app_info={"compose_hash": "e" * 64, "os_image_hash": OS_IMAGE_HASH}
+        )
+        verdict, reason = await judge(attestation, agent_answer(), payload, nonce=nonce)
+        assert verdict == RENTAL_QUOTE_REJECTED
+        assert "compose_hash" in reason
+
+    @pytest.mark.asyncio
+    async def test_fewer_gpus_than_sold_is_rejected(self, attestation):
+        """One GPU attested, two paid for. The identity half matches the one-GPU set the
+        agent really holds — this is the check that catches a short delivery."""
+        nonce = AttestationNonce.issue()
+        one_gpu = ["GPU-aaa"]
+        verdict, reason = await judge(
+            attestation,
+            agent_answer(gpu_uuids=one_gpu),
+            verifier_payload(nonce, identity=identity_half(uuids=one_gpu)),
+            nonce=nonce,
+        )
+        assert verdict == RENTAL_QUOTE_REJECTED
+        assert "gpu_count" in reason
+
+    @pytest.mark.asyncio
+    async def test_no_expectations_still_verifies_the_binding(self, attestation):
+        """An older backend sends no side-map entry; the hardware checks still apply, only
+        the order comparison has nothing to compare."""
+        nonce = AttestationNonce.issue()
+        verdict, _ = await judge(
+            attestation, agent_answer(), verifier_payload(nonce), nonce=nonce, expectations=0
+        )
+        assert verdict == RENTAL_QUOTE_VERIFIED
+
+
+class TestUnavailability:
+    @pytest.mark.asyncio
+    async def test_attestation_disabled_is_unavailable(self, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_TDX_ATTESTATION", False, raising=False)
+        service = AttestationService(redis_service=None)
+        verdict, _ = await service.verify_rented_cvm_quote(
+            agent_answer(),
+            nonce=AttestationNonce.issue(),
+            expectations=expectations_for(),
+            address="203.0.113.7",
+            port=8443,
+        )
+        assert verdict == RENTAL_QUOTE_UNAVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_a_verifier_that_cannot_be_reached_is_unavailable(self, attestation):
+        verdict, _ = await judge(attestation, agent_answer(), AttestationError("verifier 502"))
+        assert verdict == RENTAL_QUOTE_UNAVAILABLE
+
+
+class TestTheScoringDecision:
+    def renter_running(self):
+        return SwitchAssessment(
+            reachable=True,
+            state="RENTER_RUNNING",
+            cvm={"instance_id": "cvm-1", "supervisor_alive": True, "ports": []},
+            supervisor_alive=True,
+        )
+
+    @pytest.fixture
+    def lifecycle_on(self, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+        monkeypatch.setattr(settings, "ENABLE_CVM_RENTAL_SCORING", False, raising=False)
+
+    @pytest.mark.asyncio
+    async def test_a_verified_quote_scores_with_no_flag(self, lifecycle_on):
+        """The flag stays OFF here. A verified quote is full evidence by itself — this is
+        the sentence in the task that says 'if the quote is passed, we can give it full
+        score; treat it as valid'."""
+        host = cvmd_host("e-rented")
+        service, lifecycle = make_miner_service([host], self.renter_running())
+        lifecycle.request_renter_quote = AsyncMock(return_value=agent_answer())
+        service.attestation_service.verify_rented_cvm_quote = AsyncMock(
+            return_value=(RENTAL_QUOTE_VERIFIED, "bound to this cycle's nonce")
+        )
+
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD, existing=[], rented_data=rented_data_for(expectations=expectations_for())
+        )
+
+        assert len(results) == 1
+        passed = results[0]
+        assert passed.score == 1.0
+        assert passed.spec is None
+        assert passed.is_rented is True
+        assert passed.tdx_attestation_passed is True
+        assert "CVM_RENTAL_QUOTE_VERIFIED" in passed.log_text
+
+    @pytest.mark.asyncio
+    async def test_a_rejected_quote_earns_nothing_even_with_the_fallback_flag_on(self, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+        monkeypatch.setattr(settings, "ENABLE_CVM_RENTAL_SCORING", True, raising=False)
+        host = cvmd_host("e-rented")
+        service, lifecycle = make_miner_service([host], self.renter_running())
+        lifecycle.request_renter_quote = AsyncMock(return_value=agent_answer())
+        service.attestation_service.verify_rented_cvm_quote = AsyncMock(
+            return_value=(RENTAL_QUOTE_REJECTED, "identity mismatch")
+        )
+
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD, existing=[], rented_data=rented_data_for(expectations=expectations_for())
+        )
+
+        assert results == [], "evidence of a false claim outranks the host-side fallback"
+
+    @pytest.mark.asyncio
+    async def test_an_unexaminable_quote_falls_back_to_the_flagged_pass(self, monkeypatch):
+        """request_renter_quote -> None is the make_miner_service default: with the flag on,
+        the node keeps the DAH-2674 host-side pass; what absence MEANS stays with DAH-2676."""
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+        monkeypatch.setattr(settings, "ENABLE_CVM_RENTAL_SCORING", True, raising=False)
+        host = cvmd_host("e-rented")
+        service, _ = make_miner_service([host], self.renter_running())
+
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD, existing=[], rented_data=rented_data_for()
+        )
+
+        assert len(results) == 1
+        assert "CVM_RENTAL_FORCED_PASS" in results[0].log_text
+
+    @pytest.mark.asyncio
+    async def test_the_agent_port_rides_the_backend_expectations(self, lifecycle_on):
+        host = cvmd_host("e-rented")
+        service, lifecycle = make_miner_service([host], self.renter_running())
+        lifecycle.request_renter_quote = AsyncMock(return_value=agent_answer())
+        service.attestation_service.verify_rented_cvm_quote = AsyncMock(
+            return_value=(RENTAL_QUOTE_VERIFIED, "ok")
+        )
+
+        await service._record_and_grace_cvm_hosts(
+            PAYLOAD,
+            existing=[],
+            rented_data=rented_data_for(expectations=expectations_for(agent_port=9451)),
+        )
+
+        assert lifecycle.request_renter_quote.await_args.kwargs["agent_port"] == 9451
+
+
+class TestTheBackendDrivesTheRentedSweep:
+    def renter_running(self):
+        return SwitchAssessment(
+            reachable=True,
+            state="RENTER_RUNNING",
+            cvm={"instance_id": "cvm-1", "supervisor_alive": True, "ports": []},
+            supervisor_alive=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_rental_with_no_registry_entry_is_still_swept(self, monkeypatch):
+        """The stateless claim: the registry answers nothing here — an empty registry plus
+        the backend's response still finds, assesses and scores the rented node."""
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+        monkeypatch.setattr(settings, "ENABLE_CVM_RENTAL_SCORING", False, raising=False)
+        service, lifecycle = make_miner_service([], self.renter_running())
+        lifecycle.request_renter_quote = AsyncMock(return_value=agent_answer())
+        service.attestation_service.verify_rented_cvm_quote = AsyncMock(
+            return_value=(RENTAL_QUOTE_VERIFIED, "ok")
+        )
+
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD,
+            existing=[],
+            rented_data=rented_data_for(expectations=expectations_for(gpu_count=2)),
+        )
+
+        assert len(results) == 1
+        assert results[0].gpu_model == "NVIDIA H200"
+        assert results[0].gpu_count == 2
+        # And the registry was refilled from the backend's facts for the post-rental
+        # launch path — written, never read.
+        lifecycle.record_host.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_backend_gpu_facts_outrank_the_registry_entry(self, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+        monkeypatch.setattr(settings, "ENABLE_CVM_RENTAL_SCORING", False, raising=False)
+        stale_registry_host = cvmd_host("e-rented", gpu_model="NVIDIA H200", gpu_count=8)
+        service, lifecycle = make_miner_service([stale_registry_host], self.renter_running())
+        lifecycle.request_renter_quote = AsyncMock(return_value=agent_answer())
+        service.attestation_service.verify_rented_cvm_quote = AsyncMock(
+            return_value=(RENTAL_QUOTE_VERIFIED, "ok")
+        )
+
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD,
+            existing=[],
+            rented_data=rented_data_for(expectations=expectations_for(gpu_count=4)),
+        )
+
+        assert results[0].gpu_count == 4, "the order the customer paid for is the fact"
+
+    @pytest.mark.asyncio
+    async def test_a_backend_rental_for_another_miner_is_not_synthesized(self, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_CVM_LIFECYCLE", True, raising=False)
+        service, lifecycle = make_miner_service([], self.renter_running())
+
+        results = await service._record_and_grace_cvm_hosts(
+            PAYLOAD,
+            existing=[],
+            rented_data=rented_data_for(
+                miner_hotkey="5SomeoneElse", expectations=expectations_for()
+            ),
+        )
+
+        assert results == []
+        lifecycle.assess.assert_not_awaited()
+
+
+class TestTheTransport:
+    @pytest.mark.asyncio
+    async def test_attest_renter_signs_a_post_to_the_attest_path(self):
+        from bittensor_wallet import Keypair
+
+        relay = MagicMock()
+        relay.forward = AsyncMock(return_value=RelayResult(status=200, body={}))
+        client = CvmdClient(Keypair.create_from_uri("//Alice"), relay=relay)
+
+        nonce_hex = "ab" * 32
+        await client.attest_renter("https://203.0.113.7:8443", nonce_hex=nonce_hex, agent_port=9451)
+
+        sent = relay.forward.await_args.kwargs
+        assert sent["method"] == "POST"
+        assert sent["path"] == ATTEST_PATH
+        assert sent["body"] == f'{{"nonce":"{nonce_hex}","agent_port":9451}}'
+        for header in ("X-Cvmd-Hotkey", "X-Cvmd-Timestamp", "X-Cvmd-Nonce", "X-Cvmd-Signature"):
+            assert sent["headers"][header]
+
+    @pytest.mark.asyncio
+    async def test_request_renter_quote_returns_the_answer_body(self):
+        from bittensor_wallet import Keypair
+
+        service = CvmLifecycleService(MagicMock(), MagicMock(), Keypair.create_from_uri("//Alice"))
+        service.client.attest_renter = AsyncMock(
+            return_value=RelayResult(status=200, body=agent_answer())
+        )
+        answer = await service.request_renter_quote(
+            cvmd_host("e-rented"), nonce_hex="ab" * 32, agent_port=8451
+        )
+        assert answer == agent_answer()
+
+    @pytest.mark.asyncio
+    async def test_no_answer_and_error_answers_are_both_none(self):
+        from bittensor_wallet import Keypair
+
+        service = CvmLifecycleService(MagicMock(), MagicMock(), Keypair.create_from_uri("//Alice"))
+        service.client.attest_renter = AsyncMock(side_effect=CvmdRelayError("down"))
+        assert (
+            await service.request_renter_quote(cvmd_host("e-rented"), nonce_hex="ab" * 32) is None
+        )
+
+        service.client.attest_renter = AsyncMock(
+            return_value=RelayResult(status=502, body={"detail": "agent unreachable"})
+        )
+        assert (
+            await service.request_renter_quote(cvmd_host("e-rented"), nonce_hex="ab" * 32) is None
+        )

--- a/neurons/validators/tests/test_dah2675_quote_verify.py
+++ b/neurons/validators/tests/test_dah2675_quote_verify.py
@@ -3,9 +3,12 @@
 The claims pinned here:
 
   * a quote relayed through cvmd, bound to THIS cycle's fresh nonce and accepted by the
-    verifier against the agent recipe (sha256(TLS key ‖ gpu_uuid_digest) ‖ nonce) AND the
-    order's expectations, scores the node with NO feature flag — a verified quote is full
-    evidence, not a rollout experiment;
+    verifier against the agent recipe (sha256(domain tag ‖ TLS SPKI DER ‖ gpu_uuid_digest)
+    ‖ nonce) AND the order's expectations, scores the node with NO feature flag — a verified
+    quote is full evidence, not a rollout experiment;
+  * which GPUs the CVM holds is decided on the NRAS-verified per-GPU ueids, never on the
+    NVML UUIDs in the quote: those are the guest's own observation, bound so the host cannot
+    rewrite them, and binding is not authentication;
   * a quote the verifier examined and refused — bad identity binding, wrong nonce, or a
     measurement that contradicts what was sold — earns nothing, even with the DAH-2674
     fallback flag on: evidence of a false claim outranks the host-side signals;
@@ -19,7 +22,9 @@ The claims pinned here:
     and the three-way verdict encoding.
 """
 
+import base64
 import hashlib
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -59,8 +64,38 @@ def expectations_for(**overrides):
 
 
 def identity_half(tls_key: bytes = TLS_KEY, uuids: list[str] | None = None) -> bytes:
+    """The renter recipe, spelled out rather than imported from the code under test — the
+    bytes are a wire contract with a package that does not ship with this one."""
     gpu_digest = hashlib.sha256(",".join(sorted(uuids or GPU_UUIDS)).encode()).digest()
-    return hashlib.sha256(tls_key + gpu_digest).digest()
+    return hashlib.sha256(b"LIUM_RENTER_ATTEST_TLS_V1\x00" + tls_key + gpu_digest).digest()
+
+
+def gpu_evidence(nonce: AttestationNonce, count: int = 2) -> dict:
+    """What the agent returns beside the quote: submittable to NRAS as-is."""
+    return {
+        "nonce": nonce.value_hex,
+        "evidence_list": [{"gpu": index} for index in range(count)],
+        "arch": "HOPPER",
+    }
+
+
+def nras_answer(nonce: AttestationNonce, ueids: list[str], *, overall: bool = True) -> list:
+    """An NRAS response in the shape `_check_gpu_claims` reads: the overall verdict as a
+    JWT, then one per-GPU token each carrying its own attested identity."""
+
+    def jwt(claims: dict) -> str:
+        payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+        return f"header.{payload}.signature"
+
+    return [
+        ["JWT", jwt({"x-nvidia-overall-att-result": overall, "eat_nonce": nonce.value_hex})],
+        {
+            f"GPU-{index}": jwt(
+                {"measres": "success", "eat_nonce": nonce.value_hex, "ueid": ueid}
+            )
+            for index, ueid in enumerate(ueids)
+        },
+    ]
 
 
 def agent_answer(**overrides) -> dict:
@@ -98,12 +133,16 @@ def attestation(monkeypatch) -> AttestationService:
     return AttestationService(redis_service=None)
 
 
-async def judge(attestation, answer, payload, *, nonce=None, expectations=None):
+async def judge(attestation, answer, payload, *, nonce=None, expectations=None, nras=None):
     nonce = nonce or AttestationNonce.issue()
     if isinstance(payload, Exception):
         attestation._call_verifier = AsyncMock(side_effect=payload)
     else:
         attestation._call_verifier = AsyncMock(return_value=payload)
+    if isinstance(nras, Exception):
+        attestation._post_nras = AsyncMock(side_effect=nras)
+    elif nras is not None:
+        attestation._post_nras = AsyncMock(return_value=nras)
     return await attestation.verify_rented_cvm_quote(
         answer,
         nonce=nonce,
@@ -153,6 +192,21 @@ class TestTheVerificationMath:
         assert "identity" in reason
 
     @pytest.mark.asyncio
+    async def test_an_untagged_identity_digest_is_rejected(self, attestation):
+        """The domain tag is inside the hashed bytes, so the same key and GPU set hashed
+        without it is a different value. That is what the tag buys: nothing hashed over this
+        TLS key for another purpose, now or later, can be presented here as an identity."""
+        nonce = AttestationNonce.issue()
+        untagged = hashlib.sha256(
+            TLS_KEY + hashlib.sha256(",".join(sorted(GPU_UUIDS)).encode()).digest()
+        ).digest()
+        verdict, reason = await judge(
+            attestation, agent_answer(), verifier_payload(nonce, identity=untagged), nonce=nonce
+        )
+        assert verdict == RENTAL_QUOTE_REJECTED
+        assert "identity" in reason
+
+    @pytest.mark.asyncio
     async def test_a_quote_for_someone_elses_nonce_is_rejected(self, attestation):
         nonce = AttestationNonce.issue()
         stale = AttestationNonce.issue()
@@ -178,6 +232,125 @@ class TestTheVerificationMath:
             attestation, agent_answer(quote=""), verifier_payload(AttestationNonce.issue())
         )
         assert verdict == RENTAL_QUOTE_REJECTED
+
+
+class TestWhatDecidesTheGpuSet:
+    """The UUIDs in the quote and the ueids in the evidence are different kinds of claim.
+
+    An NVML UUID is read by the guest and vouched for by nobody: binding it into report_data
+    stops the host rewriting it in flight, and stops there. A ueid comes out of evidence
+    NVIDIA signed. So existence, authenticity and counting all rest on the ueids, and the
+    UUIDs are held to the one job they can do — contradicting the order.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_attested_ueids_are_what_the_count_is_taken_from(self, attestation):
+        nonce = AttestationNonce.issue()
+        verdict, reason = await judge(
+            attestation,
+            agent_answer(gpu_evidence=gpu_evidence(nonce)),
+            verifier_payload(nonce),
+            nonce=nonce,
+            nras=nras_answer(nonce, ["ueid-a", "ueid-b"]),
+        )
+        assert verdict == RENTAL_QUOTE_VERIFIED, reason
+        assert "2 GPU(s) attested by ueid" in reason
+
+    @pytest.mark.asyncio
+    async def test_a_guest_claiming_more_gpus_than_nvidia_attests_is_rejected(self, attestation):
+        """The quote binds two UUIDs and the hardware signed them — and one of the two is
+        still a device NVIDIA never vouched for. Exactly the gap the UUIDs cannot close."""
+        nonce = AttestationNonce.issue()
+        verdict, reason = await judge(
+            attestation,
+            agent_answer(gpu_evidence=gpu_evidence(nonce)),
+            verifier_payload(nonce),
+            nonce=nonce,
+            nras=nras_answer(nonce, ["ueid-a"]),
+        )
+        assert verdict == RENTAL_QUOTE_REJECTED
+        assert "gpu_set" in reason
+
+    @pytest.mark.asyncio
+    async def test_fewer_attested_gpus_than_sold_is_rejected(self, attestation):
+        nonce = AttestationNonce.issue()
+        one_gpu = ["GPU-aaa"]
+        verdict, reason = await judge(
+            attestation,
+            agent_answer(gpu_uuids=one_gpu, gpu_evidence=gpu_evidence(nonce, count=1)),
+            verifier_payload(nonce, identity=identity_half(uuids=one_gpu)),
+            nonce=nonce,
+            nras=nras_answer(nonce, ["ueid-a"]),
+        )
+        assert verdict == RENTAL_QUOTE_REJECTED
+        assert "gpu_count: sold 2, attested 1" in reason
+
+    @pytest.mark.asyncio
+    async def test_evidence_nvidia_refused_is_rejected(self, attestation):
+        nonce = AttestationNonce.issue()
+        verdict, reason = await judge(
+            attestation,
+            agent_answer(gpu_evidence=gpu_evidence(nonce)),
+            verifier_payload(nonce),
+            nonce=nonce,
+            nras=nras_answer(nonce, ["ueid-a", "ueid-b"], overall=False),
+        )
+        assert verdict == RENTAL_QUOTE_REJECTED
+        assert "NVIDIA refused" in reason
+
+    @pytest.mark.asyncio
+    async def test_evidence_for_another_challenge_is_rejected(self, attestation):
+        """A quote and an evidence set assembled from two moments is a replay, however well
+        each half verifies alone."""
+        nonce = AttestationNonce.issue()
+        verdict, reason = await judge(
+            attestation,
+            agent_answer(gpu_evidence=gpu_evidence(AttestationNonce.issue())),
+            verifier_payload(nonce),
+            nonce=nonce,
+        )
+        assert verdict == RENTAL_QUOTE_REJECTED
+        assert "not bound to the issued nonce" in reason
+
+    @pytest.mark.asyncio
+    async def test_nras_being_down_is_unavailable_not_rejected(self, attestation):
+        """This validator's condition, not the node's — the same class as the TDX verifier
+        being unreachable."""
+        nonce = AttestationNonce.issue()
+        verdict, reason = await judge(
+            attestation,
+            agent_answer(gpu_evidence=gpu_evidence(nonce)),
+            verifier_payload(nonce),
+            nonce=nonce,
+            nras=AttestationError("NRAS unreachable"),
+        )
+        assert verdict == RENTAL_QUOTE_UNAVAILABLE
+        assert "NRAS" in reason
+
+    @pytest.mark.asyncio
+    async def test_an_answer_with_no_evidence_leaves_the_gpu_set_unattested(self, attestation):
+        """Default posture: the quote still verifies, and the reason says plainly that the
+        GPU set is not attested — the count then falls back to contradicting the order."""
+        nonce = AttestationNonce.issue()
+        verdict, reason = await judge(
+            attestation, agent_answer(), verifier_payload(nonce), nonce=nonce
+        )
+        assert verdict == RENTAL_QUOTE_VERIFIED
+        assert "unattested" in reason
+
+    @pytest.mark.asyncio
+    async def test_no_evidence_is_rejected_once_gpu_enforcement_is_on(
+        self, attestation, monkeypatch
+    ):
+        """Same flag, same meaning as the validation path: when the fleet enforces GPU
+        attestation, a CVM that cannot identify its GPUs earns nothing."""
+        monkeypatch.setattr(settings, "ENABLE_GPU_ATTESTATION_ENFORCEMENT", True, raising=False)
+        nonce = AttestationNonce.issue()
+        verdict, reason = await judge(
+            attestation, agent_answer(), verifier_payload(nonce), nonce=nonce
+        )
+        assert verdict == RENTAL_QUOTE_REJECTED
+        assert "no attested GPU identity" in reason
 
 
 class TestTheOrderChecks:


### PR DESCRIPTION
## Describe your changes

The substance of DAH-2675, stacked on PR #1223 (which shipped only the log-only `/health` probe). A rented CVM node's score now rests on a live, hardware-signed TDX quote instead of inherited registry evidence.

**cvmd — `POST /v1/attest`, the authenticated relay.** The in-guest attest-agent's forward is loopback-bound by default, so only the host itself can reach it — and cvmd IS the host. The new route takes a 64-hex nonce (plus an optional `agent_port`), refuses by name when the node holds no renter CVM (409) or carries no forward for the agent's guest port (502), and otherwise dials the agent through the forward and returns its answer verbatim, status and all. Relaying adds no trust: the quote binds the agent's TLS key, the GPU digest and the caller's nonce, so the host can withhold an answer but cannot forge or replay one. TLS verification toward the agent is off deliberately — the certificate is self-signed and the quote binding, not a CA, authenticates the exchange (the same stance the validator's relay takes toward cvmd). A new narrow `attest` scope lets an operator authorize a key for exactly this call with no launch or teardown right; the route itself is open to any authorized key because the call grants nothing.

**Validator — the quote decides the rented score.** The rented branch of the cycle-end sweep now runs one live trust check per cycle: mint a fresh 32-byte nonce, request the quote through cvmd (signed with the validator's own key), verify through the existing TDX verifier, then judge three ways:

- **VERIFIED** — the quote is valid, its identity half equals `sha256(agent TLS key ‖ gpu_uuid_digest)` (the renter recipe from `attest-agent/identity.py`), it echoes this cycle's nonce, the TCB posture passes the fleet's existing policy, and the measured `compose_hash`/`os_image_hash`/GPU count match the order's `cvm_expectations`. The node scores 1.0 **with no feature flag** — a verified quote is full evidence, per the task decision.
- **REJECTED** — the verifier examined the evidence and it failed (invalid quote, wrong identity binding, stale/replayed nonce, or a measurement that contradicts what was sold). The node earns nothing, even with `ENABLE_CVM_RENTAL_SCORING` on: evidence of a false claim outranks the host-side fallback. Loki event: `CVM_RENTAL_QUOTE_REJECTED`.
- **UNAVAILABLE** — nothing could be examined (agent unreachable, cvmd refused, verifier down or not configured). What that MEANS is DAH-2676's question, so the node falls back to the DAH-2674 host-side pass, still behind its default-off flag. Loki event: `CVM_RENTAL_QUOTE_UNAVAILABLE`.

The order checks are enforced unconditionally on this path (unlike the flag-gated `_assert_renter_expectations`): the path only runs for the new scoring decision, so there is no fleet to stage it across.

**Validator — the rented path is now stateless.** Rented CVM nodes are discovered from the backend's rented-executors response (`cvm_expectations` ∩ `executors`, miner-matched), so a rental with no registry entry is still found and scored — the Redis registry is a cache, never a dependency, on this path. The backend's GPU facts outrank the registry's (the order the customer paid for is the fact), and `touch_host` is deleted: the registry entry is re-recorded from backend facts, solely because the DAH-2629 launch path must find the host once the rental ends. The idle-host side of the registry remains the declared follow-up (an idle CVM host never appears in the rented response), as recorded on the task.

**Wire contract.** The validator's `CvmExpectations` gains `agent_port` (None = cvmd's default stays in force), matching the backend PR that stops stripping it. Deploy order does not matter: an older backend leaves the field None; an older cvmd answers 404 to the relay call, which reads as UNAVAILABLE and falls back.

**Timing note.** The quote check runs inline in the sweep, bounded by cvmd's 120 s dial budget under the client's 150 s relay budget, per rented CVM host per cycle. Fine at the current fleet size (single-digit rented CVM nodes); if that grows, the checks should fan out concurrently — noted on the task rather than built speculatively.

**Verification.** CI does not run on PRs into this stack; local suites are the gate:
- cvmd: full suite, **392 passed** (22 new in `test_attest_relay.py`: scope, refusals-by-name, verbatim pass-through, dial rules)
- validators: affected set **97 passed** (18 new in `test_dah2675_quote_verify.py`: verification math, order checks, the three-verdict scoring decision, backend-driven sweep, transport)
- ruff v0.5.1 (repo pin): zero new findings vs the umbrella baseline; the 11 pre-existing `miner_service.py` findings are untouched umbrella debt

## Issue ticket number and link

- [DAH-2675 — live attestation for rented CVMs](https://www.notion.so/3bbb8bfdbde98159ad05c9aa554eaf62) — this PR delivers the quote-verification substance; the au11 hardware verification (pre-deploy steps on the task) remains before deploy
- Backend counterpart (agent_port on the rented-executors response): [lium-io-backend #917](https://github.com/Datura-ai/lium-io-backend/pull/917)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?
