### PR TITLE
DAH-2702: verify GPU persistence mode after -pm 1 in the power cap

### DIFF
--- a/neurons/validators/src/services/gpu_power_limit.py
+++ b/neurons/validators/src/services/gpu_power_limit.py
@@ -41,6 +41,7 @@ import logging
 import shlex
 import time
 from dataclasses import dataclass
+from typing import Literal
 
 import asyncssh
 from payload_models.payloads import GpuPowerLimit
@@ -108,6 +109,19 @@ class GpuPowerReadback:
     persistence_enabled: bool | None
 
 
+@dataclass(frozen=True)
+class PowerLimitSetOutcome:
+    """Outcome of one verified set: why it failed (None = success) and the persistence verdict the
+    readback saw. A successful set with persistence off can still revert on its own later."""
+
+    failure: str | None
+    persistence_enabled: bool | None
+
+
+# nvidia-smi's own labels; anything else means the GPU did not report the field.
+_PERSISTENCE_BY_LABEL: dict[str, bool] = {"enabled": True, "disabled": False}
+
+
 def _restore_key(gpu_uuid: str) -> str:
     return f"{_RESTORE_KEY_PREFIX}{gpu_uuid}"
 
@@ -144,13 +158,12 @@ def _parse_power_state_csv(stdout: str) -> dict[str, GpuPowerState]:
 
 
 def _parse_power_readback_csv(stdout: str) -> GpuPowerReadback:
-    fields = [field.strip() for field in str(stdout).strip().split(",")]
-    watts = _watts_or_none(fields[0])
-    persistence_raw = fields[1].lower() if len(fields) > 1 else ""
-    persistence_enabled: bool | None = None
-    if persistence_raw in ("enabled", "disabled"):
-        persistence_enabled = persistence_raw == "enabled"
-    return GpuPowerReadback(watts=watts, persistence_enabled=persistence_enabled)
+    # Unreported persistence ("[N/A]", missing column) is not the same as persistence being off.
+    watts_raw, _, persistence_raw = stdout.partition(",")
+    return GpuPowerReadback(
+        watts=_watts_or_none(watts_raw.strip()),
+        persistence_enabled=_PERSISTENCE_BY_LABEL.get(persistence_raw.strip().lower()),
+    )
 
 
 def _clamp_watts(target_watts: int, state: GpuPowerState) -> int:
@@ -208,12 +221,12 @@ async def _enable_persistence_mode(
 async def _read_back_power_state(ssh: asyncssh.SSHClientConnection, uuid: str) -> GpuPowerReadback:
     """Read one GPU's power.limit and persistence mode. Both come from the same nvidia-smi query, so
     verifying persistence costs no extra round trip. Unreadable -> all-None (never raises)."""
-    cmd = (
+    readback_command = (
         f"nvidia-smi -i {shlex.quote(uuid)} --query-gpu=power.limit,persistence_mode "
         f"--format=csv,noheader,nounits"
     )
     try:
-        result = await ssh.run(cmd, timeout=_NVIDIA_SMI_TIMEOUT_SECONDS)
+        result = await ssh.run(readback_command, timeout=_NVIDIA_SMI_TIMEOUT_SECONDS)
     except Exception:
         return GpuPowerReadback(watts=None, persistence_enabled=None)
     if result.exit_status != 0:
@@ -221,20 +234,11 @@ async def _read_back_power_state(ssh: asyncssh.SSHClientConnection, uuid: str) -
     return _parse_power_readback_csv(str(result.stdout))
 
 
-@dataclass(frozen=True)
-class PowerLimitSetResult:
-    """Outcome of one verified set: why it failed (None = success) and the persistence verdict the
-    readback saw. A successful set with persistence off can still revert on its own later."""
-
-    failure: str | None
-    persistence_enabled: bool | None
-
-
 async def _set_power_limit(
     ssh: asyncssh.SSHClientConnection,
     uuid: str,
     watts: int,
-) -> PowerLimitSetResult:
+) -> PowerLimitSetOutcome:
     """Set one GPU's power limit and VERIFY it stuck (never raises). nvidia-smi can report success
     while the limit silently reverts (persistence mode off, driver unloads) — only the readback
     proves the cap exists."""
@@ -243,32 +247,32 @@ async def _set_power_limit(
             f"nvidia-smi -i {shlex.quote(uuid)} -pl {watts}", timeout=_NVIDIA_SMI_TIMEOUT_SECONDS
         )
     except Exception as exc:
-        return PowerLimitSetResult(failure=f"nvidia-smi -pl errored: {exc}", persistence_enabled=None)
+        return PowerLimitSetOutcome(failure=f"nvidia-smi -pl errored: {exc}", persistence_enabled=None)
     if result.exit_status != 0:
-        return PowerLimitSetResult(
+        return PowerLimitSetOutcome(
             failure=f"nvidia-smi -pl failed: exit={result.exit_status}, stderr={result.stderr!r}",
             persistence_enabled=None,
         )
     readback = await _read_back_power_state(ssh, uuid)
     if readback.watts is None:
-        return PowerLimitSetResult(
+        return PowerLimitSetOutcome(
             failure="nvidia-smi -pl reported success but the limit could not be read back for verification",
             persistence_enabled=readback.persistence_enabled,
         )
     if readback.watts != watts:
-        return PowerLimitSetResult(
+        return PowerLimitSetOutcome(
             failure=(
                 f"nvidia-smi -pl reported success but the limit did not stick: "
                 f"readback {readback.watts}W != target {watts}W (persistence mode unavailable?)"
             ),
             persistence_enabled=readback.persistence_enabled,
         )
-    return PowerLimitSetResult(failure=None, persistence_enabled=readback.persistence_enabled)
+    return PowerLimitSetOutcome(failure=None, persistence_enabled=readback.persistence_enabled)
 
 
 async def _set_and_log_power_limit(
     ssh: asyncssh.SSHClientConnection,
-    action: str,  # "cap" | "restore"
+    action: Literal["cap", "restore", "raise"],
     executor_id: str,
     gpu_uuid: str,
     watts_before: int | None,
@@ -277,36 +281,39 @@ async def _set_and_log_power_limit(
 ) -> bool:
     # Reviewer contract (PR #1115): every PL change is logged with executor, GPU, before/after, status.
     await _enable_persistence_mode(ssh, gpu_uuid, log_extra)
-    set_result = await _set_power_limit(ssh, gpu_uuid, watts_after)
-    failure = set_result.failure
+    set_outcome = await _set_power_limit(ssh, gpu_uuid, watts_after)
+    failure = set_outcome.failure
     status = "ok" if failure is None else "failed"
     message = f"gpu power limit {action} {status}: executor={executor_id} gpu={gpu_uuid} watts {watts_before} -> {watts_after}"
     if failure is not None:
         message = f"{message} ({failure})"
-    fields: dict[str, object] = {
-        "gpu_power_action": action,
-        "executor_uuid": executor_id,
-        "gpu_uuid": gpu_uuid,
-        "watts_before": watts_before,
-        "watts_after": watts_after,
-        "status": status,
-        "persistence_enabled": set_result.persistence_enabled,
-    }
-    _log(logging.INFO if failure is None else logging.ERROR, message, fields, log_extra)
-    # DAH-2702: a verified cap with persistence off holds only until the driver unloads on an idle
-    # GPU, which is how a cap reverts with nobody touching the host. Only "cap" is at risk — a
-    # restore/raise sets the limit back UP, and a driver unload lands on the default anyway.
-    # Observability only: refusing the filler here would drop PEARL from every host that cannot
-    # hold persistence mode. Logged WITHOUT gpu_power_action/status so counters over the change
-    # events do not see this warning as a second cap.
-    if failure is None and action == "cap" and set_result.persistence_enabled is False:
-        _log(
-            logging.WARNING,
-            f"gpu power limit cap: persistence mode is off for {gpu_uuid} after -pm 1; "
-            f"the {watts_after}W cap can revert on its own when the driver unloads",
-            {"executor_uuid": executor_id, "gpu_uuid": gpu_uuid, "persistence_enabled": False},
-            log_extra,
-        )
+    # DAH-2702: with persistence off the driver unloads on an idle GPU and the stock limit returns,
+    # which is how a cap reverts untouched. Only a cap is at risk — restore/raise set the limit back
+    # UP, where an unload lands anyway. Never fail-closed: refusing the filler would drop PEARL from
+    # every host that cannot hold persistence mode.
+    cap_can_revert = failure is None and action == "cap" and set_outcome.persistence_enabled is False
+    if cap_can_revert:
+        message = f"{message} (persistence mode is off after -pm 1; this cap can revert on its own)"
+    if failure is not None:
+        level = logging.ERROR
+    elif cap_can_revert:
+        level = logging.WARNING
+    else:
+        level = logging.INFO
+    _log(
+        level,
+        message,
+        {
+            "gpu_power_action": action,
+            "executor_uuid": executor_id,
+            "gpu_uuid": gpu_uuid,
+            "watts_before": watts_before,
+            "watts_after": watts_after,
+            "status": status,
+            "persistence_enabled": set_outcome.persistence_enabled,
+        },
+        log_extra,
+    )
     return failure is None
 
 

--- a/neurons/validators/src/services/gpu_power_limit.py
+++ b/neurons/validators/src/services/gpu_power_limit.py
@@ -99,6 +99,15 @@ class GpuPowerState:
     default_watts: int | None = None
 
 
+@dataclass(frozen=True)
+class GpuPowerReadback:
+    """What one GPU reports right after a set: the limit that stuck, and whether persistence mode
+    is on. ``persistence_enabled=None`` means nvidia-smi did not report the field."""
+
+    watts: int | None
+    persistence_enabled: bool | None
+
+
 def _restore_key(gpu_uuid: str) -> str:
     return f"{_RESTORE_KEY_PREFIX}{gpu_uuid}"
 
@@ -132,6 +141,16 @@ def _parse_power_state_csv(stdout: str) -> dict[str, GpuPowerState]:
             default_watts=_watts_or_none(default_raw),
         )
     return state_by_uuid
+
+
+def _parse_power_readback_csv(stdout: str) -> GpuPowerReadback:
+    fields = [field.strip() for field in str(stdout).strip().split(",")]
+    watts = _watts_or_none(fields[0]) if fields else None
+    persistence_raw = fields[1].lower() if len(fields) > 1 else ""
+    persistence_enabled: bool | None = None
+    if persistence_raw in ("enabled", "disabled"):
+        persistence_enabled = persistence_raw == "enabled"
+    return GpuPowerReadback(watts=watts, persistence_enabled=persistence_enabled)
 
 
 def _clamp_watts(target_watts: int, state: GpuPowerState) -> int:
@@ -186,43 +205,65 @@ async def _enable_persistence_mode(
         )
 
 
-async def _read_back_power_limit(ssh: asyncssh.SSHClientConnection, uuid: str) -> int | None:
-    """Read one GPU's current power.limit in watts. Returns None when it cannot be read (never raises)."""
-    cmd = f"nvidia-smi -i {shlex.quote(uuid)} --query-gpu=power.limit --format=csv,noheader,nounits"
+async def _read_back_power_state(ssh: asyncssh.SSHClientConnection, uuid: str) -> GpuPowerReadback:
+    """Read one GPU's power.limit and persistence mode. Both come from the same nvidia-smi query, so
+    verifying persistence costs no extra round trip. Unreadable -> all-None (never raises)."""
+    cmd = (
+        f"nvidia-smi -i {shlex.quote(uuid)} --query-gpu=power.limit,persistence_mode "
+        f"--format=csv,noheader,nounits"
+    )
     try:
         result = await ssh.run(cmd, timeout=_NVIDIA_SMI_TIMEOUT_SECONDS)
     except Exception:
-        return None
+        return GpuPowerReadback(watts=None, persistence_enabled=None)
     if result.exit_status != 0:
-        return None
-    return _watts_or_none(str(result.stdout).strip())
+        return GpuPowerReadback(watts=None, persistence_enabled=None)
+    return _parse_power_readback_csv(str(result.stdout))
+
+
+@dataclass(frozen=True)
+class PowerLimitSetResult:
+    """Outcome of one verified set: why it failed (None = success) and the persistence verdict the
+    readback saw. A successful set with persistence off can still revert on its own later."""
+
+    failure: str | None
+    persistence_enabled: bool | None
 
 
 async def _set_power_limit(
     ssh: asyncssh.SSHClientConnection,
     uuid: str,
     watts: int,
-) -> str | None:
-    """Set one GPU's power limit and VERIFY it stuck. Returns None on success, else the failure
-    detail (never raises). nvidia-smi can report success while the limit silently reverts
-    (persistence mode off, driver unloads) — only the readback proves the cap exists."""
+) -> PowerLimitSetResult:
+    """Set one GPU's power limit and VERIFY it stuck (never raises). nvidia-smi can report success
+    while the limit silently reverts (persistence mode off, driver unloads) — only the readback
+    proves the cap exists."""
     try:
         result = await ssh.run(
             f"nvidia-smi -i {shlex.quote(uuid)} -pl {watts}", timeout=_NVIDIA_SMI_TIMEOUT_SECONDS
         )
     except Exception as exc:
-        return f"nvidia-smi -pl errored: {exc}"
+        return PowerLimitSetResult(failure=f"nvidia-smi -pl errored: {exc}", persistence_enabled=None)
     if result.exit_status != 0:
-        return f"nvidia-smi -pl failed: exit={result.exit_status}, stderr={result.stderr!r}"
-    observed_watts = await _read_back_power_limit(ssh, uuid)
-    if observed_watts is None:
-        return "nvidia-smi -pl reported success but the limit could not be read back for verification"
-    if observed_watts != watts:
-        return (
-            f"nvidia-smi -pl reported success but the limit did not stick: "
-            f"readback {observed_watts}W != target {watts}W (persistence mode unavailable?)"
+        return PowerLimitSetResult(
+            failure=f"nvidia-smi -pl failed: exit={result.exit_status}, stderr={result.stderr!r}",
+            persistence_enabled=None,
         )
-    return None
+    readback = await _read_back_power_state(ssh, uuid)
+    if readback.watts is None:
+        return PowerLimitSetResult(
+            failure="nvidia-smi -pl reported success but the limit could not be read back for verification",
+            persistence_enabled=readback.persistence_enabled,
+        )
+    if readback.watts != watts:
+        return PowerLimitSetResult(
+            failure=(
+                f"nvidia-smi -pl reported success but the limit did not stick: "
+                f"readback {readback.watts}W != target {watts}W (persistence mode unavailable?)"
+            ),
+            persistence_enabled=readback.persistence_enabled,
+        )
+    return PowerLimitSetResult(failure=None, persistence_enabled=readback.persistence_enabled)
 
 
 async def _set_and_log_power_limit(
@@ -236,24 +277,33 @@ async def _set_and_log_power_limit(
 ) -> bool:
     # Reviewer contract (PR #1115): every PL change is logged with executor, GPU, before/after, status.
     await _enable_persistence_mode(ssh, gpu_uuid, log_extra)
-    failure = await _set_power_limit(ssh, gpu_uuid, watts_after)
+    set_result = await _set_power_limit(ssh, gpu_uuid, watts_after)
+    failure = set_result.failure
     status = "ok" if failure is None else "failed"
     message = f"gpu power limit {action} {status}: executor={executor_id} gpu={gpu_uuid} watts {watts_before} -> {watts_after}"
     if failure is not None:
         message = f"{message} ({failure})"
-    _log(
-        logging.INFO if failure is None else logging.ERROR,
-        message,
-        {
-            "gpu_power_action": action,
-            "executor_uuid": executor_id,
-            "gpu_uuid": gpu_uuid,
-            "watts_before": watts_before,
-            "watts_after": watts_after,
-            "status": status,
-        },
-        log_extra,
-    )
+    fields: dict[str, object] = {
+        "gpu_power_action": action,
+        "executor_uuid": executor_id,
+        "gpu_uuid": gpu_uuid,
+        "watts_before": watts_before,
+        "watts_after": watts_after,
+        "status": status,
+        "persistence_enabled": set_result.persistence_enabled,
+    }
+    _log(logging.INFO if failure is None else logging.ERROR, message, fields, log_extra)
+    # DAH-2702: a verified set with persistence off holds only until the driver unloads on an idle
+    # GPU, which is how a cap reverts with nobody touching the host. Observability only — refusing
+    # the filler here would drop PEARL from every host that cannot hold persistence mode.
+    if failure is None and set_result.persistence_enabled is False:
+        _log(
+            logging.WARNING,
+            f"gpu power limit {action}: persistence mode is off for {gpu_uuid} after -pm 1; "
+            f"the {watts_after}W limit can revert on its own when the driver unloads",
+            fields,
+            log_extra,
+        )
     return failure is None
 
 

--- a/neurons/validators/src/services/gpu_power_limit.py
+++ b/neurons/validators/src/services/gpu_power_limit.py
@@ -288,9 +288,9 @@ async def _set_and_log_power_limit(
     if failure is not None:
         message = f"{message} ({failure})"
     # DAH-2702: with persistence off the driver unloads on an idle GPU and the stock limit returns,
-    # which is how a cap reverts untouched. Only a cap is at risk — restore/raise set the limit back
-    # UP, where an unload lands anyway. Never fail-closed: refusing the filler would drop PEARL from
-    # every host that cannot hold persistence mode.
+    # which is how a cap reverts untouched. Only a cap is worth warning about — an unload undoes a
+    # cap, while it can only lift a restore/raise further towards the stock limit. Never
+    # fail-closed: refusing the filler would drop PEARL from every host without persistence mode.
     cap_can_revert = failure is None and action == "cap" and set_outcome.persistence_enabled is False
     if cap_can_revert:
         message = f"{message} (persistence mode is off after -pm 1; this cap can revert on its own)"

--- a/neurons/validators/src/services/gpu_power_limit.py
+++ b/neurons/validators/src/services/gpu_power_limit.py
@@ -120,6 +120,8 @@ class PowerLimitSetOutcome:
 
 # nvidia-smi's own labels; anything else means the GPU did not report the field.
 _PERSISTENCE_BY_LABEL: dict[str, bool] = {"enabled": True, "disabled": False}
+# nvidia-smi could not be read at all — not "the limit is unset", just no answer.
+_UNREADABLE_READBACK = GpuPowerReadback(watts=None, persistence_enabled=None)
 
 
 def _restore_key(gpu_uuid: str) -> str:
@@ -228,9 +230,9 @@ async def _read_back_power_state(ssh: asyncssh.SSHClientConnection, uuid: str) -
     try:
         result = await ssh.run(readback_command, timeout=_NVIDIA_SMI_TIMEOUT_SECONDS)
     except Exception:
-        return GpuPowerReadback(watts=None, persistence_enabled=None)
+        return _UNREADABLE_READBACK
     if result.exit_status != 0:
-        return GpuPowerReadback(watts=None, persistence_enabled=None)
+        return _UNREADABLE_READBACK
     return _parse_power_readback_csv(str(result.stdout))
 
 

--- a/neurons/validators/src/services/gpu_power_limit.py
+++ b/neurons/validators/src/services/gpu_power_limit.py
@@ -145,7 +145,7 @@ def _parse_power_state_csv(stdout: str) -> dict[str, GpuPowerState]:
 
 def _parse_power_readback_csv(stdout: str) -> GpuPowerReadback:
     fields = [field.strip() for field in str(stdout).strip().split(",")]
-    watts = _watts_or_none(fields[0]) if fields else None
+    watts = _watts_or_none(fields[0])
     persistence_raw = fields[1].lower() if len(fields) > 1 else ""
     persistence_enabled: bool | None = None
     if persistence_raw in ("enabled", "disabled"):
@@ -293,15 +293,18 @@ async def _set_and_log_power_limit(
         "persistence_enabled": set_result.persistence_enabled,
     }
     _log(logging.INFO if failure is None else logging.ERROR, message, fields, log_extra)
-    # DAH-2702: a verified set with persistence off holds only until the driver unloads on an idle
-    # GPU, which is how a cap reverts with nobody touching the host. Observability only — refusing
-    # the filler here would drop PEARL from every host that cannot hold persistence mode.
-    if failure is None and set_result.persistence_enabled is False:
+    # DAH-2702: a verified cap with persistence off holds only until the driver unloads on an idle
+    # GPU, which is how a cap reverts with nobody touching the host. Only "cap" is at risk — a
+    # restore/raise sets the limit back UP, and a driver unload lands on the default anyway.
+    # Observability only: refusing the filler here would drop PEARL from every host that cannot
+    # hold persistence mode. Logged WITHOUT gpu_power_action/status so counters over the change
+    # events do not see this warning as a second cap.
+    if failure is None and action == "cap" and set_result.persistence_enabled is False:
         _log(
             logging.WARNING,
-            f"gpu power limit {action}: persistence mode is off for {gpu_uuid} after -pm 1; "
-            f"the {watts_after}W limit can revert on its own when the driver unloads",
-            fields,
+            f"gpu power limit cap: persistence mode is off for {gpu_uuid} after -pm 1; "
+            f"the {watts_after}W cap can revert on its own when the driver unloads",
+            {"executor_uuid": executor_id, "gpu_uuid": gpu_uuid, "persistence_enabled": False},
             log_extra,
         )
     return failure is None

--- a/neurons/validators/tests/test_gpu_power_limit.py
+++ b/neurons/validators/tests/test_gpu_power_limit.py
@@ -207,6 +207,20 @@ async def test_cap_with_persistence_off_still_succeeds_but_warns(caplog) -> None
     assert "persistence mode is off" in str(warnings[0].msg)
 
 
+@pytest.mark.asyncio
+async def test_restore_with_persistence_off_does_not_warn(caplog) -> None:
+    # Only a cap is at risk from a lost persistence mode: a restore sets the limit back UP, and a
+    # driver unload lands on the default anyway. Warning here would inflate the cap-side signal.
+    ssh = fake_ssh(FakeRun(stdout=STATE_CSV), *_set_ok(400, persistence="Disabled"))
+    redis = FakeRedis({_restore_key("GPU-a"): _record("GPU-a", 400)})
+
+    with caplog.at_level(logging.DEBUG):
+        restored = await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
+
+    assert restored == 1
+    assert not [record for record in caplog.records if record.levelno == logging.WARNING]
+
+
 # ---------------------------- apply_filler_gpu_power_limits (fail-closed) ----------------------------
 
 

--- a/neurons/validators/tests/test_gpu_power_limit.py
+++ b/neurons/validators/tests/test_gpu_power_limit.py
@@ -201,9 +201,12 @@ async def test_cap_with_persistence_off_still_succeeds_but_warns(caplog) -> None
         ok = await apply_filler_gpu_power_limits(ssh, _limits(GPU_a=209), FakeRedis(), POD_ID, EXECUTOR_ID)
 
     assert ok is True
-    assert set(_logged_field(caplog, "persistence_enabled")) == {False}
+    # ONE event, raised to WARNING — not a second log line, so counting capped GPUs still works.
     warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
     assert len(warnings) == 1
+    assert warnings[0].msg.extra["persistence_enabled"] is False
+    assert warnings[0].msg.extra["gpu_power_action"] == "cap"
+    assert warnings[0].msg.extra["status"] == "ok"
     assert "persistence mode is off" in str(warnings[0].msg)
 
 

--- a/neurons/validators/tests/test_gpu_power_limit.py
+++ b/neurons/validators/tests/test_gpu_power_limit.py
@@ -1,13 +1,16 @@
 import json
+import logging
 import time
 from unittest.mock import AsyncMock
 
 import pytest
 from neurons.validators.src.payload_models.payloads import GpuPowerLimit
 from neurons.validators.src.services.gpu_power_limit import (
+    GpuPowerReadback,
     GpuPowerRestoreRecord,
     GpuPowerState,
     _clamp_watts,
+    _parse_power_readback_csv,
     _parse_power_state_csv,
     _pod_index_key,
     _restore_key,
@@ -53,9 +56,18 @@ def _commands(ssh: AsyncMock) -> list[str]:
     return [call.args[0] for call in ssh.run.call_args_list]
 
 
-def _set_ok(readback_watts: int) -> list[FakeRun]:
+def _logged_field(caplog: pytest.LogCaptureFixture, field: str) -> list[object]:
+    """Values of one structured field across every log record that carries it."""
+    return [
+        record.msg.extra[field]
+        for record in caplog.records
+        if hasattr(record.msg, "extra") and field in record.msg.extra
+    ]
+
+
+def _set_ok(readback_watts: int, persistence: str = "Enabled") -> list[FakeRun]:
     """SSH responses for one successful verified set: -pm 1, -pl, readback confirming the target."""
-    return [FakeRun(), FakeRun(), FakeRun(stdout=f"{readback_watts}.00\n")]
+    return [FakeRun(), FakeRun(), FakeRun(stdout=f"{readback_watts}.00, {persistence}\n")]
 
 
 def _set_commands(gpu_uuid: str, watts: int) -> list[str]:
@@ -63,7 +75,7 @@ def _set_commands(gpu_uuid: str, watts: int) -> list[str]:
     return [
         f"nvidia-smi -i {gpu_uuid} -pm 1",
         f"nvidia-smi -i {gpu_uuid} -pl {watts}",
-        f"nvidia-smi -i {gpu_uuid} --query-gpu=power.limit --format=csv,noheader,nounits",
+        f"nvidia-smi -i {gpu_uuid} --query-gpu=power.limit,persistence_mode --format=csv,noheader,nounits",
     ]
 
 
@@ -135,6 +147,64 @@ def test_clamp_watts_skips_na_bounds() -> None:
     # bounds that came back "[N/A]" (None) are not applied — the target passes through unclamped.
     state = GpuPowerState(current_watts=350, min_watts=None, max_watts=None)
     assert _clamp_watts(217, state) == 217
+
+
+# ---------------------------- _parse_power_readback_csv (pure) ----------------------------
+
+
+def test_parse_power_readback_reads_watts_and_enabled_persistence() -> None:
+    assert _parse_power_readback_csv("315.00, Enabled\n") == GpuPowerReadback(
+        watts=315, persistence_enabled=True
+    )
+
+
+def test_parse_power_readback_reads_disabled_persistence() -> None:
+    assert _parse_power_readback_csv("315.00, Disabled\n") == GpuPowerReadback(
+        watts=315, persistence_enabled=False
+    )
+
+
+def test_parse_power_readback_keeps_watts_when_persistence_unreported() -> None:
+    # A GPU that does not expose persistence_mode must still yield a usable readback.
+    assert _parse_power_readback_csv("315.00, [N/A]\n") == GpuPowerReadback(
+        watts=315, persistence_enabled=None
+    )
+
+
+def test_parse_power_readback_unreadable_watts_is_none() -> None:
+    assert _parse_power_readback_csv("[N/A], Enabled\n") == GpuPowerReadback(
+        watts=None, persistence_enabled=True
+    )
+
+
+# ---------------------------- persistence-mode verdict (DAH-2702) ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_cap_logs_persistence_enabled_and_does_not_warn(caplog) -> None:
+    ssh = fake_ssh(FakeRun(stdout=STATE_CSV), *_set_ok(209, persistence="Enabled"))
+
+    with caplog.at_level(logging.DEBUG):
+        ok = await apply_filler_gpu_power_limits(ssh, _limits(GPU_a=209), FakeRedis(), POD_ID, EXECUTOR_ID)
+
+    assert ok is True
+    assert set(_logged_field(caplog, "persistence_enabled")) == {True}
+    assert not [record for record in caplog.records if record.levelno == logging.WARNING]
+
+
+@pytest.mark.asyncio
+async def test_cap_with_persistence_off_still_succeeds_but_warns(caplog) -> None:
+    # Not fail-closed on purpose: a host that cannot hold persistence mode would lose PEARL entirely.
+    ssh = fake_ssh(FakeRun(stdout=STATE_CSV), *_set_ok(209, persistence="Disabled"))
+
+    with caplog.at_level(logging.DEBUG):
+        ok = await apply_filler_gpu_power_limits(ssh, _limits(GPU_a=209), FakeRedis(), POD_ID, EXECUTOR_ID)
+
+    assert ok is True
+    assert set(_logged_field(caplog, "persistence_enabled")) == {False}
+    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "persistence mode is off" in str(warnings[0].msg)
 
 
 # ---------------------------- apply_filler_gpu_power_limits (fail-closed) ----------------------------

--- a/neurons/validators/tests/test_gpu_power_limit.py
+++ b/neurons/validators/tests/test_gpu_power_limit.py
@@ -211,6 +211,20 @@ async def test_cap_with_persistence_off_still_succeeds_but_warns(caplog) -> None
 
 
 @pytest.mark.asyncio
+async def test_cap_does_not_warn_when_persistence_is_unreported(caplog) -> None:
+    # Unreported ("[N/A]", no column) is not the same as off: only an explicit Disabled warns,
+    # otherwise every GPU that cannot report the field would look like a revert risk.
+    ssh = fake_ssh(FakeRun(stdout=STATE_CSV), *_set_ok(209, persistence="[N/A]"))
+
+    with caplog.at_level(logging.DEBUG):
+        ok = await apply_filler_gpu_power_limits(ssh, _limits(GPU_a=209), FakeRedis(), POD_ID, EXECUTOR_ID)
+
+    assert ok is True
+    assert _logged_field(caplog, "persistence_enabled") == [None]
+    assert not [record for record in caplog.records if record.levelno == logging.WARNING]
+
+
+@pytest.mark.asyncio
 async def test_restore_with_persistence_off_does_not_warn(caplog) -> None:
     # Only a cap is at risk from a lost persistence mode: a restore sets the limit back UP, and a
     # driver unload lands on the default anyway. Warning here would inflate the cap-side signal.

--- a/neurons/validators/tests/test_gpu_power_limit.py
+++ b/neurons/validators/tests/test_gpu_power_limit.py
@@ -56,6 +56,10 @@ def _commands(ssh: AsyncMock) -> list[str]:
     return [call.args[0] for call in ssh.run.call_args_list]
 
 
+def _warning_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [record for record in caplog.records if record.levelno == logging.WARNING]
+
+
 def _logged_field(caplog: pytest.LogCaptureFixture, field: str) -> list[object]:
     """Values of one structured field across every log record that carries it."""
     return [
@@ -181,7 +185,7 @@ def test_parse_power_readback_unreadable_watts_is_none() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cap_logs_persistence_enabled_and_does_not_warn(caplog) -> None:
+async def test_cap_logs_persistence_enabled_and_does_not_warn(caplog: pytest.LogCaptureFixture) -> None:
     ssh = fake_ssh(FakeRun(stdout=STATE_CSV), *_set_ok(209, persistence="Enabled"))
 
     with caplog.at_level(logging.DEBUG):
@@ -189,11 +193,11 @@ async def test_cap_logs_persistence_enabled_and_does_not_warn(caplog) -> None:
 
     assert ok is True
     assert set(_logged_field(caplog, "persistence_enabled")) == {True}
-    assert not [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert not _warning_records(caplog)
 
 
 @pytest.mark.asyncio
-async def test_cap_with_persistence_off_still_succeeds_but_warns(caplog) -> None:
+async def test_cap_with_persistence_off_still_succeeds_but_warns(caplog: pytest.LogCaptureFixture) -> None:
     # Not fail-closed on purpose: a host that cannot hold persistence mode would lose PEARL entirely.
     ssh = fake_ssh(FakeRun(stdout=STATE_CSV), *_set_ok(209, persistence="Disabled"))
 
@@ -202,16 +206,37 @@ async def test_cap_with_persistence_off_still_succeeds_but_warns(caplog) -> None
 
     assert ok is True
     # ONE event, raised to WARNING — not a second log line, so counting capped GPUs still works.
-    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
-    assert len(warnings) == 1
-    assert warnings[0].msg.extra["persistence_enabled"] is False
-    assert warnings[0].msg.extra["gpu_power_action"] == "cap"
-    assert warnings[0].msg.extra["status"] == "ok"
-    assert "persistence mode is off" in str(warnings[0].msg)
+    cap_warnings = _warning_records(caplog)
+    assert len(cap_warnings) == 1
+    assert cap_warnings[0].msg.extra["persistence_enabled"] is False
+    assert cap_warnings[0].msg.extra["gpu_power_action"] == "cap"
+    assert cap_warnings[0].msg.extra["status"] == "ok"
+    assert "persistence mode is off" in str(cap_warnings[0].msg)
 
 
 @pytest.mark.asyncio
-async def test_cap_does_not_warn_when_persistence_is_unreported(caplog) -> None:
+async def test_cap_warns_when_pm_failed_and_the_gpu_confirms_persistence_off(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # The production shape: -pm 1 itself fails and the readback then confirms persistence is off.
+    ssh = fake_ssh(
+        FakeRun(stdout=STATE_CSV),
+        FakeRun(exit_status=3, stderr="pm not supported"),
+        FakeRun(),
+        FakeRun(stdout="209.00, Disabled\n"),
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        ok = await apply_filler_gpu_power_limits(ssh, _limits(GPU_a=209), FakeRedis(), POD_ID, EXECUTOR_ID)
+
+    assert ok is True
+    cap_warnings = [record for record in _warning_records(caplog) if record.msg.extra.get("gpu_power_action")]
+    assert len(cap_warnings) == 1
+    assert cap_warnings[0].msg.extra["persistence_enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_cap_does_not_warn_when_persistence_is_unreported(caplog: pytest.LogCaptureFixture) -> None:
     # Unreported ("[N/A]", no column) is not the same as off: only an explicit Disabled warns,
     # otherwise every GPU that cannot report the field would look like a revert risk.
     ssh = fake_ssh(FakeRun(stdout=STATE_CSV), *_set_ok(209, persistence="[N/A]"))
@@ -221,11 +246,11 @@ async def test_cap_does_not_warn_when_persistence_is_unreported(caplog) -> None:
 
     assert ok is True
     assert _logged_field(caplog, "persistence_enabled") == [None]
-    assert not [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert not _warning_records(caplog)
 
 
 @pytest.mark.asyncio
-async def test_restore_with_persistence_off_does_not_warn(caplog) -> None:
+async def test_restore_with_persistence_off_does_not_warn(caplog: pytest.LogCaptureFixture) -> None:
     # Only a cap is at risk from a lost persistence mode: a restore sets the limit back UP, and a
     # driver unload lands on the default anyway. Warning here would inflate the cap-side signal.
     ssh = fake_ssh(FakeRun(stdout=STATE_CSV), *_set_ok(400, persistence="Disabled"))
@@ -235,7 +260,7 @@ async def test_restore_with_persistence_off_does_not_warn(caplog) -> None:
         restored = await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
 
     assert restored == 1
-    assert not [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert not _warning_records(caplog)
 
 
 # ---------------------------- apply_filler_gpu_power_limits (fail-closed) ----------------------------


### PR DESCRIPTION
The PEARL power cap runs `nvidia-smi -pm 1` before `-pl`, but only the `-pl` result is read back — the persistence-mode result is never checked or logged. Persistence mode is what keeps a set limit alive: with it off, the driver unloads on an idle GPU and the stock limit comes back on its own.

That leaves one class of revert unattributable. Over 72h in prod, 113 of 536 cap→restore pairs came back raised; 103 landed on the miner's own sub-default value (host-side re-apply, unambiguous) and 10 landed exactly on the card default — indistinguishable today from our own lost persistence.

**Change:** the existing per-GPU readback now queries `power.limit,persistence_mode` in the same `nvidia-smi` call (no extra round trip), the verdict goes into the cap/restore log event as `persistence_enabled`, and a successful set with persistence off logs a WARNING.

**Deliberately not fail-closed:** refusing the filler when `-pm` does not stick would drop PEARL from every host that cannot hold persistence mode. Observe first, decide after a week of data.

Tests: persistence parsing (enabled / disabled / unreported / unreadable watts) and both cap paths — persistence on (no warning), persistence off (cap still succeeds, warning fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)