### PR TITLE
DAH-2640: Retry temporary backup repository access denial

### DIFF
--- a/neurons/executor/src/storage/restic.py
+++ b/neurons/executor/src/storage/restic.py
@@ -31,6 +31,28 @@ TAR_RECORD_SIZE_BYTES = 20 * 512
 TAR_CHECKPOINT_RECORDS = 1024
 MEBIBYTE = 1024 * 1024
 RESTIC_TMPFS_BYTES = 512 * MEBIBYTE
+REPOSITORY_RETRY_DELAYS_SECONDS: tuple[float, ...] = (
+    2.0,
+    4.0,
+    8.0,
+    16.0,
+    30.0,
+    30.0,
+    30.0,
+    30.0,
+    30.0,
+)
+REPOSITORY_RETRY_POLL_SECONDS: float = 1.0
+RETRYABLE_REPOSITORY_ERROR_MARKERS: tuple[str, ...] = (
+    "access denied",
+    "request timeout",
+    "slow down",
+    "status code: 429",
+    "status code: 500",
+    "status code: 502",
+    "status code: 503",
+    "status code: 504",
+)
 ENCRYPTED_BACKUP_SCRIPT = 'cd "$1"; shift; exec "$@"'
 ENCRYPTED_BOOTSTRAP_SCRIPT = r"""
 set -eu
@@ -192,38 +214,119 @@ class ResticStorageRunner:
         return result
 
     def _ensure_repository_for_backup(self) -> None:
-        probe = subprocess.run(
-            self._restic_command(["snapshots", "--json"]),
-            env=self._environment,
-            capture_output=True,
-            text=True,
+        repository_probe = self._run_repository_command_with_retry(
+            ["snapshots", "--json"],
+            repository_command_name="probe",
+            accepted_exit_codes=(0, 10),
         )
-        if probe.returncode == 0:
+        if repository_probe.returncode == 0:
             return
-        if probe.returncode != 10:
-            detail = _redact(probe.stderr or probe.stdout, self._secret_values())
+        if repository_probe.returncode != 10:
+            failure_detail = self._redacted_repository_failure_detail(repository_probe)
             raise ResticOperationError(
-                f"restic repository probe failed with exit {probe.returncode}: {detail}"
+                "restic repository probe failed with exit "
+                f"{repository_probe.returncode}: {failure_detail}"
             )
 
-        initialized = subprocess.run(
-            self._restic_command(["init", "--json"]),
-            env=self._environment,
-            capture_output=True,
-            text=True,
+        repository_initialization = self._run_repository_command_with_retry(
+            ["init", "--json"],
+            repository_command_name="initialization",
         )
-        if initialized.returncode == 0:
+        if repository_initialization.returncode == 0:
             return
 
-        retry_probe = subprocess.run(
-            self._restic_command(["snapshots", "--json"]),
-            env=self._environment,
-            capture_output=True,
-            text=True,
+        # Initialization may have succeeded even if its response was lost. Probe
+        # again before retrying so we never initialize an existing repository.
+        repository_confirmation = self._run_repository_command_with_retry(
+            ["snapshots", "--json"],
+            repository_command_name="post-initialization probe",
+            accepted_exit_codes=(0, 10),
         )
-        if retry_probe.returncode != 0:
-            detail = _redact(initialized.stderr or initialized.stdout, self._secret_values())
-            raise ResticOperationError(f"restic repository initialization failed: {detail}")
+        if repository_confirmation.returncode != 0:
+            failure_detail = self._redacted_repository_failure_detail(repository_initialization)
+            raise ResticOperationError(
+                f"restic repository initialization failed: {failure_detail}"
+            )
+
+    def _run_repository_command_with_retry(
+        self,
+        restic_arguments: list[str],
+        *,
+        repository_command_name: str,
+        accepted_exit_codes: tuple[int, ...] = (0,),
+    ) -> subprocess.CompletedProcess[str]:
+        remaining_retry_delays = iter(REPOSITORY_RETRY_DELAYS_SECONDS)
+        while True:
+            self._raise_if_cancellation_requested()
+            repository_command_result = subprocess.run(
+                self._restic_command(restic_arguments),
+                env=self._environment,
+                capture_output=True,
+                text=True,
+            )
+            if repository_command_result.returncode in accepted_exit_codes:
+                return repository_command_result
+
+            failure_detail = self._redacted_repository_failure_detail(repository_command_result)
+            if not _is_retryable_repository_failure(failure_detail):
+                return repository_command_result
+            try:
+                retry_delay_seconds = next(remaining_retry_delays)
+            except StopIteration:
+                self._log_transient_repository_failure(
+                    repository_command_name,
+                    failure_detail,
+                    retry_delay_seconds=None,
+                )
+                raise ResticOperationError(
+                    "backup storage is not ready yet; please retry shortly"
+                ) from None
+            self._log_transient_repository_failure(
+                repository_command_name,
+                failure_detail,
+                retry_delay_seconds=retry_delay_seconds,
+            )
+            self._wait_before_repository_retry(retry_delay_seconds)
+
+    def _redacted_repository_failure_detail(
+        self,
+        repository_command_result: subprocess.CompletedProcess[str],
+    ) -> str:
+        command_output = repository_command_result.stderr or repository_command_result.stdout
+        return _redact(command_output, self._secret_values())
+
+    def _wait_before_repository_retry(self, delay_seconds: float) -> None:
+        deadline = time.monotonic() + delay_seconds
+        while True:
+            self._raise_if_cancellation_requested()
+            self._events.heartbeat_if_due()
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                return
+            time.sleep(min(REPOSITORY_RETRY_POLL_SECONDS, remaining_seconds))
+
+    def _raise_if_cancellation_requested(self) -> None:
+        if self._events.cancellation_requested:
+            raise StorageOperationCancelled("storage operation cancellation requested")
+
+    def _log_transient_repository_failure(
+        self,
+        repository_command_name: str,
+        failure_detail: str,
+        *,
+        retry_delay_seconds: float | None,
+    ) -> None:
+        retry_status = (
+            f"; retrying in {retry_delay_seconds:g}s"
+            if retry_delay_seconds is not None
+            else "; retries exhausted"
+        )
+        print(
+            "Transient repository "
+            f"{repository_command_name} failure{retry_status}: {failure_detail}",
+            file=sys.stderr,
+            flush=True,
+        )
 
     def _require_repository_for_restore(self) -> None:
         # Restore is read-only: a missing source must fail instead of creating an
@@ -676,6 +779,14 @@ class ResticStorageRunner:
             if isinstance(self._workspace, DockerEncryptedVolumeWorkspace)
             else "",
         )
+
+
+def _is_retryable_repository_failure(failure_detail: str) -> bool:
+    normalized_detail = failure_detail.casefold().replace(" ", "")
+    return any(
+        marker.replace(" ", "") in normalized_detail
+        for marker in RETRYABLE_REPOSITORY_ERROR_MARKERS
+    )
 
 
 def _snapshot_id(summary: Mapping[str, object] | None) -> str | None:

--- a/neurons/executor/src/storage/restic.py
+++ b/neurons/executor/src/storage/restic.py
@@ -31,17 +31,13 @@ TAR_RECORD_SIZE_BYTES = 20 * 512
 TAR_CHECKPOINT_RECORDS = 1024
 MEBIBYTE = 1024 * 1024
 RESTIC_TMPFS_BYTES = 512 * MEBIBYTE
-REPOSITORY_RETRY_DELAYS_SECONDS: tuple[float, ...] = (
-    2.0,
-    4.0,
-    8.0,
-    16.0,
-    30.0,
-    30.0,
-    30.0,
-    30.0,
-    30.0,
-)
+# Newly issued backup credentials can take a short time to become usable in AWS.
+# This budget covers repository probing, initialization, and confirmation together.
+REPOSITORY_READINESS_TIMEOUT_SECONDS: float = 180.0
+# Retry quickly at first, then cap the delay so readiness is still checked regularly.
+REPOSITORY_RETRY_INITIAL_DELAY_SECONDS: float = 2.0
+REPOSITORY_RETRY_MAX_DELAY_SECONDS: float = 30.0
+# Short waits keep cancellation and operation heartbeats responsive during backoff.
 REPOSITORY_RETRY_POLL_SECONDS: float = 1.0
 RETRYABLE_REPOSITORY_ERROR_MARKERS: tuple[str, ...] = (
     "access denied",
@@ -214,9 +210,13 @@ class ResticStorageRunner:
         return result
 
     def _ensure_repository_for_backup(self) -> None:
+        repository_readiness_deadline = (
+            time.monotonic() + REPOSITORY_READINESS_TIMEOUT_SECONDS
+        )
         repository_probe = self._run_repository_command_with_retry(
             ["snapshots", "--json"],
             repository_command_name="probe",
+            retry_deadline=repository_readiness_deadline,
             accepted_exit_codes=(0, 10),
         )
         if repository_probe.returncode == 0:
@@ -231,6 +231,7 @@ class ResticStorageRunner:
         repository_initialization = self._run_repository_command_with_retry(
             ["init", "--json"],
             repository_command_name="initialization",
+            retry_deadline=repository_readiness_deadline,
         )
         if repository_initialization.returncode == 0:
             return
@@ -240,6 +241,7 @@ class ResticStorageRunner:
         repository_confirmation = self._run_repository_command_with_retry(
             ["snapshots", "--json"],
             repository_command_name="post-initialization probe",
+            retry_deadline=repository_readiness_deadline,
             accepted_exit_codes=(0, 10),
         )
         if repository_confirmation.returncode != 0:
@@ -253,9 +255,10 @@ class ResticStorageRunner:
         restic_arguments: list[str],
         *,
         repository_command_name: str,
+        retry_deadline: float,
         accepted_exit_codes: tuple[int, ...] = (0,),
     ) -> subprocess.CompletedProcess[str]:
-        remaining_retry_delays = iter(REPOSITORY_RETRY_DELAYS_SECONDS)
+        retry_delay_seconds = REPOSITORY_RETRY_INITIAL_DELAY_SECONDS
         while True:
             self._raise_if_cancellation_requested()
             repository_command_result = subprocess.run(
@@ -270,9 +273,8 @@ class ResticStorageRunner:
             failure_detail = self._redacted_repository_failure_detail(repository_command_result)
             if not _is_retryable_repository_failure(failure_detail):
                 return repository_command_result
-            try:
-                retry_delay_seconds = next(remaining_retry_delays)
-            except StopIteration:
+            remaining_retry_seconds = retry_deadline - time.monotonic()
+            if remaining_retry_seconds <= 0:
                 self._log_transient_repository_failure(
                     repository_command_name,
                     failure_detail,
@@ -281,12 +283,17 @@ class ResticStorageRunner:
                 raise ResticOperationError(
                     "backup storage is not ready yet; please retry shortly"
                 ) from None
+            wait_seconds = min(retry_delay_seconds, remaining_retry_seconds)
             self._log_transient_repository_failure(
                 repository_command_name,
                 failure_detail,
-                retry_delay_seconds=retry_delay_seconds,
+                retry_delay_seconds=wait_seconds,
             )
-            self._wait_before_repository_retry(retry_delay_seconds)
+            self._wait_before_repository_retry(wait_seconds)
+            retry_delay_seconds = min(
+                retry_delay_seconds * 2,
+                REPOSITORY_RETRY_MAX_DELAY_SECONDS,
+            )
 
     def _redacted_repository_failure_detail(
         self,

--- a/neurons/executor/src/storage/restic.py
+++ b/neurons/executor/src/storage/restic.py
@@ -39,16 +39,9 @@ REPOSITORY_RETRY_INITIAL_DELAY_SECONDS: float = 2.0
 REPOSITORY_RETRY_MAX_DELAY_SECONDS: float = 30.0
 # Short waits keep cancellation and operation heartbeats responsive during backoff.
 REPOSITORY_RETRY_POLL_SECONDS: float = 1.0
-RETRYABLE_REPOSITORY_ERROR_MARKERS: tuple[str, ...] = (
-    "access denied",
-    "request timeout",
-    "slow down",
-    "status code: 429",
-    "status code: 500",
-    "status code: 502",
-    "status code: 503",
-    "status code: 504",
-)
+# Restic treats AccessDenied as permanent, but a newly attached IAM policy can
+# return it briefly while AWS propagates the policy to S3.
+IAM_POLICY_PROPAGATION_ERROR_MARKER = "accessdenied"
 ENCRYPTED_BACKUP_SCRIPT = 'cd "$1"; shift; exec "$@"'
 ENCRYPTED_BOOTSTRAP_SCRIPT = r"""
 set -eu
@@ -281,7 +274,8 @@ class ResticStorageRunner:
                     retry_delay_seconds=None,
                 )
                 raise ResticOperationError(
-                    "backup storage is not ready yet; please retry shortly"
+                    "Backup storage was not ready after retrying: "
+                    f"{failure_detail}"
                 ) from None
             wait_seconds = min(retry_delay_seconds, remaining_retry_seconds)
             self._log_transient_repository_failure(
@@ -790,10 +784,7 @@ class ResticStorageRunner:
 
 def _is_retryable_repository_failure(failure_detail: str) -> bool:
     normalized_detail = failure_detail.casefold().replace(" ", "")
-    return any(
-        marker.replace(" ", "") in normalized_detail
-        for marker in RETRYABLE_REPOSITORY_ERROR_MARKERS
-    )
+    return IAM_POLICY_PROPAGATION_ERROR_MARKER in normalized_detail
 
 
 def _snapshot_id(summary: Mapping[str, object] | None) -> str | None:

--- a/neurons/executor/src/storage/restic.py
+++ b/neurons/executor/src/storage/restic.py
@@ -31,17 +31,6 @@ TAR_RECORD_SIZE_BYTES = 20 * 512
 TAR_CHECKPOINT_RECORDS = 1024
 MEBIBYTE = 1024 * 1024
 RESTIC_TMPFS_BYTES = 512 * MEBIBYTE
-# Newly issued backup credentials can take a short time to become usable in AWS.
-# This budget covers repository probing, initialization, and confirmation together.
-REPOSITORY_READINESS_TIMEOUT_SECONDS: float = 180.0
-# Retry quickly at first, then cap the delay so readiness is still checked regularly.
-REPOSITORY_RETRY_INITIAL_DELAY_SECONDS: float = 2.0
-REPOSITORY_RETRY_MAX_DELAY_SECONDS: float = 30.0
-# Short waits keep cancellation and operation heartbeats responsive during backoff.
-REPOSITORY_RETRY_POLL_SECONDS: float = 1.0
-# Restic treats AccessDenied as permanent, but a newly attached IAM policy can
-# return it briefly while AWS propagates the policy to S3.
-IAM_POLICY_PROPAGATION_ERROR_MARKER = "accessdenied"
 ENCRYPTED_BACKUP_SCRIPT = 'cd "$1"; shift; exec "$@"'
 ENCRYPTED_BOOTSTRAP_SCRIPT = r"""
 set -eu
@@ -203,9 +192,9 @@ class ResticStorageRunner:
         return result
 
     def _ensure_repository_for_backup(self) -> None:
-        repository_readiness_deadline = (
-            time.monotonic() + REPOSITORY_READINESS_TIMEOUT_SECONDS
-        )
+        # A newly attached IAM policy can briefly return Access Denied while AWS
+        # propagates it. Share one three-minute readiness window across setup.
+        repository_readiness_deadline = time.monotonic() + 180.0
         repository_probe = self._run_repository_command_with_retry(
             ["snapshots", "--json"],
             repository_command_name="probe",
@@ -251,7 +240,8 @@ class ResticStorageRunner:
         retry_deadline: float,
         accepted_exit_codes: tuple[int, ...] = (0,),
     ) -> subprocess.CompletedProcess[str]:
-        retry_delay_seconds = REPOSITORY_RETRY_INITIAL_DELAY_SECONDS
+        # Start with a short delay so newly propagated permissions recover quickly.
+        retry_delay_seconds = 2.0
         while True:
             self._raise_if_cancellation_requested()
             repository_command_result = subprocess.run(
@@ -284,10 +274,8 @@ class ResticStorageRunner:
                 retry_delay_seconds=wait_seconds,
             )
             self._wait_before_repository_retry(wait_seconds)
-            retry_delay_seconds = min(
-                retry_delay_seconds * 2,
-                REPOSITORY_RETRY_MAX_DELAY_SECONDS,
-            )
+            # Avoid hammering S3 while still checking readiness at least every 30 seconds.
+            retry_delay_seconds = min(retry_delay_seconds * 2, 30.0)
 
     def _redacted_repository_failure_detail(
         self,
@@ -304,7 +292,8 @@ class ResticStorageRunner:
             remaining_seconds = deadline - time.monotonic()
             if remaining_seconds <= 0:
                 return
-            time.sleep(min(REPOSITORY_RETRY_POLL_SECONDS, remaining_seconds))
+            # Wake every second so cancellation and heartbeats remain responsive.
+            time.sleep(min(1.0, remaining_seconds))
 
     def _raise_if_cancellation_requested(self) -> None:
         if self._events.cancellation_requested:
@@ -783,8 +772,12 @@ class ResticStorageRunner:
 
 
 def _is_retryable_repository_failure(failure_detail: str) -> bool:
-    normalized_detail = failure_detail.casefold().replace(" ", "")
-    return IAM_POLICY_PROPAGATION_ERROR_MARKER in normalized_detail
+    # Restic treats AccessDenied as permanent and does not retry it, but AWS can
+    # return it temporarily while a newly attached IAM policy is propagating.
+    retryable_failure_markers = ("accessdenied",)
+    # Normalization matches both "Access Denied" and compact "AccessDenied" forms.
+    normalized_detail = "".join(failure_detail.casefold().split())
+    return any(marker in normalized_detail for marker in retryable_failure_markers)
 
 
 def _snapshot_id(summary: Mapping[str, object] | None) -> str | None:

--- a/neurons/executor/tests/test_storage_runner.py
+++ b/neurons/executor/tests/test_storage_runner.py
@@ -189,8 +189,6 @@ def test_backup_repository_probe_retries_transient_access_denied(
     monkeypatch.setattr("storage.restic.subprocess.run", repository_command_sequence)
     monkeypatch.setattr("storage.restic.time.monotonic", clock)
     monkeypatch.setattr("storage.restic.time.sleep", clock.sleep)
-    monkeypatch.setattr("storage.restic.REPOSITORY_RETRY_DELAYS_SECONDS", (2.0,))
-
     runner._ensure_repository_for_backup()
 
     assert [command[2] for command in repository_command_sequence.commands] == [
@@ -221,8 +219,6 @@ def test_backup_repository_initialization_retries_transient_access_denied(
     monkeypatch.setattr("storage.restic.subprocess.run", repository_command_sequence)
     monkeypatch.setattr("storage.restic.time.monotonic", clock)
     monkeypatch.setattr("storage.restic.time.sleep", clock.sleep)
-    monkeypatch.setattr("storage.restic.REPOSITORY_RETRY_DELAYS_SECONDS", (2.0,))
-
     runner._ensure_repository_for_backup()
 
     assert [command[2] for command in repository_command_sequence.commands] == [
@@ -257,8 +253,6 @@ def test_backup_repository_retry_stops_on_cancellation(
     )
     monkeypatch.setattr("storage.restic.time.monotonic", clock)
     monkeypatch.setattr("storage.restic.time.sleep", clock.sleep)
-    monkeypatch.setattr("storage.restic.REPOSITORY_RETRY_DELAYS_SECONDS", (2.0,))
-
     with pytest.raises(StorageOperationCancelled, match="cancellation requested"):
         runner._ensure_repository_for_backup()
 
@@ -280,7 +274,9 @@ def test_backup_repository_retry_exhaustion_returns_customer_safe_error(
     monkeypatch.setattr("storage.restic.subprocess.run", run_repository_command)
     monkeypatch.setattr("storage.restic.time.monotonic", clock)
     monkeypatch.setattr("storage.restic.time.sleep", clock.sleep)
-    monkeypatch.setattr("storage.restic.REPOSITORY_RETRY_DELAYS_SECONDS", (1.0, 2.0))
+    monkeypatch.setattr("storage.restic.REPOSITORY_READINESS_TIMEOUT_SECONDS", 3.0)
+    monkeypatch.setattr("storage.restic.REPOSITORY_RETRY_INITIAL_DELAY_SECONDS", 1.0)
+    monkeypatch.setattr("storage.restic.REPOSITORY_RETRY_MAX_DELAY_SECONDS", 2.0)
 
     with pytest.raises(ResticOperationError, match="backup storage is not ready"):
         runner._ensure_repository_for_backup()

--- a/neurons/executor/tests/test_storage_runner.py
+++ b/neurons/executor/tests/test_storage_runner.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import io
 import json
+import subprocess
+from collections.abc import Iterator
 from pathlib import Path, PurePosixPath
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -18,7 +20,13 @@ from storage.models import (
     StorageOperationSpec,
 )
 from storage.reporting import ReportingLeaseExpired, StorageEventReporter
-from storage.restic import JsonEventWriter, ResticOperationError, ResticStorageRunner, RestoreStats
+from storage.restic import (
+    JsonEventWriter,
+    ResticOperationError,
+    ResticStorageRunner,
+    RestoreStats,
+    StorageOperationCancelled,
+)
 from storage.workspace import (
     DockerUserNamespaceWorkspace,
     DockerVolumeWorkspace,
@@ -111,6 +119,204 @@ def test_restore_missing_repository_never_initializes_it(
     assert raised.value.error_code == "RESTIC_REPOSITORY_MISSING"
     assert commands
     assert all("init" not in command for command in commands)
+
+
+class _RetryClock:
+    def __init__(self) -> None:
+        self.now: float = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _repository_command_result(
+    exit_code: int,
+    *,
+    standard_output: str = "",
+    standard_error: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["restic"],
+        returncode=exit_code,
+        stdout=standard_output,
+        stderr=standard_error,
+    )
+
+
+class _RepositoryCommandSequence:
+    def __init__(self, responses: list[subprocess.CompletedProcess[str]]) -> None:
+        self.commands: list[list[str]] = []
+        self._responses: Iterator[subprocess.CompletedProcess[str]] = iter(responses)
+
+    def __call__(
+        self,
+        command: list[str],
+        **_: object,
+    ) -> subprocess.CompletedProcess[str]:
+        self.commands.append(command)
+        return next(self._responses)
+
+
+def test_backup_repository_probe_retries_transient_access_denied(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    operation = StorageOperationSpec.from_mapping(_operation_payload())
+    clock = _RetryClock()
+    event_output = io.StringIO()
+    event_writer = JsonEventWriter(
+        str(OPERATION_ID),
+        0,
+        heartbeat_interval_seconds=1.0,
+        output=event_output,
+        clock=clock,
+    )
+    runner = ResticStorageRunner(operation, LocalWorkspace(tmp_path), event_writer=event_writer)
+    repository_command_sequence = _RepositoryCommandSequence(
+        [
+            _repository_command_result(
+                1,
+                standard_error="Stat(<config/>) failed: Stat: Access Denied",
+            ),
+            _repository_command_result(10, standard_error="repository does not exist"),
+            _repository_command_result(0, standard_output="{}"),
+        ]
+    )
+
+    monkeypatch.setattr("storage.restic.subprocess.run", repository_command_sequence)
+    monkeypatch.setattr("storage.restic.time.monotonic", clock)
+    monkeypatch.setattr("storage.restic.time.sleep", clock.sleep)
+    monkeypatch.setattr("storage.restic.REPOSITORY_RETRY_DELAYS_SECONDS", (2.0,))
+
+    runner._ensure_repository_for_backup()
+
+    assert [command[2] for command in repository_command_sequence.commands] == [
+        "snapshots",
+        "snapshots",
+        "init",
+    ]
+    assert clock.now == 2.0
+    assert '"event":"heartbeat"' in event_output.getvalue()
+
+
+def test_backup_repository_initialization_retries_transient_access_denied(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    operation = StorageOperationSpec.from_mapping(_operation_payload())
+    runner = ResticStorageRunner(operation, LocalWorkspace(tmp_path))
+    clock = _RetryClock()
+    repository_command_sequence = _RepositoryCommandSequence(
+        [
+            _repository_command_result(10, standard_error="repository does not exist"),
+            _repository_command_result(1, standard_error="S3 error: AccessDenied"),
+            _repository_command_result(1, standard_error="repository already initialized"),
+            _repository_command_result(0, standard_output="[]"),
+        ]
+    )
+
+    monkeypatch.setattr("storage.restic.subprocess.run", repository_command_sequence)
+    monkeypatch.setattr("storage.restic.time.monotonic", clock)
+    monkeypatch.setattr("storage.restic.time.sleep", clock.sleep)
+    monkeypatch.setattr("storage.restic.REPOSITORY_RETRY_DELAYS_SECONDS", (2.0,))
+
+    runner._ensure_repository_for_backup()
+
+    assert [command[2] for command in repository_command_sequence.commands] == [
+        "snapshots",
+        "init",
+        "init",
+        "snapshots",
+    ]
+    assert clock.now == 2.0
+
+
+def test_backup_repository_retry_stops_on_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    operation = StorageOperationSpec.from_mapping(_operation_payload())
+    clock = _RetryClock()
+    event_writer = JsonEventWriter(
+        str(OPERATION_ID),
+        0,
+        clock=clock,
+        cancellation_probe=lambda: clock.now >= 1.0,
+    )
+    runner = ResticStorageRunner(operation, LocalWorkspace(tmp_path), event_writer=event_writer)
+
+    monkeypatch.setattr(
+        "storage.restic.subprocess.run",
+        lambda *args, **kwargs: _repository_command_result(
+            1,
+            standard_error="Stat: Access Denied",
+        ),
+    )
+    monkeypatch.setattr("storage.restic.time.monotonic", clock)
+    monkeypatch.setattr("storage.restic.time.sleep", clock.sleep)
+    monkeypatch.setattr("storage.restic.REPOSITORY_RETRY_DELAYS_SECONDS", (2.0,))
+
+    with pytest.raises(StorageOperationCancelled, match="cancellation requested"):
+        runner._ensure_repository_for_backup()
+
+    assert clock.now == 1.0
+
+
+def test_backup_repository_retry_exhaustion_returns_customer_safe_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    operation = StorageOperationSpec.from_mapping(_operation_payload())
+    runner = ResticStorageRunner(operation, LocalWorkspace(tmp_path))
+    clock = _RetryClock()
+    run_repository_command = MagicMock(
+        return_value=_repository_command_result(1, standard_error="S3 StatusCode: 503")
+    )
+
+    monkeypatch.setattr("storage.restic.subprocess.run", run_repository_command)
+    monkeypatch.setattr("storage.restic.time.monotonic", clock)
+    monkeypatch.setattr("storage.restic.time.sleep", clock.sleep)
+    monkeypatch.setattr("storage.restic.REPOSITORY_RETRY_DELAYS_SECONDS", (1.0, 2.0))
+
+    with pytest.raises(ResticOperationError, match="backup storage is not ready"):
+        runner._ensure_repository_for_backup()
+
+    assert run_repository_command.call_count == 3
+    assert clock.now == 3.0
+    assert "StatusCode: 503" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "detail",
+    (
+        "Fatal: wrong password or no key found",
+        "dial tcp: lookup invalid.example: no such host",
+    ),
+)
+def test_backup_repository_does_not_retry_permanent_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    detail: str,
+) -> None:
+    operation = StorageOperationSpec.from_mapping(_operation_payload())
+    runner = ResticStorageRunner(operation, LocalWorkspace(tmp_path))
+    run_repository_command = MagicMock(
+        return_value=_repository_command_result(1, standard_error=detail)
+    )
+    sleep_mock = MagicMock()
+
+    monkeypatch.setattr("storage.restic.subprocess.run", run_repository_command)
+    monkeypatch.setattr("storage.restic.time.sleep", sleep_mock)
+
+    with pytest.raises(ResticOperationError, match="repository probe failed"):
+        runner._ensure_repository_for_backup()
+
+    run_repository_command.assert_called_once()
+    sleep_mock.assert_not_called()
 
 
 def test_requested_path_must_stay_inside_volume() -> None:

--- a/neurons/executor/tests/test_storage_runner.py
+++ b/neurons/executor/tests/test_storage_runner.py
@@ -279,15 +279,11 @@ def test_backup_repository_retry_exhaustion_preserves_redacted_error(
     monkeypatch.setattr("storage.restic.subprocess.run", run_repository_command)
     monkeypatch.setattr("storage.restic.time.monotonic", clock)
     monkeypatch.setattr("storage.restic.time.sleep", clock.sleep)
-    monkeypatch.setattr("storage.restic.REPOSITORY_READINESS_TIMEOUT_SECONDS", 3.0)
-    monkeypatch.setattr("storage.restic.REPOSITORY_RETRY_INITIAL_DELAY_SECONDS", 1.0)
-    monkeypatch.setattr("storage.restic.REPOSITORY_RETRY_MAX_DELAY_SECONDS", 2.0)
-
     with pytest.raises(ResticOperationError, match="Backup storage was not ready") as raised:
         runner._ensure_repository_for_backup()
 
-    assert run_repository_command.call_count == 3
-    assert clock.now == 3.0
+    assert run_repository_command.call_count == 10
+    assert clock.now == 180.0
     expected_error = "Stat(<config/>) failed: Stat: Access Denied for [REDACTED]"
     assert expected_error in str(raised.value)
     assert expected_error in capsys.readouterr().err

--- a/neurons/executor/tests/test_storage_runner.py
+++ b/neurons/executor/tests/test_storage_runner.py
@@ -259,7 +259,7 @@ def test_backup_repository_retry_stops_on_cancellation(
     assert clock.now == 1.0
 
 
-def test_backup_repository_retry_exhaustion_returns_customer_safe_error(
+def test_backup_repository_retry_exhaustion_preserves_redacted_error(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -268,7 +268,12 @@ def test_backup_repository_retry_exhaustion_returns_customer_safe_error(
     runner = ResticStorageRunner(operation, LocalWorkspace(tmp_path))
     clock = _RetryClock()
     run_repository_command = MagicMock(
-        return_value=_repository_command_result(1, standard_error="S3 StatusCode: 503")
+        return_value=_repository_command_result(
+            1,
+            standard_error=(
+                "Stat(<config/>) failed: Stat: Access Denied for secret-key"
+            ),
+        )
     )
 
     monkeypatch.setattr("storage.restic.subprocess.run", run_repository_command)
@@ -278,12 +283,15 @@ def test_backup_repository_retry_exhaustion_returns_customer_safe_error(
     monkeypatch.setattr("storage.restic.REPOSITORY_RETRY_INITIAL_DELAY_SECONDS", 1.0)
     monkeypatch.setattr("storage.restic.REPOSITORY_RETRY_MAX_DELAY_SECONDS", 2.0)
 
-    with pytest.raises(ResticOperationError, match="backup storage is not ready"):
+    with pytest.raises(ResticOperationError, match="Backup storage was not ready") as raised:
         runner._ensure_repository_for_backup()
 
     assert run_repository_command.call_count == 3
     assert clock.now == 3.0
-    assert "StatusCode: 503" in capsys.readouterr().err
+    expected_error = "Stat(<config/>) failed: Stat: Access Denied for [REDACTED]"
+    assert expected_error in str(raised.value)
+    assert expected_error in capsys.readouterr().err
+    assert "secret-key" not in str(raised.value)
 
 
 @pytest.mark.parametrize(
@@ -291,9 +299,11 @@ def test_backup_repository_retry_exhaustion_returns_customer_safe_error(
     (
         "Fatal: wrong password or no key found",
         "dial tcp: lookup invalid.example: no such host",
+        "The AWS Access Key Id you provided does not exist in our records.",
+        "503 Service Unavailable",
     ),
 )
-def test_backup_repository_does_not_retry_permanent_failure(
+def test_backup_repository_does_not_retry_other_failures(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     detail: str,


### PR DESCRIPTION
## Describe your changes

Retry `AccessDenied` while the executor probes or initializes a newly created backup repository.

- Use a shared, bounded readiness deadline of 180 seconds with exponential backoff.
- Continue reporting heartbeats and honor cancellation while waiting.
- Re-probe after an ambiguous initialization result so an already-created repository is never initialized again.
- Preserve the complete redacted Restic/S3 error if readiness retries are exhausted.

### Root cause

A production user's first backup was dispatched immediately after their S3 bucket, IAM user, and policy were created. The repository probe ran before AWS had propagated the new IAM permissions and failed with `Access Denied`. A later backup using the same pod, repository, and credentials completed successfully.

Restic retries ordinary transient backend failures internally, but deliberately treats `AccessDenied` as permanent. During initial platform-managed IAM setup, that normally permanent error can be temporary while the new policy propagates. This change retries only that known exception during backup repository setup.

### Impact

Normal backups and restores are unchanged. Other S3, credential, repository, and endpoint failures do not receive an additional executor-level retry. This requires publishing the updated executor image; there are no validator protocol, database, IAM, or backend changes.

### Validation

- `ruff check src/storage/restic.py tests/test_storage_runner.py`
- `pytest tests/test_storage_runner.py -q` — 34 passed
- Covered probe recovery, initialization recovery, ambiguous initialization confirmation, heartbeats, cancellation, bounded exhaustion with the redacted cause preserved, and immediate return for non-`AccessDenied` failures including `InvalidAccessKeyId` and HTTP 503.

## Issue ticket number and link

[DAH-2640: Improve backup and restore reliability to 90% first-attempt success](https://app.notion.com/p/Epic-improve-backup-and-restore-reliability-to-90-first-attempt-success-3b8b8bfdbde981259ae5fa1155239ae1?pvs=23)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [x] Need to take care of performance?
