### PR TITLE
DAH-2705: scrape whether the executor container can apply a GPU power cap

### DIFF
--- a/neurons/validators/src/miner_jobs/machine_scrape.py
+++ b/neurons/validators/src/miner_jobs/machine_scrape.py
@@ -1097,6 +1097,8 @@ def probe_gpu_power_cap_ability() -> GpuPowerCapProbe:
     # holds CAP_SYS_ADMIN *and* its root owns /dev/nvidiactl - a sysbox userns maps the device to
     # nobody while keeping every capability, so neither reading alone tells the two apart. Report both
     # raw values and let the backend decide; an unreadable one stays empty/None, never a guess.
+    # /proc/self/status is this scrape's own process, which is meaningful only because the scrape and
+    # the validator's `nvidia-smi -pl` run in the same SSH context - keep them together.
     scrape_errors: list[str] = []
 
     cap_eff: str = ""

--- a/neurons/validators/src/miner_jobs/machine_scrape.py
+++ b/neurons/validators/src/miner_jobs/machine_scrape.py
@@ -1039,6 +1039,8 @@ def check_storage_limit_ability() -> tuple[bool, str]:
 
 NVIDIA_PARAMS_PATH = "/proc/driver/nvidia/params"
 BOOT_ID_PATH = "/proc/sys/kernel/random/boot_id"
+PROC_SELF_STATUS_PATH = "/proc/self/status"
+NVIDIACTL_PATH = "/dev/nvidiactl"
 INFINIBAND_SYSFS_PATH = "/sys/class/infiniband"
 # Enough of the GID table to carry both the link-local entries and the IPv4-mapped one. Its index
 # is driver-specific - mlx5 puts it at 2-3, Intel irdma at 1 - so consumers must match on the
@@ -1079,6 +1081,43 @@ def check_ncu_profiling_access() -> NcuProfilingObservation:
     return NcuProfilingObservation(
         "unknown", f"Unexpected RmProfilingAdminOnly value: {flag_value}"
     )
+
+
+class GpuPowerCapProbe:
+    # Plain class rather than a dataclass/NamedTuple: obfuscator.py only carries the imports on its
+    # allowlist into the packaged scrape, so this file must not grow new ones.
+    def __init__(self, cap_eff: str, nvidiactl_owner_uid: int | None, scrape_error: str) -> None:
+        self.cap_eff = cap_eff
+        self.nvidiactl_owner_uid = nvidiactl_owner_uid
+        self.scrape_error = scrape_error
+
+
+def probe_gpu_power_cap_ability() -> GpuPowerCapProbe:
+    # DAH-2704: `nvidia-smi -pl` (the PEARL filler's power cap) exits 4 unless the executor container
+    # holds CAP_SYS_ADMIN *and* its root owns /dev/nvidiactl - a sysbox userns maps the device to
+    # nobody while keeping every capability, so neither reading alone tells the two apart. Report both
+    # raw values and let the backend decide; an unreadable one stays empty/None, never a guess.
+    scrape_errors: list[str] = []
+
+    cap_eff: str = ""
+    try:
+        with open(PROC_SELF_STATUS_PATH) as status_file:
+            status_content = status_file.read()
+        match = re.search(r"^CapEff:\s*([0-9a-fA-F]+)\s*$", status_content, re.M)
+        if match is None:
+            scrape_errors.append(f"CapEff not present in {PROC_SELF_STATUS_PATH}")
+        else:
+            cap_eff = match.group(1)
+    except Exception as e:
+        scrape_errors.append(f"Cannot read {PROC_SELF_STATUS_PATH}: {e}")
+
+    nvidiactl_owner_uid: int | None = None
+    try:
+        nvidiactl_owner_uid = os.stat(NVIDIACTL_PATH).st_uid
+    except Exception as e:
+        scrape_errors.append(f"Cannot stat {NVIDIACTL_PATH}: {e}")
+
+    return GpuPowerCapProbe(cap_eff, nvidiactl_owner_uid, "; ".join(scrape_errors))
 
 
 def get_host_boot_id() -> str:
@@ -1344,6 +1383,13 @@ def get_machine_specs():
     if ncu_profiling.scrape_error:
         data["data_ncu_profiling_scrape_error"] = ncu_profiling.scrape_error
     data["data_boot_id"] = get_host_boot_id()
+
+    power_cap_probe = probe_gpu_power_cap_ability()
+    data["data_container_cap_eff"] = power_cap_probe.cap_eff
+    data["data_nvidiactl_owner_uid"] = power_cap_probe.nvidiactl_owner_uid
+    if power_cap_probe.scrape_error:
+        data["data_power_cap_probe_error"] = power_cap_probe.scrape_error
+
     infiniband = get_infiniband_ports()
     data["data_infiniband_ports"] = [port.as_payload() for port in infiniband.ports]
     if infiniband.scrape_error:

--- a/neurons/validators/src/services/file_encrypt_service.py
+++ b/neurons/validators/src/services/file_encrypt_service.py
@@ -142,6 +142,9 @@ ORIGINAL_KEYS = {
     'ib_pkey': "pkey",
     'ib_gids': "gids",
     'data_boot_id': "boot_id",
+    'data_container_cap_eff': "container_cap_eff",
+    'data_nvidiactl_owner_uid': "nvidiactl_owner_uid",
+    'data_power_cap_probe_error': "power_cap_probe_error",
 }
 
 
@@ -315,6 +318,9 @@ class FileEncryptService:
             'ib_pkey': "",
             'ib_gids': "",
             'data_boot_id': "",
+            'data_container_cap_eff': "",
+            'data_nvidiactl_owner_uid': "",
+            'data_power_cap_probe_error': "",
         }
 
         # Generate dictionary key mapping on validator side

--- a/neurons/validators/tests/helpers.py
+++ b/neurons/validators/tests/helpers.py
@@ -38,6 +38,18 @@ def build_scrape_namespace(
     return namespace
 
 
+def dict_literal_keys(module: ast.Module, dict_name: str) -> list[str]:
+    """Keys of the single dict literal assigned to `dict_name`, in source order."""
+    for node in ast.walk(module):
+        if (
+            isinstance(node, ast.Assign)
+            and getattr(node.targets[0], "id", "") == dict_name
+            and isinstance(node.value, ast.Dict)
+        ):
+            return [key.value for key in node.value.keys]
+    raise AssertionError(f"{dict_name} dict literal not found")
+
+
 class DummyScoreCalc:
     def __call__(self, *args, **kwargs):  # pragma: no cover
         return 0.0, 0.0, ""

--- a/neurons/validators/tests/test_scrape_gpu_power_cap_probe.py
+++ b/neurons/validators/tests/test_scrape_gpu_power_cap_probe.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from neurons.validators.tests.helpers import build_scrape_namespace
+from neurons.validators.tests.helpers import build_scrape_namespace, dict_literal_keys
 
 SRC = Path(__file__).resolve().parents[1] / "src"
 
@@ -96,18 +96,6 @@ def test_probe_reports_both_readings_missing_without_guessing(
     assert "Cannot read" in probe.scrape_error and "Cannot stat" in probe.scrape_error
 
 
-def _dict_literal_keys(module: ast.Module, dict_name: str) -> list[str]:
-    """Keys of the single dict literal assigned to `dict_name`, in source order."""
-    for node in ast.walk(module):
-        if (
-            isinstance(node, ast.Assign)
-            and getattr(node.targets[0], "id", "") == dict_name
-            and isinstance(node.value, ast.Dict)
-        ):
-            return [key.value for key in node.value.keys]
-    raise AssertionError(f"{dict_name} dict literal not found")
-
-
 def test_probe_keys_are_wired_through_both_obfuscation_tables() -> None:
     """A key missing from either table ships un-renamed/un-mapped - keep all three in both."""
     # Arrange
@@ -116,8 +104,8 @@ def test_probe_keys_are_wired_through_both_obfuscation_tables() -> None:
     new_keys = ["data_container_cap_eff", "data_nvidiactl_owner_uid", "data_power_cap_probe_error"]
 
     # Act
-    original_keys = _dict_literal_keys(service_module, "ORIGINAL_KEYS")
-    all_keys = _dict_literal_keys(service_module, "all_keys")
+    original_keys = dict_literal_keys(service_module, "ORIGINAL_KEYS")
+    all_keys = dict_literal_keys(service_module, "all_keys")
 
     # Assert
     for key in new_keys:

--- a/neurons/validators/tests/test_scrape_gpu_power_cap_probe.py
+++ b/neurons/validators/tests/test_scrape_gpu_power_cap_probe.py
@@ -1,0 +1,126 @@
+"""DAH-2704 - see probe_gpu_power_cap_ability() in machine_scrape.py for what makes a host able to
+apply `nvidia-smi -pl`: CAP_SYS_ADMIN in the executor container AND a /dev/nvidiactl its root owns.
+
+machine_scrape.py is a script, not a module - importing it runs the whole scrape - so the helpers
+are extracted by ast and executed in their own namespace (same pattern as test_scrape_ncu_profiling.py).
+"""
+
+import ast
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+from neurons.validators.tests.helpers import build_scrape_namespace
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+
+PROBE_HELPERS = {
+    "PROC_SELF_STATUS_PATH",
+    "NVIDIACTL_PATH",
+    "GpuPowerCapProbe",
+    "probe_gpu_power_cap_ability",
+}
+
+FULL_CAPS = "000001ffffffffff"  # privileged / sysbox container
+DEFAULT_DOCKER_CAPS = "00000000a80425fb"  # no CAP_SYS_ADMIN
+
+
+@pytest.fixture
+def scrape() -> dict[str, Any]:
+    """The power-cap probe helpers, executed in a namespace of their own."""
+    return build_scrape_namespace(
+        SRC / "miner_jobs" / "machine_scrape.py", PROBE_HELPERS, {"re": re, "os": os}
+    )
+
+
+def _status_file(tmp_path: Path, cap_eff_line: str) -> str:
+    status_file = tmp_path / "status"
+    status_file.write_text(f"Name:\tpython3\nUid:\t0\t0\t0\t0\n{cap_eff_line}\nSeccomp:\t0\n")
+    return str(status_file)
+
+
+@pytest.mark.parametrize(
+    ("cap_eff_line", "expected_cap_eff"),
+    [
+        (f"CapEff:\t{FULL_CAPS}", FULL_CAPS),
+        (f"CapEff:\t{DEFAULT_DOCKER_CAPS}", DEFAULT_DOCKER_CAPS),
+        ("CapPrm:\t000001ffffffffff", ""),  # exact-key parse, no sibling CapXxx match
+    ],
+)
+def test_probe_reads_the_effective_capability_mask(
+    scrape: dict[str, Any], tmp_path: Path, cap_eff_line: str, expected_cap_eff: str
+) -> None:
+    # Arrange
+    scrape["PROC_SELF_STATUS_PATH"] = _status_file(tmp_path, cap_eff_line)
+    scrape["NVIDIACTL_PATH"] = str(tmp_path)
+
+    # Act
+    probe = scrape["probe_gpu_power_cap_ability"]()
+
+    # Assert
+    assert probe.cap_eff == expected_cap_eff
+    if expected_cap_eff == "":
+        assert "CapEff" in probe.scrape_error
+
+
+def test_probe_reads_the_nvidiactl_owner_uid(scrape: dict[str, Any], tmp_path: Path) -> None:
+    # Arrange - a real file stands in for /dev/nvidiactl; its owner is this test process' uid
+    nvidiactl = tmp_path / "nvidiactl"
+    nvidiactl.write_text("")
+    scrape["PROC_SELF_STATUS_PATH"] = _status_file(tmp_path, f"CapEff:\t{FULL_CAPS}")
+    scrape["NVIDIACTL_PATH"] = str(nvidiactl)
+
+    # Act
+    probe = scrape["probe_gpu_power_cap_ability"]()
+
+    # Assert
+    assert probe.nvidiactl_owner_uid == os.getuid()
+    assert probe.scrape_error == ""
+
+
+def test_probe_reports_both_readings_missing_without_guessing(
+    scrape: dict[str, Any], tmp_path: Path
+) -> None:
+    # Arrange - no /proc/self/status, no /dev/nvidiactl (the backend fails open on this)
+    scrape["PROC_SELF_STATUS_PATH"] = str(tmp_path / "does-not-exist")
+    scrape["NVIDIACTL_PATH"] = str(tmp_path / "does-not-exist-either")
+
+    # Act
+    probe = scrape["probe_gpu_power_cap_ability"]()
+
+    # Assert
+    assert probe.cap_eff == ""
+    assert probe.nvidiactl_owner_uid is None
+    assert "Cannot read" in probe.scrape_error and "Cannot stat" in probe.scrape_error
+
+
+def _dict_literal_keys(module: ast.Module, dict_name: str) -> list[str]:
+    """Keys of the single dict literal assigned to `dict_name`, in source order."""
+    for node in ast.walk(module):
+        if (
+            isinstance(node, ast.Assign)
+            and getattr(node.targets[0], "id", "") == dict_name
+            and isinstance(node.value, ast.Dict)
+        ):
+            return [key.value for key in node.value.keys]
+    raise AssertionError(f"{dict_name} dict literal not found")
+
+
+def test_probe_keys_are_wired_through_both_obfuscation_tables() -> None:
+    """A key missing from either table ships un-renamed/un-mapped - keep all three in both."""
+    # Arrange
+    service_module = ast.parse((SRC / "services" / "file_encrypt_service.py").read_text())
+    scrape_text = (SRC / "miner_jobs" / "machine_scrape.py").read_text()
+    new_keys = ["data_container_cap_eff", "data_nvidiactl_owner_uid", "data_power_cap_probe_error"]
+
+    # Act
+    original_keys = _dict_literal_keys(service_module, "ORIGINAL_KEYS")
+    all_keys = _dict_literal_keys(service_module, "all_keys")
+
+    # Assert
+    for key in new_keys:
+        assert f'"{key}"' in scrape_text or f"'{key}'" in scrape_text
+        assert key in original_keys
+        assert key in all_keys

--- a/neurons/validators/tests/test_scrape_infiniband.py
+++ b/neurons/validators/tests/test_scrape_infiniband.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from neurons.validators.tests.helpers import build_scrape_namespace
+from neurons.validators.tests.helpers import build_scrape_namespace, dict_literal_keys
 
 SRC = Path(__file__).resolve().parents[1] / "src"
 
@@ -256,18 +256,6 @@ def test_unreadable_attribute_leaves_an_empty_field(scrape: dict[str, Any], tmp_
     assert ports[0].state == "4: ACTIVE"
 
 
-def _dict_literal_keys(module: ast.Module, dict_name: str) -> list[str]:
-    """Keys of the single dict literal assigned to `dict_name`, in source order."""
-    for node in ast.walk(module):
-        if (
-            isinstance(node, ast.Assign)
-            and getattr(node.targets[0], "id", "") == dict_name
-            and isinstance(node.value, ast.Dict)
-        ):
-            return [key.value for key in node.value.keys]
-    raise AssertionError(f"{dict_name} dict literal not found")
-
-
 def test_infiniband_keys_are_wired_through_both_obfuscation_tables() -> None:
     """A key missing from either table ships un-renamed/un-mapped."""
     # Arrange
@@ -291,8 +279,8 @@ def test_infiniband_keys_are_wired_through_both_obfuscation_tables() -> None:
     ]
 
     # Act
-    original_keys = _dict_literal_keys(service_module, "ORIGINAL_KEYS")
-    all_keys = _dict_literal_keys(service_module, "all_keys")
+    original_keys = dict_literal_keys(service_module, "ORIGINAL_KEYS")
+    all_keys = dict_literal_keys(service_module, "all_keys")
 
     # Assert
     for key in new_keys:

--- a/neurons/validators/tests/test_scrape_ncu_profiling.py
+++ b/neurons/validators/tests/test_scrape_ncu_profiling.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from neurons.validators.tests.helpers import build_scrape_namespace
+from neurons.validators.tests.helpers import build_scrape_namespace, dict_literal_keys
 
 SRC = Path(__file__).resolve().parents[1] / "src"
 
@@ -92,18 +92,6 @@ def test_boot_id_is_empty_when_unreadable(scrape: dict[str, Any], tmp_path: Path
     assert scrape["get_host_boot_id"]() == ""
 
 
-def _dict_literal_keys(module: ast.Module, dict_name: str) -> list[str]:
-    """Keys of the single dict literal assigned to `dict_name`, in source order."""
-    for node in ast.walk(module):
-        if (
-            isinstance(node, ast.Assign)
-            and getattr(node.targets[0], "id", "") == dict_name
-            and isinstance(node.value, ast.Dict)
-        ):
-            return [key.value for key in node.value.keys]
-    raise AssertionError(f"{dict_name} dict literal not found")
-
-
 def test_new_keys_are_wired_through_both_obfuscation_tables() -> None:
     """A key missing from either table ships un-renamed/un-mapped — keep all three in both."""
     # Arrange
@@ -112,8 +100,8 @@ def test_new_keys_are_wired_through_both_obfuscation_tables() -> None:
     new_keys = ["data_ncu_profiling_access", "data_ncu_profiling_scrape_error", "data_boot_id"]
 
     # Act
-    original_keys = _dict_literal_keys(service_module, "ORIGINAL_KEYS")
-    all_keys = _dict_literal_keys(service_module, "all_keys")
+    original_keys = dict_literal_keys(service_module, "ORIGINAL_KEYS")
+    all_keys = dict_literal_keys(service_module, "all_keys")
 
     # Assert - the scrape emits each key and both tables carry it
     for key in new_keys:
@@ -129,7 +117,7 @@ def test_no_obfuscation_key_is_a_prefix_of_a_later_one() -> None:
     service_module = ast.parse((SRC / "services" / "file_encrypt_service.py").read_text())
 
     # Act
-    all_keys = _dict_literal_keys(service_module, "all_keys")
+    all_keys = dict_literal_keys(service_module, "all_keys")
 
     # Assert
     prefixed_pairs = [


### PR DESCRIPTION
On some hosts `nvidia-smi -pl` exits 4 (no permission), so the fail-closed cap path refuses the PEARL filler every cycle and the node just idles — 223 refusals across 22 executors since 2026-07-24.

This collects the two raw readings the backend needs: the executor container's `CapEff` (`/proc/self/status`) and the owner uid of `/dev/nvidiactl`. Both are needed — a sysbox host keeps every capability but maps the device to `nobody` (uid 65534), so neither reading alone separates a healthy host from a blocked one. No verdict on the machine side; unreadable values stay empty/None and the backend fails open on them.

Verified on staging 149.36.1.151: the executor container reads `000001ffffffffff` / uid 0, while a plain unprivileged container on the same host reads `00000000a80425fb` / uid 0 and `nvidia-smi -pl` there fails with `Insufficient Permissions`, exit=4.

Backend side: Datura-ai/lium-io-backend#933 (merge this one first — the gate there is inert until specs carry the probe).

Tests: `tests/test_scrape_gpu_power_cap_probe.py`.