### PR TITLE
DAH-2721: Harden Restic snapshot argument handling

### DIFF
--- a/neurons/executor/src/storage/restic.py
+++ b/neurons/executor/src/storage/restic.py
@@ -325,7 +325,7 @@ class ResticStorageRunner:
         if not snapshot_id:
             raise ResticOperationError("restore requires a snapshot ID")
         probe = subprocess.run(
-            self._restic_command(["snapshots", "--json", snapshot_id]),
+            self._restic_command(["snapshots", "--json", "--", snapshot_id]),
             env=self._environment,
             capture_output=True,
             text=True,
@@ -589,7 +589,7 @@ class ResticStorageRunner:
             # User xattrs belong to customer data; only host-managed namespaces
             # that cannot be written from the rental user namespace are skipped.
             arguments.extend(["--exclude-xattr", "security.*", "--exclude-xattr", "trusted.*"])
-        arguments.append(snapshot_id)
+        arguments.extend(["--", snapshot_id])
         return self._execution_command(arguments, working_directory=False)
 
     def _legacy_restore_execution_command(self, object_key: str) -> tuple[list[str], str | None]:

--- a/neurons/executor/tests/test_storage_runner.py
+++ b/neurons/executor/tests/test_storage_runner.py
@@ -100,6 +100,14 @@ def test_restore_requires_snapshot_id() -> None:
         StorageOperationSpec.from_mapping(payload)
 
 
+def test_restore_rejects_snapshot_id_options() -> None:
+    payload = _operation_payload(action="restore")
+    payload["snapshot_id"] = "--password-command=malicious-command"
+
+    with pytest.raises(OperationSpecError, match="hexadecimal restic snapshot ID"):
+        StorageOperationSpec.from_mapping(payload)
+
+
 def test_restore_missing_repository_never_initializes_it(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -118,6 +126,7 @@ def test_restore_missing_repository_never_initializes_it(
 
     assert raised.value.error_code == "RESTIC_REPOSITORY_MISSING"
     assert commands
+    assert commands[0][-4:] == ["snapshots", "--json", "--", SNAPSHOT_ID]
     assert all("init" not in command for command in commands)
 
 
@@ -605,7 +614,7 @@ def test_docker_restore_uses_native_json_restore_to_requested_directory() -> Non
 
     assert "customer-volume:/workspace:rw" in command
     assert "--workdir" not in command
-    assert SNAPSHOT_ID in command
+    assert command[-2:] == ["--", SNAPSHOT_ID]
     assert "/workspace/restored" in command
     assert "restore" in command
     assert "--json" in command


### PR DESCRIPTION
## Describe your changes

Harden executor Restic snapshot handling by placing externally supplied snapshot IDs after the `--` option terminator for repository probes and restores.

The executor already rejects noncanonical snapshot IDs at operation parsing. This change adds defense in depth at both Restic command construction sites and updates the command-shape regression tests.

Related backend PR: [Datura-ai/lium-io-backend#939](https://github.com/Datura-ai/lium-io-backend/pull/939).

## Issue ticket number and link

[DAH-2721](https://app.notion.com/p/3c1b8bfdbde98137ad2df4d9e9572dd6?pvs=204)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [x] Need to take care of performance? No performance impact expected.

## Validation

- Focused executor storage runner tests: 35 passed.
- Targeted Ruff checks passed.
- `git diff --check` passed.
