### PR TITLE
DAH-2703: withhold unrented incentive when a host kills the filler at create time

### DIFF
--- a/neurons/validators/src/core/docker_utils.py
+++ b/neurons/validators/src/core/docker_utils.py
@@ -124,6 +124,9 @@ class ContainerDeathDiagnostics:
     logs_tail: str | None = None
     host_context: dict[str, str] | None = None
     capture_error: str | None = None
+    # DAH-2703: the container is not on the host at all any more. Distinguishes a container that
+    # something removed from one that merely died — only the former accuses the host.
+    container_missing: bool = False
 
     def to_log_fields(self) -> dict[str, object]:
         """Flatten into the shared Loki field shape used at both call sites."""
@@ -137,6 +140,7 @@ class ContainerDeathDiagnostics:
             "container_logs_tail": self.logs_tail,
             "container_host_context": self.host_context,
             "diagnostics_capture_error": self.capture_error,
+            "container_missing": self.container_missing,
         }
 
 
@@ -167,6 +171,15 @@ async def df_available_bytes(ssh_client: asyncssh.SSHClientConnection, host_path
     if len(columns) < 4 or not columns[3].isdigit():
         raise Exception(f"Unexpected df output: {result.stdout!r}")
     return int(columns[3])
+
+
+# Docker's two ways of saying the container is not on this host any more.
+_MISSING_CONTAINER_MARKERS = ("no such object", "no such container")
+
+
+def _reports_missing_container(message: str) -> bool:
+    lowered = message.lower()
+    return any(marker in lowered for marker in _MISSING_CONTAINER_MARKERS)
 
 
 async def collect_container_death_diagnostics(
@@ -203,6 +216,7 @@ async def collect_container_death_diagnostics(
                 capture_errors.append(f"inspect: non-object state JSON: {parsed_state!r}")
         else:
             stderr = (getattr(inspect_result, "stderr", "") or "").strip()
+            diagnostics.container_missing = _reports_missing_container(stderr)
             capture_errors.append(f"inspect: {stderr or 'empty stdout'}")
     except asyncio.CancelledError:
         raise

--- a/neurons/validators/src/core/docker_utils.py
+++ b/neurons/validators/src/core/docker_utils.py
@@ -173,7 +173,9 @@ async def df_available_bytes(ssh_client: asyncssh.SSHClientConnection, host_path
     return int(columns[3])
 
 
-# Docker's two ways of saying the container is not on this host any more.
+# Docker's two ways of saying the container is not on this host any more. Kept separate from
+# services.docker_service._is_missing_docker_container_error, which reads an exception and matches
+# case-sensitively; this one reads `docker inspect` stderr, which says "No such object".
 _MISSING_CONTAINER_MARKERS = ("no such object", "no such container")
 
 

--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -673,6 +673,10 @@ class FailedContainerErrorCodes(enum.Enum):
     RentingInProgress = "RentingInProgress"
     NoJupyterPortMapping = "NoJupyterPortMapping"
     AttestationError = "AttestationError"
+    # DAH-2703: the container we created was gone from the host before creation finished — a
+    # host-side reaper, not a container that failed on its own. The backend counts these per
+    # executor and withholds unrented incentive once they stop looking like a race.
+    ContainerVanished = "ContainerVanished"
 
 
 class FailedContainerErrorTypes(enum.Enum):

--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -674,8 +674,7 @@ class FailedContainerErrorCodes(enum.Enum):
     NoJupyterPortMapping = "NoJupyterPortMapping"
     AttestationError = "AttestationError"
     # DAH-2703: the container we created was gone from the host before creation finished — a
-    # host-side reaper, not a container that failed on its own. The backend counts these per
-    # executor and withholds unrented incentive once they stop looking like a race.
+    # host-side reaper, not a container that failed on its own.
     ContainerVanished = "ContainerVanished"
 
 

--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -115,6 +115,12 @@ class RentedExecutorsResponse(BaseModel):
     network_ema: dict[str, NetworkEMA] = {}  # executor_id → EMA network speeds, all active executors
     spot_executor_ids: list[str] = []  # executor_ids in spot tier (no incentive, no penalty)
     new_rentals_paused_executor_ids: list[str] = []  # executor_ids paused from unrented incentives
+    # DAH-2703: executor_ids whose Lium filler container was destroyed during create often enough
+    # to be a host-side reaper rather than a race. Such a run never reaches RUNNING, so the node
+    # reports no filler container and the ISSUE-050 liveness probe has nothing to check — the
+    # streak is the only evidence the default job is being killed. Additive with an empty default:
+    # a backend that does not send it simply penalizes nobody.
+    filler_create_kill_executor_ids: list[str] = []
     provider_discord_connected_executor_ids: list[str] | None = None  # executor_ids whose provider has connected Discord
     # executor_id → "miner" | "lium"; absent = no default job. Parsed leniently as str for
     # forward-compatibility (a future owner value must not break parsing of the whole response).

--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -115,11 +115,9 @@ class RentedExecutorsResponse(BaseModel):
     network_ema: dict[str, NetworkEMA] = {}  # executor_id → EMA network speeds, all active executors
     spot_executor_ids: list[str] = []  # executor_ids in spot tier (no incentive, no penalty)
     new_rentals_paused_executor_ids: list[str] = []  # executor_ids paused from unrented incentives
-    # DAH-2703: executor_ids whose Lium filler container was destroyed during create often enough
-    # to be a host-side reaper rather than a race. Such a run never reaches RUNNING, so the node
-    # reports no filler container and the ISSUE-050 liveness probe has nothing to check — the
-    # streak is the only evidence the default job is being killed. Additive with an empty default:
-    # a backend that does not send it simply penalizes nobody.
+    # DAH-2703: executor_ids whose Lium filler container is destroyed during create (see
+    # FillerRunDao.CREATE_KILL_*). Such a run never reaches RUNNING, so the ISSUE-050 liveness
+    # probe has nothing to check. Additive with an empty default: an older backend penalizes nobody.
     filler_create_kill_executor_ids: list[str] = []
     provider_discord_connected_executor_ids: list[str] | None = None  # executor_ids whose provider has connected Discord
     # executor_id → "miner" | "lium"; absent = no default job. Parsed leniently as str for

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -2043,9 +2043,8 @@ class DockerService:
     ) -> bool:
         """Remove the failed container's artifacts; report whether it was already gone.
 
-        DAH-2703: "already gone" is the host-reaper signature — the container existed (we created
-        it) and something outside the platform removed it before this cleanup ran. Unproven cases
-        (SSH dead, diagnostics failed) report False: never accuse a host on missing evidence.
+        DAH-2703: unproven cases (SSH dead, diagnostics failed) report False — never accuse a host
+        on missing evidence.
         """
         container_missing = False
         try:
@@ -3873,9 +3872,8 @@ class DockerService:
         log_tag = "container_creation"
         current_step = "start"
         # DAH-2703: the container reached the host and then disappeared from it — the host-reaper
-        # signature, and the error code the failure is reported with. `container_created` is what
-        # keeps it honest: before `docker run` succeeds there is nothing to remove, so a missing
-        # container there is an ordinary create failure, not a kill.
+        # signature. `container_created` keeps it honest: before `docker run` succeeds there is
+        # nothing to remove, so a missing container there is an ordinary create failure.
         container_created = False
         container_vanished = False
         volume_encryption_status = VolumeEncryptionStatus.DISABLED

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -2040,16 +2040,24 @@ class DockerService:
         container_name: str,
         volume_name: str | None = None,
         remove_volume: bool = False,
-    ) -> None:
+    ) -> bool:
+        """Remove the failed container's artifacts; report whether it was already gone.
+
+        DAH-2703: "already gone" is the host-reaper signature — the container existed (we created
+        it) and something outside the platform removed it before this cleanup ran. Unproven cases
+        (SSH dead, diagnostics failed) report False: never accuse a host on missing evidence.
+        """
+        container_missing = False
         try:
             # DAH-2395: read the death evidence before `rm -fv` destroys it —
             # without this line, "why did the container die" (OOM vs entrypoint
             # crash) is unanswerable: the host is the miner's, not ours.
-            await self.capture_failed_container_diagnostics(
+            diagnostics = await self.capture_failed_container_diagnostics(
                 ssh_client=ssh_client,
                 default_extra=default_extra,
                 container_name=container_name,
             )
+            container_missing = diagnostics.container_missing
 
             container = shlex.quote(container_name)
             await retry_ssh_command(
@@ -2081,6 +2089,7 @@ class DockerService:
                 ),
                 exc_info=True,
             )
+        return container_missing
 
     async def _image_has_encrypted_volume_label(
         self,
@@ -3863,6 +3872,12 @@ class DockerService:
 
         log_tag = "container_creation"
         current_step = "start"
+        # DAH-2703: the container reached the host and then disappeared from it — the host-reaper
+        # signature, and the error code the failure is reported with. `container_created` is what
+        # keeps it honest: before `docker run` succeeds there is nothing to remove, so a missing
+        # container there is an ordinary create failure, not a kill.
+        container_created = False
+        container_vanished = False
         volume_encryption_status = VolumeEncryptionStatus.DISABLED
 
         # DAH-2211: a custom-build payload carries `dockerfile_content` (may be
@@ -4569,6 +4584,7 @@ class DockerService:
                         log_tag=log_tag,
                     )
 
+                    container_created = True
                     logger.info("Container creation step finished")
 
                     # DAH-1524: isolate the bare `docker run` (dominated by the NVIDIA
@@ -4623,13 +4639,14 @@ class DockerService:
 
                         raise Exception("Run docker run command but container is not running")
                 except Exception:
-                    await self.cleanup_failed_container_creation(
+                    container_missing = await self.cleanup_failed_container_creation(
                         ssh_client=ssh_client,
                         default_extra=default_extra,
                         container_name=container_name,
                         volume_name=local_volume,
                         remove_volume=created_local_volume,
                     )
+                    container_vanished = container_created and container_missing
                     # DAH-2211: inline cleanup of custom-build artifacts on docker_run failure.
                     if is_custom_build:
                         await self._cleanup_custom_build_artifacts(
@@ -4782,13 +4799,14 @@ class DockerService:
                     )
                     prev_timestamp = now_ms()
                 except Exception:
-                    await self.cleanup_failed_container_creation(
+                    container_missing = await self.cleanup_failed_container_creation(
                         ssh_client=ssh_client,
                         default_extra=default_extra,
                         container_name=container_name,
                         volume_name=local_volume,
                         remove_volume=created_local_volume,
                     )
+                    container_vanished = container_created and container_missing
                     # DAH-2211: inline cleanup of custom-build artifacts on post-run failure.
                     if is_custom_build:
                         await self._cleanup_custom_build_artifacts(
@@ -4904,7 +4922,11 @@ class DockerService:
                 msg=str(log_text),
                 detail=failure_detail,
                 error_type=FailedContainerErrorTypes.ContainerCreationFailed,
-                error_code=FailedContainerErrorCodes.UnknownError,
+                error_code=(
+                    FailedContainerErrorCodes.ContainerVanished
+                    if container_vanished
+                    else FailedContainerErrorCodes.UnknownError
+                ),
                 failure_step=current_step,
                 volume_encryption_status=(
                     VolumeEncryptionStatus.FAILED

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 import asyncssh
 
 from core.config import settings
+from core.utils import _m, get_extra_info
 from core.docker_utils import DockerCommand, collect_container_death_diagnostics
 from protocol.vc_protocol.compute_requests import (
     CPU_QUOTA_EXCEEDS_HOST_REASON,
@@ -108,14 +109,27 @@ class RentalVerificationCheck:
         )
         if create_killed and not has_customer_rental and settings.FILLER_LIVENESS_CHECK_ENABLED:
             if settings.FILLER_LIVENESS_ENFORCEMENT_ENABLED:
-                return self._filler_create_kill_result(ctx)
+                event = render_message(
+                    Msg.FILLER_KILLED_AT_CREATE,
+                    ctx=ctx,
+                    check_id=self.check_id,
+                    what={"verified": False, "executor_uuid": ctx.executor.uuid, "enforced": True},
+                )
+                return CheckResult(passed=False, event=event, updates={})
             # Shadow: observe and fall through to the normal verification. Returning a pass here
             # would hand the node a free pass — it skips the backend health check the node would
             # otherwise have to survive, so shadow mode would be an upgrade, not an observation.
+            # A check owns one event and the fall-through path writes it, so the shadow verdict
+            # rides a log line carrying the same reason code the enforced event uses.
             logger.warning(
-                "%s (shadow): executor %s is destroying its Lium default job during create",
-                Msg.FILLER_KILLED_AT_CREATE.reason,
-                ctx.executor.uuid,
+                _m(
+                    "Lium default job is destroyed during create (shadow)",
+                    extra=get_extra_info({
+                        "reason_code": Msg.FILLER_KILLED_AT_CREATE.reason,
+                        "executor_uuid": ctx.executor.uuid,
+                        "enforced": False,
+                    }),
+                )
             )
 
         if filler_containers and not has_customer_rental:
@@ -508,20 +522,6 @@ class RentalVerificationCheck:
             },
         )
         return CheckResult(passed=not enforce, event=event, updates={})
-
-    def _filler_create_kill_result(self, ctx: Context) -> CheckResult:
-        """Render the create-time kill verdict. Enforcement only — shadow never lands here."""
-        event = render_message(
-            Msg.FILLER_KILLED_AT_CREATE,
-            ctx=ctx,
-            check_id=self.check_id,
-            what={
-                "verified": False,
-                "executor_uuid": ctx.executor.uuid,
-                "enforced": True,
-            },
-        )
-        return CheckResult(passed=False, event=event, updates={})
 
     def _filler_state_unknown_result(
         self,

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -117,6 +117,18 @@ class RentalVerificationCheck:
                 ctx, filler_containers, enforce=settings.FILLER_LIVENESS_ENFORCEMENT_ENABLED
             )
 
+        # DAH-2703: same offence, earlier kill. A host reaper that removes the filler seconds after
+        # `docker run` leaves no RUNNING run and no container, so the probe above never sees it and
+        # the node collects unrented incentive while never running a default job. The backend counts
+        # those create-time kills per executor and lists the ones past the streak threshold here.
+        create_killed: bool = bool(
+            rented_data and ctx.executor.uuid in rented_data.filler_create_kill_executor_ids
+        )
+        if create_killed and not has_customer_rental and settings.FILLER_LIVENESS_CHECK_ENABLED:
+            return self._filler_create_kill_result(
+                ctx, enforce=settings.FILLER_LIVENESS_ENFORCEMENT_ENABLED
+            )
+
         # Get required info from context
         backend_client = ctx.services.backend
         executor = ctx.executor
@@ -480,6 +492,22 @@ class RentalVerificationCheck:
                 "run_age_seconds": run_age.total_seconds(),
                 "enforced": enforce,
                 **death_fields,
+            },
+        )
+        return CheckResult(passed=not enforce, event=event, updates={})
+
+    def _filler_create_kill_result(self, ctx: Context, *, enforce: bool) -> CheckResult:
+        """Render the create-time kill verdict for a node with no filler container to probe."""
+        event = render_message(
+            Msg.FILLER_KILLED_AT_CREATE,
+            ctx=ctx,
+            check_id=self.check_id,
+            severity=None if enforce else "warning",
+            impact=None if enforce else "Shadow observation only: incentive was NOT withheld",
+            what={
+                "verified": False,
+                "executor_uuid": ctx.executor.uuid,
+                "enforced": enforce,
             },
         )
         return CheckResult(passed=not enforce, event=event, updates={})

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -93,6 +93,21 @@ class RentalVerificationCheck:
         # VRAM bundle (DAH-2465), and checking only the first left the siblings unverifiable — a
         # removed sibling was never observed, so it was neither punished nor reconciled (DAH-2471).
         filler_containers: list[str] = rented_data.get_filler_containers(ctx.executor.uuid) if rented_data else []
+        # DAH-2703: same offence, earlier kill. A host reaper that removes the filler seconds after
+        # `docker run` leaves no RUNNING run and no container, so the liveness probe below never
+        # sees it and the node collects unrented incentive while never running a default job. The
+        # backend counts those create-time kills per executor and lists the ones past the streak
+        # threshold. Judged BEFORE the liveness probe on purpose: a GPU-split node runs one filler
+        # per bundle, and one surviving bundle would otherwise return a clean verdict for a host
+        # that destroys every other bundle it is given.
+        create_killed: bool = bool(
+            rented_data and ctx.executor.uuid in rented_data.filler_create_kill_executor_ids
+        )
+        if create_killed and not has_customer_rental and settings.FILLER_LIVENESS_CHECK_ENABLED:
+            return self._filler_create_kill_result(
+                ctx, enforce=settings.FILLER_LIVENESS_ENFORCEMENT_ENABLED
+            )
+
         if filler_containers and not has_customer_rental:
             # ISSUE-050: the backend's word alone is not proof the filler is alive — some hosts
             # remove Lium filler containers while the run stays RUNNING and keep earning
@@ -115,18 +130,6 @@ class RentalVerificationCheck:
 
             return await self._verify_every_filler_alive(
                 ctx, filler_containers, enforce=settings.FILLER_LIVENESS_ENFORCEMENT_ENABLED
-            )
-
-        # DAH-2703: same offence, earlier kill. A host reaper that removes the filler seconds after
-        # `docker run` leaves no RUNNING run and no container, so the probe above never sees it and
-        # the node collects unrented incentive while never running a default job. The backend counts
-        # those create-time kills per executor and lists the ones past the streak threshold here.
-        create_killed: bool = bool(
-            rented_data and ctx.executor.uuid in rented_data.filler_create_kill_executor_ids
-        )
-        if create_killed and not has_customer_rental and settings.FILLER_LIVENESS_CHECK_ENABLED:
-            return self._filler_create_kill_result(
-                ctx, enforce=settings.FILLER_LIVENESS_ENFORCEMENT_ENABLED
             )
 
         # Get required info from context

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
@@ -19,6 +20,8 @@ from ..messages import MessageTemplate, render_message
 from ..messages import RentalVerificationMessages as Msg
 from ..pipeline import CheckResult, Context
 from .cpu_truth import advertised_cpu_count
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -104,8 +107,15 @@ class RentalVerificationCheck:
             rented_data and ctx.executor.uuid in rented_data.filler_create_kill_executor_ids
         )
         if create_killed and not has_customer_rental and settings.FILLER_LIVENESS_CHECK_ENABLED:
-            return self._filler_create_kill_result(
-                ctx, enforce=settings.FILLER_LIVENESS_ENFORCEMENT_ENABLED
+            if settings.FILLER_LIVENESS_ENFORCEMENT_ENABLED:
+                return self._filler_create_kill_result(ctx)
+            # Shadow: observe and fall through to the normal verification. Returning a pass here
+            # would hand the node a free pass — it skips the backend health check the node would
+            # otherwise have to survive, so shadow mode would be an upgrade, not an observation.
+            logger.warning(
+                "%s (shadow): executor %s is destroying its Lium default job during create",
+                Msg.FILLER_KILLED_AT_CREATE.reason,
+                ctx.executor.uuid,
             )
 
         if filler_containers and not has_customer_rental:
@@ -499,21 +509,19 @@ class RentalVerificationCheck:
         )
         return CheckResult(passed=not enforce, event=event, updates={})
 
-    def _filler_create_kill_result(self, ctx: Context, *, enforce: bool) -> CheckResult:
-        """Render the create-time kill verdict for a node with no filler container to probe."""
+    def _filler_create_kill_result(self, ctx: Context) -> CheckResult:
+        """Render the create-time kill verdict. Enforcement only — shadow never lands here."""
         event = render_message(
             Msg.FILLER_KILLED_AT_CREATE,
             ctx=ctx,
             check_id=self.check_id,
-            severity=None if enforce else "warning",
-            impact=None if enforce else "Shadow observation only: incentive was NOT withheld",
             what={
                 "verified": False,
                 "executor_uuid": ctx.executor.uuid,
-                "enforced": enforce,
+                "enforced": True,
             },
         )
-        return CheckResult(passed=not enforce, event=event, updates={})
+        return CheckResult(passed=False, event=event, updates={})
 
     def _filler_state_unknown_result(
         self,

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -1058,8 +1058,8 @@ class RentalVerificationMessages:
         severity="error",
         category="policy",
         impact=(
-            "Unrented incentive withheld: every Lium default job assigned to this machine is "
-            "destroyed seconds after it starts, so the machine never runs the job it is paid for"
+            "Unrented incentive withheld: Lium default jobs assigned to this machine were "
+            "destroyed seconds after they started, repeatedly over the last 24 hours"
         ),
         remediation=(
             "Stop the host-side process that removes containers it does not recognise, or "

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -1052,6 +1052,22 @@ class RentalVerificationMessages:
             "Contact Lium support if this container was not removed by you."
         ),
     )
+    FILLER_KILLED_AT_CREATE = MessageTemplate(
+        event="Lium default job container is removed on the host right after it is created",
+        reason="FILLER_KILLED_AT_CREATE",
+        severity="error",
+        category="policy",
+        impact=(
+            "Unrented incentive withheld: every Lium default job assigned to this machine is "
+            "destroyed seconds after it starts, so the machine never runs the job it is paid for"
+        ),
+        remediation=(
+            "Stop the host-side process that removes containers it does not recognise, or "
+            "allow-list Lium default-job (filler_*) containers in it. "
+            "Incentive resumes once a default job runs undisturbed. "
+            "Contact Lium support if nothing on this host removes containers."
+        ),
+    )
     FILLER_STATE_UNKNOWN = MessageTemplate(
         event="Lium default job state could not be verified",
         reason="FILLER_STATE_UNKNOWN",

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -6113,3 +6113,105 @@ async def test_recover_pod_reports_failure_when_start_raises(docker_service, mon
     # the container may already be up with no plaintext mount, and no later cycle revisits a
     # running pod — put it back down so POD_NOT_RUNNING keeps matching what the customer sees
     assert "docker stop pod_pod-1" in ssh_client.run.await_args.args[0]
+
+
+# DAH-2703: a create that fails because the container was removed from the host mid-creation is
+# reported with its own error code, so the backend can count host kills separately from ordinary
+# create failures.
+
+
+def _filler_create_payload() -> ContainerCreateRequest:
+    return ContainerCreateRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        workload_kind=WorkloadKind.FILLER,
+        docker_image="daturaai/pearl-miner:test",
+        user_public_keys=["ssh-ed25519 test-key"],
+        gpu_uuids=["GPU-test"],
+        cpu_count=1,
+        memory_gb=1,
+        volume_limit_gb=2,
+        storage_limit_gb=1,
+        available_ports=[PayloadPortMapping(internal_port=20020, external_port=20020)],
+        pod_mapping=[],
+        active_container_names=[],
+        active_volume_names=[],
+    )
+
+
+def _filler_executor_info(payload: ContainerCreateRequest) -> ExecutorSSHInfo:
+    return ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
+    )
+
+
+@pytest.mark.parametrize(
+    "container_was_removed,expected_error_code",
+    [
+        (True, FailedContainerErrorCodes.ContainerVanished),
+        (False, FailedContainerErrorCodes.UnknownError),
+    ],
+)
+@pytest.mark.asyncio
+async def test_create_failure_reports_a_container_removed_by_the_host(
+    docker_service, monkeypatch, container_was_removed, expected_error_code
+):
+    _patch_create_container_happy_path(docker_service, monkeypatch)
+    # The container is created, then the next step finds it gone.
+    monkeypatch.setattr(
+        docker_service,
+        "add_ssh_public_keys_with_rental_docker",
+        AsyncMock(side_effect=RuntimeError("404 No such container")),
+    )
+    monkeypatch.setattr(
+        docker_service,
+        "cleanup_failed_container_creation",
+        AsyncMock(return_value=container_was_removed),
+    )
+    payload = _filler_create_payload()
+
+    result = await docker_service.create_container(
+        payload=payload,
+        executor_info=_filler_executor_info(payload),
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    assert isinstance(result, FailedContainerRequest)
+    assert result.error_code == expected_error_code
+
+
+@pytest.mark.asyncio
+async def test_create_failure_before_the_container_exists_is_not_a_host_kill(
+    docker_service, monkeypatch
+):
+    """`docker run` itself failed: there was never a container, so "gone" proves nothing."""
+    _patch_create_container_happy_path(docker_service, monkeypatch)
+    monkeypatch.setattr(
+        docker_service,
+        "_run_rental_docker_create_with_port_retry",
+        AsyncMock(side_effect=RuntimeError("no such image")),
+    )
+    cleanup = AsyncMock(return_value=True)
+    monkeypatch.setattr(docker_service, "cleanup_failed_container_creation", cleanup)
+    payload = _filler_create_payload()
+
+    result = await docker_service.create_container(
+        payload=payload,
+        executor_info=_filler_executor_info(payload),
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    assert isinstance(result, FailedContainerRequest)
+    assert result.error_code == FailedContainerErrorCodes.UnknownError
+    # The verdict must never cost us the cleanup itself — volumes and leftovers still go.
+    cleanup.assert_awaited_once()

--- a/neurons/validators/tests/test_failed_container_diagnostics.py
+++ b/neurons/validators/tests/test_failed_container_diagnostics.py
@@ -214,3 +214,80 @@ async def test_diagnostics_propagates_cancellation(docker_service):
             default_extra=DEFAULT_EXTRA,
             container_name=CONTAINER_NAME,
         )
+
+
+# DAH-2703: a create failure whose container is already gone from the host is a different
+# offence from a container that failed on its own — the backend counts only the former.
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_flag_a_container_that_vanished_from_the_host(docker_service):
+    # Arrange: inspect says the object does not exist any more
+    ssh_client = _FakeSSHClient()
+    ssh_client.results_by_substring["docker inspect"] = _SSHRunResult(
+        exit_status=1, stderr=f"Error: No such object: {CONTAINER_NAME}"
+    )
+
+    # Act
+    diagnostics = await docker_service.capture_failed_container_diagnostics(
+        ssh_client=ssh_client,
+        default_extra=DEFAULT_EXTRA,
+        container_name=CONTAINER_NAME,
+    )
+
+    # Assert
+    assert diagnostics.container_missing is True
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_do_not_flag_a_container_that_died_on_its_own(docker_service):
+    # Arrange: the container is still there, it just exited
+    ssh_client = _FakeSSHClient()
+    ssh_client.results_by_substring["docker inspect"] = _SSHRunResult(stdout=INSPECT_STATE_JSON)
+
+    # Act
+    diagnostics = await docker_service.capture_failed_container_diagnostics(
+        ssh_client=ssh_client,
+        default_extra=DEFAULT_EXTRA,
+        container_name=CONTAINER_NAME,
+    )
+
+    # Assert
+    assert diagnostics.container_missing is False
+
+
+@pytest.mark.asyncio
+async def test_cleanup_reports_whether_the_container_was_already_gone(docker_service):
+    # Arrange
+    ssh_client = _FakeSSHClient()
+    ssh_client.results_by_substring["docker inspect"] = _SSHRunResult(
+        exit_status=1, stderr=f"Error: No such object: {CONTAINER_NAME}"
+    )
+
+    # Act
+    container_missing = await docker_service.cleanup_failed_container_creation(
+        ssh_client=ssh_client,
+        default_extra=DEFAULT_EXTRA,
+        container_name=CONTAINER_NAME,
+    )
+
+    # Assert: the cleanup still runs, and it reports what it found
+    assert container_missing is True
+    assert ssh_client.command_index("docker rm -fv") >= 0
+
+
+@pytest.mark.asyncio
+async def test_cleanup_reports_no_kill_when_diagnostics_cannot_be_captured(docker_service):
+    # Arrange: SSH is broken, so "gone" is unproven — fail open, never accuse the host
+    ssh_client = _FakeSSHClient()
+    ssh_client.errors_by_substring["docker inspect"] = ConnectionError("ssh channel died")
+
+    # Act
+    container_missing = await docker_service.cleanup_failed_container_creation(
+        ssh_client=ssh_client,
+        default_extra=DEFAULT_EXTRA,
+        container_name=CONTAINER_NAME,
+    )
+
+    # Assert
+    assert container_missing is False

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -1159,18 +1159,24 @@ def _create_kill_context(
 
 
 @pytest.mark.asyncio
-async def test_rental_verification_filler_create_kill_shadow_mode_passes_but_logs():
-    """Shadow mode: the create-kill streak is logged with enforced=False, incentive untouched."""
+async def test_rental_verification_filler_create_kill_shadow_mode_only_observes():
+    """Shadow mode observes and then verifies as usual — it must never replace the normal check."""
     backend_client = DummyBackendClient(
         response=ExecutorHealthCheckResponse(success=True, error=None, details={})
     )
     ctx = _create_kill_context(backend_client=backend_client, ssh_client=FillerSSHClient())
 
-    result = await _run_filler_check(ctx, enforcement=False)
+    with patch("neurons.validators.src.services.task.checks.rental_verification.logger") as mock_logger:
+        result = await _run_filler_check(ctx, enforcement=False)
 
     assert result.passed is True
-    assert result.event.reason_code == Msg.FILLER_KILLED_AT_CREATE.reason
-    assert result.event.what_we_saw["enforced"] is False
+    assert result.event.reason_code == Msg.VERIFIED.reason
+    # The node still went through the backend health check it would have had without this feature.
+    assert backend_client.called_with is not None
+    assert any(
+        Msg.FILLER_KILLED_AT_CREATE.reason in str(call)
+        for call in mock_logger.warning.call_args_list
+    )
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -505,17 +505,40 @@ def _filler_context(
     ssh_client: FillerSSHClient,
     filler_container: str = "filler_11111111-2222-3333-4444-555555555555",
     filler_containers: list[str] | None = None,
+    running_fillers: bool = True,
+    create_killed: bool = False,
+    rented_pods: list[RentedPod] | None = None,
 ) -> Context:
     # filler_containers = a GPU-split node's full bundle list (DAH-2465); the legacy single map is
-    # still populated so the protocol's fallback path stays covered.
-    all_containers: list[str] = filler_containers or [filler_container]
+    # still populated so the protocol's fallback path stays covered. running_fillers=False is the
+    # DAH-2703 shape: the node reports no filler container because none ever survived its create.
+    all_containers: list[str] = filler_containers if filler_containers else [filler_container]
+    legacy_filler_by_executor: dict[str, str] = (
+        {"executor-123": all_containers[0]} if running_fillers else {}
+    )
+    all_fillers_by_executor: dict[str, list[str]] = (
+        {"executor-123": all_containers} if running_fillers else {}
+    )
+    executors: dict[str, RentedExecutor] = (
+        {
+            "executor-123": RentedExecutor(
+                miner_hotkey="miner-hotkey",
+                executor_ip_address="127.0.0.1",
+                executor_ip_port="8000",
+                pods=rented_pods,
+            )
+        }
+        if rented_pods
+        else {}
+    )
     services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
     state = build_state(
         specs={"verified_ports": [8080]},
         rented_data=RentedExecutorsResponse(
-            executors={},
-            filler_containers_by_executor={"executor-123": all_containers[0]},
-            all_filler_containers_by_executor={"executor-123": all_containers},
+            executors=executors,
+            filler_containers_by_executor=legacy_filler_by_executor,
+            all_filler_containers_by_executor=all_fillers_by_executor,
+            filler_create_kill_executor_ids=["executor-123"] if create_killed else [],
         ),
     )
     from tests.helpers import make_context
@@ -1127,44 +1150,18 @@ async def test_cpu_count_is_not_sent_for_a_tdx_host():
 # to probe, so the liveness check above never runs. The backend reports the kill streak instead.
 
 
-def _create_kill_context(
-    *,
-    backend_client: DummyBackendClient,
-    ssh_client: FillerSSHClient,
-    rented_pods: list[RentedPod] | None = None,
-) -> Context:
-    executors = (
-        {
-            "executor-123": RentedExecutor(
-                miner_hotkey="miner-hotkey",
-                executor_ip_address="127.0.0.1",
-                executor_ip_port="8000",
-                pods=rented_pods,
-            )
-        }
-        if rented_pods
-        else {}
-    )
-    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
-    state = build_state(
-        specs={"verified_ports": [8080]},
-        rented_data=RentedExecutorsResponse(
-            executors=executors,
-            filler_create_kill_executor_ids=["executor-123"],
-        ),
-    )
-    from tests.helpers import make_context
-
-    return make_context(services=services, state=state, ssh=ssh_client)
-
-
 @pytest.mark.asyncio
 async def test_rental_verification_filler_create_kill_shadow_mode_only_observes():
     """Shadow mode observes and then verifies as usual — it must never replace the normal check."""
     backend_client = DummyBackendClient(
         response=ExecutorHealthCheckResponse(success=True, error=None, details={})
     )
-    ctx = _create_kill_context(backend_client=backend_client, ssh_client=FillerSSHClient())
+    ctx = _filler_context(
+        backend_client=backend_client,
+        ssh_client=FillerSSHClient(),
+        running_fillers=False,
+        create_killed=True,
+    )
 
     with patch("neurons.validators.src.services.task.checks.rental_verification.logger") as mock_logger:
         result = await _run_filler_check(ctx, enforcement=False)
@@ -1174,7 +1171,7 @@ async def test_rental_verification_filler_create_kill_shadow_mode_only_observes(
     # The node still went through the backend health check it would have had without this feature.
     assert backend_client.called_with is not None
     assert any(
-        Msg.FILLER_KILLED_AT_CREATE.reason in str(call)
+        Msg.FILLER_KILLED_AT_CREATE.reason in str(call.args[0].extra)
         for call in mock_logger.warning.call_args_list
     )
 
@@ -1185,7 +1182,12 @@ async def test_rental_verification_filler_create_kill_enforcement_fails():
     backend_client = DummyBackendClient(
         response=ExecutorHealthCheckResponse(success=True, error=None, details={})
     )
-    ctx = _create_kill_context(backend_client=backend_client, ssh_client=FillerSSHClient())
+    ctx = _filler_context(
+        backend_client=backend_client,
+        ssh_client=FillerSSHClient(),
+        running_fillers=False,
+        create_killed=True,
+    )
 
     result = await _run_filler_check(ctx, enforcement=True)
 
@@ -1202,7 +1204,12 @@ async def test_rental_verification_filler_create_kill_ignored_when_check_disable
     backend_client = DummyBackendClient(
         response=ExecutorHealthCheckResponse(success=True, error=None, details={})
     )
-    ctx = _create_kill_context(backend_client=backend_client, ssh_client=FillerSSHClient())
+    ctx = _filler_context(
+        backend_client=backend_client,
+        ssh_client=FillerSSHClient(),
+        running_fillers=False,
+        create_killed=True,
+    )
 
     result = await _run_filler_check(ctx, check_enabled=False, enforcement=True)
 
@@ -1216,9 +1223,11 @@ async def test_rental_verification_filler_create_kill_ignored_for_a_customer_ren
     backend_client = DummyBackendClient(
         response=ExecutorHealthCheckResponse(success=True, error=None, details={})
     )
-    ctx = _create_kill_context(
+    ctx = _filler_context(
         backend_client=backend_client,
         ssh_client=FillerSSHClient(),
+        running_fillers=False,
+        create_killed=True,
         rented_pods=[RentedPod(pod_id="pod-1", container_name="pod_1")],
     )
 
@@ -1234,20 +1243,11 @@ async def test_rental_verification_create_kill_is_not_masked_by_a_surviving_fill
     backend_client = DummyBackendClient(
         response=ExecutorHealthCheckResponse(success=True, error=None, details={})
     )
-    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
-    surviving = "filler_11111111-2222-3333-4444-555555555555"
-    state = build_state(
-        specs={"verified_ports": [8080]},
-        rented_data=RentedExecutorsResponse(
-            executors={},
-            filler_containers_by_executor={"executor-123": surviving},
-            all_filler_containers_by_executor={"executor-123": [surviving]},
-            filler_create_kill_executor_ids=["executor-123"],
-        ),
+    ctx = _filler_context(
+        backend_client=backend_client,
+        ssh_client=FillerSSHClient(running=True),
+        create_killed=True,
     )
-    from tests.helpers import make_context
-
-    ctx = make_context(services=services, state=state, ssh=FillerSSHClient(running=True))
 
     result = await _run_filler_check(ctx, enforcement=True)
 

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -1220,3 +1220,30 @@ async def test_rental_verification_filler_create_kill_ignored_for_a_customer_ren
 
     assert result.passed is True
     assert result.event.reason_code == Msg.VERIFIED.reason
+
+
+@pytest.mark.asyncio
+async def test_rental_verification_create_kill_is_not_masked_by_a_surviving_filler():
+    """A split node that lets one bundle run while killing the others is still killing them."""
+    backend_client = DummyBackendClient(
+        response=ExecutorHealthCheckResponse(success=True, error=None, details={})
+    )
+    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
+    surviving = "filler_11111111-2222-3333-4444-555555555555"
+    state = build_state(
+        specs={"verified_ports": [8080]},
+        rented_data=RentedExecutorsResponse(
+            executors={},
+            filler_containers_by_executor={"executor-123": surviving},
+            all_filler_containers_by_executor={"executor-123": [surviving]},
+            filler_create_kill_executor_ids=["executor-123"],
+        ),
+    )
+    from tests.helpers import make_context
+
+    ctx = make_context(services=services, state=state, ssh=FillerSSHClient(running=True))
+
+    result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.FILLER_KILLED_AT_CREATE.reason

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -1121,3 +1121,102 @@ async def test_cpu_count_is_not_sent_for_a_tdx_host():
         await RentalVerificationCheck().run(ctx)
 
     assert backend_client.called_with["cpu_count"] is None
+
+
+# DAH-2703: a host reaper that removes the filler seconds after `docker run` leaves no container
+# to probe, so the liveness check above never runs. The backend reports the kill streak instead.
+
+
+def _create_kill_context(
+    *,
+    backend_client: DummyBackendClient,
+    ssh_client: FillerSSHClient,
+    rented_pods: list[RentedPod] | None = None,
+) -> Context:
+    executors = (
+        {
+            "executor-123": RentedExecutor(
+                miner_hotkey="miner-hotkey",
+                executor_ip_address="127.0.0.1",
+                executor_ip_port="8000",
+                pods=rented_pods,
+            )
+        }
+        if rented_pods
+        else {}
+    )
+    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
+    state = build_state(
+        specs={"verified_ports": [8080]},
+        rented_data=RentedExecutorsResponse(
+            executors=executors,
+            filler_create_kill_executor_ids=["executor-123"],
+        ),
+    )
+    from tests.helpers import make_context
+
+    return make_context(services=services, state=state, ssh=ssh_client)
+
+
+@pytest.mark.asyncio
+async def test_rental_verification_filler_create_kill_shadow_mode_passes_but_logs():
+    """Shadow mode: the create-kill streak is logged with enforced=False, incentive untouched."""
+    backend_client = DummyBackendClient(
+        response=ExecutorHealthCheckResponse(success=True, error=None, details={})
+    )
+    ctx = _create_kill_context(backend_client=backend_client, ssh_client=FillerSSHClient())
+
+    result = await _run_filler_check(ctx, enforcement=False)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.FILLER_KILLED_AT_CREATE.reason
+    assert result.event.what_we_saw["enforced"] is False
+
+
+@pytest.mark.asyncio
+async def test_rental_verification_filler_create_kill_enforcement_fails():
+    """Enforcement mode: the streak fails the fatal check -> no unrented incentive."""
+    backend_client = DummyBackendClient(
+        response=ExecutorHealthCheckResponse(success=True, error=None, details={})
+    )
+    ctx = _create_kill_context(backend_client=backend_client, ssh_client=FillerSSHClient())
+
+    result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.FILLER_KILLED_AT_CREATE.reason
+    assert result.event.what_we_saw["enforced"] is True
+    # The node is never contacted for a health check once the streak decides the verdict.
+    assert backend_client.called_with is None
+
+
+@pytest.mark.asyncio
+async def test_rental_verification_filler_create_kill_ignored_when_check_disabled():
+    """CHECK_ENABLED off is the master kill switch here too: normal verification runs."""
+    backend_client = DummyBackendClient(
+        response=ExecutorHealthCheckResponse(success=True, error=None, details={})
+    )
+    ctx = _create_kill_context(backend_client=backend_client, ssh_client=FillerSSHClient())
+
+    result = await _run_filler_check(ctx, check_enabled=False, enforcement=True)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.VERIFIED.reason
+
+
+@pytest.mark.asyncio
+async def test_rental_verification_filler_create_kill_ignored_for_a_customer_rental():
+    """A paying customer's pod is never punished for the node's default-job history."""
+    backend_client = DummyBackendClient(
+        response=ExecutorHealthCheckResponse(success=True, error=None, details={})
+    )
+    ctx = _create_kill_context(
+        backend_client=backend_client,
+        ssh_client=FillerSSHClient(),
+        rented_pods=[RentedPod(pod_id="pod-1", container_name="pod_1")],
+    )
+
+    result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.VERIFIED.reason


### PR DESCRIPTION
## Why

ISSUE-050 / DAH-2439 punishes a host that kills a **RUNNING** filler. It does nothing when the container is removed seconds after `docker run`: the run never reaches RUNNING, the backend reports no filler container for the executor, `RentalVerificationCheck` takes the normal path, and the node collects unrented incentive while never running the default job it was assigned.

Prod, 2026-08-16..18: one miner, 6 executors on two hosts, 37 runs killed this way, zero fillers ever running. Timeline for one of them — `23:10:12.932 Created Docker Container` → `23:10:14.315 SDK op failed` → `23:10:15.969 inspect: no such object`. Nothing on our side removed it.

## What this PR does

**Detect** — the create flow now distinguishes "the container we created disappeared from the host" from any other create failure:
- `ContainerDeathDiagnostics.container_missing`, set when docker answers *no such object / no such container*;
- `cleanup_failed_container_creation()` returns that verdict;
- the failure is reported to the backend as `FailedContainerErrorCodes.ContainerVanished`, but **only** if `docker run` had already succeeded — before that there is no container to remove, and a failed pull must never read as a kill. Unproven cases (SSH dead, diagnostics failed) stay `UnknownError`: never accuse a host on missing evidence.

**Punish** — `RentalVerificationCheck` fails the fatal check for an unrented executor the backend lists in `filler_create_kill_executor_ids` (3+ create kills in 24 h), emitting a customer-facing `FILLER_KILLED_AT_CREATE` with remediation. A customer rental on the node is never punished for its default-job history.

Gated by the existing DAH-2439 pair: `FILLER_LIVENESS_CHECK_ENABLED` (master switch) and `FILLER_LIVENESS_ENFORCEMENT_ENABLED` (withholds). One switch now covers both offences — killed at start, killed while running.

Two things the review changed: the streak is judged **before** the liveness probe (a GPU-split node running one surviving bundle would otherwise return a clean verdict for a host that destroys every other bundle it is given), and **shadow mode only logs and falls through** to the normal verification — returning a pass there would have skipped the backend health check the node otherwise has to survive, making shadow an upgrade rather than an observation.

## Deploy order

Backend (Datura-ai/lium-io-backend#931) first — it must accept the new error code and publish the streak. Ships in shadow; enforcement is flipped in the deploy repo afterwards.

## Tests

`test_rental_verification_check.py`: streak → shadow logs / enforcement fails / check-disabled ignores / customer rental exempt. `test_failed_container_diagnostics.py`: vanished vs died-on-its-own, cleanup reports the verdict and still runs, unproven → False. `test_docker_service.py`: create failure maps to the right error code, and a `docker run` failure is never reported as a kill. Full validator suite: 1591 passed (3 pre-existing sshd-bootstrap failures, unrelated).

Notion: DAH-2703
