### PR TITLE
DAH-2708: pass the image registry to docker login so private registries authenticate

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -3877,6 +3877,7 @@ class DockerService:
         # nothing to remove, so a missing container there is an ordinary create failure.
         container_created = False
         container_vanished = False
+        login_error: str | None = None
         volume_encryption_status = VolumeEncryptionStatus.DISABLED
 
         # DAH-2211: a custom-build payload carries `dockerfile_content` (may be
@@ -4082,8 +4083,9 @@ class DockerService:
                 # `ships_sshd` IS the "renter selected a default image" signal — the
                 # backend sets it from the same check that resolves the recommended image
                 # for this executor's GPU+driver (executor.py: `ships_sshd=is_cached`,
-                # with `is_cached=False` forced for custom builds, whose `FROM` may pull a
-                # private base image and so must keep the login). Don't re-derive it here:
+                # with `is_cached=False` forced for custom builds, so they keep this login
+                # path as-is; the DinD `docker build` never sees this SDK login, and
+                # passing credentials into it is a separate task). Don't re-derive it here:
                 # a second, validator-side notion of "is this a default image?" could
                 # disagree with the backend's and skip a login that was actually needed.
                 has_credentials = bool(payload.docker_username and payload.docker_password)
@@ -4105,11 +4107,13 @@ class DockerService:
                             call=lambda: docker_client.login(
                                 username=payload.docker_username,
                                 password=payload.docker_password,
+                                image=payload.docker_image,
                             ),
                             username_present=True,
                             username_len=len(payload.docker_username),
                         )
                     except Exception as exc:
+                        login_error = str(exc)
                         logger.warning(
                             _m(
                                 "Docker registry login failed",
@@ -4889,6 +4893,10 @@ class DockerService:
                     volume_encryption_status=volume_encryption_status,
                 )
         except Exception as e:
+            # a pull that fails after a failed registry login is most likely the
+            # login's fault (docker-py silently pulls anonymously) — attribute it
+            if current_step == "docker_pull" and login_error is not None:
+                current_step = "docker_login"
             log_text = _m(
                 "Failed create_container",
                 extra=get_extra_info({
@@ -4912,6 +4920,8 @@ class DockerService:
                 and isinstance(e, RentalDockerConnectionError)
             ):
                 failure_detail = f"{failure_detail}: {e}"
+            if current_step == "docker_login" and login_error is not None:
+                failure_detail = f"{failure_detail} (earlier login failure: {login_error})"
 
             return FailedContainerRequest(
                 miner_hotkey=payload.miner_hotkey,

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -97,6 +97,7 @@ from services.rental_docker_sdk import (
     DeviceMount,
     PortBinding,
     RentalDockerConnectionError,
+    RentalDockerOperationError,
     RentalDockerSdkClient,
     RentalDockerSdkClientFactory,
     VolumeMount,
@@ -4205,12 +4206,22 @@ class DockerService:
                             "success",
                             log_tag,
                         )
-                        await run_logged_rental_docker_sdk_operation(
-                            operation="pull",
-                            log_extra=default_extra,
-                            call=lambda: docker_client.pull(image=payload.docker_image),
-                            image=payload.docker_image,
-                        )
+                        try:
+                            await run_logged_rental_docker_sdk_operation(
+                                operation="pull",
+                                log_extra=default_extra,
+                                call=lambda: docker_client.pull(image=payload.docker_image),
+                                image=payload.docker_image,
+                            )
+                        except Exception as exc:
+                            if login_error is None:
+                                raise
+                            # docker-py pulls anonymously after a failed login, so the
+                            # pull failure is most likely the login's fault — attribute it
+                            current_step = "docker_login"
+                            raise RentalDockerOperationError(
+                                f"{exc} (earlier login failure: {login_error})"
+                            ) from exc
 
                         # Add profiler for docker pull
                         profilers.append(ProfilerStep.since(ProfilerStepName.DOCKER_PULL, prev_timestamp))
@@ -4893,10 +4904,6 @@ class DockerService:
                     volume_encryption_status=volume_encryption_status,
                 )
         except Exception as e:
-            # a pull that fails after a failed registry login is most likely the
-            # login's fault (docker-py silently pulls anonymously) — attribute it
-            if current_step == "docker_pull" and login_error is not None:
-                current_step = "docker_login"
             log_text = _m(
                 "Failed create_container",
                 extra=get_extra_info({
@@ -4920,8 +4927,6 @@ class DockerService:
                 and isinstance(e, RentalDockerConnectionError)
             ):
                 failure_detail = f"{failure_detail}: {e}"
-            if current_step == "docker_login" and login_error is not None:
-                failure_detail = f"{failure_detail} (earlier login failure: {login_error})"
 
             return FailedContainerRequest(
                 miner_hotkey=payload.miner_hotkey,

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -154,12 +154,20 @@ class RentalDockerSdkClient:
         self._api_client = api_client
         self._pull_timeout_seconds = pull_timeout_seconds
 
-    async def login(self, *, username: str, password: str) -> None:
+    async def login(self, *, username: str, password: str, image: str) -> None:
+        # docker-py stores the credential under docker.io unless the registry
+        # is passed explicitly, so resolve it from the image the pull will use.
+        from docker import auth, utils
+
+        repository, _ = utils.parse_repository_tag(image)
+        registry, _ = auth.resolve_repository_name(repository)
+        registry = None if registry == auth.INDEX_NAME else registry
         await self._call_api(
-            operation_label="login",
+            operation_label="login" if registry is None else f"login for {registry}",
             api_method=self._api_client.login,
             username=username,
             password=password,
+            registry=registry,
             reauth=True,
         )
 

--- a/neurons/validators/tests/test_custom_dockerfile_build.py
+++ b/neurons/validators/tests/test_custom_dockerfile_build.py
@@ -77,8 +77,8 @@ class _FakeRentalDockerClient:
         self.pull_error = None
         self.run_error = None
 
-    async def login(self, *, username: str, password: str) -> None:
-        self.login_calls.append({"username": username, "password": password})
+    async def login(self, *, username: str, password: str, image: str) -> None:
+        self.login_calls.append({"username": username, "password": password, "image": image})
 
     async def pull(self, *, image: str) -> None:
         self.pulled_images.append(image)

--- a/neurons/validators/tests/test_deploy_optimizations.py
+++ b/neurons/validators/tests/test_deploy_optimizations.py
@@ -99,8 +99,8 @@ class _FakeRentalDockerClient:
         self.exec_specs = []
         self.login_calls = []
 
-    async def login(self, *, username: str, password: str) -> None:
-        self.login_calls.append({"username": username, "password": password})
+    async def login(self, *, username: str, password: str, image: str) -> None:
+        self.login_calls.append({"username": username, "password": password, "image": image})
 
     async def image_exists(self, *, image: str) -> bool:
         self.image_exists_calls.append(image)
@@ -842,7 +842,9 @@ async def test_docker_login_runs_for_non_default_image_with_credentials(svc, mon
     )
 
     assert isinstance(result, ContainerCreated)
-    assert _docker_client(svc).login_calls == [{"username": "renter", "password": "renter-secret"}]
+    assert _docker_client(svc).login_calls == [
+        {"username": "renter", "password": "renter-secret", "image": "private/repo:1.0.0"}
+    ]
     assert _login_step(result).skipped is False
 
 
@@ -856,7 +858,9 @@ async def test_docker_login_runs_when_ships_sshd_is_none(svc, monkeypatch):
     result = await _run(svc, _payload(docker_image="private/repo:1.0.0", **_CREDS))
 
     assert isinstance(result, ContainerCreated)
-    assert _docker_client(svc).login_calls == [{"username": "renter", "password": "renter-secret"}]
+    assert _docker_client(svc).login_calls == [
+        {"username": "renter", "password": "renter-secret", "image": "private/repo:1.0.0"}
+    ]
     assert _login_step(result).skipped is False
 
 
@@ -876,9 +880,10 @@ async def test_docker_login_step_marked_skipped_when_no_credentials(svc, monkeyp
 
 @pytest.mark.asyncio
 async def test_docker_login_runs_for_custom_build(svc, monkeypatch):
-    """A custom build's `FROM` may pull a private base image, so the login stays. The
-    backend guarantees this by forcing is_cached=False (→ ships_sshd=False) for custom
-    builds, even when the base image happens to be a default ref."""
+    """Custom builds keep ships_sshd=False (the backend forces is_cached=False for them,
+    even when the base image happens to be a default ref), so they keep the login path
+    as-is. The DinD `docker build` never sees this SDK login; passing credentials into
+    it is a separate task."""
     ssh_client = _ssh_client(inspect_exit=0)
     _patch_happy(svc, monkeypatch, ssh_client)
     monkeypatch.setattr(svc, "_custom_build_image", AsyncMock(return_value=(True, None)))
@@ -894,5 +899,7 @@ async def test_docker_login_runs_for_custom_build(svc, monkeypatch):
     )
 
     assert isinstance(result, ContainerCreated)
-    assert _docker_client(svc).login_calls == [{"username": "renter", "password": "renter-secret"}]
+    assert _docker_client(svc).login_calls == [
+        {"username": "renter", "password": "renter-secret", "image": _DEFAULT_IMAGE}
+    ]
     assert _login_step(result).skipped is False

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -35,6 +35,7 @@ from services.rental_docker_sdk import (
 )
 from payload_models.payloads import (
     AddSshPublicKeyRequest,
+    ContainerCreated,
     ContainerCreateRequest,
     CustomOptions,
     ContainerDeleteRequest,
@@ -86,6 +87,7 @@ class _FakeRentalDockerClient:
         self.created_volumes = []
         self.removed_volumes = []
         self.pruned_images = 0
+        self.login_error = None
         self.pull_error = None
         self.run_error = None
         self.start_error = None
@@ -94,8 +96,10 @@ class _FakeRentalDockerClient:
         self.remove_volume_error = None
         self.prune_images_error = None
 
-    async def login(self, *, username: str, password: str) -> None:
-        self.login_calls.append({"username": username, "password": password})
+    async def login(self, *, username: str, password: str, image: str) -> None:
+        self.login_calls.append({"username": username, "password": password, "image": image})
+        if self.login_error is not None:
+            raise self.login_error
 
     async def image_exists(self, *, image: str) -> bool:
         self.inspected_images.append(image)
@@ -3417,6 +3421,140 @@ async def test_create_container_reports_docker_pull_failure_step(
         payload.executor_id,
         payload.pod_id,
     )
+
+
+def _private_registry_create_payload() -> ContainerCreateRequest:
+    return ContainerCreateRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        docker_image="registry.digitalocean.com/team/app:1.0",
+        docker_username="team-user",
+        docker_password="team-secret",
+        user_public_keys=["ssh-ed25519 test-key"],
+        gpu_uuids=["GPU-test"],
+        cpu_count=1,
+        memory_gb=1,
+        volume_limit_gb=2,
+        storage_limit_gb=1,
+        available_ports=[PayloadPortMapping(internal_port=20001, external_port=20001)],
+        pod_mapping=[],
+        active_container_names=[],
+        active_volume_names=[],
+    )
+
+
+def _patch_private_registry_create_happy_path(docker_service, monkeypatch) -> None:
+    # image inspect reports ABSENT so the pull runs; everything else succeeds
+    ssh_client = AsyncMock()
+
+    def _ssh_run_side(cmd, *args, **kwargs):
+        if "image inspect" in cmd:
+            return _make_ssh_command_result(exit_status=1)
+        return _make_ssh_command_result()
+
+    ssh_client.run = AsyncMock(side_effect=_ssh_run_side)
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr(
+        "services.docker_service.build_gpu_docker_config_for_executor",
+        AsyncMock(return_value=build_gpu_docker_config(["GPU-test"])),
+    )
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.add_pending_pod = AsyncMock()
+    docker_service.redis_service.remove_pending_pod = AsyncMock()
+    docker_service.redis_service.add_rented_pod = AsyncMock()
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        docker_service,
+        "generate_portMappings",
+        AsyncMock(return_value=([(22, 20001, 20001)], None)),
+    )
+    monkeypatch.setattr(docker_service, "execute_and_stream_logs", AsyncMock(return_value=(True, "")))
+    monkeypatch.setattr(docker_service, "clean_existing_containers", AsyncMock())
+    monkeypatch.setattr(docker_service, "clean_stale_vloopback_volumes", AsyncMock())
+    monkeypatch.setattr(docker_service, "create_local_volume", AsyncMock())
+    monkeypatch.setattr(
+        docker_service,
+        "wait_for_port_check_containers",
+        AsyncMock(return_value=(True, "ok")),
+    )
+    monkeypatch.setattr(docker_service, "check_container_running", AsyncMock(return_value=True))
+    monkeypatch.setattr(docker_service, "stream_log", AsyncMock())
+    monkeypatch.setattr(docker_service, "finish_stream_logs", AsyncMock())
+    monkeypatch.setattr(docker_service, "handle_stream_logs", AsyncMock())
+
+
+@pytest.mark.asyncio
+async def test_create_container_reports_docker_login_failure_step_when_pull_also_fails(
+    docker_service,
+    monkeypatch,
+):
+    _patch_private_registry_create_happy_path(docker_service, monkeypatch)
+    docker_client = docker_service.rental_docker_client_factory.client
+    docker_client.login_error = Exception(
+        "Docker SDK login for registry.digitalocean.com failed: unauthorized"
+    )
+    docker_client.pull_error = Exception("blocked")
+    payload = _private_registry_create_payload()
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
+    )
+
+    result = await docker_service.create_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    assert isinstance(result, FailedContainerRequest)
+    assert result.failure_step == "docker_login"
+    assert "registry.digitalocean.com" in result.detail
+    assert "unauthorized" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_create_container_login_failure_does_not_block_successful_pull(
+    docker_service,
+    monkeypatch,
+):
+    _patch_private_registry_create_happy_path(docker_service, monkeypatch)
+    docker_client = docker_service.rental_docker_client_factory.client
+    docker_client.login_error = Exception(
+        "Docker SDK login for registry.digitalocean.com failed: unauthorized"
+    )
+    payload = _private_registry_create_payload()
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
+    )
+
+    result = await docker_service.create_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    assert isinstance(result, ContainerCreated)
+    assert docker_client.pulled_images == [payload.docker_image]
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -3444,56 +3444,12 @@ def _private_registry_create_payload() -> ContainerCreateRequest:
     )
 
 
-def _patch_private_registry_create_happy_path(docker_service, monkeypatch) -> None:
-    # image inspect reports ABSENT so the pull runs; everything else succeeds
-    ssh_client = AsyncMock()
-
-    def _ssh_run_side(cmd, *args, **kwargs):
-        if "image inspect" in cmd:
-            return _make_ssh_command_result(exit_status=1)
-        return _make_ssh_command_result()
-
-    ssh_client.run = AsyncMock(side_effect=_ssh_run_side)
-    monkeypatch.setattr(
-        "services.docker_service.asyncssh.connect",
-        Mock(return_value=DummySSHConnectionManager(ssh_client)),
-    )
-    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
-    monkeypatch.setattr(
-        "services.docker_service.build_gpu_docker_config_for_executor",
-        AsyncMock(return_value=build_gpu_docker_config(["GPU-test"])),
-    )
-    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
-    docker_service.redis_service.add_pending_pod = AsyncMock()
-    docker_service.redis_service.remove_pending_pod = AsyncMock()
-    docker_service.redis_service.add_rented_pod = AsyncMock()
-    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
-    monkeypatch.setattr(
-        docker_service,
-        "generate_portMappings",
-        AsyncMock(return_value=([(22, 20001, 20001)], None)),
-    )
-    monkeypatch.setattr(docker_service, "execute_and_stream_logs", AsyncMock(return_value=(True, "")))
-    monkeypatch.setattr(docker_service, "clean_existing_containers", AsyncMock())
-    monkeypatch.setattr(docker_service, "clean_stale_vloopback_volumes", AsyncMock())
-    monkeypatch.setattr(docker_service, "create_local_volume", AsyncMock())
-    monkeypatch.setattr(
-        docker_service,
-        "wait_for_port_check_containers",
-        AsyncMock(return_value=(True, "ok")),
-    )
-    monkeypatch.setattr(docker_service, "check_container_running", AsyncMock(return_value=True))
-    monkeypatch.setattr(docker_service, "stream_log", AsyncMock())
-    monkeypatch.setattr(docker_service, "finish_stream_logs", AsyncMock())
-    monkeypatch.setattr(docker_service, "handle_stream_logs", AsyncMock())
-
-
 @pytest.mark.asyncio
 async def test_create_container_reports_docker_login_failure_step_when_pull_also_fails(
     docker_service,
     monkeypatch,
 ):
-    _patch_private_registry_create_happy_path(docker_service, monkeypatch)
+    _patch_create_container_happy_path(docker_service, monkeypatch)
     docker_client = docker_service.rental_docker_client_factory.client
     docker_client.login_error = Exception(
         "Docker SDK login for registry.digitalocean.com failed: unauthorized"
@@ -3529,7 +3485,7 @@ async def test_create_container_login_failure_does_not_block_successful_pull(
     docker_service,
     monkeypatch,
 ):
-    _patch_private_registry_create_happy_path(docker_service, monkeypatch)
+    _patch_create_container_happy_path(docker_service, monkeypatch)
     docker_client = docker_service.rental_docker_client_factory.client
     docker_client.login_error = Exception(
         "Docker SDK login for registry.digitalocean.com failed: unauthorized"

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -3476,8 +3476,10 @@ async def test_create_container_reports_docker_login_failure_step_when_pull_also
 
     assert isinstance(result, FailedContainerRequest)
     assert result.failure_step == "docker_login"
-    assert "registry.digitalocean.com" in result.detail
-    assert "unauthorized" in result.detail
+    assert (
+        "earlier login failure: Docker SDK login for registry.digitalocean.com failed: unauthorized"
+        in result.detail
+    )
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service_rental_security.py
+++ b/neurons/validators/tests/test_docker_service_rental_security.py
@@ -86,8 +86,8 @@ class RecordingRentalDockerClient:
         self.pruned_images = 0
         self.run_container_error = None
 
-    async def login(self, *, username: str, password: str) -> None:
-        self.login_calls.append({"username": username, "password": password})
+    async def login(self, *, username: str, password: str, image: str) -> None:
+        self.login_calls.append({"username": username, "password": password, "image": image})
 
     async def image_exists(self, *, image: str) -> bool:
         self.inspected_images.append(image)
@@ -410,7 +410,7 @@ async def test_create_container_keeps_hostile_fields_out_of_host_shell_commands(
         ],
     )
     assert docker_client.login_calls == [
-        {"username": HOSTILE_USERNAME, "password": HOSTILE_PASSWORD}
+        {"username": HOSTILE_USERNAME, "password": HOSTILE_PASSWORD, "image": HOSTILE_IMAGE}
     ]
     assert docker_client.pulled_images == [HOSTILE_IMAGE]
     assert run_spec.image == HOSTILE_IMAGE

--- a/neurons/validators/tests/test_rental_docker_sdk.py
+++ b/neurons/validators/tests/test_rental_docker_sdk.py
@@ -356,46 +356,22 @@ async def test_login_passes_credentials_as_sdk_data():
     ]
 
 
+@pytest.mark.parametrize(
+    ("image", "expected_registry"),
+    [
+        ("registry.digitalocean.com/team/app:1.0", "registry.digitalocean.com"),
+        ("daturaai/pytorch:test", None),
+        ("localhost:5000/team/app:1", "localhost:5000"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_login_resolves_registry_from_private_image():
+async def test_login_resolves_registry_from_image(image, expected_registry):
     api_client = FakeApiClient()
     client = RentalDockerSdkClient(api_client)
 
-    await client.login(
-        username="team-user",
-        password=INCIDENT_DOCKER_PASSWORD,
-        image="registry.digitalocean.com/team/app:1.0",
-    )
+    await client.login(username="team-user", password=INCIDENT_DOCKER_PASSWORD, image=image)
 
-    assert api_client.login_calls[0]["registry"] == "registry.digitalocean.com"
-
-
-@pytest.mark.asyncio
-async def test_login_uses_no_registry_for_docker_hub_image():
-    api_client = FakeApiClient()
-    client = RentalDockerSdkClient(api_client)
-
-    await client.login(
-        username="hub-user",
-        password=INCIDENT_DOCKER_PASSWORD,
-        image="daturaai/pytorch:test",
-    )
-
-    assert api_client.login_calls[0]["registry"] is None
-
-
-@pytest.mark.asyncio
-async def test_login_resolves_registry_with_port_from_image():
-    api_client = FakeApiClient()
-    client = RentalDockerSdkClient(api_client)
-
-    await client.login(
-        username="local-user",
-        password=INCIDENT_DOCKER_PASSWORD,
-        image="localhost:5000/team/app:1",
-    )
-
-    assert api_client.login_calls[0]["registry"] == "localhost:5000"
+    assert api_client.login_calls[0]["registry"] == expected_registry
 
 
 @pytest.mark.parametrize(

--- a/neurons/validators/tests/test_rental_docker_sdk.py
+++ b/neurons/validators/tests/test_rental_docker_sdk.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import os
 import socket
 import struct
@@ -6,6 +8,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+from docker import auth as docker_auth
 from docker.errors import APIError
 from docker.types import ContainerConfig
 
@@ -308,6 +311,27 @@ class PullApiClient(FakeApiClient):
         return self.pull_events
 
 
+class LoginThenPullApiClient(PullApiClient):
+    def __init__(self):
+        super().__init__()
+        self.credstore_env = None
+        self._auth_configs = docker_auth.AuthConfig({"auths": {}})
+
+    def login(self, *, username, password, registry=None, reauth=False):
+        self.login_calls.append(
+            {
+                "username": username,
+                "password": password,
+                "registry": registry,
+                "reauth": reauth,
+            }
+        )
+        self._auth_configs.add_auth(
+            registry or docker_auth.INDEX_NAME,
+            {"username": username, "password": password, "serveraddress": registry},
+        )
+
+
 class ImageNotFound(Exception):
     pass
 
@@ -318,15 +342,60 @@ async def test_login_passes_credentials_as_sdk_data():
     client = RentalDockerSdkClient(api_client)
     username = "user'; rm -rf / #"
 
-    await client.login(username=username, password=INCIDENT_DOCKER_PASSWORD)
+    await client.login(
+        username=username, password=INCIDENT_DOCKER_PASSWORD, image="ubuntu:latest"
+    )
 
     assert api_client.login_calls == [
         {
             "username": username,
             "password": INCIDENT_DOCKER_PASSWORD,
+            "registry": None,
             "reauth": True,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_login_resolves_registry_from_private_image():
+    api_client = FakeApiClient()
+    client = RentalDockerSdkClient(api_client)
+
+    await client.login(
+        username="team-user",
+        password=INCIDENT_DOCKER_PASSWORD,
+        image="registry.digitalocean.com/team/app:1.0",
+    )
+
+    assert api_client.login_calls[0]["registry"] == "registry.digitalocean.com"
+
+
+@pytest.mark.asyncio
+async def test_login_uses_no_registry_for_docker_hub_image():
+    api_client = FakeApiClient()
+    client = RentalDockerSdkClient(api_client)
+
+    await client.login(
+        username="hub-user",
+        password=INCIDENT_DOCKER_PASSWORD,
+        image="daturaai/pytorch:test",
+    )
+
+    assert api_client.login_calls[0]["registry"] is None
+
+
+@pytest.mark.asyncio
+async def test_login_resolves_registry_with_port_from_image():
+    api_client = FakeApiClient()
+    client = RentalDockerSdkClient(api_client)
+
+    await client.login(
+        username="local-user",
+        password=INCIDENT_DOCKER_PASSWORD,
+        image="localhost:5000/team/app:1",
+    )
+
+    assert api_client.login_calls[0]["registry"] == "localhost:5000"
 
 
 @pytest.mark.parametrize(
@@ -343,9 +412,29 @@ async def test_login_preserves_legitimate_password_metacharacters(password):
     api_client = FakeApiClient()
     client = RentalDockerSdkClient(api_client)
 
-    await client.login(username="registry-user", password=password)
+    await client.login(
+        username="registry-user", password=password, image="daturaai/pytorch:test"
+    )
 
     assert api_client.login_calls[0]["password"] == password
+
+
+@pytest.mark.asyncio
+async def test_pull_sends_registry_auth_header_for_private_registry_login():
+    api_client = LoginThenPullApiClient()
+    client = RentalDockerSdkClient(api_client, pull_timeout_seconds=123)
+    image = "registry.digitalocean.com/team/app:1.0"
+
+    await client.login(
+        username="team-user", password=INCIDENT_DOCKER_PASSWORD, image=image
+    )
+    await client.pull(image=image)
+
+    headers = api_client.post_calls[0]["kwargs"]["headers"]
+    assert "X-Registry-Auth" in headers
+    decoded = json.loads(base64.urlsafe_b64decode(headers["X-Registry-Auth"]))
+    assert decoded["serveraddress"] == "registry.digitalocean.com"
+    assert decoded["username"] == "team-user"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Describe your changes

`RentalDockerSdkClient.login` called docker-py `APIClient.login` without `registry`, so the credential was always stored under `docker.io` and a pull from any other registry (`registry.digitalocean.com/...`, `ghcr.io/...`, `localhost:5000/...`) went out without `X-Registry-Auth` and failed as anonymous.

- `rental_docker_sdk.py`: `login` now takes `image`, resolves the registry host from it (`docker.auth.resolve_repository_name`) and passes `registry=` to the SDK; Docker Hub images still log in with `registry=None`.
- `docker_service.py`: passes `payload.docker_image` to `login`; login stays non-fatal, but when the subsequent pull fails after a failed login the failure is reported with `failure_step="docker_login"` and the login error appended to `detail`, instead of a misleading `docker_pull`.
- Comment/docstring wording fix: the SDK login does not feed the custom-build DinD `docker build` (DinD credentials are a separate task).
- Tests: registry resolution (private host, Docker Hub, host:port), `X-Registry-Auth` carries `serveraddress` of the private registry after login, login→pull failure attribution, login failure not blocking a successful pull; five test doubles updated.

Out of scope: DinD/custom-build credentials, `image@sha256:...:latest` (compute-app), payload/contract unchanged.

## Issue ticket number and link

[DAH-2708](https://www.notion.so/3c1b8bfdbde9818087abe93805891246)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?
