### PR TITLE
DAH-2684 - Give the renter SSH into the CVM itself: the guest-SSH service

### DIFF
--- a/.github/workflows/cvm-ssh-publish.yml
+++ b/.github/workflows/cvm-ssh-publish.yml
@@ -1,0 +1,83 @@
+# DAH-2684 — build and publish the renter CVM's guest-SSH image, pinned by digest.
+#
+# The digest this job prints is THE deployment artifact: CVM_SSH_IMAGE must name
+# the image by digest, never by tag, because the injected compose is measured — a mutable
+# tag would mean the approved bytes stay approved while the image behind them changes.
+#
+# Re-publishing is a CATALOG event, not a swap: a new digest changes every derived renter
+# compose hash, so it rolls out through new catalog rows (with grace for in-flight
+# rentals) and the old digest stays valid until its rows are deprecated. See
+# neurons/executor/cvm-ssh/PUBLISHING.md.
+
+name: "Publish: cvm-ssh image"
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "cvm-ssh-v*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: datura-ai/lium-cvm-ssh
+
+concurrency:
+  group: cvm-ssh-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./neurons/executor/cvm-ssh
+          push: true
+          # Provenance attestations wrap the image in an OCI index whose digest differs
+          # from the plain manifest's; disabled so the digest below is the one a docker
+          # pull resolves.
+          provenance: false
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          cache-from: type=gha,scope=cvm-ssh
+          cache-to: type=gha,mode=max,scope=cvm-ssh
+
+      - name: Summary — the digest to pin
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          COMMIT: ${{ github.sha }}
+        run: |
+          echo "### cvm-ssh (guest-SSH) published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Pin this, by digest (DAH-2684):**" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "CVM_SSH_IMAGE=$IMAGE@$DIGEST" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** \`$COMMIT\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "A new digest changes every derived renter compose hash — roll it through" >> $GITHUB_STEP_SUMMARY
+          echo "the catalog (new rows, grace for in-flight rentals); never swap in place." >> $GITHUB_STEP_SUMMARY

--- a/neurons/executor/cvm-ssh/Dockerfile
+++ b/neurons/executor/cvm-ssh/Dockerfile
@@ -1,0 +1,35 @@
+# The renter CVM's guest-SSH service (DAH-2684).
+#
+# A renter's SSH session lands IN THE CVM ITSELF — the guest OS: its processes, its network,
+# its filesystem, its docker daemon and its GPUs — not inside a container the renter has to
+# describe. The dstack production image (dstack-nvidia-0.5.11) ships no sshd, no login and a
+# read-only dm-verity rootfs, so "SSH into the guest" cannot be a guest service. It is this
+# container instead: sshd runs here, and every session it opens is moved into PID 1's
+# namespaces (mount, uts, ipc, net, pid) before the renter's shell starts. See entrypoint.sh
+# for exactly how, and README.md for what the renter can and cannot do from there.
+#
+# Shipped THROUGH the measured customer compose, like the attest-agent: the backend injects
+# it (services/cvm_compose.py) pinned by digest, with the renter's authorized keys in the
+# same service block. So the compose hash the hardware measures covers WHICH sshd runs and
+# WHOSE keys it accepts, and the renter can check both against the quote.
+#
+# Everything this image contains is needed to open a session into the guest and nothing
+# else. It is not the renter's toolbox — the guest is.
+
+FROM alpine:3.20
+
+# openssh-server: the daemon. busybox-static: a nsenter that runs from inside the guest's
+# own root filesystem (see entrypoint.sh — the login shell is chrooted into the guest, where
+# no nsenter exists, so one that needs no shared libraries is copied in).
+RUN apk add --no-cache openssh-server busybox-static \
+    && rm -f /etc/ssh/ssh_host_*_key* \
+    && mkdir -p /etc/ssh/hostkeys /etc/ssh/authorized
+
+COPY entrypoint.sh /usr/local/bin/lium-cvm-ssh
+RUN chmod 0755 /usr/local/bin/lium-cvm-ssh
+
+# The port is fleet convention (cvmd's cvm_ssh_guest_port, forwarded by cvm_ports); the
+# entrypoint reads LIUM_SSH_PORT and this is documentation of the default only.
+EXPOSE 2200
+
+ENTRYPOINT ["/usr/local/bin/lium-cvm-ssh"]

--- a/neurons/executor/cvm-ssh/PUBLISHING.md
+++ b/neurons/executor/cvm-ssh/PUBLISHING.md
@@ -1,0 +1,39 @@
+# Publishing the guest-SSH image (DAH-2684)
+
+The guest-SSH service ships the same way the attest-agent does — **through the measured
+customer compose**, injected by the backend (`services/cvm_compose.py`) as an image
+reference pinned **by digest**. That digest is folded into every derived renter
+`compose_hash`, which the host measures and the validator verifies. The rules are the
+attest-agent's rules (`../attest-agent/PUBLISHING.md`); restated here so nobody has to
+guess whether they apply:
+
+1. **Only a digest may be deployed.** `CVM_SSH_IMAGE` must be of the form
+   `ghcr.io/datura-ai/lium-cvm-ssh@sha256:<64 hex>`. A tag would let the sshd that
+   authenticates renters change underneath an approved measurement.
+
+2. **A new digest is a catalog rollout, never a swap.** Rentals derived before the change
+   keep measuring as their old hash and stay valid until they end (`pod.cvm_info.expectations`
+   is per order). To re-publish:
+
+   1. Run the `Publish: cvm-ssh image` workflow (or push a `cvm-ssh-v*` tag). The job
+      summary prints the exact `CVM_SSH_IMAGE` line to deploy.
+   2. Set it in the target environment's config and restart the backend. New orders derive
+      with the new digest from that moment.
+   3. Leave existing rentals alone; there is nothing to migrate.
+
+3. **Never a personal namespace in staging or production config.** The org image is
+   `ghcr.io/datura-ai/lium-cvm-ssh`, built by CI from this directory with `GITHUB_TOKEN`
+   and reproducible from the commit in the job summary.
+
+## Before pinning a build
+
+`bash tests/test_guest_ssh.sh` against the built image is the mechanism check (see
+README). The golden loop — the backend's derive with the pinned digest producing a compose
+whose hash the host measures identically — is pinned by the same tests as the agent's
+(`lium-io-backend: test_dah2580_renter_provisioning.py`, `cvmd: tests/test_renter_launch.py`).
+
+To see what a digest resolves to:
+
+```bash
+docker buildx imagetools inspect ghcr.io/datura-ai/lium-cvm-ssh@sha256:<digest>
+```

--- a/neurons/executor/cvm-ssh/README.md
+++ b/neurons/executor/cvm-ssh/README.md
@@ -1,0 +1,97 @@
+# lium-cvm-ssh — SSH into the renter CVM itself (DAH-2684)
+
+A renter of a Lium CVM logs in **to the CVM**: root on the guest OS, with the guest's
+processes, network, filesystem, docker daemon and GPUs. Not into a container they had to
+describe first.
+
+The dstack production image (`dstack-nvidia-0.5.11`) makes that non-trivial: it ships no
+sshd, removes every login path (`nologin`), and its rootfs is a read-only, dm-verity-checked
+squashfs. So the SSH daemon lives in this container, and every session it opens is moved
+into the guest before the renter's shell starts:
+
+```
+renter ── ssh -p <host port> root@<node ip> ──▶ host forward ──▶ guest :2200
+                                                                    │
+                                          this container: sshd authenticates the key
+                                                                    │
+                                          ChrootDirectory /host  (the guest's own root fs)
+                                                                    │
+                                          /run/lium-ssh/shell: nsenter -t 1 -m -u -i -n -p
+                                                                    │
+                                                            the guest's /bin/sh, as root
+```
+
+The backend injects this service into every renter compose (`services/cvm_compose.py`),
+pinned by digest, with the renter's authorized keys in the same service block. The compose
+is measured (`compose_hash` → RTMR3), so the quote covers **which sshd runs and whose keys
+it accepts**, and the renter can check both against what they ordered.
+
+## The service block the backend writes
+
+```yaml
+services:
+  lium-ssh:
+    image: ghcr.io/datura-ai/lium-cvm-ssh@sha256:…
+    restart: always
+    network_mode: host      # sshd binds guest :2200 — the port cvmd forwards and waits on
+    pid: host               # PID 1 is the guest's init, the target of nsenter
+    privileged: true        # setns into another process's namespaces
+    environment:
+      - LIUM_SSH_PORT=2200
+      - "LIUM_SSH_AUTHORIZED_KEYS=ssh-ed25519 AAAA… renter@laptop\nssh-ed25519 AAAA… ci"
+    volumes:
+      - /:/host                        # the guest root: the chroot the session lives in
+      - /dev/pts:/dev/pts              # the guest's terminals, so a login has a working tty
+      - lium-cvm-ssh-hostkeys:/etc/ssh/hostkeys   # host keys survive restarts (fingerprint stays)
+volumes:
+  lium-cvm-ssh-hostkeys:
+```
+
+The entrypoint **refuses to start** — with the missing line named — if any of those is
+absent. Each one is load-bearing, and an sshd missing one would still start and quietly
+land sessions in the container instead of the guest, which is precisely the thing a
+renter must never be handed under the name "your CVM".
+
+| Env | Meaning |
+|---|---|
+| `LIUM_SSH_AUTHORIZED_KEYS` | One OpenSSH public key per line. Required; nothing else authorizes a login. |
+| `LIUM_SSH_PORT` | Guest port to bind (default `2200`, cvmd's `cvm_ssh_guest_port`). |
+
+Keys only: `PermitRootLogin prohibit-password`, `PasswordAuthentication no`, root has no
+password, no other account exists. Port forwarding (`-L`/`-R`/`-D`) is on and terminates in
+the guest's network namespace. X11 and layer-3 tunnels are off.
+
+## What the renter gets, and what they do not
+
+**On the guest:** root; `docker` (the guest's daemon, GPU-capable through the NVIDIA
+container toolkit baked into the image), `nvidia-smi`, `systemctl`, `ip`, `curl`, `jq`,
+busybox. Persistent storage is the encrypted data disk: `/dstack/persistent`, and docker
+volumes/images under `/var/lib/docker`. `/etc`, `/usr`, `/bin` and `/home` are volatile
+overlays — writable, reset on reboot.
+
+**Not on the guest, by construction of the dstack image:** `bash`, `apt`, `rsync`, `scp`
+(the server side). `sftp` and modern `scp` (which speaks SFTP) work — the session is
+chrooted into the guest root, so they read and write the guest. Legacy `scp -O` and `rsync`
+need a binary the guest does not have; the practical answer is `docker run` for tooling, or
+`tar | ssh`.
+
+The shell is the guest's busybox `ash`. That is a fact about the image the platform
+attests, not a limitation of this service.
+
+## Verifying it locally
+
+```bash
+bash tests/test_guest_ssh.sh
+```
+
+Runs the built image against *this* machine as the guest — the same compose shape — and
+checks: each missing precondition is refused with its reason; a session's hostname, mount
+namespace, uid and root are the host's; an interactive login gets a real tty; a quoted
+remote command runs; a second listed key logs in; an unlisted key and password auth are
+refused; scp writes the host filesystem; the host-key fingerprint survives a container
+restart. No CVM needed: chroot + nsenter behave the same on any Linux host.
+
+## Publishing
+
+See `PUBLISHING.md`. Digest only, and a new digest is a catalog event — it changes the
+compose hash of every rental derived after it.

--- a/neurons/executor/cvm-ssh/entrypoint.sh
+++ b/neurons/executor/cvm-ssh/entrypoint.sh
@@ -1,0 +1,202 @@
+#!/bin/sh
+# The renter CVM's guest-SSH service (DAH-2684): an sshd whose every session is opened
+# inside the guest OS, not inside this container.
+#
+# How a session reaches the guest, in the order it happens:
+#
+#   1. sshd authenticates the renter here, in this container, against the keys the
+#      backend put in this service's environment (LIUM_SSH_AUTHORIZED_KEYS). Those keys are
+#      part of the measured compose, so the quote covers who may log in.
+#   2. sshd chroots the session into /host — the guest's own root filesystem, bind-mounted
+#      in by the compose (`/:/host`). From this point the session sees the guest's files
+#      and nothing of this image; sftp and scp therefore read and write the guest.
+#   3. The renter's login shell is /run/lium-ssh/shell INSIDE that chroot — a script this
+#      entrypoint stages into the guest's /run — which moves the process into PID 1's
+#      remaining namespaces (mount, uts, ipc, net, pid) with a statically linked busybox
+#      nsenter staged beside it, then execs the guest's own /bin/sh. The guest ships no
+#      nsenter and no bash: the shell is the guest's busybox ash, and that is the point —
+#      the renter is on the guest, with what the guest has.
+#
+# What this needs from the compose, and refuses to start without: `pid: host` (so PID 1 is
+# the guest's init), `privileged: true` (setns into another process's namespaces), the
+# guest root at /host, and `network_mode: host` (so the port sshd binds is the guest port
+# the host forwards). A container missing any of these could still start an sshd — one
+# whose sessions land in this container — and that is exactly the wrong thing to hand a
+# renter who was told they are logging into their CVM, so it is refused with the reason.
+#
+# Never a password path. Root here has no password, PasswordAuthentication is off, and the
+# only identities accepted are the ones the compose named.
+
+set -eu
+
+log() { printf 'lium-cvm-ssh: %s\n' "$*" >&2; }
+die() { log "refusing to start: $*"; exit 64; }
+
+PORT="${LIUM_SSH_PORT:-2200}"
+GUEST_ROOT="${LIUM_SSH_GUEST_ROOT:-/host}"
+HOSTKEY_DIR="${LIUM_SSH_HOSTKEY_DIR:-/etc/ssh/hostkeys}"
+AUTHORIZED_DIR=/etc/ssh/authorized
+# Inside the guest's /run — a tmpfs, so it is writable on a read-only rootfs and gone on
+# reboot, which is right: it is re-staged every time this container starts.
+STAGE_REL=/run/lium-ssh
+STAGE="$GUEST_ROOT$STAGE_REL"
+
+# ---------------------------------------------------------------- preconditions
+
+case "$PORT" in
+    ''|*[!0-9]*) die "LIUM_SSH_PORT must be a port number, got '$PORT'" ;;
+esac
+[ "$PORT" -ge 1 ] && [ "$PORT" -le 65535 ] || die "LIUM_SSH_PORT out of range: $PORT"
+
+[ "$(id -u)" = "0" ] || die "must run as root to enter the guest's namespaces"
+
+# The guest root must be mounted, and it must be a DIFFERENT filesystem from ours: a compose
+# that forgot the bind would leave /host an empty directory, and a session chrooted into an
+# empty directory has no shell to run.
+[ -d "$GUEST_ROOT/proc" ] && [ -x "$GUEST_ROOT/bin/sh" ] \
+    || die "the guest root is not mounted at $GUEST_ROOT (the compose must bind '/:$GUEST_ROOT')"
+
+# `pid: host` — PID 1 in our view must be the guest's init. Under a private pid namespace
+# this very shell is PID 1, and nsenter would "enter" our own namespaces.
+[ "$$" != "1" ] || die "this container has its own pid namespace (the compose must set 'pid: host')"
+
+# `privileged: true` — reading another process's namespace links and setns into them need
+# CAP_SYS_PTRACE and CAP_SYS_ADMIN. Probed with the same static nsenter the sessions use.
+if [ -z "$(readlink /proc/1/ns/mnt 2>/dev/null)" ]; then
+    die "cannot read PID 1's namespaces (the compose must set 'privileged: true')"
+fi
+/bin/busybox.static nsenter --target 1 --mount -- /bin/true 2>/dev/null \
+    || die "cannot enter PID 1's namespaces (the compose must set 'privileged: true')"
+
+# `network_mode: host` — sshd binds $PORT in whatever network namespace this container has.
+# If that is a private one, the guest port cvmd forwards has no listener and the CVM is
+# never declared ready. PID 1's net namespace must be ours.
+[ "$(readlink /proc/self/ns/net)" = "$(readlink /proc/1/ns/net)" ] \
+    || die "this container is not in the guest's network namespace (the compose must set 'network_mode: host')"
+
+# `/dev/pts:/dev/pts` — sshd allocates a session's terminal from OUR /dev/pts, and the
+# session then runs in the guest's mount namespace, where the terminal must exist under the
+# same name. Docker gives a container a private devpts instance by default; a pty from that
+# instance is invisible on the guest and every interactive login reads as "not a tty". So
+# the compose binds the guest's instance over ours, and this checks they are one and the
+# same device.
+[ "$(stat -c %d /dev/pts 2>/dev/null)" = "$(stat -c %d "$GUEST_ROOT/dev/pts" 2>/dev/null)" ] \
+    || die "/dev/pts is not the guest's (the compose must bind '/dev/pts:/dev/pts'); sessions would have no terminal"
+
+[ -n "${LIUM_SSH_AUTHORIZED_KEYS:-}" ] \
+    || die "LIUM_SSH_AUTHORIZED_KEYS is empty; an sshd nobody can log into is not a service"
+
+# --------------------------------------------------------------- authorized keys
+
+# One key per line, exactly as the backend wrote them into the compose. CRs stripped so a
+# key pasted from a Windows client is not silently ignored by sshd. Written to a root-owned
+# path outside any home directory: sshd reads it BEFORE the chroot, so it lives in this
+# image, and StrictModes wants it and its directory root-owned and not group/world-writable.
+mkdir -p "$AUTHORIZED_DIR"
+chmod 0755 "$AUTHORIZED_DIR"
+printf '%s\n' "$LIUM_SSH_AUTHORIZED_KEYS" | tr -d '\r' | grep -v '^[[:space:]]*$' > "$AUTHORIZED_DIR/root"
+chmod 0644 "$AUTHORIZED_DIR/root"
+KEY_COUNT="$(wc -l < "$AUTHORIZED_DIR/root" | tr -d ' ')"
+[ "$KEY_COUNT" -gt 0 ] || die "LIUM_SSH_AUTHORIZED_KEYS holds no key lines"
+
+# ---------------------------------------------------------------- host keys
+
+# Persisted in a named volume by the compose. The launch report carries this fingerprint
+# and the renter pins it; a restart of this container must not change it.
+mkdir -p "$HOSTKEY_DIR"
+chmod 0700 "$HOSTKEY_DIR"
+for type in ed25519 rsa ecdsa; do
+    key="$HOSTKEY_DIR/ssh_host_${type}_key"
+    if [ ! -f "$key" ]; then
+        ssh-keygen -q -N '' -t "$type" -f "$key"
+        log "generated a new $type host key"
+    fi
+done
+
+# ---------------------------------------------------------------- the guest-side stage
+
+# The chrooted session can only run what exists under the guest root, so the two things it
+# needs are copied there: a static busybox (for nsenter — the guest's own busybox is built
+# without that applet) and the login shell that uses it.
+mkdir -p "$STAGE" || die "cannot write $STAGE_REL under the guest root; is the guest's /run writable?"
+cp /bin/busybox.static "$STAGE/busybox"
+chmod 0755 "$STAGE/busybox"
+
+# The login shell, as sshd runs it after the chroot: with no arguments for an interactive
+# session, or `-c <command>` for `ssh host <command>`. Both end in the guest's /bin/sh with
+# the process fully inside PID 1's namespaces. Its shebang is the GUEST's /bin/sh — this
+# script executes inside the chroot, so `/bin/sh` here is the guest's busybox ash.
+cat > "$STAGE/shell" <<'EOF'
+#!/bin/sh
+# lium-cvm-ssh login shell: staged by the guest-SSH container, runs chrooted in the guest.
+NSENTER="/run/lium-ssh/busybox nsenter --target 1 --mount --uts --ipc --net --pid"
+# root's home as the GUEST names it, not as this container's passwd does.
+GUEST_HOME="$(awk -F: '$1=="root"{print $6}' /etc/passwd 2>/dev/null)"
+[ -n "$GUEST_HOME" ] && [ -d "$GUEST_HOME" ] || GUEST_HOME=/
+export HOME="$GUEST_HOME"
+if [ "${1:-}" = "-c" ]; then
+    # sshd hands `ssh host <command>` over as exactly one argument after -c.
+    exec $NSENTER --wd="$HOME" -- /bin/sh -c "$2"
+fi
+exec $NSENTER --wd="$HOME" -- /bin/sh -l
+EOF
+chmod 0755 "$STAGE/shell"
+
+# Root's shell in THIS container's passwd is the staged script, by its path inside the
+# chroot. sshd resolves the shell after chrooting, so the path must be the guest-side one.
+sed -i "s#^root:\([^:]*\):0:0:\([^:]*\):\([^:]*\):.*#root:\1:0:0:\2:\3:$STAGE_REL/shell#" /etc/passwd
+grep -q "^root:.*:$STAGE_REL/shell\$" /etc/passwd || die "could not set root's login shell"
+
+# ---------------------------------------------------------------- sshd
+
+cat > /etc/ssh/sshd_config <<EOF
+# Written by lium-cvm-ssh at start; not user-editable. See entrypoint.sh.
+Port $PORT
+AddressFamily inet
+ListenAddress 0.0.0.0
+HostKey $HOSTKEY_DIR/ssh_host_ed25519_key
+HostKey $HOSTKEY_DIR/ssh_host_rsa_key
+HostKey $HOSTKEY_DIR/ssh_host_ecdsa_key
+
+# Keys only. Root has no password and there is no other account.
+PermitRootLogin prohibit-password
+PubkeyAuthentication yes
+AuthorizedKeysFile $AUTHORIZED_DIR/%u
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PermitEmptyPasswords no
+AllowUsers root
+MaxAuthTries 6
+LoginGraceTime 30
+StrictModes yes
+
+# Every session lives in the guest: chrooted into its root, then moved into PID 1's
+# namespaces by the login shell staged at $STAGE_REL/shell.
+ChrootDirectory $GUEST_ROOT
+Subsystem sftp internal-sftp
+PermitTTY yes
+
+# Tunnels are the renter's, and they terminate in the guest's network namespace because this
+# container shares it. No X11, no layer-3 tunnels.
+AllowTcpForwarding yes
+AllowAgentForwarding yes
+AllowStreamLocalForwarding yes
+GatewayPorts no
+X11Forwarding no
+PermitTunnel no
+PermitUserEnvironment no
+
+UseDNS no
+PrintMotd no
+ClientAliveInterval 60
+ClientAliveCountMax 5
+LogLevel INFO
+PidFile /run/lium-cvm-sshd.pid
+EOF
+
+/usr/sbin/sshd -t -f /etc/ssh/sshd_config || die "the generated sshd_config does not pass sshd -t"
+
+log "guest SSH on port $PORT; $KEY_COUNT authorized key(s); sessions land in the guest via $STAGE_REL/shell"
+log "host key fingerprint: $(ssh-keygen -lf "$HOSTKEY_DIR/ssh_host_ed25519_key.pub" | awk '{print $2}')"
+
+exec /usr/sbin/sshd -D -e -f /etc/ssh/sshd_config

--- a/neurons/executor/cvm-ssh/tests/test_guest_ssh.sh
+++ b/neurons/executor/cvm-ssh/tests/test_guest_ssh.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Local proof of the guest-SSH image (DAH-2684). Runs the container against THIS machine as
+# if it were the guest — the same `pid: host` / `network_mode: host` / `privileged` /
+# `/:/host` / `/dev/pts:/dev/pts` shape the backend writes into every renter compose — and
+# checks that an SSH session lands on the host, not in the container.
+#
+# Needs docker and a free TCP port (default 2200; override with LIUM_SSH_TEST_PORT). It
+# does not touch a CVM: the mechanism (chroot into the guest root, nsenter into PID 1's
+# namespaces) is identical on any Linux host, which is what makes this runnable anywhere.
+#
+# Usage:  bash tests/test_guest_ssh.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PORT="${LIUM_SSH_TEST_PORT:-2200}"
+IMAGE="lium-cvm-ssh:test-$$"
+NAME="lium-cvm-ssh-test-$$"
+VOLUME="lium-cvm-ssh-test-hostkeys-$$"
+WORK="$(mktemp -d)"
+PASS=0
+FAIL=0
+
+cleanup() {
+    docker rm -f "$NAME" >/dev/null 2>&1
+    docker volume rm "$VOLUME" >/dev/null 2>&1
+    docker rmi "$IMAGE" >/dev/null 2>&1
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+ok()   { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad()  { FAIL=$((FAIL + 1)); printf '  FAIL  %s%s\n' "$1" "${2:+ — $2}"; }
+check() { if [ "$1" = "true" ]; then ok "$2"; else bad "$2" "${3:-}"; fi; }
+
+ssh-keygen -q -t ed25519 -N '' -f "$WORK/renter" -C renter@test
+ssh-keygen -q -t ed25519 -N '' -f "$WORK/second" -C second@test
+ssh-keygen -q -t ed25519 -N '' -f "$WORK/stranger" -C stranger@test
+KEYS="$(cat "$WORK/renter.pub")
+$(cat "$WORK/second.pub")"
+
+SSH_OPTS=(-o StrictHostKeyChecking=no -o "UserKnownHostsFile=$WORK/known" -o BatchMode=yes -o ConnectTimeout=5)
+as_renter() { ssh -i "$WORK/renter" "${SSH_OPTS[@]}" -p "$PORT" root@127.0.0.1 "$@"; }
+
+run_container() {
+    docker rm -f "$NAME" >/dev/null 2>&1
+    docker run -d --name "$NAME" "$@" \
+        -e "LIUM_SSH_PORT=$PORT" -e "LIUM_SSH_AUTHORIZED_KEYS=$KEYS" "$IMAGE" >/dev/null
+    sleep 2
+}
+last_log_line() { docker logs "$NAME" 2>&1 | tail -1; }
+
+echo "== build"
+docker build -q -t "$IMAGE" "$HERE" >/dev/null
+ok "image builds"
+
+echo "== every missing precondition is refused with its reason"
+run_container --network=host --privileged -v /:/host -v /dev/pts:/dev/pts
+case "$(last_log_line)" in *"pid: host"*) ok "no pid host -> refused" ;; *) bad "no pid host -> refused" "$(last_log_line)" ;; esac
+run_container --pid=host --network=host -v /:/host -v /dev/pts:/dev/pts
+case "$(last_log_line)" in *"privileged: true"*) ok "not privileged -> refused" ;; *) bad "not privileged -> refused" "$(last_log_line)" ;; esac
+run_container --pid=host --privileged -v /:/host -v /dev/pts:/dev/pts
+case "$(last_log_line)" in *"network_mode: host"*) ok "private network -> refused" ;; *) bad "private network -> refused" "$(last_log_line)" ;; esac
+run_container --pid=host --network=host --privileged -v /dev/pts:/dev/pts
+case "$(last_log_line)" in *"/:/host"*) ok "no guest root -> refused" ;; *) bad "no guest root -> refused" "$(last_log_line)" ;; esac
+run_container --pid=host --network=host --privileged -v /:/host
+case "$(last_log_line)" in *"/dev/pts:/dev/pts"*) ok "private devpts -> refused" ;; *) bad "private devpts -> refused" "$(last_log_line)" ;; esac
+docker rm -f "$NAME" >/dev/null 2>&1
+docker run -d --name "$NAME" --pid=host --network=host --privileged -v /:/host -v /dev/pts:/dev/pts \
+    -e "LIUM_SSH_PORT=$PORT" -e "LIUM_SSH_AUTHORIZED_KEYS=" "$IMAGE" >/dev/null
+sleep 1
+case "$(last_log_line)" in *"LIUM_SSH_AUTHORIZED_KEYS is empty"*) ok "no keys -> refused" ;; *) bad "no keys -> refused" "$(last_log_line)" ;; esac
+
+echo "== the real shape"
+run_container --pid=host --network=host --privileged -v /:/host -v /dev/pts:/dev/pts -v "$VOLUME:/etc/ssh/hostkeys"
+FP1="$(docker logs "$NAME" 2>&1 | sed -n 's/.*host key fingerprint: //p' | head -1)"
+check "$([ -n "$FP1" ] && echo true || echo false)" "sshd started and printed a host-key fingerprint" "$(last_log_line)"
+
+HOST_MNT="$(readlink /proc/1/ns/mnt 2>/dev/null || sudo -n readlink /proc/1/ns/mnt 2>/dev/null || true)"
+# shellcheck disable=SC2016  # expanded on the guest, not here
+SESSION="$(as_renter 'echo "$(hostname)|$(readlink /proc/self/ns/mnt)|$(id -u)|$([ -d /host ] && echo container || echo guest)"' 2>/dev/null || true)"
+check "$([ "${SESSION%%|*}" = "$(hostname)" ] && echo true || echo false)" "session hostname is the guest's" "$SESSION"
+if [ -n "$HOST_MNT" ]; then
+    check "$([ "$(echo "$SESSION" | cut -d'|' -f2)" = "$HOST_MNT" ] && echo true || echo false)" "session is in PID 1's mount namespace" "$SESSION"
+fi
+check "$([ "$(echo "$SESSION" | cut -d'|' -f3)" = "0" ] && echo true || echo false)" "session is root" "$SESSION"
+check "$([ "$(echo "$SESSION" | cut -d'|' -f4)" = "guest" ] && echo true || echo false)" "session sees the guest root, not the container" "$SESSION"
+
+TTY="$(ssh -i "$WORK/renter" "${SSH_OPTS[@]}" -tt -p "$PORT" root@127.0.0.1 'tty' 2>/dev/null | tr -d '\r' | head -1 || true)"
+case "$TTY" in /dev/pts/*) ok "an interactive session gets a working terminal ($TTY)" ;; *) bad "an interactive session gets a working terminal" "$TTY" ;; esac
+
+WORDS="$(as_renter 'echo "a b c" | wc -w' 2>/dev/null | tr -d ' ' || true)"
+check "$([ "$WORDS" = "3" ] && echo true || echo false)" "a quoted remote command runs in the guest" "$WORDS"
+
+SECOND="$(ssh -i "$WORK/second" "${SSH_OPTS[@]}" -p "$PORT" root@127.0.0.1 'echo second-ok' 2>/dev/null || true)"
+check "$([ "$SECOND" = "second-ok" ] && echo true || echo false)" "the second authorized key logs in too" "$SECOND"
+
+STRANGER_RC=0
+ssh -i "$WORK/stranger" "${SSH_OPTS[@]}" -p "$PORT" root@127.0.0.1 true 2>/dev/null || STRANGER_RC=$?
+check "$([ "$STRANGER_RC" -ne 0 ] && echo true || echo false)" "an unlisted key is refused" "rc=$STRANGER_RC"
+
+PW_RC=0
+ssh -o PreferredAuthentications=password -o PubkeyAuthentication=no "${SSH_OPTS[@]}" -p "$PORT" root@127.0.0.1 true 2>/dev/null || PW_RC=$?
+check "$([ "$PW_RC" -ne 0 ] && echo true || echo false)" "password authentication is refused" "rc=$PW_RC"
+
+PROBE="/tmp/lium-cvm-ssh-probe-$$"
+echo "hello-from-renter" > "$WORK/probe.txt"
+scp -q -i "$WORK/renter" "${SSH_OPTS[@]}" -P "$PORT" "$WORK/probe.txt" "root@127.0.0.1:$PROBE" 2>/dev/null || true
+UPLOADED="$(as_renter "cat $PROBE && rm -f $PROBE" 2>/dev/null || true)"
+check "$([ "$UPLOADED" = "hello-from-renter" ] && echo true || echo false)" "scp/sftp writes the guest filesystem" "$UPLOADED"
+
+echo "== the host key survives a container restart"
+run_container --pid=host --network=host --privileged -v /:/host -v /dev/pts:/dev/pts -v "$VOLUME:/etc/ssh/hostkeys"
+FP2="$(docker logs "$NAME" 2>&1 | sed -n 's/.*host key fingerprint: //p' | head -1)"
+check "$([ -n "$FP1" ] && [ "$FP1" = "$FP2" ] && echo true || echo false)" "same fingerprint after restart" "$FP1 vs $FP2"
+
+echo
+echo "passed: $PASS  failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/neurons/executor/cvmd/README.md
+++ b/neurons/executor/cvmd/README.md
@@ -51,6 +51,12 @@ nothing forwards is refused up front, because it would leave the launch with no 
 at all. On a host with no `ssh-keyscan` installed, readiness degrades to a TCP accept and the
 report's fingerprint is null; the note in the report says which happened.
 
+What answers on that guest port is the same for both kinds of CVM by fleet convention (2200):
+the executor's sshd in a validation CVM, and in a renter CVM the platform's guest-SSH service
+(DAH-2684, `neurons/executor/cvm-ssh/`) — the sshd the renter logs into the CVM through, which
+the backend injects into every renter compose with the renter's keys. The fingerprint in the
+launch report is therefore the one the renter pins.
+
 ### The measurement gate
 
 cvmd imports `dstacktee/scripts/dstack.py` **as a library** and calls the same functions its CLI

--- a/neurons/executor/cvmd/packaging/config.toml
+++ b/neurons/executor/cvmd/packaging/config.toml
@@ -69,7 +69,9 @@ max_body_bytes = 65536
 #
 # The guest-side port carrying SSH. Set it and cvmd reports the guest's host-key fingerprint
 # and uses reading it as proof the CVM is up; leave it unset and readiness is a TCP accept,
-# which only proves QEMU is listening.
+# which only proves QEMU is listening. 2200 is the fleet convention: the executor's sshd in a
+# validation CVM, and the platform's guest-SSH service (the renter's way into the CVM itself)
+# in a renter CVM both bind it — so it must be one of the cvm_ports forwards above.
 # cvm_ssh_guest_port = 2200
 #
 # Both change the QEMU command line and therefore the measurements. lium-cvm.sh passes neither.

--- a/neurons/executor/cvmd/src/cvmd/routes/cvm.py
+++ b/neurons/executor/cvmd/src/cvmd/routes/cvm.py
@@ -42,8 +42,8 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-# A renter compose is a customer's docker-compose with one service injected, so it is far larger
-# than a validation body's three hashes — but it is still a compose file, and a request carrying
+# A renter compose is a customer's docker-compose with the platform's services injected (the
+# attest-agent and the guest-SSH service), so it is far larger than a validation body's three hashes — but it is still a compose file, and a request carrying
 # megabytes of one is not an order. The daemon's own `max_body_bytes` (64 KiB by default) is the
 # hard cap; this bound sits under it so an oversized compose is refused by name rather than as an
 # unexplained 413.

--- a/tools/cvm-local-e2e/run.py
+++ b/tools/cvm-local-e2e/run.py
@@ -13,6 +13,9 @@ What one run proves, in order:
     1. the host starts idle and its port range cannot touch the production port
     2. a renter order derived by the backend launches, and the host MEASURES the same
        compose hash the backend derived (the DAH-2632 golden loop, on hardware)
+    2b. the renter's own key logs into the CVM ITSELF as root — the guest OS, not the sshd
+       container — through the forwarded guest SSH port (DAH-2684), and the host-key
+       fingerprint the renter sees is the one the launch reported
     3. the validator key cannot create or destroy a renter CVM (403 by scope)
     4. teardown is verified, and the switch window is observed as SWITCHING with a
        readable start time — the exact facts DAH-2630's grace decides on
@@ -32,16 +35,18 @@ Usage (from a lium-io checkout, with the validators venv):
     neurons/validators/.venv/bin/python tools/cvm-local-e2e/run.py \\
         --host ubuntu@203.98.89.178 --ssh-key ~/.ssh/waris_local \\
         --backend-src ../lium-io-backend/apps/server/src \\
-        --agent-image "$CVM_ATTEST_AGENT_IMAGE"
+        --agent-image "$CVM_ATTEST_AGENT_IMAGE" --ssh-image "$CVM_SSH_IMAGE"
 """
 
 import argparse
 import atexit
 import json
+import shutil
 import socket
 import ssl
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import urllib.error
@@ -52,18 +57,19 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "neurons" / "validators" / "src"))
 
-# The customer's own half of the order. It must open the guest SSH port cvmd's readiness
-# gate waits on (2200 by fleet convention — `cvm_ssh_guest_port`): a compose with nothing
-# listening there launches a guest that is never declared ready and the create answers 504.
-# That is also what a real customer ships — SSH access to their CVM is the product.
+# The customer's own half of the order — optional since DAH-2684, and no longer where SSH
+# comes from. The platform injects the guest-SSH service on guest port 2200 (the port cvmd's
+# readiness gate waits on, `cvm_ssh_guest_port`) with the renter's keys, so the customer's
+# compose is just their workload. Kept here so the harness proves both halves coexist.
 CUSTOMER_COMPOSE = """services:
-  ssh:
+  workload:
     image: alpine:3.20
-    command: sh -c "apk add --no-cache openssh && ssh-keygen -A && /usr/sbin/sshd -D -e"
-    ports:
-      - "2200:22"
+    command: sleep infinity
     restart: unless-stopped
 """
+
+# The guest port the platform's SSH service binds. Mirrors services/cvm_compose.py.
+SSH_GUEST_PORT = 2200
 
 FORBIDDEN_PORT = 32000
 
@@ -161,6 +167,7 @@ def main() -> int:
     parser.add_argument("--ssh-key", required=True)
     parser.add_argument("--backend-src", required=True, help="path to lium-io-backend/apps/server/src")
     parser.add_argument("--agent-image", required=True, help="attest-agent image, pinned by digest")
+    parser.add_argument("--ssh-image", required=True, help="guest-SSH image (DAH-2684), pinned by digest")
     parser.add_argument("--local-port", type=int, default=18443)
     parser.add_argument("--remote-port", type=int, default=8443)
     parser.add_argument("--platform-uri", default="//Bob", help="renter-scope key (dev key of the test daemon)")
@@ -181,7 +188,19 @@ def main() -> int:
     backend_cvm_compose = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(backend_cvm_compose)
     AgentSpec = backend_cvm_compose.AgentSpec
+    SshSpec = backend_cvm_compose.SshSpec
     derive = backend_cvm_compose.derive
+
+    # A throwaway renter identity: the harness IS the renter, and the point of DAH-2684 is
+    # that this key — and only this key — opens the CVM itself.
+    renter_key_dir = Path(tempfile.mkdtemp(prefix="cvm-e2e-renter-"))
+    atexit.register(shutil.rmtree, renter_key_dir, True)
+    renter_key = renter_key_dir / "id_ed25519"
+    subprocess.run(
+        ["ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(renter_key), "-C", "cvm-e2e-renter"],
+        check=True,
+    )
+    renter_pubkey = (renter_key_dir / "id_ed25519.pub").read_text().strip()
 
     platform = Keypair.create_from_uri(args.platform_uri)
     validator = Keypair.create_from_uri(args.validator_uri)
@@ -223,7 +242,11 @@ def main() -> int:
         return summary()
 
     print("== 3. a renter order, derived by the backend's own code")
-    injected, compose_hash = derive(CUSTOMER_COMPOSE, AgentSpec(image=args.agent_image))
+    injected, compose_hash = derive(
+        CUSTOMER_COMPOSE,
+        AgentSpec(image=args.agent_image),
+        SshSpec(image=args.ssh_image, authorized_keys=(renter_pubkey,)),
+    )
     order = {
         "kind": "renter",
         "qemu": base["qemu"],
@@ -255,6 +278,57 @@ def main() -> int:
         all(p.get("host_port") != FORBIDDEN_PORT for p in ports),
         f"no forwarded port is {FORBIDDEN_PORT}",
     )
+
+    print("== 3b. the renter logs into the CVM itself (DAH-2684)")
+    ssh_host_port = next(
+        (p.get("host_port") for p in ports if p.get("guest_port") == SSH_GUEST_PORT and p.get("host_port")), None
+    )
+    if check(ssh_host_port is not None, f"the host forwards the guest SSH port {SSH_GUEST_PORT}", str(ssh_host_port)):
+        # Through the host's own sshd as a jump, so the check does not depend on the DC
+        # firewall exposing the forwarded port to this machine.
+        def as_renter(command: str) -> subprocess.CompletedProcess:
+            return subprocess.run(
+                [
+                    "ssh",
+                    "-i", str(renter_key),
+                    "-o", "BatchMode=yes",
+                    "-o", "StrictHostKeyChecking=no",
+                    "-o", f"UserKnownHostsFile={renter_key_dir / 'known_hosts'}",
+                    "-o", f"ProxyCommand=ssh -i {args.ssh_key} -o BatchMode=yes -W %h:%p {args.host}",
+                    "-p", str(ssh_host_port),
+                    "root@127.0.0.1",
+                    command,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=90,
+            )
+
+        session = as_renter("echo uid=$(id -u) host=$(hostname); test -d /host && echo IN_CONTAINER || echo IN_GUEST")
+        check(
+            session.returncode == 0 and "uid=0" in session.stdout,
+            "the renter's key logs in as root",
+            (session.stdout or session.stderr).strip()[:120],
+        )
+        check(
+            "IN_GUEST" in session.stdout,
+            "the session is in the guest OS, not in the sshd container",
+            session.stdout.strip()[:120],
+        )
+        guest_docker = as_renter("docker ps --format '{{.Names}}'")
+        check(
+            guest_docker.returncode == 0 and "lium-attest-agent" in guest_docker.stdout,
+            "the guest's docker daemon is the renter's, and shows the platform services",
+            guest_docker.stdout.replace(chr(10), " ").strip()[:120],
+        )
+        reported_fp = report.get("ssh_host_key_fingerprint")
+        scanned = ssh(args, f"ssh-keyscan -T 10 -p {ssh_host_port} -t ed25519 127.0.0.1 2>/dev/null")
+        if reported_fp and scanned.returncode == 0 and scanned.stdout.strip():
+            keyfile = renter_key_dir / "scanned.pub"
+            keyfile.write_text(scanned.stdout)
+            fp = subprocess.run(["ssh-keygen", "-lf", str(keyfile)], capture_output=True, text=True)
+            seen = fp.stdout.split()[1] if fp.returncode == 0 and len(fp.stdout.split()) > 1 else ""
+            check(seen == reported_fp, "the fingerprint the renter sees is the one the launch reported", seen[:30])
 
     print("== 4. the validator key cannot destroy it either")
     status, _ = call(base_url, validator, "DELETE", "/v1/cvm")


### PR DESCRIPTION
## Describe your changes

A renter's SSH session now lands **on the CVM itself** — root on the guest OS (its processes, network, filesystem, docker daemon, GPUs) — instead of inside a container the renter had to describe in their compose. This is the lium-io half; the backend half is Datura-ai/lium-io-backend (`feat/2684-cvm-guest-ssh`, PR linked below) and the browse-form half is Datura-ai/lium-io-frontend (`feat/2684-cvm-rent-form`).

**Why a container at all.** The dstack production image (`dstack-nvidia-0.5.11`) ships no sshd, removes every login path (`nologin`) and its rootfs is a read-only dm-verity squashfs. So "SSH into the guest" cannot be a guest service. It is a platform container the backend injects into the measured compose beside the attest-agent, pinned by digest, with the renter's authorized keys in the same service block — so `compose_hash` covers which sshd runs *and* whose keys it accepts.

**`neurons/executor/cvm-ssh/`** (new): sshd authenticates the renter's keys, `ChrootDirectory /host` (the guest root, bind-mounted), and the login shell staged into the guest's `/run` moves the session into PID 1's namespaces (`nsenter -m -u -i -n -p`, static busybox) and execs the guest's own `/bin/sh`. sftp/scp therefore read and write the guest. Keys only; no password path. The entrypoint **refuses to start, naming the missing line**, if the compose lacks `pid: host` / `privileged` / `network_mode: host` / `/:/host` / `/dev/pts:/dev/pts` — an sshd missing one would still run, with its sessions landing in the container, which is exactly what a renter told "this is your CVM" must never get.

**Proven locally** (`neurons/executor/cvm-ssh/tests/test_guest_ssh.sh`, 18/18, runs the container against this machine as the guest — chroot + nsenter behave the same on any Linux host): each precondition refused with its reason; session hostname / mount namespace / uid / root are the host's; interactive login gets a real tty; quoted remote command runs; a second listed key logs in; unlisted key and password auth refused; scp writes the host filesystem; host-key fingerprint survives a container restart. shellcheck clean.

Also in this PR:
- `.github/workflows/cvm-ssh-publish.yml` — mirrors the attest-agent publish job; the digest it prints is `CVM_SSH_IMAGE`. Rules in `cvm-ssh/PUBLISHING.md` (digest only; a new digest is a catalog event).
- `tools/cvm-local-e2e/run.py` — orders with the platform SSH service (`--ssh-image`) and, after the launch, **logs into the CVM through the forwarded guest port as the renter** and checks it is the guest OS (not the sshd container), that the guest's docker shows the platform services, and that the fingerprint the renter sees is the one the launch reported.
- cvmd README / packaging sample / `routes/cvm.py` comment: what serves guest 2200 in each kind of CVM.

**Not done here, stated plainly:** no image is published yet (needs the workflow run → `CVM_SSH_IMAGE`), and the hardware leg (the harness against au11 with a real TDX guest, on a test port — never 32000) has not run. cvmd itself is unchanged in behaviour (358 tests pass); nothing on the validator changes.

## Issue ticket number and link

[DAH-2684 — CVM v2 — renter rental UX](https://app.notion.com/p/CVM-v2-renter-rental-UX-generate-the-compose-from-a-template-no-raw-YAML-3bcb8bfdbde9811b8672cb0c1b0ffd22) — the direction changed from "generate a compose with an sshd container from a template" to "SSH into the CVM itself"; the task body needs that update.

Backend PR: https://github.com/Datura-ai/lium-io-backend/pull/928 · Frontend PR (draft): https://github.com/Datura-ai/lium-io-frontend/pull/251

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?
