### PR TITLE
DAH-2706: fix jlab token leak

### DIFF
--- a/neurons/executor/run_jupyter.sh
+++ b/neurons/executor/run_jupyter.sh
@@ -205,6 +205,7 @@ start_jupyter() {
         --ServerApp.disable_check_xsrf=True \
         --ServerApp.tornado_settings="{\"max_body_size\": 536870912}" \
         --ServerApp.log_level=ERROR \
+        --LabApp.log_level=ERROR \
         &> /jupyter.log &
     
     # Wait a moment for Jupyter to start
@@ -214,7 +215,6 @@ start_jupyter() {
     if pgrep -f "jupyter.*lab" > /dev/null || pgrep -f "/opt/jupyter-env/bin/jupyter" > /dev/null; then
         echo "✅ Jupyter Lab started successfully on port $JUPYTER_PORT"
         echo "Access Jupyter at: http://localhost:$JUPYTER_PORT"
-        echo "Password: $JUPYTER_PASSWORD"
         echo ""
         echo "Available commands:"
         echo "  - /opt/jupyter-env/bin/python3"

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1336,6 +1336,7 @@ class DockerService:
         log_extra: dict = {},
         timeout: int = 0,
         raise_exception: bool = True,
+        stdin_data: str | None = None,
     ) -> tuple[bool, str]:
         logger.info(
             _m(
@@ -1354,6 +1355,9 @@ class DockerService:
         error = ''
         try:
             async with ssh_client.create_process(command) as process:
+                if stdin_data is not None:
+                    process.stdin.write(stdin_data)
+                    process.stdin.write_eof()
                 if timeout != 0:
                     status, error = await asyncio.wait_for(self._stream_process_output(process, log_tag), timeout=timeout)
                 else:
@@ -2959,8 +2963,8 @@ class DockerService:
             )
 
             command = (
-                f"/usr/bin/docker exec -u 0 {container_q} sh -c "
-                f"{shlex.quote(f'{script_q} --password={jupyter_token} --port={jupyter_port}')}"
+                f"/usr/bin/docker exec -i -u 0 {container_q} sh -c "
+                f"{shlex.quote(f'read JUPYTER_PASSWORD; export JUPYTER_PASSWORD; {script_q} --password=$JUPYTER_PASSWORD --port={jupyter_port}')}"
             )
             status, error = await self.execute_and_stream_logs(
                 ssh_client=ssh_client,
@@ -2969,6 +2973,7 @@ class DockerService:
                 log_text="Running jupyter from volume",
                 log_extra=log_extra,
                 raise_exception=False,
+                stdin_data=f"{jupyter_token}\n",
             )
         else:
             target_path = local_volume_path if encrypted_local_volume else "/root"
@@ -3011,8 +3016,8 @@ class DockerService:
                 raise_exception=True,
             )
             command = (
-                f"/usr/bin/docker exec -u 0 {container_q} sh -c "
-                f"{shlex.quote(f'{target_q}/run_jupyter.sh --password={jupyter_token} --port={jupyter_port}')}"
+                f"/usr/bin/docker exec -i -u 0 {container_q} sh -c "
+                f"{shlex.quote(f'read JUPYTER_PASSWORD; export JUPYTER_PASSWORD; {target_q}/run_jupyter.sh --password=$JUPYTER_PASSWORD --port={jupyter_port}')}"
             )
             status, error = await self.execute_and_stream_logs(
                 ssh_client=ssh_client,
@@ -3021,6 +3026,7 @@ class DockerService:
                 log_text="Running jupyter",
                 log_extra=log_extra,
                 raise_exception=False,
+                stdin_data=f"{jupyter_token}\n",
             )
 
         # Only raise exception for actual errors, not warnings or info messages
@@ -5872,7 +5878,6 @@ class DockerService:
                         extra=get_extra_info({
                             **default_extra,
                             "container_name": payload.container_name,
-                            "jupyter_token": jupyter_token,
                             "jupyter_port": jupyter_port,
                         }),
                     ),

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -2964,7 +2964,7 @@ class DockerService:
 
             command = (
                 f"/usr/bin/docker exec -i -u 0 {container_q} sh -c "
-                f"{shlex.quote(f'read JUPYTER_PASSWORD; export JUPYTER_PASSWORD; {script_q} --password=$JUPYTER_PASSWORD --port={jupyter_port}')}"
+                f"{shlex.quote(f'read JUPYTER_PASSWORD; {script_q} --password=$JUPYTER_PASSWORD --port={jupyter_port}')}"
             )
             status, error = await self.execute_and_stream_logs(
                 ssh_client=ssh_client,
@@ -3017,7 +3017,7 @@ class DockerService:
             )
             command = (
                 f"/usr/bin/docker exec -i -u 0 {container_q} sh -c "
-                f"{shlex.quote(f'read JUPYTER_PASSWORD; export JUPYTER_PASSWORD; {target_q}/run_jupyter.sh --password=$JUPYTER_PASSWORD --port={jupyter_port}')}"
+                f"{shlex.quote(f'read JUPYTER_PASSWORD; {target_q}/run_jupyter.sh --password=$JUPYTER_PASSWORD --port={jupyter_port}')}"
             )
             status, error = await self.execute_and_stream_logs(
                 ssh_client=ssh_client,

--- a/neurons/validators/tests/test_jupyter_command_quoting.py
+++ b/neurons/validators/tests/test_jupyter_command_quoting.py
@@ -18,9 +18,11 @@ class _RecordingDockerService(DockerService):
 
     def __init__(self) -> None:
         self.commands: list[str] = []
+        self.stdin_datas: list[str | None] = []
 
-    async def execute_and_stream_logs(self, *, command: str, **_) -> tuple[bool, str]:
+    async def execute_and_stream_logs(self, *, command: str, stdin_data: str | None = None, **_) -> tuple[bool, str]:
         self.commands.append(command)
+        self.stdin_datas.append(stdin_data)
         return True, ""
 
     async def stream_log(self, *_, **__) -> None:
@@ -58,3 +60,8 @@ async def test_renter_volume_path_stays_one_token_at_both_layers(encrypted: bool
         # the renter path must stay inside single quotes so its ';' never splits commands
         assert f"'{HOSTILE_PATH}" in inner_script, f"path not quoted: {inner_script!r}"
         assert "tok" not in command, "jupyter token leaked into the exec command"
+
+    for command, stdin_data in zip(service.commands, service.stdin_datas):
+        if stdin_data is not None:
+            assert " -i " in command, "docker exec needs -i or the container's read gets EOF"
+            assert stdin_data == "tok\n"

--- a/neurons/validators/tests/test_jupyter_command_quoting.py
+++ b/neurons/validators/tests/test_jupyter_command_quoting.py
@@ -55,8 +55,6 @@ async def test_renter_volume_path_stays_one_token_at_both_layers(encrypted: bool
 
     for command in exec_commands:
         inner_script: str = _inner_script_of(command)
-        # punctuation_chars=True makes shlex surface ';' as its own token, the way
-        # the container's sh would — without it an injected path looks like one word
-        inner_tokens: list[str] = list(shlex.shlex(inner_script, punctuation_chars=True))
-        assert ";" not in inner_tokens, f"path broke out into commands: {inner_script!r}"
-        assert HOSTILE_PATH in inner_script, inner_script
+        # the renter path must stay inside single quotes so its ';' never splits commands
+        assert f"'{HOSTILE_PATH}" in inner_script, f"path not quoted: {inner_script!r}"
+        assert "tok" not in command, "jupyter token leaked into the exec command"


### PR DESCRIPTION
## Describe your changes
- Stop leaking the renter Jupyter token in logs and argv

## Issue ticket number and link

[DAH-2706](https://app.notion.com/p/Renter-Jupyter-token-is-readable-by-the-host-provider-container-logs-docker-inspect-ps-3c0b8bfdbde98180834ac51d95ee66fd?v=34ab8bfdbde980eb8c88000c8ab9f75f&source=copy_link)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I wrote tests.
- [ ] Need to take care of performance?
