### PR TITLE
DAH-2641, reduce backup transfer concurrency

### DIFF
--- a/neurons/executor/src/storage/models.py
+++ b/neurons/executor/src/storage/models.py
@@ -47,7 +47,6 @@ class RepositorySpec:
     session_token: str | None = field(default=None, repr=False)
     region: str = "us-east-1"
     endpoint: str = "s3.amazonaws.com"
-    s3_connections: int = 64
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, object]) -> RepositorySpec:
@@ -59,13 +58,6 @@ class RepositorySpec:
             session_token=_optional_nullable_string(value, "session_token"),
             region=_optional_string(value, "region", "us-east-1"),
             endpoint=_optional_string(value, "endpoint", "s3.amazonaws.com"),
-            s3_connections=_optional_bounded_integer(
-                value,
-                "s3_connections",
-                default=64,
-                minimum=1,
-                maximum=128,
-            ),
         )
 
     def url_for_pod(self, pod_id: UUID) -> str:
@@ -252,22 +244,6 @@ def _optional_nullable_string(value: Mapping[str, object], key: str) -> str | No
     if not isinstance(item, str) or not item.strip():
         raise OperationSpecError(f"{key} must be a non-empty string when provided")
     return item.strip()
-
-
-def _optional_bounded_integer(
-    value: Mapping[str, object],
-    key: str,
-    *,
-    default: int,
-    minimum: int,
-    maximum: int,
-) -> int:
-    item = value.get(key, default)
-    if not isinstance(item, int) or isinstance(item, bool):
-        raise OperationSpecError(f"{key} must be an integer")
-    if item < minimum or item > maximum:
-        raise OperationSpecError(f"{key} must be between {minimum} and {maximum}")
-    return item
 
 
 def _optional_nullable_nonnegative_integer(value: Mapping[str, object], key: str) -> int | None:

--- a/neurons/executor/src/storage/restic.py
+++ b/neurons/executor/src/storage/restic.py
@@ -30,10 +30,7 @@ RESTORE_CHECKPOINT_PREFIX = "LIUM_RESTORE_CHECKPOINT_"
 TAR_RECORD_SIZE_BYTES = 20 * 512
 TAR_CHECKPOINT_RECORDS = 1024
 MEBIBYTE = 1024 * 1024
-RESTIC_PACK_SIZE_BYTES = 16 * MEBIBYTE
-RESTIC_OPEN_PACKER_COUNT = 4
-RESTIC_TEMP_PACK_HEADROOM = 2
-RESTIC_MINIMUM_TMPFS_BYTES = 256 * MEBIBYTE
+RESTIC_TMPFS_BYTES = 512 * MEBIBYTE
 ENCRYPTED_BACKUP_SCRIPT = 'cd "$1"; shift; exec "$@"'
 ENCRYPTED_BOOTSTRAP_SCRIPT = r"""
 set -eu
@@ -601,12 +598,6 @@ class ResticStorageRunner:
         ]
 
     def _docker_helper_base(self) -> list[str]:
-        tmpfs_size_bytes = max(
-            RESTIC_MINIMUM_TMPFS_BYTES,
-            (self._operation.repository.s3_connections + RESTIC_OPEN_PACKER_COUNT)
-            * RESTIC_PACK_SIZE_BYTES
-            * RESTIC_TEMP_PACK_HEADROOM,
-        )
         return [
             self._docker_binary,
             "run",
@@ -617,7 +608,7 @@ class ResticStorageRunner:
             "none",
             "--read-only",
             "--tmpfs",
-            f"/tmp:rw,nosuid,nodev,size={tmpfs_size_bytes}",
+            f"/tmp:rw,nosuid,nodev,size={RESTIC_TMPFS_BYTES}",
             "-e",
             "AWS_ACCESS_KEY_ID",
             "-e",
@@ -638,16 +629,13 @@ class ResticStorageRunner:
         return f"lium-storage-{str(self._operation.operation_id)[:12]}"
 
     def _restic_command(self, arguments: list[str]) -> list[str]:
+        # Restic's native concurrency avoided the intermittent S3 transfer tails
+        # observed when Lium forced 64 connections.
         return [
             self._restic_binary,
             "--no-cache",
-            "-o",
-            self._s3_connection_option(),
             *arguments,
         ]
-
-    def _s3_connection_option(self) -> str:
-        return f"s3.connections={self._operation.repository.s3_connections}"
 
     def _workspace_path(self) -> str:
         return str(self._workspace.path)

--- a/neurons/executor/tests/test_storage_runner.py
+++ b/neurons/executor/tests/test_storage_runner.py
@@ -59,7 +59,6 @@ def _operation_payload(
             "secret_access_key": "secret-key",
             "session_token": "session-token",
             "password": "repository-password",
-            "s3_connections": 64,
         },
         "workspace": workspace,
     }
@@ -71,6 +70,18 @@ def test_operation_derives_repository_from_pod() -> None:
     assert operation.repository.url_for_pod(operation.pod_id) == (
         f"s3:s3.amazonaws.com/backup-bucket/restic/v1/pods/{POD_ID}"
     )
+
+
+def test_legacy_s3_connection_override_is_ignored() -> None:
+    payload = _operation_payload()
+    repository = payload["repository"]
+    assert isinstance(repository, dict)
+    repository["s3_connections"] = 64
+
+    operation = StorageOperationSpec.from_mapping(payload)
+    runner = ResticStorageRunner(operation, LocalWorkspace(Path("/workspace")))
+
+    assert "s3.connections=64" not in runner._restic_command("snapshots")
 
 
 def test_restore_requires_snapshot_id() -> None:
@@ -100,17 +111,6 @@ def test_restore_missing_repository_never_initializes_it(
     assert raised.value.error_code == "RESTIC_REPOSITORY_MISSING"
     assert commands
     assert all("init" not in command for command in commands)
-
-
-@pytest.mark.parametrize("value", [0, 129, 1.5, True])
-def test_s3_connections_must_be_a_bounded_integer(value: object) -> None:
-    payload = _operation_payload()
-    repository = payload["repository"]
-    assert isinstance(repository, dict)
-    repository["s3_connections"] = value
-
-    with pytest.raises(OperationSpecError, match="s3_connections"):
-        StorageOperationSpec.from_mapping(payload)
 
 
 def test_requested_path_must_stay_inside_volume() -> None:
@@ -151,7 +151,7 @@ def test_plain_backup_uses_read_only_volume_and_keeps_secrets_out_of_arguments()
     assert "customer-volume:/workspace:ro" in command
     assert command[command.index("--workdir") + 1] == "/workspace/checkpoints"
     assert command[command.index("--log-driver") + 1] == "none"
-    assert command[command.index("--tmpfs") + 1] == "/tmp:rw,nosuid,nodev,size=2281701376"
+    assert command[command.index("--tmpfs") + 1] == "/tmp:rw,nosuid,nodev,size=536870912"
     assert "AWS_ACCESS_KEY_ID" in command
     assert "AWS_SESSION_TOKEN" in command
     assert "access-key" not in command
@@ -428,7 +428,7 @@ def test_encrypted_backup_enters_only_the_rental_user_namespace() -> None:
     assert "-U" in command
     assert "-m" not in command
     assert "/proc/4321/root/root/checkpoints" in command
-    assert "s3.connections=64" in command
+    assert not any(argument.startswith("s3.connections=") for argument in command)
 
 
 def test_encrypted_restore_preserves_user_xattrs() -> None:

--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -232,7 +232,6 @@ class BootstrapRestoreSpec(BaseModel):
     legacy_object_size_bytes: int | None = None
     auth_token: str = Field(repr=False)
     restore_path: str
-    s3_connections: int = Field(default=64, ge=1, le=128)
     failure_timeout_seconds: int = Field(default=600, gt=0)
 
 
@@ -437,7 +436,6 @@ class BackupContainerRequest(ContainerBaseRequest):
     backup_engine: str = "tar_aws_cli"
     repository_pod_id: str | None = None
     repository_password: str | None = Field(default=None, repr=False)
-    s3_connections: int = Field(default=64, ge=1, le=128)
     failure_timeout_seconds: int = Field(default=600, gt=0)
 
 
@@ -457,7 +455,6 @@ class RestoreContainerRequest(ContainerBaseRequest):
     repository_password: str | None = Field(default=None, repr=False)
     snapshot_id: str | None = None
     legacy_object_size_bytes: int | None = None
-    s3_connections: int = Field(default=64, ge=1, le=128)
     failure_timeout_seconds: int = Field(default=600, gt=0)
 
 

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -4961,7 +4961,6 @@ class DockerService:
             "secret_access_key": restore.backup_volume_info.iam_user_secret_key,
             "session_token": restore.backup_volume_info.session_token,
             "password": restore.repository_password,
-            "s3_connections": restore.s3_connections,
         }
         spec: dict[str, object] = {
             "operation_id": restore.restore_log_id,

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -93,7 +93,6 @@ def _get_error_details(error: Exception) -> str:
 def _storage_repository_spec(
     volume_info,
     password: str | None,
-    s3_connections: int,
 ) -> dict[str, object]:
     return {
         "bucket": volume_info.name,
@@ -101,7 +100,6 @@ def _storage_repository_spec(
         "secret_access_key": volume_info.iam_user_secret_key,
         "session_token": volume_info.session_token,
         "password": password,
-        "s3_connections": s3_connections,
     }
 
 
@@ -1598,7 +1596,6 @@ class MinerService:
             "repository": _storage_repository_spec(
                 payload.backup_volume_info,
                 payload.repository_password,
-                payload.s3_connections,
             ),
             "workspace": {
                 "mode": "encrypted_running" if payload.volume_encrypted else "plain_volume",
@@ -1627,7 +1624,6 @@ class MinerService:
             "repository": _storage_repository_spec(
                 payload.backup_volume_info,
                 payload.repository_password,
-                payload.s3_connections,
             ),
             "workspace": {
                 "mode": "encrypted_running" if payload.volume_encrypted else "plain_volume",

--- a/neurons/validators/tests/test_encrypted_volume_wire_contract.py
+++ b/neurons/validators/tests/test_encrypted_volume_wire_contract.py
@@ -51,6 +51,7 @@ def test_backend_backup_json_parses_encryption_fields():
         "backup_log_id": "backup-log-id",
         "volume_encrypted": True,
         "container_name": "pod_abc",
+        "s3_connections": 64,
     }
 
     parsed = BaseServerRequest.parse(json.dumps(payload))
@@ -58,6 +59,7 @@ def test_backend_backup_json_parses_encryption_fields():
     assert isinstance(parsed, BackupContainerRequest)
     assert parsed.volume_encrypted is True
     assert parsed.container_name == "pod_abc"
+    assert not hasattr(parsed, "s3_connections")
 
 
 def test_backend_restore_json_parses_encryption_fields():
@@ -72,6 +74,7 @@ def test_backend_restore_json_parses_encryption_fields():
         "restore_path": "/workspace/data",
         "volume_encrypted": True,
         "container_name": "pod_abc",
+        "s3_connections": 64,
     }
 
     parsed = BaseServerRequest.parse(json.dumps(payload))
@@ -79,3 +82,4 @@ def test_backend_restore_json_parses_encryption_fields():
     assert isinstance(parsed, RestoreContainerRequest)
     assert parsed.volume_encrypted is True
     assert parsed.container_name == "pod_abc"
+    assert not hasattr(parsed, "s3_connections")


### PR DESCRIPTION
## Describe your changes

Stop forcing 64 concurrent S3 connections for backup, restore, and repository operations. The validator/executor contract no longer carries that tuning value, and executor commands now use Restic's native connection behavior.

The previous 64-connection setting performed well on the original fast-host benchmark, but final staging smoke tests reproduced intermittent transfer tails across two executors, encrypted and plain volumes, and both upload and restore directions. Controlled retries showed that the native default completed consistently without those tails while retaining acceptable throughput.

This PR:

- removes `s3_connections` from validator payloads and executor repository specs;
- omits `s3.connections` from executor Restic commands;
- retains Restic's built-in five-minute stuck-request retry behavior;
- uses a fixed, non-preallocated 512 MiB helper tmpfs instead of sizing it from the removed 64-connection override;
- safely ignores the former field from older backend/validator payloads during rollout; and
- documents why the native default is intentional at the command construction point.

No backup format, repository layout, encryption flow, database schema, IAM policy, secret, or infrastructure change is included.

## Issue ticket number and link

[DAH-2641 — Complete Backup V2 product, API, clients and operations](https://app.notion.com/p/Complete-Backup-V2-product-API-clients-and-operations-3b8b8bfdbde98149a361cb8244f44359)

## Testing

- Executor storage-runner suite: **26 passed**
- Validator wire-contract and workspace backup/restore suites: **25 passed**
- Compatibility coverage confirms the removed `s3_connections` field is ignored safely during rolling deployment.
- `git diff --check` passed.

## Related PRs

- Backend: https://github.com/Datura-ai/lium-io-backend/pull/908
- CLI/SDK: https://github.com/Datura-ai/lium/pull/108

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [x] Need to take care of performance?
