### PR TITLE
DAH-2697: preserve provider routing during portal outages

### DIFF
--- a/neurons/validators/src/clients/subtensor_client.py
+++ b/neurons/validators/src/clients/subtensor_client.py
@@ -160,7 +160,7 @@ def _apply_eligibility_floor(
 
 def _classify_missing_scored_hotkeys(
     miner_scores: dict[str, float],
-    snapshot_miner_hotkeys: set[str],
+    selected_miner_hotkeys: set[str],
     registered_hotkeys: set[str],
     active_hotkeys: set[str],
 ) -> MissingScoredHotkeys:
@@ -169,7 +169,7 @@ def _classify_missing_scored_hotkeys(
         for hotkey, score in miner_scores.items()
         if score > 0
         and hotkey in registered_hotkeys
-        and hotkey not in snapshot_miner_hotkeys
+        and hotkey not in selected_miner_hotkeys
     )
     active_missing_hotkeys = [
         hotkey for hotkey in missing_hotkeys if hotkey in active_hotkeys
@@ -497,7 +497,7 @@ class SubtensorClient:
         self._report_cached_opted_in_miners_usage(cached_snapshot)
         return cached_snapshot.miners
 
-    def _build_miners_from_opted_in_snapshot(
+    def _build_serving_miners_with_opted_in_routing(
         self,
         opted_in_miners: Sequence[OptedInMiner],
     ) -> list[bittensor.NeuronInfo]:
@@ -539,7 +539,7 @@ class SubtensorClient:
                     )
                 )
                 return
-            miners = self._build_miners_from_opted_in_snapshot(opted_in_miners)
+            miners = self._build_serving_miners_with_opted_in_routing(opted_in_miners)
 
         logger.info(
             _m(
@@ -583,16 +583,16 @@ class SubtensorClient:
         except Exception as e:
             logger.error(_m("[send_weights_to_lium] Failed to post latest-set-weights", extra=get_extra_info({"error": str(e)})))
 
-    def _log_scored_hotkeys_missing_from_snapshot(
+    def _log_scored_hotkeys_missing_from_selected_miners(
         self,
         miner_scores: dict[str, float],
-        snapshot_miners: Sequence[bittensor.NeuronInfo],
+        selected_miners: Sequence[bittensor.NeuronInfo],
         registered_miners: Sequence[bittensor.NeuronInfo],
         active_hotkeys: set[str],
     ) -> None:
         missing_hotkeys = _classify_missing_scored_hotkeys(
             miner_scores=miner_scores,
-            snapshot_miner_hotkeys={miner.hotkey for miner in snapshot_miners},
+            selected_miner_hotkeys={miner.hotkey for miner in selected_miners},
             registered_hotkeys={miner.hotkey for miner in registered_miners},
             active_hotkeys=active_hotkeys,
         )
@@ -609,7 +609,7 @@ class SubtensorClient:
         )
         log_diagnostic(
             _m(
-                "[set_weights] scored miners missing from provider snapshot",
+                "[set_weights] scored miners missing from selected miner set",
                 extra=get_extra_info(
                     {
                         **self.default_extra,
@@ -656,9 +656,9 @@ class SubtensorClient:
             return
 
         metagraph = self.get_metagraph()
-        self._log_scored_hotkeys_missing_from_snapshot(
+        self._log_scored_hotkeys_missing_from_selected_miners(
             miner_scores=miner_scores,
-            snapshot_miners=miners,
+            selected_miners=miners,
             registered_miners=metagraph.neurons,
             active_hotkeys=active_hotkeys or set(),
         )

--- a/neurons/validators/src/clients/subtensor_client.py
+++ b/neurons/validators/src/clients/subtensor_client.py
@@ -1,21 +1,23 @@
 import asyncio
-import bittensor
 import contextlib
-import numpy as np
-import time
-from typing import Self, TYPE_CHECKING
-from bittensor.utils.weight_utils import process_weights_for_netuid
-from websockets.protocol import State as WebSocketClientState
-from datetime import datetime
 import json
-import aiohttp
-from pydantic import BaseModel, Field, ValidationError
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Self
 
+import aiohttp
+import bittensor
+import numpy as np
+from bittensor.utils.weight_utils import process_weights_for_netuid
+from pydantic import BaseModel, Field, ValidationError
+from websockets.protocol import State as WebSocketClientState
+
+from clients.validator_portal_api import OptedInMiner, ValidatorPortalAPI
 from core.config import settings
 from core.utils import _m, get_extra_info, get_logger
-
 from services.redis_service import NORMALIZED_SCORE_CHANNEL, RedisService
-from clients.validator_portal_api import OptedInMiner, ValidatorPortalAPI
 
 if TYPE_CHECKING:
     from bittensor_wallet import bittensor_wallet
@@ -25,8 +27,8 @@ logger = get_logger(__name__)
 SYNC_CYCLE = 12
 SUBTENSOR_BACKOFF_INITIAL = 12
 SUBTENSOR_BACKOFF_MAX = 300
-PORTAL_MINERS_CACHE_KEY = "validator:portal:opted_in_miners:last_good"
-PORTAL_MINERS_CACHE_ALERT_SECONDS = 60 * 60
+PORTAL_MINERS_CACHE_KEY: str = "validator:portal:opted_in_miners:last_good"
+PORTAL_MINERS_CACHE_ALERT_SECONDS: int = 60 * 60
 
 
 class OptedInMinerSnapshot(BaseModel):
@@ -34,8 +36,14 @@ class OptedInMinerSnapshot(BaseModel):
     miners: list[OptedInMiner]
 
 
+@dataclass(frozen=True)
+class MissingScoredHotkeys:
+    active_in_last_cycle: list[str]
+    inactive_in_last_cycle: list[str]
+
+
 class ProviderPortalDataUnavailable(RuntimeError):
-    """No live, Redis-cached, or in-memory provider snapshot is available."""
+    """No live or Redis-cached provider snapshot is available."""
 
 
 @contextlib.contextmanager
@@ -155,7 +163,7 @@ def _classify_missing_scored_hotkeys(
     snapshot_miner_hotkeys: set[str],
     registered_hotkeys: set[str],
     active_hotkeys: set[str],
-) -> tuple[list[str], list[str]]:
+) -> MissingScoredHotkeys:
     missing_hotkeys = sorted(
         hotkey
         for hotkey, score in miner_scores.items()
@@ -169,7 +177,10 @@ def _classify_missing_scored_hotkeys(
     inactive_missing_hotkeys = [
         hotkey for hotkey in missing_hotkeys if hotkey not in active_hotkeys
     ]
-    return active_missing_hotkeys, inactive_missing_hotkeys
+    return MissingScoredHotkeys(
+        active_in_last_cycle=active_missing_hotkeys,
+        inactive_in_last_cycle=inactive_missing_hotkeys,
+    )
 
 
 class SubtensorClient:
@@ -201,7 +212,7 @@ class SubtensorClient:
         self.netuid = settings.BITTENSOR_NETUID
         self.config = settings.get_bittensor_config()
         self.redis_service = RedisService()
-        self._portal_cache_stale_alerted = False
+        self._has_alerted_for_stale_portal_snapshot = False
 
         # Calculate version key
         major, minor, patch = map(int, settings.VERSION.split('.'))
@@ -358,7 +369,9 @@ class SubtensorClient:
     def get_tempo(self):
         return self.subtensor.tempo(self.netuid)
 
-    async def _load_cached_opted_in_miners(self) -> OptedInMinerSnapshot | None:
+    async def _load_cached_opted_in_miners_snapshot(
+        self,
+    ) -> OptedInMinerSnapshot | None:
         try:
             cached_json = await self.redis_service.get(PORTAL_MINERS_CACHE_KEY)
         except Exception as exc:
@@ -377,7 +390,7 @@ class SubtensorClient:
 
         try:
             return OptedInMinerSnapshot.model_validate_json(cached_json)
-        except (ValidationError, TypeError, ValueError) as exc:
+        except (ValidationError, TypeError) as exc:
             logger.error(
                 _m(
                     "[fetch_miners] invalid provider snapshot cache",
@@ -388,7 +401,10 @@ class SubtensorClient:
             )
             return None
 
-    async def _cache_opted_in_miners(self, miners: list[OptedInMiner]) -> None:
+    async def _store_opted_in_miners_snapshot(
+        self,
+        miners: list[OptedInMiner],
+    ) -> None:
         snapshot = OptedInMinerSnapshot(cached_at=time.time(), miners=miners)
         try:
             await self.redis_service.set(
@@ -405,25 +421,46 @@ class SubtensorClient:
                 )
             )
 
-    async def fetch_miners(self):
-        logger.info(
+    def _report_cached_opted_in_miners_usage(
+        self,
+        snapshot: OptedInMinerSnapshot,
+    ) -> None:
+        cache_age_seconds = int(max(0, time.time() - snapshot.cached_at))
+        log_context = {
+            **self.default_extra,
+            "provider_count": len(snapshot.miners),
+            "cache_age_seconds": cache_age_seconds,
+            "snapshot_source": "redis_cache",
+        }
+        logger.warning(
             _m(
-                "[fetch_miners] Fetching miners",
-                extra=get_extra_info(self.default_extra),
-            ),
+                "[fetch_miners] using cached provider snapshot",
+                extra=get_extra_info(log_context),
+            )
         )
+        if (
+            cache_age_seconds >= PORTAL_MINERS_CACHE_ALERT_SECONDS
+            and not self._has_alerted_for_stale_portal_snapshot
+        ):
+            logger.critical(
+                _m(
+                    "[fetch_miners] provider snapshot cache exceeded alert threshold",
+                    extra=get_extra_info(
+                        {
+                            **log_context,
+                            "alert_threshold_seconds": PORTAL_MINERS_CACHE_ALERT_SECONDS,
+                        }
+                    ),
+                )
+            )
+            self._has_alerted_for_stale_portal_snapshot = True
 
-        if self.debug_miner:
-            miners = [self.debug_miner]
-        else:
-            portal_miners = await ValidatorPortalAPI.get_opted_in_miners()
-            if portal_miners is not None:
-                previous_snapshot = await self._load_cached_opted_in_miners()
-                if (
-                    previous_snapshot is not None
-                    and previous_snapshot.miners
-                    and not portal_miners
-                ):
+    async def _resolve_opted_in_miners(self) -> list[OptedInMiner]:
+        live_miners = await ValidatorPortalAPI.get_opted_in_miners()
+        if live_miners is not None:
+            if not live_miners:
+                previous_snapshot = await self._load_cached_opted_in_miners_snapshot()
+                if previous_snapshot is not None and previous_snapshot.miners:
                     logger.warning(
                         _m(
                             "[fetch_miners] opted-in provider count dropped to zero",
@@ -436,94 +473,73 @@ class SubtensorClient:
                             ),
                         )
                     )
-                await self._cache_opted_in_miners(portal_miners)
-                self._portal_cache_stale_alerted = False
-                snapshot_source = "portal"
-            else:
-                cached_snapshot = await self._load_cached_opted_in_miners()
-                if cached_snapshot is not None:
-                    portal_miners = cached_snapshot.miners
-                    cache_age_seconds = int(
-                        max(0, time.time() - cached_snapshot.cached_at)
-                    )
-                    snapshot_source = "redis_cache"
-                    logger.warning(
-                        _m(
-                            "[fetch_miners] using cached provider snapshot",
-                            extra=get_extra_info(
-                                {
-                                    **self.default_extra,
-                                    "provider_count": len(portal_miners),
-                                    "cache_age_seconds": cache_age_seconds,
-                                }
-                            ),
-                        )
-                    )
-                    if (
-                        cache_age_seconds >= PORTAL_MINERS_CACHE_ALERT_SECONDS
-                        and not getattr(self, "_portal_cache_stale_alerted", False)
-                    ):
-                        logger.critical(
-                            _m(
-                                "[fetch_miners] provider snapshot cache exceeded alert threshold",
-                                extra=get_extra_info(
-                                    {
-                                        **self.default_extra,
-                                        "provider_count": len(portal_miners),
-                                        "cache_age_seconds": cache_age_seconds,
-                                        "alert_threshold_seconds": PORTAL_MINERS_CACHE_ALERT_SECONDS,
-                                    }
-                                ),
-                            )
-                        )
-                        self._portal_cache_stale_alerted = True
-                elif self.miners:
-                    logger.warning(
-                        _m(
-                            "[fetch_miners] using in-memory provider snapshot",
-                            extra=get_extra_info(
-                                {
-                                    **self.default_extra,
-                                    "provider_count": len(self.miners),
-                                }
-                            ),
-                        )
-                    )
-                    return
-                else:
-                    raise ProviderPortalDataUnavailable(
-                        "provider portal unavailable and no cached snapshot exists"
-                    )
-
+            await self._store_opted_in_miners_snapshot(live_miners)
+            self._has_alerted_for_stale_portal_snapshot = False
             logger.info(
                 _m(
                     "[fetch_miners] resolved opted-in providers",
                     extra=get_extra_info(
                         {
                             **self.default_extra,
-                            "provider_count": len(portal_miners),
-                            "snapshot_source": snapshot_source,
+                            "provider_count": len(live_miners),
+                            "snapshot_source": "portal",
                         }
                     ),
                 )
             )
+            return live_miners
 
-            metagraph = self.get_metagraph()
-            hotkey_to_opt_in = {
-                opt_in.miner_hotkey: opt_in for opt_in in portal_miners
-            }
-            for miner in metagraph.neurons:
-                opt_in = hotkey_to_opt_in.get(miner.hotkey)
-                if opt_in is not None:
-                    miner.axon_info.ip = opt_in.central_miner_ip
-                    miner.axon_info.port = opt_in.central_miner_port
+        cached_snapshot = await self._load_cached_opted_in_miners_snapshot()
+        if cached_snapshot is None:
+            raise ProviderPortalDataUnavailable(
+                "provider portal unavailable and no cached snapshot exists"
+            )
+        self._report_cached_opted_in_miners_usage(cached_snapshot)
+        return cached_snapshot.miners
 
-            miners = [
-                neuron
-                for neuron in metagraph.neurons
-                if neuron.hotkey in hotkey_to_opt_in
-                or neuron.uid in (settings.BURNERS + settings.NEW_BURNERS)
-            ]
+    def _build_miners_from_opted_in_snapshot(
+        self,
+        opted_in_miners: Sequence[OptedInMiner],
+    ) -> list[bittensor.NeuronInfo]:
+        metagraph = self.get_metagraph()
+        opted_in_by_hotkey = {
+            opted_in.miner_hotkey: opted_in for opted_in in opted_in_miners
+        }
+        for neuron in metagraph.neurons:
+            opted_in = opted_in_by_hotkey.get(neuron.hotkey)
+            if opted_in is not None:
+                neuron.axon_info.ip = opted_in.central_miner_ip
+                neuron.axon_info.port = opted_in.central_miner_port
+
+        burner_uids = {*settings.BURNERS, *settings.NEW_BURNERS}
+        return [
+            neuron
+            for neuron in metagraph.neurons
+            if neuron.hotkey in opted_in_by_hotkey or neuron.uid in burner_uids
+        ]
+
+    async def fetch_miners(self) -> None:
+        if self.debug_miner:
+            miners = [self.debug_miner]
+        else:
+            try:
+                opted_in_miners = await self._resolve_opted_in_miners()
+            except ProviderPortalDataUnavailable:
+                if not self.miners:
+                    raise
+                logger.warning(
+                    _m(
+                        "[fetch_miners] using in-memory provider snapshot",
+                        extra=get_extra_info(
+                            {
+                                **self.default_extra,
+                                "provider_count": len(self.miners),
+                            }
+                        ),
+                    )
+                )
+                return
+            miners = self._build_miners_from_opted_in_snapshot(opted_in_miners)
 
         logger.info(
             _m(
@@ -567,7 +583,48 @@ class SubtensorClient:
         except Exception as e:
             logger.error(_m("[send_weights_to_lium] Failed to post latest-set-weights", extra=get_extra_info({"error": str(e)})))
 
-    async def set_weights(self, miner_scores: dict[str, float], active_hotkeys: set[str] | None = None):
+    def _log_scored_hotkeys_missing_from_snapshot(
+        self,
+        miner_scores: dict[str, float],
+        snapshot_miners: Sequence[bittensor.NeuronInfo],
+        registered_miners: Sequence[bittensor.NeuronInfo],
+        active_hotkeys: set[str],
+    ) -> None:
+        missing_hotkeys = _classify_missing_scored_hotkeys(
+            miner_scores=miner_scores,
+            snapshot_miner_hotkeys={miner.hotkey for miner in snapshot_miners},
+            registered_hotkeys={miner.hotkey for miner in registered_miners},
+            active_hotkeys=active_hotkeys,
+        )
+        if not (
+            missing_hotkeys.active_in_last_cycle
+            or missing_hotkeys.inactive_in_last_cycle
+        ):
+            return
+
+        log_diagnostic = (
+            logger.critical
+            if missing_hotkeys.active_in_last_cycle
+            else logger.warning
+        )
+        log_diagnostic(
+            _m(
+                "[set_weights] scored miners missing from provider snapshot",
+                extra=get_extra_info(
+                    {
+                        **self.default_extra,
+                        "active_missing_hotkeys": missing_hotkeys.active_in_last_cycle,
+                        "inactive_missing_hotkeys": missing_hotkeys.inactive_in_last_cycle,
+                    }
+                ),
+            ),
+        )
+
+    async def set_weights(
+        self,
+        miner_scores: dict[str, float],
+        active_hotkeys: set[str] | None = None,
+    ) -> None:
         """Set weights using accumulated scores with burning already applied.
 
         The miner_scores dict already includes burning logic from calculate_final_weights
@@ -599,32 +656,12 @@ class SubtensorClient:
             return
 
         metagraph = self.get_metagraph()
-        snapshot_miner_hotkeys = {miner.hotkey for miner in miners}
-        registered_hotkeys = {neuron.hotkey for neuron in metagraph.neurons}
-        active_missing_hotkeys, inactive_missing_hotkeys = (
-            _classify_missing_scored_hotkeys(
-                miner_scores,
-                snapshot_miner_hotkeys,
-                registered_hotkeys,
-                active_hotkeys or set(),
-            )
+        self._log_scored_hotkeys_missing_from_snapshot(
+            miner_scores=miner_scores,
+            snapshot_miners=miners,
+            registered_miners=metagraph.neurons,
+            active_hotkeys=active_hotkeys or set(),
         )
-        if active_missing_hotkeys or inactive_missing_hotkeys:
-            log_diagnostic = (
-                logger.critical if active_missing_hotkeys else logger.warning
-            )
-            log_diagnostic(
-                _m(
-                    "[set_weights] scored miners missing from provider snapshot",
-                    extra=get_extra_info(
-                        {
-                            **self.default_extra,
-                            "active_missing_hotkeys": active_missing_hotkeys,
-                            "inactive_missing_hotkeys": inactive_missing_hotkeys,
-                        }
-                    ),
-                ),
-            )
 
         # Build uids and weights arrays
         uids = np.zeros(len(miners), dtype=np.int64)
@@ -883,17 +920,14 @@ class SubtensorClient:
 
                 backoff = SUBTENSOR_BACKOFF_INITIAL
                 await asyncio.sleep(SYNC_CYCLE)
-            except ProviderPortalDataUnavailable as e:
+            except ProviderPortalDataUnavailable as exc:
                 logger.error(
                     _m(
                         "[_warm_up_subtensor] Provider portal snapshot unavailable",
-                        extra=get_extra_info({
-                            **self.default_extra,
-                            "error": str(e),
-                            "backoff": backoff,
-                        }),
+                        extra=get_extra_info(
+                            {**self.default_extra, "error": str(exc), "backoff": backoff}
+                        ),
                     ),
-                    exc_info=True,
                 )
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, SUBTENSOR_BACKOFF_MAX)

--- a/neurons/validators/src/clients/subtensor_client.py
+++ b/neurons/validators/src/clients/subtensor_client.py
@@ -515,7 +515,7 @@ class SubtensorClient:
         return [
             neuron
             for neuron in metagraph.neurons
-            if neuron.hotkey in opted_in_by_hotkey or neuron.uid in burner_uids
+            if neuron.axon_info.is_serving or neuron.uid in burner_uids
         ]
 
     async def fetch_miners(self) -> None:

--- a/neurons/validators/src/clients/subtensor_client.py
+++ b/neurons/validators/src/clients/subtensor_client.py
@@ -9,12 +9,13 @@ from websockets.protocol import State as WebSocketClientState
 from datetime import datetime
 import json
 import aiohttp
+from pydantic import BaseModel, Field, ValidationError
 
 from core.config import settings
 from core.utils import _m, get_extra_info, get_logger
 
 from services.redis_service import NORMALIZED_SCORE_CHANNEL, RedisService
-from clients.validator_portal_api import ValidatorPortalAPI
+from clients.validator_portal_api import OptedInMiner, ValidatorPortalAPI
 
 if TYPE_CHECKING:
     from bittensor_wallet import bittensor_wallet
@@ -24,6 +25,17 @@ logger = get_logger(__name__)
 SYNC_CYCLE = 12
 SUBTENSOR_BACKOFF_INITIAL = 12
 SUBTENSOR_BACKOFF_MAX = 300
+PORTAL_MINERS_CACHE_KEY = "validator:portal:opted_in_miners:last_good"
+PORTAL_MINERS_CACHE_ALERT_SECONDS = 60 * 60
+
+
+class OptedInMinerSnapshot(BaseModel):
+    cached_at: float = Field(ge=0)
+    miners: list[OptedInMiner]
+
+
+class ProviderPortalDataUnavailable(RuntimeError):
+    """No live, Redis-cached, or in-memory provider snapshot is available."""
 
 
 @contextlib.contextmanager
@@ -138,6 +150,28 @@ def _apply_eligibility_floor(
     return out_uids, out_weights, floored_hotkeys
 
 
+def _classify_missing_scored_hotkeys(
+    miner_scores: dict[str, float],
+    snapshot_miner_hotkeys: set[str],
+    registered_hotkeys: set[str],
+    active_hotkeys: set[str],
+) -> tuple[list[str], list[str]]:
+    missing_hotkeys = sorted(
+        hotkey
+        for hotkey, score in miner_scores.items()
+        if score > 0
+        and hotkey in registered_hotkeys
+        and hotkey not in snapshot_miner_hotkeys
+    )
+    active_missing_hotkeys = [
+        hotkey for hotkey in missing_hotkeys if hotkey in active_hotkeys
+    ]
+    inactive_missing_hotkeys = [
+        hotkey for hotkey in missing_hotkeys if hotkey not in active_hotkeys
+    ]
+    return active_missing_hotkeys, inactive_missing_hotkeys
+
+
 class SubtensorClient:
     # Static class variables (shared across all instances)
     _instance = None
@@ -167,6 +201,7 @@ class SubtensorClient:
         self.netuid = settings.BITTENSOR_NETUID
         self.config = settings.get_bittensor_config()
         self.redis_service = RedisService()
+        self._portal_cache_stale_alerted = False
 
         # Calculate version key
         major, minor, patch = map(int, settings.VERSION.split('.'))
@@ -323,6 +358,53 @@ class SubtensorClient:
     def get_tempo(self):
         return self.subtensor.tempo(self.netuid)
 
+    async def _load_cached_opted_in_miners(self) -> OptedInMinerSnapshot | None:
+        try:
+            cached_json = await self.redis_service.get(PORTAL_MINERS_CACHE_KEY)
+        except Exception as exc:
+            logger.warning(
+                _m(
+                    "[fetch_miners] failed to read provider snapshot cache",
+                    extra=get_extra_info(
+                        {**self.default_extra, "error": str(exc)}
+                    ),
+                )
+            )
+            return None
+
+        if cached_json is None:
+            return None
+
+        try:
+            return OptedInMinerSnapshot.model_validate_json(cached_json)
+        except (ValidationError, TypeError, ValueError) as exc:
+            logger.error(
+                _m(
+                    "[fetch_miners] invalid provider snapshot cache",
+                    extra=get_extra_info(
+                        {**self.default_extra, "error": str(exc)}
+                    ),
+                )
+            )
+            return None
+
+    async def _cache_opted_in_miners(self, miners: list[OptedInMiner]) -> None:
+        snapshot = OptedInMinerSnapshot(cached_at=time.time(), miners=miners)
+        try:
+            await self.redis_service.set(
+                PORTAL_MINERS_CACHE_KEY,
+                snapshot.model_dump_json(),
+            )
+        except Exception as exc:
+            logger.warning(
+                _m(
+                    "[fetch_miners] failed to cache provider snapshot",
+                    extra=get_extra_info(
+                        {**self.default_extra, "error": str(exc)}
+                    ),
+                )
+            )
+
     async def fetch_miners(self):
         logger.info(
             _m(
@@ -334,46 +416,113 @@ class SubtensorClient:
         if self.debug_miner:
             miners = [self.debug_miner]
         else:
-            metagraph = self.get_metagraph()
-
-            miners = metagraph.neurons
-
-            # Get miners that have opted in from portal BE
-            miners_with_opt_in_status = await ValidatorPortalAPI.get_opted_in_miners()
-            if miners_with_opt_in_status is None:
-                logger.error(
-                    _m(
-                        "[fetch_miners] provider portal unavailable; keeping previous miner snapshot",
-                        extra=get_extra_info(
-                            {
-                                **self.default_extra,
-                                "previous_miner_count": len(self.miners),
-                            }
-                        ),
-                    ),
-                )
-                raise RuntimeError("provider portal unavailable")
+            portal_miners = await ValidatorPortalAPI.get_opted_in_miners()
+            if portal_miners is not None:
+                previous_snapshot = await self._load_cached_opted_in_miners()
+                if (
+                    previous_snapshot is not None
+                    and previous_snapshot.miners
+                    and not portal_miners
+                ):
+                    logger.warning(
+                        _m(
+                            "[fetch_miners] opted-in provider count dropped to zero",
+                            extra=get_extra_info(
+                                {
+                                    **self.default_extra,
+                                    "previous_provider_count": len(previous_snapshot.miners),
+                                    "provider_count": 0,
+                                }
+                            ),
+                        )
+                    )
+                await self._cache_opted_in_miners(portal_miners)
+                self._portal_cache_stale_alerted = False
+                snapshot_source = "portal"
+            else:
+                cached_snapshot = await self._load_cached_opted_in_miners()
+                if cached_snapshot is not None:
+                    portal_miners = cached_snapshot.miners
+                    cache_age_seconds = int(
+                        max(0, time.time() - cached_snapshot.cached_at)
+                    )
+                    snapshot_source = "redis_cache"
+                    logger.warning(
+                        _m(
+                            "[fetch_miners] using cached provider snapshot",
+                            extra=get_extra_info(
+                                {
+                                    **self.default_extra,
+                                    "provider_count": len(portal_miners),
+                                    "cache_age_seconds": cache_age_seconds,
+                                }
+                            ),
+                        )
+                    )
+                    if (
+                        cache_age_seconds >= PORTAL_MINERS_CACHE_ALERT_SECONDS
+                        and not getattr(self, "_portal_cache_stale_alerted", False)
+                    ):
+                        logger.critical(
+                            _m(
+                                "[fetch_miners] provider snapshot cache exceeded alert threshold",
+                                extra=get_extra_info(
+                                    {
+                                        **self.default_extra,
+                                        "provider_count": len(portal_miners),
+                                        "cache_age_seconds": cache_age_seconds,
+                                        "alert_threshold_seconds": PORTAL_MINERS_CACHE_ALERT_SECONDS,
+                                    }
+                                ),
+                            )
+                        )
+                        self._portal_cache_stale_alerted = True
+                elif self.miners:
+                    logger.warning(
+                        _m(
+                            "[fetch_miners] using in-memory provider snapshot",
+                            extra=get_extra_info(
+                                {
+                                    **self.default_extra,
+                                    "provider_count": len(self.miners),
+                                }
+                            ),
+                        )
+                    )
+                    return
+                else:
+                    raise ProviderPortalDataUnavailable(
+                        "provider portal unavailable and no cached snapshot exists"
+                    )
 
             logger.info(
                 _m(
-                    f"[fetch_miners] Found {len(miners_with_opt_in_status)} opted-in miners from portal",
-                    extra=get_extra_info(self.default_extra),
-                ),
+                    "[fetch_miners] resolved opted-in providers",
+                    extra=get_extra_info(
+                        {
+                            **self.default_extra,
+                            "provider_count": len(portal_miners),
+                            "snapshot_source": snapshot_source,
+                        }
+                    ),
+                )
             )
-            # Update miners in `miners` list based on miners_with_opt_in_status.
+
+            metagraph = self.get_metagraph()
             hotkey_to_opt_in = {
-                opt_in["miner_hotkey"]: opt_in for opt_in in miners_with_opt_in_status if opt_in.get("miner_hotkey", None)
+                opt_in.miner_hotkey: opt_in for opt_in in portal_miners
             }
-            for miner in miners:
+            for miner in metagraph.neurons:
                 opt_in = hotkey_to_opt_in.get(miner.hotkey)
                 if opt_in is not None:
-                    miner.axon_info.ip = opt_in.get("central_miner_ip")
-                    miner.axon_info.port = opt_in.get("central_miner_port")
-                    
+                    miner.axon_info.ip = opt_in.central_miner_ip
+                    miner.axon_info.port = opt_in.central_miner_port
+
             miners = [
                 neuron
                 for neuron in metagraph.neurons
-                if neuron.axon_info.is_serving or neuron.uid in (settings.BURNERS + settings.NEW_BURNERS)
+                if neuron.hotkey in hotkey_to_opt_in
+                or neuron.uid in (settings.BURNERS + settings.NEW_BURNERS)
             ]
 
         logger.info(
@@ -450,29 +599,31 @@ class SubtensorClient:
             return
 
         metagraph = self.get_metagraph()
-        available_miner_hotkeys = {miner.hotkey for miner in miners}
+        snapshot_miner_hotkeys = {miner.hotkey for miner in miners}
         registered_hotkeys = {neuron.hotkey for neuron in metagraph.neurons}
-        missing_positive_score_hotkeys = sorted(
-            hotkey
-            for hotkey, score in miner_scores.items()
-            if score > 0
-            and hotkey in registered_hotkeys
-            and hotkey not in available_miner_hotkeys
+        active_missing_hotkeys, inactive_missing_hotkeys = (
+            _classify_missing_scored_hotkeys(
+                miner_scores,
+                snapshot_miner_hotkeys,
+                registered_hotkeys,
+                active_hotkeys or set(),
+            )
         )
-        if missing_positive_score_hotkeys:
-            logger.critical(
+        if active_missing_hotkeys or inactive_missing_hotkeys:
+            log_diagnostic = (
+                logger.critical if active_missing_hotkeys else logger.warning
+            )
+            log_diagnostic(
                 _m(
-                    "[set_weights] refusing to omit registered positive-score miners",
+                    "[set_weights] scored miners missing from provider snapshot",
                     extra=get_extra_info(
                         {
                             **self.default_extra,
-                            "missing_hotkeys": missing_positive_score_hotkeys,
+                            "active_missing_hotkeys": active_missing_hotkeys,
+                            "inactive_missing_hotkeys": inactive_missing_hotkeys,
                         }
                     ),
                 ),
-            )
-            raise RuntimeError(
-                "positive-score miners are missing from the current miner snapshot"
             )
 
         # Build uids and weights arrays
@@ -732,6 +883,20 @@ class SubtensorClient:
 
                 backoff = SUBTENSOR_BACKOFF_INITIAL
                 await asyncio.sleep(SYNC_CYCLE)
+            except ProviderPortalDataUnavailable as e:
+                logger.error(
+                    _m(
+                        "[_warm_up_subtensor] Provider portal snapshot unavailable",
+                        extra=get_extra_info({
+                            **self.default_extra,
+                            "error": str(e),
+                            "backoff": backoff,
+                        }),
+                    ),
+                    exc_info=True,
+                )
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, SUBTENSOR_BACKOFF_MAX)
             except Exception as e:
                 logger.error(
                     _m(

--- a/neurons/validators/src/clients/subtensor_client.py
+++ b/neurons/validators/src/clients/subtensor_client.py
@@ -340,6 +340,19 @@ class SubtensorClient:
 
             # Get miners that have opted in from portal BE
             miners_with_opt_in_status = await ValidatorPortalAPI.get_opted_in_miners()
+            if miners_with_opt_in_status is None:
+                logger.error(
+                    _m(
+                        "[fetch_miners] provider portal unavailable; keeping previous miner snapshot",
+                        extra=get_extra_info(
+                            {
+                                **self.default_extra,
+                                "previous_miner_count": len(self.miners),
+                            }
+                        ),
+                    ),
+                )
+                raise RuntimeError("provider portal unavailable")
 
             logger.info(
                 _m(
@@ -436,6 +449,32 @@ class SubtensorClient:
             )
             return
 
+        metagraph = self.get_metagraph()
+        available_miner_hotkeys = {miner.hotkey for miner in miners}
+        registered_hotkeys = {neuron.hotkey for neuron in metagraph.neurons}
+        missing_positive_score_hotkeys = sorted(
+            hotkey
+            for hotkey, score in miner_scores.items()
+            if score > 0
+            and hotkey in registered_hotkeys
+            and hotkey not in available_miner_hotkeys
+        )
+        if missing_positive_score_hotkeys:
+            logger.critical(
+                _m(
+                    "[set_weights] refusing to omit registered positive-score miners",
+                    extra=get_extra_info(
+                        {
+                            **self.default_extra,
+                            "missing_hotkeys": missing_positive_score_hotkeys,
+                        }
+                    ),
+                ),
+            )
+            raise RuntimeError(
+                "positive-score miners are missing from the current miner snapshot"
+            )
+
         # Build uids and weights arrays
         uids = np.zeros(len(miners), dtype=np.int64)
         weights = np.zeros(len(miners), dtype=np.float32)
@@ -462,7 +501,6 @@ class SubtensorClient:
         await self.redis_service.publish(NORMALIZED_SCORE_CHANNEL, message)
 
         # Process weights for blockchain
-        metagraph = self.get_metagraph()
         processed_uids, processed_weights = process_weights_for_netuid(
             uids=uids,
             weights=weights,

--- a/neurons/validators/src/clients/validator_portal_api.py
+++ b/neurons/validators/src/clients/validator_portal_api.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class ValidatorPortalAPI:
     @staticmethod
-    async def get_opted_in_miners() -> list[dict]:
+    async def get_opted_in_miners() -> list[dict] | None:
         """Fetch list of miners that have opted in.
 
         Returns list of dicts with shape:
@@ -28,7 +28,8 @@ class ValidatorPortalAPI:
                 },
                 ...
             ]
-        Returns empty list on error.
+        Returns None on error so callers can distinguish portal unavailability
+        from a successful response with no opted-in miners.
         """
         try:
             keypair: bittensor.Keypair = settings.get_bittensor_wallet().get_hotkey()
@@ -36,7 +37,7 @@ class ValidatorPortalAPI:
 
             api_base = settings.MINER_PORTAL_REST_API_URL.rstrip("/") if settings.MINER_PORTAL_REST_API_URL else ""
             if not api_base:
-                return []
+                return None
 
             url = f"{api_base}/validators/opted-in"
 
@@ -68,16 +69,24 @@ class ValidatorPortalAPI:
                                     }),
                                 )
                             )
-                            return []
+                            return None
 
                         data = await resp.json()
-                        return data if isinstance(data, list) else []
+                        if not isinstance(data, list):
+                            logger.error(
+                                _m(
+                                    "Invalid opted-in miners response from portal",
+                                    extra=get_extra_info({"url": url}),
+                                )
+                            )
+                            return None
+                        return data
                 except asyncio.TimeoutError:
                     logger.error(_m("Timeout fetching opted-in miners from portal", extra=get_extra_info({"url": url})))
-                    return []
+                    return None
                 except Exception as e:
                     logger.error(_m("Error fetching opted-in miners from portal", extra=get_extra_info({"url": url, "error": str(e)})))
-                    return []
+                    return None
         except Exception as e:
             logger.error(_m("Unexpected error during opted-in miners fetch", extra=get_extra_info({"error": str(e)})))
-            return []
+            return None

--- a/neurons/validators/src/clients/validator_portal_api.py
+++ b/neurons/validators/src/clients/validator_portal_api.py
@@ -1,10 +1,10 @@
-import aiohttp
 import asyncio
-import json
 import logging
 import time
 
+import aiohttp
 import bittensor
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from core.config import settings
 from core.utils import _m, get_extra_info
@@ -13,29 +13,40 @@ from core.utils import _m, get_extra_info
 logger = logging.getLogger(__name__)
 
 
+class OptedInMiner(BaseModel):
+    miner_hotkey: str = Field(min_length=1)
+    central_miner_ip: str = Field(min_length=1)
+    central_miner_port: int = Field(strict=True, ge=1, le=65535)
+
+    @field_validator("miner_hotkey", "central_miner_ip")
+    @classmethod
+    def validate_nonempty_string(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("must not be empty")
+        return value
+
+    @field_validator("central_miner_ip")
+    @classmethod
+    def validate_serving_ip(cls, value: str) -> str:
+        if value == "0.0.0.0":
+            raise ValueError("must identify a serving endpoint")
+        return value
+
+
 class ValidatorPortalAPI:
     @staticmethod
-    async def get_opted_in_miners() -> list[dict] | None:
-        """Fetch list of miners that have opted in.
-
-        Returns list of dicts with shape:
-            [
-                {
-                    "miner_hotkey": str,
-                    "miner_coldkey": str,
-                    "central_miner_ip": str,
-                    "central_miner_port": int,
-                },
-                ...
-            ]
-        Returns None on error so callers can distinguish portal unavailability
-        from a successful response with no opted-in miners.
-        """
+    async def get_opted_in_miners() -> list[OptedInMiner] | None:
+        """Return None on failure and an empty list for a successful empty response."""
         try:
             keypair: bittensor.Keypair = settings.get_bittensor_wallet().get_hotkey()
             validator_hotkey = keypair.ss58_address
 
-            api_base = settings.MINER_PORTAL_REST_API_URL.rstrip("/") if settings.MINER_PORTAL_REST_API_URL else ""
+            api_base = (
+                settings.MINER_PORTAL_REST_API_URL.rstrip("/")
+                if settings.MINER_PORTAL_REST_API_URL
+                else ""
+            )
             if not api_base:
                 return None
 
@@ -80,13 +91,43 @@ class ValidatorPortalAPI:
                                 )
                             )
                             return None
-                        return data
+                        try:
+                            return [OptedInMiner.model_validate(item) for item in data]
+                        except ValidationError as exc:
+                            logger.error(
+                                _m(
+                                    "Invalid opted-in miner record from portal",
+                                    extra=get_extra_info(
+                                        {
+                                            "url": url,
+                                            "record_count": len(data),
+                                            "error": str(exc),
+                                        }
+                                    ),
+                                )
+                            )
+                            return None
                 except asyncio.TimeoutError:
-                    logger.error(_m("Timeout fetching opted-in miners from portal", extra=get_extra_info({"url": url})))
+                    logger.error(
+                        _m(
+                            "Timeout fetching opted-in miners from portal",
+                            extra=get_extra_info({"url": url}),
+                        )
+                    )
                     return None
                 except Exception as e:
-                    logger.error(_m("Error fetching opted-in miners from portal", extra=get_extra_info({"url": url, "error": str(e)})))
+                    logger.error(
+                        _m(
+                            "Error fetching opted-in miners from portal",
+                            extra=get_extra_info({"url": url, "error": str(e)}),
+                        )
+                    )
                     return None
         except Exception as e:
-            logger.error(_m("Unexpected error during opted-in miners fetch", extra=get_extra_info({"error": str(e)})))
+            logger.error(
+                _m(
+                    "Unexpected error during opted-in miners fetch",
+                    extra=get_extra_info({"error": str(e)}),
+                )
+            )
             return None

--- a/neurons/validators/src/clients/validator_portal_api.py
+++ b/neurons/validators/src/clients/validator_portal_api.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import time
+from collections.abc import Mapping
 
 import aiohttp
 import bittensor
@@ -36,98 +37,104 @@ class OptedInMiner(BaseModel):
 
 class ValidatorPortalAPI:
     @staticmethod
-    async def get_opted_in_miners() -> list[OptedInMiner] | None:
-        """Return None on failure and an empty list for a successful empty response."""
-        try:
-            keypair: bittensor.Keypair = settings.get_bittensor_wallet().get_hotkey()
-            validator_hotkey = keypair.ss58_address
-
-            api_base = (
-                settings.MINER_PORTAL_REST_API_URL.rstrip("/")
-                if settings.MINER_PORTAL_REST_API_URL
-                else ""
-            )
-            if not api_base:
-                return None
-
-            url = f"{api_base}/validators/opted-in"
-
-            timestamp = int(time.time())
-            signature = f"0x{keypair.sign(str(timestamp)).hex()}"
-
-            headers = {
-                "hotkey": validator_hotkey,
-                "timestamp": str(timestamp),
-                "signature": signature,
-            }
-
-            # Generous total timeout so we survive short event-loop stalls from concurrent
-            # sync bittensor/subtensor calls in this process. aiohttp's timer is driven by
-            # the event loop, so a 10s cap fires spuriously whenever the loop stays blocked.
-            timeout = aiohttp.ClientTimeout(total=60)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                try:
-                    async with session.get(url, headers=headers) as resp:
-                        if resp.status != 200:
-                            text = await resp.text()
-                            logger.error(
-                                _m(
-                                    "Failed to fetch opted-in miners from portal",
-                                    extra=get_extra_info({
-                                        "status": resp.status,
-                                        "body": text,
-                                        "url": url,
-                                    }),
-                                )
-                            )
-                            return None
-
-                        data = await resp.json()
-                        if not isinstance(data, list):
-                            logger.error(
-                                _m(
-                                    "Invalid opted-in miners response from portal",
-                                    extra=get_extra_info({"url": url}),
-                                )
-                            )
-                            return None
-                        try:
-                            return [OptedInMiner.model_validate(item) for item in data]
-                        except ValidationError as exc:
-                            logger.error(
-                                _m(
-                                    "Invalid opted-in miner record from portal",
-                                    extra=get_extra_info(
-                                        {
-                                            "url": url,
-                                            "record_count": len(data),
-                                            "error": str(exc),
-                                        }
-                                    ),
-                                )
-                            )
-                            return None
-                except asyncio.TimeoutError:
-                    logger.error(
-                        _m(
-                            "Timeout fetching opted-in miners from portal",
-                            extra=get_extra_info({"url": url}),
-                        )
-                    )
-                    return None
-                except Exception as e:
-                    logger.error(
-                        _m(
-                            "Error fetching opted-in miners from portal",
-                            extra=get_extra_info({"url": url, "error": str(e)}),
-                        )
-                    )
-                    return None
-        except Exception as e:
+    def _validate_opted_in_miners_response(
+        response_data: object,
+        url: str,
+    ) -> list[OptedInMiner] | None:
+        if not isinstance(response_data, list):
             logger.error(
                 _m(
-                    "Unexpected error during opted-in miners fetch",
-                    extra=get_extra_info({"error": str(e)}),
+                    "Invalid opted-in miners response from portal",
+                    extra=get_extra_info({"url": url}),
+                )
+            )
+            return None
+
+        try:
+            return [OptedInMiner.model_validate(item) for item in response_data]
+        except ValidationError as exc:
+            logger.error(
+                _m(
+                    "Invalid opted-in miner record from portal",
+                    extra=get_extra_info(
+                        {
+                            "url": url,
+                            "record_count": len(response_data),
+                            "error": str(exc),
+                        }
+                    ),
+                )
+            )
+            return None
+
+    @staticmethod
+    async def _request_opted_in_miners(
+        url: str,
+        headers: Mapping[str, str],
+    ) -> list[OptedInMiner] | None:
+        # aiohttp's timer uses the event loop, so short timeouts fire during synchronous
+        # bittensor/subtensor calls elsewhere in this process.
+        timeout = aiohttp.ClientTimeout(total=60)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(url, headers=headers) as response:
+                if response.status != 200:
+                    response_body = await response.text()
+                    logger.error(
+                        _m(
+                            "Failed to fetch opted-in miners from portal",
+                            extra=get_extra_info(
+                                {
+                                    "status": response.status,
+                                    "body": response_body,
+                                    "url": url,
+                                }
+                            ),
+                        )
+                    )
+                    return None
+
+                response_data = await response.json()
+                return ValidatorPortalAPI._validate_opted_in_miners_response(
+                    response_data,
+                    url,
+                )
+
+    @staticmethod
+    async def get_opted_in_miners() -> list[OptedInMiner] | None:
+        """Return None on failure and an empty list for a successful empty response."""
+        api_base = (
+            settings.MINER_PORTAL_REST_API_URL.rstrip("/")
+            if settings.MINER_PORTAL_REST_API_URL
+            else ""
+        )
+        if not api_base:
+            return None
+
+        url = f"{api_base}/validators/opted-in"
+        try:
+            keypair: bittensor.Keypair = settings.get_bittensor_wallet().get_hotkey()
+            timestamp = int(time.time())
+            return await ValidatorPortalAPI._request_opted_in_miners(
+                url=url,
+                headers={
+                    "hotkey": keypair.ss58_address,
+                    "timestamp": str(timestamp),
+                    "signature": f"0x{keypair.sign(str(timestamp)).hex()}",
+                },
+            )
+        except asyncio.TimeoutError:
+            logger.error(
+                _m(
+                    "Timeout fetching opted-in miners from portal",
+                    extra=get_extra_info({"url": url}),
+                )
+            )
+            return None
+        except Exception as exc:
+            logger.error(
+                _m(
+                    "Error fetching opted-in miners from portal",
+                    extra=get_extra_info({"url": url, "error": str(exc)}),
                 )
             )
             return None

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -5,7 +5,7 @@ import time
 from datetime import UTC, datetime
 
 from clients.backend_client import BackendClient
-from clients.subtensor_client import SubtensorClient
+from clients.subtensor_client import ProviderPortalDataUnavailable, SubtensorClient
 from incentive.eligibility import is_missing_discord_after_cutoff
 from incentive.factory import IncentiveFactory
 from incentive.rental_price import precompute_all_estimates
@@ -161,8 +161,18 @@ class Validator:
                 ),
             )
 
-            # fetch miners
-            miners = await self.subtensor_client.get_miners()
+            try:
+                miners = await self.subtensor_client.get_miners()
+            except ProviderPortalDataUnavailable as exc:
+                logger.error(
+                    _m(
+                        "[sync] No reliable provider snapshot, skipping iteration",
+                        extra=get_extra_info(
+                            {**self.default_extra, "error": str(exc)}
+                        ),
+                    )
+                )
+                return
 
             try:
                 if await self.subtensor_client.should_set_weights():

--- a/neurons/validators/tests/test_validator_portal_fail_safe.py
+++ b/neurons/validators/tests/test_validator_portal_fail_safe.py
@@ -26,6 +26,10 @@ class _AxonInfo:
     ip: str = "0.0.0.0"
     port: int = 0
 
+    @property
+    def is_serving(self) -> bool:
+        return self.ip != "0.0.0.0"
+
 
 @dataclass
 class _Neuron:
@@ -323,13 +327,16 @@ async def test_live_provider_count_transition_to_zero_warns_and_caches_empty(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     client = _make_subtensor_client()
-    opted_out_provider = _Neuron(
+    serving_non_opted_in_provider = _Neuron(
         uid=100,
-        hotkey="opted-out-provider",
+        hotkey="serving-non-opted-in-provider",
         axon_info=_AxonInfo("192.0.2.100", 8091),
     )
+    non_serving_provider = _Neuron(uid=101, hotkey="non-serving-provider")
     client.get_metagraph = MagicMock(
-        return_value=MagicMock(neurons=[opted_out_provider])
+        return_value=MagicMock(
+            neurons=[serving_non_opted_in_provider, non_serving_provider]
+        )
     )
     client.redis_service.get.return_value = _cached_miners_json(
         _opted_in_miner(),
@@ -354,7 +361,7 @@ async def test_live_provider_count_transition_to_zero_warns_and_caches_empty(
         client.redis_service.set.await_args.args[1]
     )
     assert cached.miners == []
-    assert client.miners == []
+    assert client.miners == [serving_non_opted_in_provider]
 
 
 @pytest.mark.parametrize(

--- a/neurons/validators/tests/test_validator_portal_fail_safe.py
+++ b/neurons/validators/tests/test_validator_portal_fail_safe.py
@@ -1,24 +1,69 @@
 import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import bittensor
 import pytest
+from pydantic import ValidationError
 
-from clients.subtensor_client import SubtensorClient
-from clients.validator_portal_api import ValidatorPortalAPI
+from clients.subtensor_client import (
+    PORTAL_MINERS_CACHE_ALERT_SECONDS,
+    PORTAL_MINERS_CACHE_KEY,
+    OptedInMinerSnapshot,
+    ProviderPortalDataUnavailable,
+    SubtensorClient,
+)
+from clients.validator_portal_api import OptedInMiner, ValidatorPortalAPI
 from core.config import settings
+from core.validator import MINER_SCORES_KEY, Validator
 
 
-def _neuron(uid: int, hotkey: str, *, is_serving: bool) -> bittensor.NeuronInfo:
-    neuron = MagicMock(spec=bittensor.NeuronInfo)
-    neuron.uid = uid
-    neuron.hotkey = hotkey
-    neuron.coldkey = "coldkey"
-    neuron.axon_info = MagicMock()
-    neuron.axon_info.ip = "192.0.2.1"
-    neuron.axon_info.port = 8091
-    neuron.axon_info.is_serving = is_serving
-    return neuron
+@dataclass
+class _AxonInfo:
+    ip: str = "0.0.0.0"
+    port: int = 0
+
+    @property
+    def is_serving(self) -> bool:
+        return self.ip != "0.0.0.0"
+
+
+@dataclass
+class _Neuron:
+    uid: int
+    hotkey: str
+    coldkey: str = "coldkey"
+    axon_info: _AxonInfo = field(default_factory=_AxonInfo)
+
+
+def _portal_miner(hotkey: str = "portal-provider") -> OptedInMiner:
+    return OptedInMiner(
+        miner_hotkey=hotkey,
+        central_miner_ip="192.0.2.10",
+        central_miner_port=8091,
+    )
+
+
+def _client(*, miners: list[_Neuron] | None = None) -> SubtensorClient:
+    client = SubtensorClient.__new__(SubtensorClient)
+    client.debug_miner = None
+    client.default_extra = {}
+    client.miners = miners or []
+    client.redis_service = AsyncMock()
+    client.redis_service.get.return_value = None
+    return client
+
+
+def _cache_payload(*miners: OptedInMiner, cached_at: float) -> str:
+    return OptedInMinerSnapshot(
+        cached_at=cached_at,
+        miners=list(miners),
+    ).model_dump_json()
+
+
+def _structured_extra(record: logging.LogRecord) -> dict:
+    return record.msg.extra
 
 
 @pytest.mark.asyncio
@@ -49,99 +94,339 @@ async def test_portal_timeout_is_not_reported_as_empty_opt_in_list():
 
 
 @pytest.mark.asyncio
-async def test_failed_portal_refresh_keeps_previous_miner_snapshot():
-    cached_provider = _neuron(100, "portal-provider", is_serving=True)
-    on_chain_miner = _neuron(2, "on-chain-miner", is_serving=True)
-    registered_provider = _neuron(100, "portal-provider", is_serving=False)
+async def test_portal_rejects_response_with_a_malformed_provider():
+    keypair = MagicMock(ss58_address="validator-hotkey")
+    keypair.sign.return_value = b"signed"
+    wallet = MagicMock()
+    wallet.get_hotkey.return_value = keypair
 
-    client = SubtensorClient.__new__(SubtensorClient)
-    client.debug_miner = None
-    client.default_extra = {}
-    client.miners = [cached_provider, on_chain_miner]
-    previous_snapshot = client.miners
-    client.get_metagraph = MagicMock(
-        return_value=MagicMock(neurons=[registered_provider, on_chain_miner])
+    response = MagicMock(status=200)
+    response.json = AsyncMock(
+        return_value=[
+            {
+                "miner_hotkey": "portal-provider",
+                "central_miner_ip": None,
+                "central_miner_port": 8091,
+            }
+        ]
     )
+    response_context = MagicMock()
+    response_context.__aenter__ = AsyncMock(return_value=response)
+    response_context.__aexit__ = AsyncMock(return_value=None)
+    session = MagicMock()
+    session.get.return_value = response_context
+    session_context = MagicMock()
+    session_context.__aenter__ = AsyncMock(return_value=session)
+    session_context.__aexit__ = AsyncMock(return_value=None)
 
-    with patch.object(
+    with (
+        patch("core.config.Settings.get_bittensor_wallet", return_value=wallet),
+        patch.object(settings, "MINER_PORTAL_REST_API_URL", "https://portal.test"),
+        patch(
+            "clients.validator_portal_api.aiohttp.ClientSession",
+            return_value=session_context,
+        ),
+    ):
+        result = await ValidatorPortalAPI.get_opted_in_miners()
+
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    ("field_name", "invalid_value"),
+    [
+        ("miner_hotkey", ""),
+        ("central_miner_ip", None),
+        ("central_miner_ip", ""),
+        ("central_miner_ip", "0.0.0.0"),
+        ("central_miner_port", None),
+        ("central_miner_port", 0),
+        ("central_miner_port", 65536),
+    ],
+)
+def test_opted_in_miner_requires_a_usable_endpoint(field_name, invalid_value):
+    data = {
+        "miner_hotkey": "portal-provider",
+        "central_miner_ip": "192.0.2.10",
+        "central_miner_port": 8091,
+    }
+    data[field_name] = invalid_value
+
+    with pytest.raises(ValidationError):
+        OptedInMiner.model_validate(data)
+
+
+@pytest.mark.asyncio
+async def test_live_portal_snapshot_is_cached_and_used(monkeypatch):
+    provider = _Neuron(uid=100, hotkey="portal-provider")
+    client = _client()
+    client.get_metagraph = MagicMock(return_value=MagicMock(neurons=[provider]))
+    monkeypatch.setattr(
         ValidatorPortalAPI,
         "get_opted_in_miners",
-        new=AsyncMock(return_value=None),
-    ):
-        with pytest.raises(RuntimeError, match="provider portal"):
-            await client.fetch_miners()
+        AsyncMock(return_value=[_portal_miner()]),
+    )
+
+    await client.fetch_miners()
+
+    assert client.miners == [provider]
+    assert provider.axon_info.ip == "192.0.2.10"
+    client.redis_service.set.assert_awaited_once()
+    cache_key, cache_json = client.redis_service.set.await_args.args
+    assert cache_key == PORTAL_MINERS_CACHE_KEY
+    cached = OptedInMinerSnapshot.model_validate_json(cache_json)
+    assert cached.miners == [_portal_miner()]
+
+
+@pytest.mark.asyncio
+async def test_failed_portal_refresh_uses_redis_snapshot_after_restart(monkeypatch):
+    provider = _Neuron(uid=100, hotkey="portal-provider")
+    client = _client()
+    client.get_metagraph = MagicMock(return_value=MagicMock(neurons=[provider]))
+    client.redis_service.get.return_value = _cache_payload(
+        _portal_miner(),
+        cached_at=1_000,
+    )
+    monkeypatch.setattr(
+        ValidatorPortalAPI,
+        "get_opted_in_miners",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr("clients.subtensor_client.time.time", lambda: 1_100)
+
+    await client.fetch_miners()
+
+    assert client.miners == [provider]
+    assert provider.axon_info.ip == "192.0.2.10"
+    client.redis_service.set.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_portal_and_cache_refresh_keeps_in_memory_snapshot(monkeypatch):
+    previous_snapshot = [
+        _Neuron(
+            uid=100,
+            hotkey="portal-provider",
+            axon_info=_AxonInfo("192.0.2.10", 8091),
+        )
+    ]
+    client = _client(miners=previous_snapshot)
+    client.redis_service.get.side_effect = RuntimeError("redis unavailable")
+    monkeypatch.setattr(
+        ValidatorPortalAPI,
+        "get_opted_in_miners",
+        AsyncMock(return_value=None),
+    )
+
+    await client.fetch_miners()
 
     assert client.miners is previous_snapshot
-    assert [miner.hotkey for miner in client.miners] == [
-        "portal-provider",
-        "on-chain-miner",
-    ]
 
 
 @pytest.mark.asyncio
-async def test_cold_start_portal_failure_does_not_submit_restored_scores():
-    provider_hotkey = "portal-provider"
-    registered_provider = _neuron(100, provider_hotkey, is_serving=False)
-
-    client = SubtensorClient.__new__(SubtensorClient)
-    client.debug_miner = None
-    client.default_extra = {}
-    client.miners = []
-    client.get_metagraph = MagicMock(
-        return_value=MagicMock(neurons=[registered_provider])
-    )
-
-    subtensor = MagicMock()
-    SubtensorClient._subtensor = subtensor
-
-    with patch.object(
+async def test_portal_failure_without_any_snapshot_is_explicit(monkeypatch):
+    client = _client()
+    monkeypatch.setattr(
         ValidatorPortalAPI,
         "get_opted_in_miners",
-        new=AsyncMock(return_value=None),
-    ):
-        with pytest.raises(RuntimeError, match="provider portal"):
-            await client.set_weights(miner_scores={provider_hotkey: 1.0})
+        AsyncMock(return_value=None),
+    )
 
-    assert client.miners == []
-    subtensor.set_weights.assert_not_called()
+    with pytest.raises(ProviderPortalDataUnavailable):
+        await client.fetch_miners()
 
 
 @pytest.mark.asyncio
-async def test_set_weights_stops_before_chain_when_registered_positive_score_is_missing():
-    provider_hotkey = "portal-provider"
-    on_chain_miner = _neuron(2, "on-chain-miner", is_serving=True)
-    registered_provider = _neuron(100, provider_hotkey, is_serving=False)
+async def test_sync_skips_cleanly_when_no_provider_snapshot_exists(caplog):
+    validator = Validator.__new__(Validator)
+    validator.default_extra = {}
+    validator.miner_scores = {"portal-provider": 1.0}
+    validator.subtensor_client = MagicMock()
+    validator.subtensor_client.get_miners = AsyncMock(
+        side_effect=ProviderPortalDataUnavailable("no snapshot")
+    )
+    validator.redis_service = AsyncMock()
 
-    client = SubtensorClient.__new__(SubtensorClient)
+    with caplog.at_level(logging.ERROR):
+        await validator.sync()
+
+    assert "[sync] No reliable provider snapshot, skipping iteration" in caplog.text
+    assert "[sync] Unknown error" not in caplog.text
+    cache_key, scores_json = validator.redis_service.set.await_args.args
+    assert cache_key == MINER_SCORES_KEY
+    assert json.loads(scores_json) == validator.miner_scores
+
+
+@pytest.mark.asyncio
+async def test_stale_redis_snapshot_is_used_and_pages_once(monkeypatch, caplog):
+    provider = _Neuron(uid=100, hotkey="portal-provider")
+    client = _client()
+    client.get_metagraph = MagicMock(return_value=MagicMock(neurons=[provider]))
+    client.redis_service.get.return_value = _cache_payload(
+        _portal_miner(),
+        cached_at=1_000,
+    )
+    monkeypatch.setattr(
+        ValidatorPortalAPI,
+        "get_opted_in_miners",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        "clients.subtensor_client.time.time",
+        lambda: 1_000 + PORTAL_MINERS_CACHE_ALERT_SECONDS,
+    )
+
+    with caplog.at_level(logging.CRITICAL):
+        await client.fetch_miners()
+        await client.fetch_miners()
+
+    alerts = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "[fetch_miners] provider snapshot cache exceeded alert threshold"
+    ]
+    assert len(alerts) == 1
+    assert _structured_extra(alerts[0])["cache_age_seconds"] == PORTAL_MINERS_CACHE_ALERT_SECONDS
+    assert client.miners == [provider]
+
+
+@pytest.mark.asyncio
+async def test_live_provider_count_transition_to_zero_warns_and_caches_empty(monkeypatch, caplog):
+    client = _client()
+    opted_out_provider = _Neuron(
+        uid=100,
+        hotkey="opted-out-provider",
+        axon_info=_AxonInfo("192.0.2.100", 8091),
+    )
+    client.get_metagraph = MagicMock(
+        return_value=MagicMock(neurons=[opted_out_provider])
+    )
+    client.redis_service.get.return_value = _cache_payload(
+        _portal_miner(),
+        cached_at=1_000,
+    )
+    monkeypatch.setattr(
+        ValidatorPortalAPI,
+        "get_opted_in_miners",
+        AsyncMock(return_value=[]),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        await client.fetch_miners()
+
+    warnings = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "[fetch_miners] opted-in provider count dropped to zero"
+    ]
+    assert len(warnings) == 1
+    cached = OptedInMinerSnapshot.model_validate_json(
+        client.redis_service.set.await_args.args[1]
+    )
+    assert cached.miners == []
+    assert client.miners == []
+
+
+@pytest.mark.parametrize(
+    ("active_hotkeys", "expected_level", "expected_active", "expected_inactive"),
+    [
+        ({"portal-provider"}, logging.CRITICAL, ["portal-provider"], []),
+        (set(), logging.WARNING, [], ["portal-provider"]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_missing_scored_provider_is_diagnosed_without_blocking_submission(
+    monkeypatch,
+    caplog,
+    active_hotkeys,
+    expected_level,
+    expected_active,
+    expected_inactive,
+):
+    provider_hotkey = "portal-provider"
+    snapshot_miner = _Neuron(
+        uid=2,
+        hotkey="snapshot-miner",
+        axon_info=_AxonInfo("192.0.2.2", 8091),
+    )
+    registered_provider = _Neuron(uid=100, hotkey=provider_hotkey)
+    client = _client()
     client.netuid = 1
-    client.default_extra = {}
     client.version_key = 10000
     client.wallet = MagicMock()
-    client.redis_service = AsyncMock()
     client.send_weights_to_lium = AsyncMock()
     client.get_current_block = MagicMock(return_value=100)
-    client.get_miners = AsyncMock(return_value=[on_chain_miner])
+    client.get_miners = AsyncMock(return_value=[snapshot_miner])
     client.get_metagraph = MagicMock(
-        return_value=MagicMock(neurons=[on_chain_miner, registered_provider])
+        return_value=MagicMock(neurons=[snapshot_miner, registered_provider])
     )
 
     subtensor = MagicMock()
     subtensor.set_weights.return_value = (True, "ok")
-    SubtensorClient._subtensor = subtensor
+    monkeypatch.setattr(SubtensorClient, "_subtensor", subtensor)
 
     def preserve_weights(*, uids, weights, **_kwargs):
         return uids, weights
 
-    with patch(
+    monkeypatch.setattr(
         "clients.subtensor_client.process_weights_for_netuid",
-        side_effect=preserve_weights,
-    ):
-        with pytest.raises(RuntimeError, match="positive-score"):
-            await client.set_weights(
-                miner_scores={"on-chain-miner": 0.5, provider_hotkey: 0.5},
-                active_hotkeys={provider_hotkey},
-            )
+        preserve_weights,
+    )
 
-    client.redis_service.publish.assert_not_awaited()
-    client.send_weights_to_lium.assert_not_awaited()
-    subtensor.set_weights.assert_not_called()
+    with caplog.at_level(expected_level):
+        await client.set_weights(
+            miner_scores={"snapshot-miner": 0.5, provider_hotkey: 0.5},
+            active_hotkeys=active_hotkeys,
+        )
+
+    diagnostics = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "[set_weights] scored miners missing from provider snapshot"
+    ]
+    assert len(diagnostics) == 1
+    diagnostic = diagnostics[0]
+    assert diagnostic.levelno == expected_level
+    assert _structured_extra(diagnostic)["active_missing_hotkeys"] == expected_active
+    assert _structured_extra(diagnostic)["inactive_missing_hotkeys"] == expected_inactive
+    client.redis_service.publish.assert_awaited_once()
+    client.send_weights_to_lium.assert_awaited_once()
+    subtensor.set_weights.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_legitimate_opt_out_keeps_preexisting_vector_behavior(monkeypatch):
+    snapshot_miner = _Neuron(
+        uid=2,
+        hotkey="snapshot-miner",
+        axon_info=_AxonInfo("192.0.2.2", 8091),
+    )
+    opted_out_provider = _Neuron(
+        uid=100,
+        hotkey="opted-out-provider",
+        axon_info=_AxonInfo("192.0.2.100", 8091),
+    )
+    client = _client()
+    client.netuid = 1
+    client.version_key = 10000
+    client.wallet = MagicMock()
+    client.send_weights_to_lium = AsyncMock()
+    client.get_current_block = MagicMock(return_value=100)
+    client.get_miners = AsyncMock(return_value=[snapshot_miner])
+    client.get_metagraph = MagicMock(
+        return_value=MagicMock(neurons=[snapshot_miner, opted_out_provider])
+    )
+
+    subtensor = MagicMock()
+    subtensor.set_weights.return_value = (True, "ok")
+    monkeypatch.setattr(SubtensorClient, "_subtensor", subtensor)
+    monkeypatch.setattr(
+        "clients.subtensor_client.process_weights_for_netuid",
+        lambda *, uids, weights, **_kwargs: (uids, weights),
+    )
+
+    await client.set_weights(
+        miner_scores={"snapshot-miner": 0.5, "opted-out-provider": 0.5},
+    )
+
+    assert list(subtensor.set_weights.call_args.kwargs["uids"]) == [2]

--- a/neurons/validators/tests/test_validator_portal_fail_safe.py
+++ b/neurons/validators/tests/test_validator_portal_fail_safe.py
@@ -1,0 +1,147 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import bittensor
+import pytest
+
+from clients.subtensor_client import SubtensorClient
+from clients.validator_portal_api import ValidatorPortalAPI
+from core.config import settings
+
+
+def _neuron(uid: int, hotkey: str, *, is_serving: bool) -> bittensor.NeuronInfo:
+    neuron = MagicMock(spec=bittensor.NeuronInfo)
+    neuron.uid = uid
+    neuron.hotkey = hotkey
+    neuron.coldkey = "coldkey"
+    neuron.axon_info = MagicMock()
+    neuron.axon_info.ip = "192.0.2.1"
+    neuron.axon_info.port = 8091
+    neuron.axon_info.is_serving = is_serving
+    return neuron
+
+
+@pytest.mark.asyncio
+async def test_portal_timeout_is_not_reported_as_empty_opt_in_list():
+    keypair = MagicMock()
+    keypair.ss58_address = "validator-hotkey"
+    keypair.sign.return_value = b"signed"
+    wallet = MagicMock()
+    wallet.get_hotkey.return_value = keypair
+
+    session = MagicMock()
+    session.get.side_effect = asyncio.TimeoutError
+    session_context = MagicMock()
+    session_context.__aenter__ = AsyncMock(return_value=session)
+    session_context.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("core.config.Settings.get_bittensor_wallet", return_value=wallet),
+        patch.object(settings, "MINER_PORTAL_REST_API_URL", "https://portal.test"),
+        patch(
+            "clients.validator_portal_api.aiohttp.ClientSession",
+            return_value=session_context,
+        ),
+    ):
+        result = await ValidatorPortalAPI.get_opted_in_miners()
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_failed_portal_refresh_keeps_previous_miner_snapshot():
+    cached_provider = _neuron(100, "portal-provider", is_serving=True)
+    on_chain_miner = _neuron(2, "on-chain-miner", is_serving=True)
+    registered_provider = _neuron(100, "portal-provider", is_serving=False)
+
+    client = SubtensorClient.__new__(SubtensorClient)
+    client.debug_miner = None
+    client.default_extra = {}
+    client.miners = [cached_provider, on_chain_miner]
+    previous_snapshot = client.miners
+    client.get_metagraph = MagicMock(
+        return_value=MagicMock(neurons=[registered_provider, on_chain_miner])
+    )
+
+    with patch.object(
+        ValidatorPortalAPI,
+        "get_opted_in_miners",
+        new=AsyncMock(return_value=None),
+    ):
+        with pytest.raises(RuntimeError, match="provider portal"):
+            await client.fetch_miners()
+
+    assert client.miners is previous_snapshot
+    assert [miner.hotkey for miner in client.miners] == [
+        "portal-provider",
+        "on-chain-miner",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cold_start_portal_failure_does_not_submit_restored_scores():
+    provider_hotkey = "portal-provider"
+    registered_provider = _neuron(100, provider_hotkey, is_serving=False)
+
+    client = SubtensorClient.__new__(SubtensorClient)
+    client.debug_miner = None
+    client.default_extra = {}
+    client.miners = []
+    client.get_metagraph = MagicMock(
+        return_value=MagicMock(neurons=[registered_provider])
+    )
+
+    subtensor = MagicMock()
+    SubtensorClient._subtensor = subtensor
+
+    with patch.object(
+        ValidatorPortalAPI,
+        "get_opted_in_miners",
+        new=AsyncMock(return_value=None),
+    ):
+        with pytest.raises(RuntimeError, match="provider portal"):
+            await client.set_weights(miner_scores={provider_hotkey: 1.0})
+
+    assert client.miners == []
+    subtensor.set_weights.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_weights_stops_before_chain_when_registered_positive_score_is_missing():
+    provider_hotkey = "portal-provider"
+    on_chain_miner = _neuron(2, "on-chain-miner", is_serving=True)
+    registered_provider = _neuron(100, provider_hotkey, is_serving=False)
+
+    client = SubtensorClient.__new__(SubtensorClient)
+    client.netuid = 1
+    client.default_extra = {}
+    client.version_key = 10000
+    client.wallet = MagicMock()
+    client.redis_service = AsyncMock()
+    client.send_weights_to_lium = AsyncMock()
+    client.get_current_block = MagicMock(return_value=100)
+    client.get_miners = AsyncMock(return_value=[on_chain_miner])
+    client.get_metagraph = MagicMock(
+        return_value=MagicMock(neurons=[on_chain_miner, registered_provider])
+    )
+
+    subtensor = MagicMock()
+    subtensor.set_weights.return_value = (True, "ok")
+    SubtensorClient._subtensor = subtensor
+
+    def preserve_weights(*, uids, weights, **_kwargs):
+        return uids, weights
+
+    with patch(
+        "clients.subtensor_client.process_weights_for_netuid",
+        side_effect=preserve_weights,
+    ):
+        with pytest.raises(RuntimeError, match="positive-score"):
+            await client.set_weights(
+                miner_scores={"on-chain-miner": 0.5, provider_hotkey: 0.5},
+                active_hotkeys={provider_hotkey},
+            )
+
+    client.redis_service.publish.assert_not_awaited()
+    client.send_weights_to_lium.assert_not_awaited()
+    subtensor.set_weights.assert_not_called()

--- a/neurons/validators/tests/test_validator_portal_fail_safe.py
+++ b/neurons/validators/tests/test_validator_portal_fail_safe.py
@@ -1,7 +1,9 @@
 import asyncio
 import json
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -24,20 +26,15 @@ class _AxonInfo:
     ip: str = "0.0.0.0"
     port: int = 0
 
-    @property
-    def is_serving(self) -> bool:
-        return self.ip != "0.0.0.0"
-
 
 @dataclass
 class _Neuron:
     uid: int
     hotkey: str
-    coldkey: str = "coldkey"
     axon_info: _AxonInfo = field(default_factory=_AxonInfo)
 
 
-def _portal_miner(hotkey: str = "portal-provider") -> OptedInMiner:
+def _opted_in_miner(hotkey: str = "portal-provider") -> OptedInMiner:
     return OptedInMiner(
         miner_hotkey=hotkey,
         central_miner_ip="192.0.2.10",
@@ -45,29 +42,42 @@ def _portal_miner(hotkey: str = "portal-provider") -> OptedInMiner:
     )
 
 
-def _client(*, miners: list[_Neuron] | None = None) -> SubtensorClient:
+def _make_subtensor_client(
+    *,
+    miners: list[_Neuron] | None = None,
+) -> SubtensorClient:
     client = SubtensorClient.__new__(SubtensorClient)
     client.debug_miner = None
     client.default_extra = {}
     client.miners = miners or []
     client.redis_service = AsyncMock()
     client.redis_service.get.return_value = None
+    client._has_alerted_for_stale_portal_snapshot = False
     return client
 
 
-def _cache_payload(*miners: OptedInMiner, cached_at: float) -> str:
+def _cached_miners_json(*miners: OptedInMiner, cached_at: float) -> str:
     return OptedInMinerSnapshot(
         cached_at=cached_at,
         miners=list(miners),
     ).model_dump_json()
 
 
-def _structured_extra(record: logging.LogRecord) -> dict:
-    return record.msg.extra
+def _structured_extra(record: logging.LogRecord) -> Mapping[str, object]:
+    return cast(Mapping[str, object], getattr(record.msg, "extra"))
+
+
+def _preserve_weights(
+    *,
+    uids: object,
+    weights: object,
+    **_kwargs: object,
+) -> tuple[object, object]:
+    return uids, weights
 
 
 @pytest.mark.asyncio
-async def test_portal_timeout_is_not_reported_as_empty_opt_in_list():
+async def test_portal_timeout_is_not_reported_as_empty_opt_in_list() -> None:
     keypair = MagicMock()
     keypair.ss58_address = "validator-hotkey"
     keypair.sign.return_value = b"signed"
@@ -94,7 +104,7 @@ async def test_portal_timeout_is_not_reported_as_empty_opt_in_list():
 
 
 @pytest.mark.asyncio
-async def test_portal_rejects_response_with_a_malformed_provider():
+async def test_portal_rejects_response_with_a_malformed_provider() -> None:
     keypair = MagicMock(ss58_address="validator-hotkey")
     keypair.sign.return_value = b"signed"
     wallet = MagicMock()
@@ -144,7 +154,10 @@ async def test_portal_rejects_response_with_a_malformed_provider():
         ("central_miner_port", 65536),
     ],
 )
-def test_opted_in_miner_requires_a_usable_endpoint(field_name, invalid_value):
+def test_opted_in_miner_requires_a_usable_endpoint(
+    field_name: str,
+    invalid_value: object,
+) -> None:
     data = {
         "miner_hotkey": "portal-provider",
         "central_miner_ip": "192.0.2.10",
@@ -157,34 +170,39 @@ def test_opted_in_miner_requires_a_usable_endpoint(field_name, invalid_value):
 
 
 @pytest.mark.asyncio
-async def test_live_portal_snapshot_is_cached_and_used(monkeypatch):
+async def test_live_portal_snapshot_is_cached_and_used(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     provider = _Neuron(uid=100, hotkey="portal-provider")
-    client = _client()
+    client = _make_subtensor_client()
     client.get_metagraph = MagicMock(return_value=MagicMock(neurons=[provider]))
     monkeypatch.setattr(
         ValidatorPortalAPI,
         "get_opted_in_miners",
-        AsyncMock(return_value=[_portal_miner()]),
+        AsyncMock(return_value=[_opted_in_miner()]),
     )
 
     await client.fetch_miners()
 
     assert client.miners == [provider]
     assert provider.axon_info.ip == "192.0.2.10"
+    client.redis_service.get.assert_not_awaited()
     client.redis_service.set.assert_awaited_once()
     cache_key, cache_json = client.redis_service.set.await_args.args
     assert cache_key == PORTAL_MINERS_CACHE_KEY
     cached = OptedInMinerSnapshot.model_validate_json(cache_json)
-    assert cached.miners == [_portal_miner()]
+    assert cached.miners == [_opted_in_miner()]
 
 
 @pytest.mark.asyncio
-async def test_failed_portal_refresh_uses_redis_snapshot_after_restart(monkeypatch):
+async def test_failed_portal_refresh_uses_redis_snapshot_after_restart(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     provider = _Neuron(uid=100, hotkey="portal-provider")
-    client = _client()
+    client = _make_subtensor_client()
     client.get_metagraph = MagicMock(return_value=MagicMock(neurons=[provider]))
-    client.redis_service.get.return_value = _cache_payload(
-        _portal_miner(),
+    client.redis_service.get.return_value = _cached_miners_json(
+        _opted_in_miner(),
         cached_at=1_000,
     )
     monkeypatch.setattr(
@@ -202,7 +220,9 @@ async def test_failed_portal_refresh_uses_redis_snapshot_after_restart(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_failed_portal_and_cache_refresh_keeps_in_memory_snapshot(monkeypatch):
+async def test_failed_portal_and_cache_refresh_keeps_in_memory_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     previous_snapshot = [
         _Neuron(
             uid=100,
@@ -210,7 +230,7 @@ async def test_failed_portal_and_cache_refresh_keeps_in_memory_snapshot(monkeypa
             axon_info=_AxonInfo("192.0.2.10", 8091),
         )
     ]
-    client = _client(miners=previous_snapshot)
+    client = _make_subtensor_client(miners=previous_snapshot)
     client.redis_service.get.side_effect = RuntimeError("redis unavailable")
     monkeypatch.setattr(
         ValidatorPortalAPI,
@@ -224,8 +244,10 @@ async def test_failed_portal_and_cache_refresh_keeps_in_memory_snapshot(monkeypa
 
 
 @pytest.mark.asyncio
-async def test_portal_failure_without_any_snapshot_is_explicit(monkeypatch):
-    client = _client()
+async def test_portal_failure_without_any_snapshot_is_explicit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _make_subtensor_client()
     monkeypatch.setattr(
         ValidatorPortalAPI,
         "get_opted_in_miners",
@@ -237,7 +259,9 @@ async def test_portal_failure_without_any_snapshot_is_explicit(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_sync_skips_cleanly_when_no_provider_snapshot_exists(caplog):
+async def test_sync_skips_cleanly_when_no_provider_snapshot_exists(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     validator = Validator.__new__(Validator)
     validator.default_extra = {}
     validator.miner_scores = {"portal-provider": 1.0}
@@ -258,12 +282,15 @@ async def test_sync_skips_cleanly_when_no_provider_snapshot_exists(caplog):
 
 
 @pytest.mark.asyncio
-async def test_stale_redis_snapshot_is_used_and_pages_once(monkeypatch, caplog):
+async def test_stale_redis_snapshot_is_used_and_pages_once(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     provider = _Neuron(uid=100, hotkey="portal-provider")
-    client = _client()
+    client = _make_subtensor_client()
     client.get_metagraph = MagicMock(return_value=MagicMock(neurons=[provider]))
-    client.redis_service.get.return_value = _cache_payload(
-        _portal_miner(),
+    client.redis_service.get.return_value = _cached_miners_json(
+        _opted_in_miner(),
         cached_at=1_000,
     )
     monkeypatch.setattr(
@@ -291,8 +318,11 @@ async def test_stale_redis_snapshot_is_used_and_pages_once(monkeypatch, caplog):
 
 
 @pytest.mark.asyncio
-async def test_live_provider_count_transition_to_zero_warns_and_caches_empty(monkeypatch, caplog):
-    client = _client()
+async def test_live_provider_count_transition_to_zero_warns_and_caches_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client = _make_subtensor_client()
     opted_out_provider = _Neuron(
         uid=100,
         hotkey="opted-out-provider",
@@ -301,8 +331,8 @@ async def test_live_provider_count_transition_to_zero_warns_and_caches_empty(mon
     client.get_metagraph = MagicMock(
         return_value=MagicMock(neurons=[opted_out_provider])
     )
-    client.redis_service.get.return_value = _cache_payload(
-        _portal_miner(),
+    client.redis_service.get.return_value = _cached_miners_json(
+        _opted_in_miner(),
         cached_at=1_000,
     )
     monkeypatch.setattr(
@@ -336,13 +366,13 @@ async def test_live_provider_count_transition_to_zero_warns_and_caches_empty(mon
 )
 @pytest.mark.asyncio
 async def test_missing_scored_provider_is_diagnosed_without_blocking_submission(
-    monkeypatch,
-    caplog,
-    active_hotkeys,
-    expected_level,
-    expected_active,
-    expected_inactive,
-):
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    active_hotkeys: set[str],
+    expected_level: int,
+    expected_active: list[str],
+    expected_inactive: list[str],
+) -> None:
     provider_hotkey = "portal-provider"
     snapshot_miner = _Neuron(
         uid=2,
@@ -350,7 +380,7 @@ async def test_missing_scored_provider_is_diagnosed_without_blocking_submission(
         axon_info=_AxonInfo("192.0.2.2", 8091),
     )
     registered_provider = _Neuron(uid=100, hotkey=provider_hotkey)
-    client = _client()
+    client = _make_subtensor_client()
     client.netuid = 1
     client.version_key = 10000
     client.wallet = MagicMock()
@@ -365,12 +395,9 @@ async def test_missing_scored_provider_is_diagnosed_without_blocking_submission(
     subtensor.set_weights.return_value = (True, "ok")
     monkeypatch.setattr(SubtensorClient, "_subtensor", subtensor)
 
-    def preserve_weights(*, uids, weights, **_kwargs):
-        return uids, weights
-
     monkeypatch.setattr(
         "clients.subtensor_client.process_weights_for_netuid",
-        preserve_weights,
+        _preserve_weights,
     )
 
     with caplog.at_level(expected_level):
@@ -395,7 +422,9 @@ async def test_missing_scored_provider_is_diagnosed_without_blocking_submission(
 
 
 @pytest.mark.asyncio
-async def test_legitimate_opt_out_keeps_preexisting_vector_behavior(monkeypatch):
+async def test_legitimate_opt_out_keeps_preexisting_vector_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     snapshot_miner = _Neuron(
         uid=2,
         hotkey="snapshot-miner",
@@ -406,7 +435,7 @@ async def test_legitimate_opt_out_keeps_preexisting_vector_behavior(monkeypatch)
         hotkey="opted-out-provider",
         axon_info=_AxonInfo("192.0.2.100", 8091),
     )
-    client = _client()
+    client = _make_subtensor_client()
     client.netuid = 1
     client.version_key = 10000
     client.wallet = MagicMock()
@@ -422,7 +451,7 @@ async def test_legitimate_opt_out_keeps_preexisting_vector_behavior(monkeypatch)
     monkeypatch.setattr(SubtensorClient, "_subtensor", subtensor)
     monkeypatch.setattr(
         "clients.subtensor_client.process_weights_for_netuid",
-        lambda *, uids, weights, **_kwargs: (uids, weights),
+        _preserve_weights,
     )
 
     await client.set_weights(

--- a/neurons/validators/tests/test_validator_portal_fail_safe.py
+++ b/neurons/validators/tests/test_validator_portal_fail_safe.py
@@ -60,6 +60,24 @@ def _make_subtensor_client(
     return client
 
 
+def _make_weight_submission_client(
+    *,
+    selected_miners: list[_Neuron],
+    registered_miners: list[_Neuron],
+) -> SubtensorClient:
+    client = _make_subtensor_client()
+    client.netuid = 1
+    client.version_key = 10000
+    client.wallet = MagicMock()
+    client.send_weights_to_lium = AsyncMock()
+    client.get_current_block = MagicMock(return_value=100)
+    client.get_miners = AsyncMock(return_value=selected_miners)
+    client.get_metagraph = MagicMock(
+        return_value=MagicMock(neurons=registered_miners)
+    )
+    return client
+
+
 def _cached_miners_json(*miners: OptedInMiner, cached_at: float) -> str:
     return OptedInMinerSnapshot(
         cached_at=cached_at,
@@ -69,6 +87,13 @@ def _cached_miners_json(*miners: OptedInMiner, cached_at: float) -> str:
 
 def _structured_extra(record: logging.LogRecord) -> Mapping[str, object]:
     return cast(Mapping[str, object], getattr(record.msg, "extra"))
+
+
+def _records_with_message(
+    caplog: pytest.LogCaptureFixture,
+    message: str,
+) -> list[logging.LogRecord]:
+    return [record for record in caplog.records if record.getMessage() == message]
 
 
 def _preserve_weights(
@@ -381,21 +406,15 @@ async def test_missing_scored_provider_is_diagnosed_without_blocking_submission(
     expected_inactive: list[str],
 ) -> None:
     provider_hotkey = "portal-provider"
-    snapshot_miner = _Neuron(
+    selected_miner = _Neuron(
         uid=2,
-        hotkey="snapshot-miner",
+        hotkey="selected-miner",
         axon_info=_AxonInfo("192.0.2.2", 8091),
     )
     registered_provider = _Neuron(uid=100, hotkey=provider_hotkey)
-    client = _make_subtensor_client()
-    client.netuid = 1
-    client.version_key = 10000
-    client.wallet = MagicMock()
-    client.send_weights_to_lium = AsyncMock()
-    client.get_current_block = MagicMock(return_value=100)
-    client.get_miners = AsyncMock(return_value=[snapshot_miner])
-    client.get_metagraph = MagicMock(
-        return_value=MagicMock(neurons=[snapshot_miner, registered_provider])
+    client = _make_weight_submission_client(
+        selected_miners=[selected_miner],
+        registered_miners=[selected_miner, registered_provider],
     )
 
     subtensor = MagicMock()
@@ -409,15 +428,14 @@ async def test_missing_scored_provider_is_diagnosed_without_blocking_submission(
 
     with caplog.at_level(expected_level):
         await client.set_weights(
-            miner_scores={"snapshot-miner": 0.5, provider_hotkey: 0.5},
+            miner_scores={"selected-miner": 0.5, provider_hotkey: 0.5},
             active_hotkeys=active_hotkeys,
         )
 
-    diagnostics = [
-        record
-        for record in caplog.records
-        if record.getMessage() == "[set_weights] scored miners missing from provider snapshot"
-    ]
+    diagnostics = _records_with_message(
+        caplog,
+        "[set_weights] scored miners missing from selected miner set",
+    )
     assert len(diagnostics) == 1
     diagnostic = diagnostics[0]
     assert diagnostic.levelno == expected_level
@@ -429,28 +447,21 @@ async def test_missing_scored_provider_is_diagnosed_without_blocking_submission(
 
 
 @pytest.mark.asyncio
-async def test_legitimate_opt_out_keeps_preexisting_vector_behavior(
+async def test_registered_non_serving_provider_is_omitted_from_weight_vector(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    snapshot_miner = _Neuron(
+    selected_miner = _Neuron(
         uid=2,
-        hotkey="snapshot-miner",
+        hotkey="selected-miner",
         axon_info=_AxonInfo("192.0.2.2", 8091),
     )
-    opted_out_provider = _Neuron(
+    non_serving_provider = _Neuron(
         uid=100,
-        hotkey="opted-out-provider",
-        axon_info=_AxonInfo("192.0.2.100", 8091),
+        hotkey="non-serving-provider",
     )
-    client = _make_subtensor_client()
-    client.netuid = 1
-    client.version_key = 10000
-    client.wallet = MagicMock()
-    client.send_weights_to_lium = AsyncMock()
-    client.get_current_block = MagicMock(return_value=100)
-    client.get_miners = AsyncMock(return_value=[snapshot_miner])
-    client.get_metagraph = MagicMock(
-        return_value=MagicMock(neurons=[snapshot_miner, opted_out_provider])
+    client = _make_weight_submission_client(
+        selected_miners=[selected_miner],
+        registered_miners=[selected_miner, non_serving_provider],
     )
 
     subtensor = MagicMock()
@@ -462,7 +473,7 @@ async def test_legitimate_opt_out_keeps_preexisting_vector_behavior(
     )
 
     await client.set_weights(
-        miner_scores={"snapshot-miner": 0.5, "opted-out-provider": 0.5},
+        miner_scores={"selected-miner": 0.5, "non-serving-provider": 0.5},
     )
 
     assert list(subtensor.set_weights.call_args.kwargs["uids"]) == [2]


### PR DESCRIPTION
## Summary

Keep the last successful provider-portal response available across validator restarts so a portal outage does not remove central-routed providers from the existing serving-miner set.

## Change

- Validate portal records as `OptedInMiner`; hotkey, central IP, and central port are required, and unusable endpoints make the response unavailable.
- Preserve the distinction between portal failure (`None`) and a successful empty response (`[]`).
- Cache every valid portal response in Redis without a TTL. On portal failure, use the Redis snapshot; if Redis is unavailable, retain the in-memory miner list.
- Apply the live or cached portal response only as IP/port routing overrides. Miner eligibility remains unchanged: serving axons plus configured burner UIDs.
- If no live, Redis, or in-memory snapshot exists, skip the validator iteration explicitly while keeping accumulated scores persisted.
- Report scored registered hotkeys missing from the final miner set as diagnostics only. Weight submission continues.
- Log cache source, provider count, and age; emit a critical alert once the cached response is one hour old, and warn when a previously non-empty provider response becomes empty.

## Scope

A successful `200 []` remains authoritative and is cached. Detecting a portal response that is syntactically successful but semantically incomplete requires a stronger portal API contract and is outside this validator fix.

This change does not redesign scoring or miner eligibility. It only prevents a failed portal request from being interpreted as an empty routing response.

## Validation

- `tests/test_validator_portal_fail_safe.py`: 19 passed.
- The regression coverage verifies that cached portal routing survives a failed refresh, serving non-opted-in miners remain eligible, and non-serving miners remain excluded.
- Full validator suite on commit `6b84d253`: 1599 passed, 9 skipped, with the same 3 unrelated SSH bootstrap failures in the untouched test file.
- `git diff --check` passed.

Corrected staging smoke is pending deployment of commit `6b84d253`.
