### PR TITLE
DAH-2715: withhold the unrented incentive from executors that cannot apply a GPU power cap

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -281,9 +281,11 @@ class Settings(BaseSettings):
     # DAH-2715 — GPU power cap capability gate. When True, an unrented executor whose
     # container provably cannot apply a GPU power cap (no CAP_SYS_ADMIN, or /dev/nvidiactl
     # not owned by root - see DAH-2705) loses the unrented rental incentive while staying
-    # active. When False, the breach is only logged (shadow mode) so prod impact can be
-    # observed before enforcing. A node whose probe is missing is never penalized.
-    ENABLE_UNRENTED_POWER_CAP_LIMIT: bool = Field(env="ENABLE_UNRENTED_POWER_CAP_LIMIT", default=False)
+    # active. A node whose probe is missing or unreadable is never penalized.
+    # Unlike the gates above this one ships ENFORCED: the fix is one compose flag on the
+    # provider's side, and the shadow window would only delay it. Set to False to fall back
+    # to logging the breach without withholding anything.
+    ENABLE_UNRENTED_POWER_CAP_LIMIT: bool = Field(env="ENABLE_UNRENTED_POWER_CAP_LIMIT", default=True)
 
     COLLATERAL_CONTRACT_ADDRESS: str = Field(
         env='COLLATERAL_CONTRACT_ADDRESS', default='0x8A4023FdD1eaA7b242F3723a7d096B6CC693c7C6'

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -278,6 +278,13 @@ class Settings(BaseSettings):
     # (shadow mode) so prod impact can be observed before enforcing.
     ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT: bool = Field(env="ENABLE_UNRENTED_FLAGSHIP_CAPABILITY_LIMIT", default=False)
 
+    # DAH-2715 — GPU power cap capability gate. When True, an unrented executor whose
+    # container provably cannot apply a GPU power cap (no CAP_SYS_ADMIN, or /dev/nvidiactl
+    # not owned by root - see DAH-2705) loses the unrented rental incentive while staying
+    # active. When False, the breach is only logged (shadow mode) so prod impact can be
+    # observed before enforcing. A node whose probe is missing is never penalized.
+    ENABLE_UNRENTED_POWER_CAP_LIMIT: bool = Field(env="ENABLE_UNRENTED_POWER_CAP_LIMIT", default=False)
+
     COLLATERAL_CONTRACT_ADDRESS: str = Field(
         env='COLLATERAL_CONTRACT_ADDRESS', default='0x8A4023FdD1eaA7b242F3723a7d096B6CC693c7C6'
     )

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -9,7 +9,7 @@ WHERE A NODE EARNS (two "pools" of subnet emission; the rest is burned):
 HOW A NODE PICKS A POOL:
   rented?                                              -> mining pool (always earns)
   idle AND model in program AND price ok AND disk >= 1.5x VRAM
-       AND (not flagship-8x OR NCU/split/attested-CVM offered)
+       AND (not flagship-8x OR NCU/split/attested-CVM offered) AND power cap appliable
                                AND capacity?            -> unrented pool (earns)
   otherwise                                            -> 0 incentive (reason below)
 
@@ -26,6 +26,7 @@ WHAT THIS CATALOG HOLDS — every `MinerLogLine` the miner-facing log block
      total disk below 1.5x total GPU VRAM (add disk to earn),
      8x H200/B200/B300 with no NCU profiling, GPU splitting or passed TDX
        attestation (offer any of the three to earn),
+     container that cannot apply a GPU power cap (give it CAP_SYS_ADMIN to earn),
      no unrented capacity for that GPU-count tier this cycle,
      NVIDIA driver below the minimum, sysbox runtime not enabled
 
@@ -53,7 +54,7 @@ from pydantic import BaseModel, Field
 from core.utils import _m, _StructuredMessage, get_extra_info
 
 if TYPE_CHECKING:
-    from incentive.rental_price import InsufficientDisk, MissingFlagshipCapability
+    from incentive.rental_price import InsufficientDisk, MissingFlagshipCapability, PowerCapIncapable
     from services.task_service import JobResult
 
 
@@ -78,6 +79,7 @@ class ZeroIncentiveReason(StrEnum):
     INSUFFICIENT_DISK_FOR_VRAM = "insufficient_disk_for_vram"
     SYSBOX_NOT_ENABLED = "sysbox_not_enabled"
     FLAGSHIP_WITHOUT_NCU_OR_SPLIT = "flagship_without_ncu_or_split"
+    CANNOT_APPLY_GPU_POWER_CAP = "cannot_apply_gpu_power_cap"
 
 
 class IncentiveReason(BaseModel):
@@ -359,6 +361,27 @@ class MinerLogLine(BaseModel):
                 "ncu_profiling_scrape_error": missing.ncu_profiling_scrape_error,
                 "supports_gpu_splitting": result.supports_gpu_splitting,
                 "gpu_splitting_min_count": result.gpu_splitting_min_count,
+            },
+        )
+
+    @staticmethod
+    def no_payout_because_cannot_apply_gpu_power_cap(
+        result: JobResult, incapable: PowerCapIncapable
+    ) -> MinerLogLine:
+        return MinerLogLine._no_payout(
+            result,
+            reason=ZeroIncentiveReason.CANNOT_APPLY_GPU_POWER_CAP,
+            message=(
+                "No unrented incentive: this executor's container cannot set a GPU power limit "
+                "(nvidia-smi -pl), which Lium's own idle jobs need. Run the executor container "
+                "with privileged: true (or add CAP_SYS_ADMIN) and make sure /dev/nvidiactl is "
+                "owned by root inside it - under sysbox the device is mapped to an unprivileged "
+                "uid, so the executor must run outside the sysbox user namespace. Fix it, or "
+                "rent this executor out to earn."
+            ),
+            extra_fields={
+                "container_cap_eff": incapable.container_cap_eff,
+                "nvidiactl_owner_uid": incapable.nvidiactl_owner_uid,
             },
         )
 

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -373,11 +373,13 @@ class MinerLogLine(BaseModel):
             reason=ZeroIncentiveReason.CANNOT_APPLY_GPU_POWER_CAP,
             message=(
                 "No unrented incentive: this executor's container cannot set a GPU power limit "
-                "(nvidia-smi -pl), which Lium's own idle jobs need. Run the executor container "
-                "with privileged: true (or add CAP_SYS_ADMIN) and make sure /dev/nvidiactl is "
-                "owned by root inside it - under sysbox the device is mapped to an unprivileged "
-                "uid, so the executor must run outside the sysbox user namespace. Fix it, or "
-                "rent this executor out to earn."
+                "(nvidia-smi -pl), which Lium's own idle jobs need. The official executor stack "
+                "already runs privileged, so first update it: 'docker compose pull && docker "
+                "compose up -d' in neurons/executor. If you run a custom compose, give the "
+                "executor container privileged: true (or CAP_SYS_ADMIN) and make sure "
+                "/dev/nvidiactl is owned by root inside it - under sysbox the device is mapped "
+                "to an unprivileged uid, so the executor must run outside the sysbox user "
+                "namespace. Fix it, or rent this executor out to earn."
             ),
             extra_fields={
                 "container_cap_eff": incapable.container_cap_eff,

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -413,18 +413,38 @@ class RentalPriceIncentive(DefaultIncentive):
         # reading, not a breach. bool is excluded explicitly - it passes isinstance(int)
         # and would otherwise read as uid 1, i.e. "not root", i.e. a penalty.
         if not isinstance(cap_eff, str) or not isinstance(owner_uid, int) or isinstance(owner_uid, bool):
+            self._log_power_cap_unmeasured(result, "cap_eff or nvidiactl owner missing from the scrape")
             return None
         try:
             capability_mask: int = int(cap_eff, 16)
         except ValueError:
+            self._log_power_cap_unmeasured(result, f"unreadable capability mask: {cap_eff!r}")
             return None
         has_sys_admin: bool = bool(capability_mask >> CAP_SYS_ADMIN_BIT & 1)
         if has_sys_admin and owner_uid == NVIDIACTL_ROOT_UID:
             return None
         return PowerCapIncapable(container_cap_eff=cap_eff, nvidiactl_owner_uid=owner_uid)
 
+    def _log_power_cap_unmeasured(self, result: JobResult, cause: str) -> None:
+        # gate could not run: a shadow report must not read this executor as "can be capped".
+        # The probe's own error is carried so a broken probe is separable from a host that
+        # simply never reported the readings.
+        logger.warning(
+            _m(
+                "Cannot measure whether the executor container can apply a GPU power cap; "
+                "unrented incentive kept",
+                extra={
+                    "executor_id": str(result.executor_info.uuid),
+                    "gpu_model": result.gpu_model,
+                    "gpu_count": result.gpu_count,
+                    "cause": cause,
+                    "power_cap_probe_error": (result.spec or {}).get("power_cap_probe_error"),
+                    "reason": "power_cap_capability_unmeasured",
+                },
+            )
+        )
+
     def _log_power_cap_limit(self, result: JobResult, incapable: PowerCapIncapable) -> None:
-        # structured log for every rental-eligible unrented executor that cannot be capped
         enforced: bool = settings.ENABLE_UNRENTED_POWER_CAP_LIMIT
         logger.info(
             _m(
@@ -826,6 +846,8 @@ class RentalPriceIncentive(DefaultIncentive):
         # DAH-2715 power cap gate: an idle machine whose container cannot apply a GPU power
         # cap is not fully usable for Lium's own jobs, so it forfeits the unrented incentive
         # (node stays active). While the flag is off we only log the would-be exclusion.
+        # Last in the chain, so a node already excluded by an ENFORCED gate above is not
+        # measured here - read the shadow numbers against the flags that were on that cycle.
         power_cap_incapable: PowerCapIncapable | None = (
             self._power_cap_incapable(job_result) if eligible_for_rental_share else None
         )

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -11,7 +11,7 @@ rental subsidy. See `incentive/config.py:MAX_UNRENTED_GPUS_BY_TYPE`.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import bittensor
 from pydantic import BaseModel, Field
@@ -52,6 +52,13 @@ FLAGSHIP_CAPABILITY_GPU_COUNT = 8
 # Value the machine scrape reports when RmProfilingAdminOnly is 0 on the host (DAH-2182).
 NCU_PROFILING_UNRESTRICTED = "unrestricted"
 
+# DAH-2715 — GPU power cap capability gate. An unrented executor whose container provably
+# cannot apply a GPU power cap forfeits the unrented incentive but stays active. The scrape
+# (DAH-2705) reports the two readings `nvidia-smi -pl` needs: the container's effective
+# capability mask and the owner of /dev/nvidiactl, which sysbox maps away from root.
+CAP_SYS_ADMIN_BIT = 21
+NVIDIACTL_ROOT_UID = 0
+
 
 # ── Spec measurements ────────────────────────────────────────────────────────
 
@@ -69,6 +76,17 @@ class MissingFlagshipCapability(BaseModel):
 
     ncu_profiling_access: str | None  # None = the scrape carries no observation at all
     ncu_profiling_scrape_error: str | None  # set when the probe could not read the driver params
+
+
+class PowerCapIncapable(BaseModel):
+    """The two scrape readings that prove a container cannot apply a GPU power cap.
+
+    Both are carried verbatim so the miner is shown the numbers that were judged, and a
+    sysbox host (full caps, device owned by 65534) reads differently from a host that
+    simply dropped CAP_SYS_ADMIN. Sole owner of these scrape keys."""
+
+    container_cap_eff: str  # effective capability mask of the executor container, hex
+    nvidiactl_owner_uid: int  # owner uid of /dev/nvidiactl inside the container
 
 
 # ── Snapshot models ──────────────────────────────────────────────────────────
@@ -377,6 +395,49 @@ class RentalPriceIncentive(DefaultIncentive):
                     "tdx_quote_present": bool(result.executor_info.tdx_quote),
                     "enforced": enforced,
                     "reason": ZeroIncentiveReason.FLAGSHIP_WITHOUT_NCU_OR_SPLIT,
+                    "pool": "rental_excluded" if enforced else "rental_kept_shadow",
+                },
+            )
+        )
+
+    def _power_cap_incapable(self, result: JobResult) -> PowerCapIncapable | None:
+        # None whenever the scrape does not PROVE the container cannot cap: a missing or
+        # unreadable probe (validator older than DAH-2705, probe error) must never cost a
+        # miner the incentive, so every unknown fails open
+        if result.spec is None:
+            # no scrape at all: a synthetic or estimated job result, nothing to measure
+            return None
+        cap_eff: Any = result.spec.get("container_cap_eff")
+        owner_uid: Any = result.spec.get("nvidiactl_owner_uid")
+        # the scrape is written on the miner's machine: a wrong JSON type is a missing
+        # reading, not a breach. bool is excluded explicitly - it passes isinstance(int)
+        # and would otherwise read as uid 1, i.e. "not root", i.e. a penalty.
+        if not isinstance(cap_eff, str) or not isinstance(owner_uid, int) or isinstance(owner_uid, bool):
+            return None
+        try:
+            capability_mask: int = int(cap_eff, 16)
+        except ValueError:
+            return None
+        has_sys_admin: bool = bool(capability_mask >> CAP_SYS_ADMIN_BIT & 1)
+        if has_sys_admin and owner_uid == NVIDIACTL_ROOT_UID:
+            return None
+        return PowerCapIncapable(container_cap_eff=cap_eff, nvidiactl_owner_uid=owner_uid)
+
+    def _log_power_cap_limit(self, result: JobResult, incapable: PowerCapIncapable) -> None:
+        # structured log for every rental-eligible unrented executor that cannot be capped
+        enforced: bool = settings.ENABLE_UNRENTED_POWER_CAP_LIMIT
+        logger.info(
+            _m(
+                "Unrented executor cannot apply a GPU power cap"
+                + ("" if enforced else " (shadow only - flag off)"),
+                extra={
+                    "executor_id": str(result.executor_info.uuid),
+                    "gpu_model": result.gpu_model,
+                    "gpu_count": result.gpu_count,
+                    "container_cap_eff": incapable.container_cap_eff,
+                    "nvidiactl_owner_uid": incapable.nvidiactl_owner_uid,
+                    "enforced": enforced,
+                    "reason": ZeroIncentiveReason.CANNOT_APPLY_GPU_POWER_CAP,
                     "pool": "rental_excluded" if enforced else "rental_kept_shadow",
                 },
             )
@@ -759,6 +820,21 @@ class RentalPriceIncentive(DefaultIncentive):
                 eligible_for_rental_share = False
                 reason: MinerLogLine = MinerLogLine.no_payout_because_flagship_without_ncu_or_split(
                     job_result, missing_capability
+                )
+                job_result.record_incentive_log(reason)
+
+        # DAH-2715 power cap gate: an idle machine whose container cannot apply a GPU power
+        # cap is not fully usable for Lium's own jobs, so it forfeits the unrented incentive
+        # (node stays active). While the flag is off we only log the would-be exclusion.
+        power_cap_incapable: PowerCapIncapable | None = (
+            self._power_cap_incapable(job_result) if eligible_for_rental_share else None
+        )
+        if power_cap_incapable is not None:
+            self._log_power_cap_limit(job_result, power_cap_incapable)
+            if settings.ENABLE_UNRENTED_POWER_CAP_LIMIT:
+                eligible_for_rental_share = False
+                reason: MinerLogLine = MinerLogLine.no_payout_because_cannot_apply_gpu_power_cap(
+                    job_result, power_cap_incapable
                 )
                 job_result.record_incentive_log(reason)
 

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -7,7 +7,12 @@ fields, and that a line actually lands in JobResult.incentive_logs.
 import pytest
 from datura.requests.miner_requests import ExecutorSSHInfo
 from incentive.miner_incentive_log import MinerLogLine, ZeroIncentiveReason
-from incentive.rental_price import InsufficientDisk, MissingFlagshipCapability, RentalPriceIncentive
+from incentive.rental_price import (
+    InsufficientDisk,
+    MissingFlagshipCapability,
+    PowerCapIncapable,
+    RentalPriceIncentive,
+)
 from services.task_service import JobResult
 
 H200 = "NVIDIA H200"
@@ -29,6 +34,7 @@ def test_reason_enum_pins_the_stable_code_contract():
         "sysbox_not_enabled",
         "insufficient_disk_for_vram",
         "flagship_without_ncu_or_split",
+        "cannot_apply_gpu_power_cap",
     }
 
 
@@ -128,6 +134,14 @@ def _job(**overrides) -> JobResult:
             ),
             "flagship_without_ncu_or_split",
             "NCU profiling",
+        ),
+        (
+            lambda job: MinerLogLine.no_payout_because_cannot_apply_gpu_power_cap(
+                job,
+                PowerCapIncapable(container_cap_eff="00000000a80425fb", nvidiactl_owner_uid=0),
+            ),
+            "cannot_apply_gpu_power_cap",
+            "CAP_SYS_ADMIN",
         ),
     ],
 )

--- a/neurons/validators/tests/test_unrented_power_cap_capability.py
+++ b/neurons/validators/tests/test_unrented_power_cap_capability.py
@@ -141,6 +141,53 @@ async def test_malformed_scrape_never_breaks_scoring(monkeypatch, spec):
     assert result.eligible_for_rental_share is True
 
 
+def _logged_reasons(caplog) -> list[str]:
+    # the reason codes of the structured lines captured so far; _m keeps them off the message
+    return [r.msg.extra.get("reason") for r in caplog.records if hasattr(r.msg, "extra")]
+
+
+def test_estimated_job_result_is_not_logged_as_unmeasured(caplog):
+    # estimate_executor builds a spec-less JobResult for every GPU model every cycle;
+    # warning on those would drown the shadow measurement this log exists to feed.
+    incentive = _build_incentive()
+    job = _make_job()
+    job.spec = None
+
+    with caplog.at_level(logging.WARNING):
+        incentive._power_cap_incapable(job)
+
+    assert "power_cap_capability_unmeasured" not in _logged_reasons(caplog)
+
+
+def test_scrape_without_the_probe_keys_is_logged_as_unmeasured(caplog):
+    # A real scrape that carries no probe (validator older than DAH-2705) is a measurable
+    # fact and belongs in the denominator, unlike a synthetic spec-less result.
+    incentive = _build_incentive()
+
+    with caplog.at_level(logging.WARNING):
+        incentive._power_cap_incapable(_make_job(spec={}))
+
+    assert "power_cap_capability_unmeasured" in _logged_reasons(caplog)
+
+
+def test_broken_probe_is_logged_as_unmeasured(caplog):
+    # A node whose probe failed must be distinguishable from one that passed the gate,
+    # or the shadow window has no denominator. The probe's own error rides along.
+    incentive = _build_incentive()
+
+    with caplog.at_level(logging.WARNING):
+        incentive._power_cap_incapable(
+            _make_job(spec={"container_cap_eff": "", "nvidiactl_owner_uid": 0,
+                            "power_cap_probe_error": "cannot read /proc/self/status"})
+        )
+
+    unmeasured = next(
+        r.msg for r in caplog.records
+        if hasattr(r.msg, "extra") and r.msg.extra.get("reason") == "power_cap_capability_unmeasured"
+    )
+    assert unmeasured.extra["power_cap_probe_error"] == "cannot read /proc/self/status"
+
+
 def test_enforcement_defaults_to_shadow_mode():
     # Rollout contract: first deploy must be shadow-only, so the flag default
     # (not the env-resolved value) must stay False.

--- a/neurons/validators/tests/test_unrented_power_cap_capability.py
+++ b/neurons/validators/tests/test_unrented_power_cap_capability.py
@@ -2,9 +2,9 @@
 
 An unrented executor whose container provably cannot apply a GPU power cap
 (no CAP_SYS_ADMIN, or /dev/nvidiactl not owned by root — see DAH-2705) forfeits
-the unrented rental incentive while staying active. Enforcement is gated by
-ENABLE_UNRENTED_POWER_CAP_LIMIT; while the flag is off the breach is only logged
-(shadow mode) and the payout is unchanged.
+the unrented rental incentive while staying active. Enforcement is ON by default
+and can be switched off with ENABLE_UNRENTED_POWER_CAP_LIMIT; with the flag off
+the breach is only logged (shadow mode) and the payout is unchanged.
 """
 
 import logging
@@ -188,12 +188,12 @@ def test_broken_probe_is_logged_as_unmeasured(caplog):
     assert unmeasured.extra["power_cap_probe_error"] == "cannot read /proc/self/status"
 
 
-def test_enforcement_defaults_to_shadow_mode():
-    # Rollout contract: first deploy must be shadow-only, so the flag default
-    # (not the env-resolved value) must stay False.
+def test_enforcement_is_on_by_default():
+    # Rollout contract: this gate ships enforced (the provider fix is one compose flag),
+    # so the flag default - not the env-resolved value - must stay True.
     default = type(settings).model_fields["ENABLE_UNRENTED_POWER_CAP_LIMIT"].default
 
-    assert default is False
+    assert default is True
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_unrented_power_cap_capability.py
+++ b/neurons/validators/tests/test_unrented_power_cap_capability.py
@@ -1,0 +1,242 @@
+"""DAH-2715 — unrented incentive GPU power cap gate.
+
+An unrented executor whose container provably cannot apply a GPU power cap
+(no CAP_SYS_ADMIN, or /dev/nvidiactl not owned by root — see DAH-2705) forfeits
+the unrented rental incentive while staying active. Enforcement is gated by
+ENABLE_UNRENTED_POWER_CAP_LIMIT; while the flag is off the breach is only logged
+(shadow mode) and the payout is unchanged.
+"""
+
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+from datura.requests.miner_requests import ExecutorSSHInfo
+
+from core.config import settings
+from incentive.config import IncentiveConfig
+from incentive.rental_price import RentalPriceIncentive
+from services.task_service import JobResult
+
+H200 = "NVIDIA H200"  # base model H200 is rental-eligible by default
+
+CAPS_WITH_SYS_ADMIN = "000001ffffffffff"   # sysbox / privileged container: every capability
+CAPS_WITHOUT_SYS_ADMIN = "00000000a80425fb"  # prod 128.140.36.181: default docker caps
+NOBODY_UID = 65534  # what sysbox maps /dev/nvidiactl to (prod 88.22.127.152)
+
+
+def _build_incentive() -> RentalPriceIncentive:
+    return RentalPriceIncentive(IncentiveConfig(), AsyncMock(), {}, {})
+
+
+def _make_job(
+    *,
+    cap_eff: str | None = CAPS_WITHOUT_SYS_ADMIN,
+    owner_uid: int | None = 0,
+    is_rented: bool = False,
+    spec: dict | None = None,
+) -> JobResult:
+    if spec is None:
+        spec = {}
+        if cap_eff is not None:
+            spec["container_cap_eff"] = cap_eff
+        if owner_uid is not None:
+            spec["nvidiactl_owner_uid"] = owner_uid
+
+    return JobResult(
+        spec=spec,
+        executor_info=ExecutorSSHInfo(
+            uuid="exec-1",
+            address="10.0.0.1",
+            port=8080,
+            ssh_username="root",
+            ssh_port=22,
+            python_path="/usr/bin/python3",
+            root_dir="/tmp",
+            price_per_gpu=1.0,
+        ),
+        score=1.0,
+        job_score=1.0,
+        job_batch_id="batch",
+        log_status="success",
+        log_text="ok",
+        gpu_model=H200,
+        gpu_count=8,
+        is_rented=is_rented,
+        collateral_deposited=True,
+        sysbox_runtime=True,
+    )
+
+
+def test_missing_cap_sys_admin_is_flagged():
+    # Arrange — prod case: default docker capabilities, device owned by root
+    incentive = _build_incentive()
+
+    # Act
+    incapable = incentive._power_cap_incapable(_make_job())
+
+    # Assert
+    assert incapable is not None
+    assert incapable.container_cap_eff == CAPS_WITHOUT_SYS_ADMIN
+    assert incapable.nvidiactl_owner_uid == 0
+
+
+def test_device_not_owned_by_root_is_flagged():
+    # Arrange — prod sysbox case: every capability held, but the device is mapped away
+    incentive = _build_incentive()
+
+    # Act
+    incapable = incentive._power_cap_incapable(
+        _make_job(cap_eff=CAPS_WITH_SYS_ADMIN, owner_uid=NOBODY_UID)
+    )
+
+    # Assert
+    assert incapable is not None
+    assert incapable.nvidiactl_owner_uid == NOBODY_UID
+
+
+def test_capable_executor_is_not_flagged():
+    # Arrange — both conditions met, which is what `nvidia-smi -pl` needs
+    incentive = _build_incentive()
+
+    # Act
+    incapable = incentive._power_cap_incapable(
+        _make_job(cap_eff=CAPS_WITH_SYS_ADMIN, owner_uid=0)
+    )
+
+    # Assert
+    assert incapable is None
+
+
+UNPROVEN_SPECS: list[dict] = [
+    {},                                                             # validator older than DAH-2705
+    {"container_cap_eff": CAPS_WITHOUT_SYS_ADMIN},                   # uid reading missing
+    {"nvidiactl_owner_uid": 0},                                      # cap mask missing
+    {"container_cap_eff": None, "nvidiactl_owner_uid": 0},           # probe reported nothing
+    {"container_cap_eff": "not-hex", "nvidiactl_owner_uid": 0},      # unparsable mask
+    {"container_cap_eff": CAPS_WITHOUT_SYS_ADMIN, "nvidiactl_owner_uid": "0"},  # uid as a string
+    {"container_cap_eff": CAPS_WITHOUT_SYS_ADMIN, "nvidiactl_owner_uid": True},  # bool is not a uid
+    {"container_cap_eff": ["ffff"], "nvidiactl_owner_uid": 0},       # mask came back as a list
+]
+
+
+@pytest.mark.parametrize("spec", UNPROVEN_SPECS)
+def test_unproven_probe_is_never_flagged(spec):
+    # Fail open: only a proven false is penalized. The scrape is written on the miner's
+    # machine, so a wrong type is a missing reading, not a breach.
+    incentive = _build_incentive()
+
+    assert incentive._power_cap_incapable(_make_job(spec=spec)) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("spec", UNPROVEN_SPECS)
+async def test_malformed_scrape_never_breaks_scoring(monkeypatch, spec):
+    # Raising out of calculate_executor_score would cost EVERY miner this cycle's weights.
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_POWER_CAP_LIMIT", True)
+    incentive = _build_incentive()
+
+    result = await incentive.calculate_executor_score(_make_job(spec=spec))
+
+    assert result.eligible_for_rental_share is True
+
+
+def test_enforcement_defaults_to_shadow_mode():
+    # Rollout contract: first deploy must be shadow-only, so the flag default
+    # (not the env-resolved value) must stay False.
+    default = type(settings).model_fields["ENABLE_UNRENTED_POWER_CAP_LIMIT"].default
+
+    assert default is False
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_keeps_rental_eligibility(monkeypatch):
+    # Arrange — incapable container but flag off → shadow only
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_POWER_CAP_LIMIT", False)
+    incentive = _build_incentive()
+
+    # Act
+    result = await incentive.calculate_executor_score(_make_job())
+
+    # Assert — still eligible for the unrented rental pool, nothing told to the miner
+    assert result.eligible_for_rental_share is True
+    assert "cannot_apply_gpu_power_cap" not in "\n".join(result.incentive_logs)
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_emits_the_measurement_log(monkeypatch, caplog):
+    # The shadow log is the whole deliverable of the first deploy: the rollout decision
+    # is made from these fields, so they are a dashboard contract.
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_POWER_CAP_LIMIT", False)
+    incentive = _build_incentive()
+
+    with caplog.at_level(logging.INFO):
+        await incentive.calculate_executor_score(_make_job())
+
+    breach = next(
+        r.msg for r in caplog.records
+        if hasattr(r.msg, "extra") and r.msg.extra.get("reason") == "cannot_apply_gpu_power_cap"
+    )
+    assert "shadow only - flag off" in breach.message
+    assert breach.extra["container_cap_eff"] == CAPS_WITHOUT_SYS_ADMIN
+    assert breach.extra["nvidiactl_owner_uid"] == 0
+    assert breach.extra["enforced"] is False
+    assert breach.extra["pool"] == "rental_kept_shadow"
+
+
+@pytest.mark.asyncio
+async def test_enforced_drops_rental_eligibility(monkeypatch):
+    # Arrange — incapable container and flag on
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_POWER_CAP_LIMIT", True)
+    incentive = _build_incentive()
+
+    # Act
+    result = await incentive.calculate_executor_score(_make_job())
+
+    # Assert — excluded from the rental pool, no mining either (active but no incentive)
+    assert result.eligible_for_rental_share is False
+    assert result.mining_score == 0
+
+
+@pytest.mark.asyncio
+async def test_enforced_appends_customer_facing_incentive_log(monkeypatch):
+    # DAH-2327: the zero-incentive reason must reach the customer-facing incentive log,
+    # carrying both readings so the provider can tell which of the two to fix.
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_POWER_CAP_LIMIT", True)
+    incentive = _build_incentive()
+
+    result = await incentive.calculate_executor_score(
+        _make_job(cap_eff=CAPS_WITH_SYS_ADMIN, owner_uid=NOBODY_UID)
+    )
+
+    log = "\n".join(result.incentive_logs)
+    assert "cannot_apply_gpu_power_cap" in log
+    assert CAPS_WITH_SYS_ADMIN in log
+    assert str(NOBODY_UID) in log
+    assert [reason.reason for reason in result.zero_incentive_reasons] == ["cannot_apply_gpu_power_cap"]
+
+
+@pytest.mark.asyncio
+async def test_capable_executor_keeps_eligibility_when_enforced(monkeypatch):
+    # Arrange — flag on but the container can apply a cap
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_POWER_CAP_LIMIT", True)
+    incentive = _build_incentive()
+
+    # Act
+    result = await incentive.calculate_executor_score(
+        _make_job(cap_eff=CAPS_WITH_SYS_ADMIN, owner_uid=0)
+    )
+
+    # Assert
+    assert result.eligible_for_rental_share is True
+
+
+@pytest.mark.asyncio
+async def test_rented_executor_is_not_gated(monkeypatch):
+    # A rented machine earns from the rented path and must not be touched by this gate.
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_POWER_CAP_LIMIT", True)
+    incentive = _build_incentive()
+
+    result = await incentive.calculate_executor_score(_make_job(is_rented=True))
+
+    assert "cannot_apply_gpu_power_cap" not in "\n".join(result.incentive_logs)


### PR DESCRIPTION
[DAH-2715](https://app.notion.com/p/Penalize-executors-that-cannot-apply-a-GPU-power-cap-no-CAP_SYS_ADMIN-device-not-root-owned-3c1b8bfdbde981e0bd08f763ca1f0304)

Since DAH-2705 every scrape carries whether the executor container can apply a GPU power cap. A node that cannot is silently skipped for capped fillers (PEARL) but keeps its unrented incentive, so the provider has no reason to fix the host.

This adds a fourth unrented gate next to the price / disk / flagship ones: an idle executor whose container provably cannot cap forfeits the unrented incentive and stays active. The miner is told why and how to fix it (`privileged: true` / `CAP_SYS_ADMIN`, and `/dev/nvidiactl` owned by root — the sysbox case needs the executor out of the user namespace).

**Enforced on merge.** `ENABLE_UNRENTED_POWER_CAP_LIMIT` defaults to `True` — the provider fix is one compose flag, so there is no shadow window. Set the env to `false` to fall back to logging the breach without withholding anything.

**Blast radius (prod, 2026-08-20):** 379 active executors probed — 371 capable, 3 incapable, 5 with no probe (never penalized, the gate fails open on every unknown). Of the 3, one is rented (untouched) and two earn idle incentive today: `178.105.229.97` (4x RTX PRO 6000, 0.0617 α / 24 h) and `88.22.127.152` (RTX 5090, sysbox uid 65534, 0.0057 α / 24 h).

**Staging-verified end to end** on a rented A6000: capable → routed to the unrented pool, gate silent; the same node recreated without `privileged` (CapEff `00000000a80425fb`) → excluded from the pool, cycle stored with `incentive=0`, `reason=cannot_apply_gpu_power_cap` and the full fix text, which is the row the miner portal renders. Shadow mode (flag off) was verified too: breach logged, incentive kept.

Tests: `pytest tests/test_unrented_power_cap_capability.py` (29) + full validator suite green.