### PR TITLE
DAH-2728: cancel an in-flight create when its delete arrives

### DIFF
--- a/neurons/validators/src/clients/compute_client.py
+++ b/neurons/validators/src/clients/compute_client.py
@@ -68,6 +68,7 @@ from websockets.asyncio.client import ClientConnection
 from core.config import settings
 from core.utils import _m, get_extra_info
 from clients.subtensor_client import SubtensorClient
+from services.docker_service import inflight_creates
 from services.miner_service import MinerService
 from incentive.rental_price import ExecutorEstimateParams, RentalPriceSnapshot, estimate_executor
 from services.redis_service import (
@@ -746,6 +747,29 @@ class ComputeClient:
         return miner.axon_info
 
     async def miner_driver(
+        self,
+        job_request: ContainerCreateRequest
+        | ContainerDeleteRequest
+        | ContainerStopRequest
+        | ContainerStartRequest
+        | AddSshPublicKeyRequest
+        | RemoveSshPublicKeysRequest
+        | ExecutorRentFinishedRequest
+        | GetPodLogsRequestFromServer
+        | AddDebugSshKeyRequest
+        | BackupContainerRequest
+        | RestoreContainerRequest
+        | InstallJupyterServerRequest
+    ):
+        # DAH-2728: track the create from the moment this task picks it up. The axon lookup below
+        # fetches the whole miner set on a cold cache, so a delete arriving seconds later can sail
+        # past it and find nothing to cancel — and the create it raced then orphans its container.
+        if not isinstance(job_request, ContainerCreateRequest):
+            return await self._drive_miner_job(job_request)
+        with inflight_creates.track(job_request.pod_id):
+            return await self._drive_miner_job(job_request)
+
+    async def _drive_miner_job(
         self,
         job_request: ContainerCreateRequest
         | ContainerDeleteRequest

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -10,7 +10,7 @@ import secrets
 import shlex
 import time
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Annotated, Any
 from uuid import UUID, uuid4
@@ -387,6 +387,7 @@ class _InflightCreate:
     # entry outlives any single one of them and only the last to leave clears it.
     running: int = 0
     cancelled_by_delete: bool = False
+    done: asyncio.Event = field(default_factory=asyncio.Event)
 
 
 class _InflightCreateRegistry:
@@ -412,6 +413,7 @@ class _InflightCreateRegistry:
             create.running -= 1
             if create.running <= 0:
                 self._creates_by_pod_id.pop(pod_id, None)
+                create.done.set()
 
     def cancel(self, pod_id: str) -> bool:
         """Flag the in-flight create for this pod. False when no create is running."""
@@ -428,10 +430,26 @@ class _InflightCreateRegistry:
     def is_running(self, pod_id: str) -> bool:
         return pod_id in self._creates_by_pod_id
 
+    async def wait_until_done(self, pod_id: str, timeout: float) -> bool:
+        """Wait for the create(s) on this pod to leave. False when the wait ran out."""
+        create = self._creates_by_pod_id.get(pod_id)
+        if create is None:
+            return True
+        try:
+            await asyncio.wait_for(create.done.wait(), timeout)
+        except asyncio.TimeoutError:
+            return False
+        return True
+
 
 # In-process: a pod's create and delete are driven by the same validator event loop. Move it to
 # Redis if the two ever land in different processes.
 inflight_creates = _InflightCreateRegistry()
+
+# How long a delete waits for the create it just cancelled. The create reads the flag at its next
+# checkpoint, and the only checkpoint gap that can orphan a container is the short one before
+# `docker run` — a pull-length wait would hold the customer's delete for nothing.
+CANCELLED_CREATE_ABORT_TIMEOUT_SECONDS = 30.0
 
 
 def _is_missing_docker_container_error(exc: Exception) -> bool:
@@ -5803,6 +5821,14 @@ class DockerService:
         # refuses cannot kill a healthy create.
         if inflight_creates.cancel(payload.pod_id):
             log.info("Cancelled the in-flight create for this pod")
+            # Let the create finish tearing itself down before this teardown runs, so the last
+            # actor on the host is never a create that ran after we answered "deleted". On timeout
+            # we tear the container down ourselves, which is what this delete did before DAH-2728.
+            create_aborted = await inflight_creates.wait_until_done(
+                payload.pod_id, CANCELLED_CREATE_ABORT_TIMEOUT_SECONDS
+            )
+            if not create_aborted:
+                log.warning("The cancelled create is still running; deleting without it")
 
         private_key = self.ssh_service.decrypt_payload(keypair.ss58_address, private_key)
         pkey = asyncssh.import_private_key(private_key)

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -381,6 +381,14 @@ class _CreateCancelledByDelete(Exception):
     """Raised at a create checkpoint when this pod's delete has already reported it gone."""
 
 
+@dataclass
+class _InflightCreate:
+    # A retried rent can put a second create on the same pod while the first still runs, so the
+    # entry outlives any single one of them and only the last to leave clears it.
+    running: int = 0
+    cancelled_by_delete: bool = False
+
+
 class _InflightCreateRegistry:
     """Creates running right now, and whether a delete has already cancelled them.
 
@@ -392,25 +400,33 @@ class _InflightCreateRegistry:
     """
 
     def __init__(self) -> None:
-        self._cancelled_by_pod_id: dict[str, bool] = {}
+        self._creates_by_pod_id: dict[str, _InflightCreate] = {}
 
     @contextlib.contextmanager
     def track(self, pod_id: str) -> Iterator[None]:
-        self._cancelled_by_pod_id[pod_id] = False
+        create = self._creates_by_pod_id.setdefault(pod_id, _InflightCreate())
+        create.running += 1
         try:
             yield
         finally:
-            self._cancelled_by_pod_id.pop(pod_id, None)
+            create.running -= 1
+            if create.running <= 0:
+                self._creates_by_pod_id.pop(pod_id, None)
 
     def cancel(self, pod_id: str) -> bool:
         """Flag the in-flight create for this pod. False when no create is running."""
-        if pod_id not in self._cancelled_by_pod_id:
+        create = self._creates_by_pod_id.get(pod_id)
+        if create is None:
             return False
-        self._cancelled_by_pod_id[pod_id] = True
+        create.cancelled_by_delete = True
         return True
 
     def is_cancelled(self, pod_id: str) -> bool:
-        return self._cancelled_by_pod_id.get(pod_id, False)
+        create = self._creates_by_pod_id.get(pod_id)
+        return create is not None and create.cancelled_by_delete
+
+    def is_running(self, pod_id: str) -> bool:
+        return pod_id in self._creates_by_pod_id
 
 
 # In-process: a pod's create and delete are driven by the same validator event loop. Move it to
@@ -3885,8 +3901,16 @@ class DockerService:
             )
         )
         if payload.workload_kind == WorkloadKind.FILLER:
-            # DAH-2356: the power cap is applied before `docker run`, and the delete that cancelled
-            # us restored nothing — at that point this pod had no record yet.
+            # Remove the container BEFORE lifting the cap. The enclosing handler removes it again
+            # (both are idempotent), but restoring full power while a filler is still running is
+            # the DAH-2356 hard-ban failure — an uncapped PEARL miner.
+            await self.cleanup_failed_container_creation(
+                ssh_client=ssh_client,
+                default_extra=default_extra,
+                container_name=container_name,
+            )
+            # DAH-2356: the cap is applied before `docker run`, and the delete that cancelled us
+            # restored nothing — at that point this pod had no record yet.
             await restore_filler_pod_gpu_power_limits(
                 ssh_client, self.redis_service, payload.pod_id, log_extra=default_extra
             )

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -5758,6 +5758,14 @@ class DockerService:
         default_extra = _delete_container_log_extra(payload, executor_info)
         log = _BoundLog(default_extra)
 
+        # DAH-2728: the backend has no container name until the create answers, so a delete that
+        # races an in-flight create arrives without one. The name is ours to derive — the create
+        # builds it from the same pod id.
+        if not payload.container_name:
+            payload.container_name = self.get_container_name(payload)
+            log.info("Derived the container name for a delete that carried none",
+                     container_name=payload.container_name)
+
         log.info("Deleting Docker Container", payload=str(payload))
 
         try:

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -5758,9 +5758,9 @@ class DockerService:
         default_extra = _delete_container_log_extra(payload, executor_info)
         log = _BoundLog(default_extra)
 
-        # DAH-2728: the backend has no container name until the create answers, so a delete that
-        # races an in-flight create arrives without one. The name is ours to derive — the create
-        # builds it from the same pod id.
+        # DAH-2728: a delete that races an in-flight create can arrive before any container name
+        # exists. The create built its name from the pod id, so the same rule reconstructs it here
+        # rather than letting the teardown run against an empty name.
         if not payload.container_name:
             payload.container_name = self.get_container_name(payload)
             log.info("Derived the container name for a delete that carried none",

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -392,29 +392,29 @@ class _InflightCreateRegistry:
     """
 
     def __init__(self) -> None:
-        self._cancelled_by_delete: dict[str, bool] = {}
+        self._cancelled_by_pod_id: dict[str, bool] = {}
 
     @contextlib.contextmanager
     def track(self, pod_id: str) -> Iterator[None]:
-        self._cancelled_by_delete[pod_id] = False
+        self._cancelled_by_pod_id[pod_id] = False
         try:
             yield
         finally:
-            self._cancelled_by_delete.pop(pod_id, None)
+            self._cancelled_by_pod_id.pop(pod_id, None)
 
     def cancel(self, pod_id: str) -> bool:
         """Flag the in-flight create for this pod. False when no create is running."""
-        if pod_id not in self._cancelled_by_delete:
+        if pod_id not in self._cancelled_by_pod_id:
             return False
-        self._cancelled_by_delete[pod_id] = True
+        self._cancelled_by_pod_id[pod_id] = True
         return True
 
     def is_cancelled(self, pod_id: str) -> bool:
-        return self._cancelled_by_delete.get(pod_id, False)
+        return self._cancelled_by_pod_id.get(pod_id, False)
 
 
-# ponytail: in-process — a pod's create and delete are driven by the same validator event loop.
-# Move it to Redis if the two ever land in different processes.
+# In-process: a pod's create and delete are driven by the same validator event loop. Move it to
+# Redis if the two ever land in different processes.
 inflight_creates = _InflightCreateRegistry()
 
 
@@ -3867,24 +3867,17 @@ class DockerService:
                 )
             )
 
-    async def create_container(
-        self,
-        payload: ContainerCreateRequest,
-        executor_info: ExecutorSSHInfo,
-        keypair: bittensor.Keypair,
-        private_key: str,
-    ):
-        # DAH-2728: register before any work, so a delete arriving mid-create can cancel it.
-        with inflight_creates.track(payload.pod_id):
-            return await self._create_container(payload, executor_info, keypair, private_key)
-
-    async def _abort_create_cancelled_by_delete(
+    async def _abort_if_cancelled_by_delete(
         self,
         ssh_client: asyncssh.SSHClientConnection,
         payload: ContainerCreateRequest,
-        container_name: str,
         default_extra: dict,
     ) -> None:
+        """Tear this create down when its own delete has already reported the pod gone (DAH-2728)."""
+        if not inflight_creates.is_cancelled(payload.pod_id):
+            return
+
+        container_name = self.get_container_name(payload)
         logger.warning(
             _m(
                 "Create cancelled by an in-flight delete",
@@ -3897,9 +3890,11 @@ class DockerService:
             await restore_filler_pod_gpu_power_limits(
                 ssh_client, self.redis_service, payload.pod_id, log_extra=default_extra
             )
-        raise _CreateCancelledByDelete(container_name)
+        raise _CreateCancelledByDelete(
+            f"delete for pod {payload.pod_id} arrived while {container_name} was being created"
+        )
 
-    async def _create_container(
+    async def create_container(
         self,
         payload: ContainerCreateRequest,
         executor_info: ExecutorSSHInfo,
@@ -4136,6 +4131,10 @@ class DockerService:
                 # Add profiler for ssh connection
                 profilers.append(ProfilerStep.since(ProfilerStepName.SSH_CONNECTION_ESTABLISHED, prev_timestamp))
                 prev_timestamp = now_ms()
+
+                # DAH-2728: cheapest place to notice the delete — the image pull/build below is
+                # where a cancelled create spends its minutes, and nothing is on the host yet.
+                await self._abort_if_cancelled_by_delete(ssh_client, payload, default_extra)
 
                 # set real-time logging
                 self.log_task = asyncio.create_task(
@@ -4667,11 +4666,7 @@ class DockerService:
                 try:
                     current_step = "docker_run"
                     # DAH-2728: last look before the host ports get bound.
-                    if inflight_creates.is_cancelled(payload.pod_id):
-                        current_step = "cancelled_by_delete"
-                        await self._abort_create_cancelled_by_delete(
-                            ssh_client, payload, container_name, default_extra
-                        )
+                    await self._abort_if_cancelled_by_delete(ssh_client, payload, default_extra)
                     await self.stream_log("Creating docker container", "success", log_tag)
                     await self._run_rental_docker_create_with_port_retry(
                         docker_client=docker_client,
@@ -4737,14 +4732,6 @@ class DockerService:
                             logger.error(_m("docker run failed", extra=log_extra))
 
                         raise Exception("Run docker run command but container is not running")
-
-                    # DAH-2728: the delete may have landed while `docker run` was in progress —
-                    # the container we just started is exactly the orphan it could not see.
-                    if inflight_creates.is_cancelled(payload.pod_id):
-                        current_step = "cancelled_by_delete"
-                        await self._abort_create_cancelled_by_delete(
-                            ssh_client, payload, container_name, default_extra
-                        )
                 except Exception:
                     container_missing = await self.cleanup_failed_container_creation(
                         ssh_client=ssh_client,
@@ -4880,6 +4867,10 @@ class DockerService:
 
                     await self.finish_stream_logs()
 
+                    # DAH-2728: last call before the pod is cached as rented — a delete that landed
+                    # during the run or the bootstrap above is holding ports it could not see.
+                    await self._abort_if_cancelled_by_delete(ssh_client, payload, default_extra)
+
                     current_step = "finalize"
                     await self._cache_rented_pod_best_effort(
                         executor_info=executor_info,
@@ -4997,6 +4988,8 @@ class DockerService:
                     volume_encryption_status=volume_encryption_status,
                 )
         except Exception as e:
+            if isinstance(e, _CreateCancelledByDelete):
+                current_step = "cancelled_by_delete"
             log_text = _m(
                 "Failed create_container",
                 extra=get_extra_info({
@@ -5767,16 +5760,17 @@ class DockerService:
 
         log.info("Deleting Docker Container", payload=str(payload))
 
-        # DAH-2728: a create still in flight for this pod would otherwise finish behind our back and
-        # leave an orphan container holding the ports.
-        if inflight_creates.cancel(payload.pod_id):
-            log.info("Cancelled the in-flight create for this pod")
-
         try:
             _validate_delete_volume_names(payload)
         except ValueError as exc:
             log.error("Invalid Docker volume name", error=str(exc))
             return self._failed_delete(payload, msg="Invalid Docker volume name")
+
+        # DAH-2728: a create still in flight would otherwise finish behind our back and leave an
+        # orphan container holding the ports. Past the validation above, so a delete this validator
+        # refuses cannot kill a healthy create.
+        if inflight_creates.cancel(payload.pod_id):
+            log.info("Cancelled the in-flight create for this pod")
 
         private_key = self.ssh_service.decrypt_payload(keypair.ss58_address, private_key)
         pkey = asyncssh.import_private_key(private_key)

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -377,6 +377,47 @@ def _exception_texts(exc: Exception) -> list[str]:
     return texts
 
 
+class _CreateCancelledByDelete(Exception):
+    """Raised at a create checkpoint when this pod's delete has already reported it gone."""
+
+
+class _InflightCreateRegistry:
+    """Creates running right now, and whether a delete has already cancelled them.
+
+    DAH-2728: a delete that lands while the create for the same pod is still in flight finds no
+    container yet ("No such container"), reports the pod deleted, and the create goes on to bind
+    the host ports minutes later. That orphan then blocks the next paying rental with "port is
+    already allocated". Only the create can undo itself, so the delete flips the flag here and the
+    create tears itself down at its next checkpoint.
+    """
+
+    def __init__(self) -> None:
+        self._cancelled_by_delete: dict[str, bool] = {}
+
+    @contextlib.contextmanager
+    def track(self, pod_id: str) -> Iterator[None]:
+        self._cancelled_by_delete[pod_id] = False
+        try:
+            yield
+        finally:
+            self._cancelled_by_delete.pop(pod_id, None)
+
+    def cancel(self, pod_id: str) -> bool:
+        """Flag the in-flight create for this pod. False when no create is running."""
+        if pod_id not in self._cancelled_by_delete:
+            return False
+        self._cancelled_by_delete[pod_id] = True
+        return True
+
+    def is_cancelled(self, pod_id: str) -> bool:
+        return self._cancelled_by_delete.get(pod_id, False)
+
+
+# ponytail: in-process — a pod's create and delete are driven by the same validator event loop.
+# Move it to Redis if the two ever land in different processes.
+inflight_creates = _InflightCreateRegistry()
+
+
 def _is_missing_docker_container_error(exc: Exception) -> bool:
     return any(_DOCKER_NO_SUCH_CONTAINER_PHRASE in text for text in _exception_texts(exc))
 
@@ -3833,6 +3874,38 @@ class DockerService:
         keypair: bittensor.Keypair,
         private_key: str,
     ):
+        # DAH-2728: register before any work, so a delete arriving mid-create can cancel it.
+        with inflight_creates.track(payload.pod_id):
+            return await self._create_container(payload, executor_info, keypair, private_key)
+
+    async def _abort_create_cancelled_by_delete(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        payload: ContainerCreateRequest,
+        container_name: str,
+        default_extra: dict,
+    ) -> None:
+        logger.warning(
+            _m(
+                "Create cancelled by an in-flight delete",
+                extra=get_extra_info({**default_extra, "container_name": container_name}),
+            )
+        )
+        if payload.workload_kind == WorkloadKind.FILLER:
+            # DAH-2356: the power cap is applied before `docker run`, and the delete that cancelled
+            # us restored nothing — at that point this pod had no record yet.
+            await restore_filler_pod_gpu_power_limits(
+                ssh_client, self.redis_service, payload.pod_id, log_extra=default_extra
+            )
+        raise _CreateCancelledByDelete(container_name)
+
+    async def _create_container(
+        self,
+        payload: ContainerCreateRequest,
+        executor_info: ExecutorSSHInfo,
+        keypair: bittensor.Keypair,
+        private_key: str,
+    ):
         warnings = []
         local_volume = payload.local_volume
         external_volume_info = payload.external_volume_info
@@ -4593,6 +4666,12 @@ class DockerService:
 
                 try:
                     current_step = "docker_run"
+                    # DAH-2728: last look before the host ports get bound.
+                    if inflight_creates.is_cancelled(payload.pod_id):
+                        current_step = "cancelled_by_delete"
+                        await self._abort_create_cancelled_by_delete(
+                            ssh_client, payload, container_name, default_extra
+                        )
                     await self.stream_log("Creating docker container", "success", log_tag)
                     await self._run_rental_docker_create_with_port_retry(
                         docker_client=docker_client,
@@ -4658,6 +4737,14 @@ class DockerService:
                             logger.error(_m("docker run failed", extra=log_extra))
 
                         raise Exception("Run docker run command but container is not running")
+
+                    # DAH-2728: the delete may have landed while `docker run` was in progress —
+                    # the container we just started is exactly the orphan it could not see.
+                    if inflight_creates.is_cancelled(payload.pod_id):
+                        current_step = "cancelled_by_delete"
+                        await self._abort_create_cancelled_by_delete(
+                            ssh_client, payload, container_name, default_extra
+                        )
                 except Exception:
                     container_missing = await self.cleanup_failed_container_creation(
                         ssh_client=ssh_client,
@@ -5679,6 +5766,11 @@ class DockerService:
         log = _BoundLog(default_extra)
 
         log.info("Deleting Docker Container", payload=str(payload))
+
+        # DAH-2728: a create still in flight for this pod would otherwise finish behind our back and
+        # leave an orphan container holding the ports.
+        if inflight_creates.cancel(payload.pod_id):
+            log.info("Cancelled the in-flight create for this pod")
 
         try:
             _validate_delete_volume_names(payload)

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -159,10 +159,14 @@ def _parse_miner_response(response_data: dict) -> AcceptSSHKeyRequest | FailedRe
 
 
 def _bypasses_renting_in_progress(payload: ContainerBaseRequest) -> bool:
-    return (
-        isinstance(payload, ContainerDeleteRequest)
-        and payload.workload_kind == WorkloadKind.FILLER
-    )
+    if not isinstance(payload, ContainerDeleteRequest):
+        return False
+    if payload.workload_kind == WorkloadKind.FILLER:
+        return True
+    # DAH-2728: the pending-pod flag this guard reads is set by the very create this delete is
+    # about to cancel, so declining here would leave that create to finish and orphan its
+    # container — the exact failure the delete was sent to prevent.
+    return inflight_creates.is_running(payload.pod_id)
 
 
 JOB_LENGTH = 30

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -62,7 +62,7 @@ from core.config import settings
 from core.utils import _m, _StructuredMessage, get_extra_info
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.attestation_service import AttestationService
-from services.docker_service import DockerService
+from services.docker_service import DockerService, inflight_creates
 from services.redis_service import MACHINE_SPEC_CHANNEL, RedisService
 from services.ssh_service import SSHService
 from incentive.config import BASE_GPU_MAP
@@ -855,7 +855,16 @@ class MinerService:
             )
 
     async def handle_container(self, payload: ContainerBaseRequest):
-        """Handle container request - uses REST API if configured, otherwise WebSocket."""
+        """Handle container request, tracking the create so its own delete can cancel it."""
+        # DAH-2728: register the create BEFORE the miner handshake — a delete whose handshake is
+        # quicker would otherwise reach the executor first and see a pod that does not exist yet.
+        if not isinstance(payload, ContainerCreateRequest):
+            return await self._route_container(payload)
+        with inflight_creates.track(payload.pod_id):
+            return await self._route_container(payload)
+
+    async def _route_container(self, payload: ContainerBaseRequest):
+        """Route a container request - uses REST API if configured, otherwise WebSocket."""
         if settings.USE_REST_API:
             logger.info(
                 _m(

--- a/neurons/validators/tests/test_delete_cancels_inflight_create.py
+++ b/neurons/validators/tests/test_delete_cancels_inflight_create.py
@@ -14,12 +14,23 @@ import pytest
 import services.docker_service as ds_module
 from payload_models.payloads import ContainerCreateRequest, PayloadPortMapping, WorkloadKind
 from services.docker_service import DockerService, _CreateCancelledByDelete, inflight_creates
+from services.miner_service import MinerService
 
 
 @pytest.fixture
 def svc() -> DockerService:
     return DockerService(
         ssh_service=Mock(),
+        redis_service=Mock(),
+        attestation_service=Mock(),
+    )
+
+
+@pytest.fixture
+def miner_service() -> MinerService:
+    return MinerService(
+        ssh_service=Mock(),
+        task_service=Mock(),
         redis_service=Mock(),
         attestation_service=Mock(),
     )
@@ -47,19 +58,19 @@ def _payload(**over) -> ContainerCreateRequest:
 
 
 @pytest.mark.asyncio
-async def test_delete_during_create_marks_the_create_cancelled(svc: DockerService) -> None:
+async def test_delete_during_create_marks_the_create_cancelled(miner_service: MinerService) -> None:
     payload = _payload()
     seen_by_create: dict[str, bool] = {}
 
-    async def fake_create(inner_payload: ContainerCreateRequest, *args) -> str:
+    async def fake_route(routed: ContainerCreateRequest) -> str:
         # A delete for the same pod lands right here, while the create is still running.
-        seen_by_create["delete_found_the_create"] = inflight_creates.cancel(inner_payload.pod_id)
-        seen_by_create["checkpoint"] = inflight_creates.is_cancelled(inner_payload.pod_id)
+        seen_by_create["delete_found_the_create"] = inflight_creates.cancel(routed.pod_id)
+        seen_by_create["checkpoint"] = inflight_creates.is_cancelled(routed.pod_id)
         return "created"
 
-    svc._create_container = fake_create
+    miner_service._route_container = fake_route
 
-    assert await svc.create_container(payload, Mock(), Mock(), "key") == "created"
+    assert await miner_service.handle_container(payload) == "created"
     assert seen_by_create == {"delete_found_the_create": True, "checkpoint": True}
     # The registration must not outlive the create, or a later pod id reuse would abort at once.
     assert inflight_creates.is_cancelled(payload.pod_id) is False
@@ -69,24 +80,32 @@ def test_delete_with_no_create_running_cancels_nothing() -> None:
     assert inflight_creates.cancel(str(uuid4())) is False
 
 
+@pytest.mark.parametrize(
+    ("workload_kind", "power_restored"),
+    [(WorkloadKind.FILLER, True), (WorkloadKind.CUSTOMER_RENTAL, False)],
+)
 @pytest.mark.asyncio
-async def test_abort_restores_filler_power_before_raising(svc: DockerService, monkeypatch) -> None:
-    payload = _payload(workload_kind=WorkloadKind.FILLER)
-    restore = AsyncMock()
-    monkeypatch.setattr(ds_module, "restore_filler_pod_gpu_power_limits", restore)
+async def test_abort_restores_only_filler_power(
+    svc: DockerService,
+    monkeypatch: pytest.MonkeyPatch,
+    workload_kind: WorkloadKind,
+    power_restored: bool,
+) -> None:
+    payload = _payload(workload_kind=workload_kind)
+    restore_power_limits = AsyncMock()
+    monkeypatch.setattr(ds_module, "restore_filler_pod_gpu_power_limits", restore_power_limits)
 
-    with pytest.raises(_CreateCancelledByDelete):
-        await svc._abort_create_cancelled_by_delete(Mock(), payload, "filler_x", {})
+    with inflight_creates.track(payload.pod_id):
+        inflight_creates.cancel(payload.pod_id)
+        with pytest.raises(_CreateCancelledByDelete):
+            await svc._abort_if_cancelled_by_delete(Mock(), payload, {})
 
-    restore.assert_awaited_once()
+    assert restore_power_limits.await_count == (1 if power_restored else 0)
 
 
 @pytest.mark.asyncio
-async def test_abort_leaves_rental_power_alone(svc: DockerService, monkeypatch) -> None:
-    restore = AsyncMock()
-    monkeypatch.setattr(ds_module, "restore_filler_pod_gpu_power_limits", restore)
+async def test_a_create_nobody_cancelled_runs_on(svc: DockerService) -> None:
+    payload = _payload()
 
-    with pytest.raises(_CreateCancelledByDelete):
-        await svc._abort_create_cancelled_by_delete(Mock(), _payload(), "pod_x", {})
-
-    restore.assert_not_awaited()
+    with inflight_creates.track(payload.pod_id):
+        assert await svc._abort_if_cancelled_by_delete(Mock(), payload, {}) is None

--- a/neurons/validators/tests/test_delete_cancels_inflight_create.py
+++ b/neurons/validators/tests/test_delete_cancels_inflight_create.py
@@ -19,7 +19,7 @@ from payload_models.payloads import (
     WorkloadKind,
 )
 from services.docker_service import DockerService, _CreateCancelledByDelete, inflight_creates
-from services.miner_service import MinerService
+from services.miner_service import MinerService, _bypasses_renting_in_progress
 
 
 @pytest.fixture
@@ -131,3 +131,41 @@ def test_container_name_is_derived_when_the_delete_carries_none(
     )
 
     assert svc.get_container_name(payload) == f"{prefix}{pod_id}"
+
+
+def test_a_customer_delete_passes_the_pending_rent_guard_only_while_its_create_runs() -> None:
+    # The guard reads the pending-pod flag the create itself set, so declining the delete would
+    # leave that create to finish and orphan its container.
+    pod_id = str(uuid4())
+    delete = ContainerDeleteRequest(
+        miner_hotkey="miner", executor_id=str(uuid4()), pod_id=pod_id,
+        container_name=f"pod_{pod_id}",
+    )
+
+    assert _bypasses_renting_in_progress(delete) is False
+    with inflight_creates.track(pod_id):
+        assert _bypasses_renting_in_progress(delete) is True
+
+
+@pytest.mark.asyncio
+async def test_a_retried_create_does_not_untrack_the_one_still_running() -> None:
+    # The rent retry can put a second create on the same pod; when it leaves, the first must stay
+    # cancellable, or the delete goes back to seeing "no container" and the orphan returns.
+    pod_id = str(uuid4())
+
+    with inflight_creates.track(pod_id):
+        with inflight_creates.track(pod_id):
+            pass
+        assert inflight_creates.is_running(pod_id) is True
+        assert inflight_creates.cancel(pod_id) is True
+
+    assert inflight_creates.is_running(pod_id) is False
+
+
+def test_a_second_create_does_not_clear_a_cancel_already_raised() -> None:
+    pod_id = str(uuid4())
+
+    with inflight_creates.track(pod_id):
+        inflight_creates.cancel(pod_id)
+        with inflight_creates.track(pod_id):
+            assert inflight_creates.is_cancelled(pod_id) is True

--- a/neurons/validators/tests/test_delete_cancels_inflight_create.py
+++ b/neurons/validators/tests/test_delete_cancels_inflight_create.py
@@ -7,6 +7,7 @@ the next paying rental.
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
@@ -169,3 +170,50 @@ def test_a_second_create_does_not_clear_a_cancel_already_raised() -> None:
         inflight_creates.cancel(pod_id)
         with inflight_creates.track(pod_id):
             assert inflight_creates.is_cancelled(pod_id) is True
+
+
+@pytest.mark.asyncio
+async def test_wait_returns_at_once_when_no_create_runs() -> None:
+    """Nothing to wait for: the delete goes straight to its own teardown."""
+    pod_id = str(uuid4())
+
+    finished: bool = await inflight_creates.wait_until_done(pod_id, timeout=0.01)
+
+    assert finished is True
+
+
+@pytest.mark.asyncio
+async def test_wait_returns_when_the_create_leaves() -> None:
+    """The delete holds until the cancelled create has torn itself down."""
+    pod_id = str(uuid4())
+
+    async def create() -> None:
+        with inflight_creates.track(pod_id):
+            await asyncio.sleep(0.05)
+
+    create_task: asyncio.Task[None] = asyncio.create_task(create())
+    await asyncio.sleep(0)  # let the create register itself
+
+    finished: bool = await inflight_creates.wait_until_done(pod_id, timeout=5)
+
+    assert finished is True
+    assert inflight_creates.is_running(pod_id) is False
+    await create_task
+
+
+@pytest.mark.asyncio
+async def test_wait_gives_up_on_a_create_that_does_not_stop() -> None:
+    """A create stuck between checkpoints must not hold the delete forever."""
+    pod_id = str(uuid4())
+
+    async def create() -> None:
+        with inflight_creates.track(pod_id):
+            await asyncio.sleep(5)
+
+    create_task: asyncio.Task[None] = asyncio.create_task(create())
+    await asyncio.sleep(0)
+
+    finished: bool = await inflight_creates.wait_until_done(pod_id, timeout=0.05)
+
+    assert finished is False
+    create_task.cancel()

--- a/neurons/validators/tests/test_delete_cancels_inflight_create.py
+++ b/neurons/validators/tests/test_delete_cancels_inflight_create.py
@@ -1,0 +1,92 @@
+"""DAH-2728 — a delete must cancel the create it raced, not assume the pod is absent.
+
+A delete arriving mid-create used to see no container yet ("No such container"), report the pod
+deleted, and let the create finish minutes later — the orphan then held the host ports and blocked
+the next paying rental.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+import services.docker_service as ds_module
+from payload_models.payloads import ContainerCreateRequest, PayloadPortMapping, WorkloadKind
+from services.docker_service import DockerService, _CreateCancelledByDelete, inflight_creates
+
+
+@pytest.fixture
+def svc() -> DockerService:
+    return DockerService(
+        ssh_service=Mock(),
+        redis_service=Mock(),
+        attestation_service=Mock(),
+    )
+
+
+def _payload(**over) -> ContainerCreateRequest:
+    base = dict(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        docker_image="daturaai/pytorch:1.0.0",
+        user_public_keys=["ssh-ed25519 test-key"],
+        gpu_uuids=["GPU-test"],
+        cpu_count=1,
+        memory_gb=1,
+        volume_limit_gb=2,
+        storage_limit_gb=1,
+        available_ports=[PayloadPortMapping(internal_port=20001, external_port=20001)],
+        pod_mapping=[],
+        active_container_names=[],
+        active_volume_names=[],
+    )
+    base.update(over)
+    return ContainerCreateRequest(**base)
+
+
+@pytest.mark.asyncio
+async def test_delete_during_create_marks_the_create_cancelled(svc: DockerService) -> None:
+    payload = _payload()
+    seen_by_create: dict[str, bool] = {}
+
+    async def fake_create(inner_payload: ContainerCreateRequest, *args) -> str:
+        # A delete for the same pod lands right here, while the create is still running.
+        seen_by_create["delete_found_the_create"] = inflight_creates.cancel(inner_payload.pod_id)
+        seen_by_create["checkpoint"] = inflight_creates.is_cancelled(inner_payload.pod_id)
+        return "created"
+
+    svc._create_container = fake_create
+
+    assert await svc.create_container(payload, Mock(), Mock(), "key") == "created"
+    assert seen_by_create == {"delete_found_the_create": True, "checkpoint": True}
+    # The registration must not outlive the create, or a later pod id reuse would abort at once.
+    assert inflight_creates.is_cancelled(payload.pod_id) is False
+
+
+def test_delete_with_no_create_running_cancels_nothing() -> None:
+    assert inflight_creates.cancel(str(uuid4())) is False
+
+
+@pytest.mark.asyncio
+async def test_abort_restores_filler_power_before_raising(svc: DockerService, monkeypatch) -> None:
+    payload = _payload(workload_kind=WorkloadKind.FILLER)
+    restore = AsyncMock()
+    monkeypatch.setattr(ds_module, "restore_filler_pod_gpu_power_limits", restore)
+
+    with pytest.raises(_CreateCancelledByDelete):
+        await svc._abort_create_cancelled_by_delete(Mock(), payload, "filler_x", {})
+
+    restore.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_abort_leaves_rental_power_alone(svc: DockerService, monkeypatch) -> None:
+    restore = AsyncMock()
+    monkeypatch.setattr(ds_module, "restore_filler_pod_gpu_power_limits", restore)
+
+    with pytest.raises(_CreateCancelledByDelete):
+        await svc._abort_create_cancelled_by_delete(Mock(), _payload(), "pod_x", {})
+
+    restore.assert_not_awaited()

--- a/neurons/validators/tests/test_delete_cancels_inflight_create.py
+++ b/neurons/validators/tests/test_delete_cancels_inflight_create.py
@@ -12,7 +12,12 @@ from uuid import uuid4
 
 import pytest
 import services.docker_service as ds_module
-from payload_models.payloads import ContainerCreateRequest, PayloadPortMapping, WorkloadKind
+from payload_models.payloads import (
+    ContainerCreateRequest,
+    ContainerDeleteRequest,
+    PayloadPortMapping,
+    WorkloadKind,
+)
 from services.docker_service import DockerService, _CreateCancelledByDelete, inflight_creates
 from services.miner_service import MinerService
 
@@ -109,3 +114,20 @@ async def test_a_create_nobody_cancelled_runs_on(svc: DockerService) -> None:
 
     with inflight_creates.track(payload.pod_id):
         assert await svc._abort_if_cancelled_by_delete(Mock(), payload, {}) is None
+
+
+@pytest.mark.parametrize(
+    ("workload_kind", "prefix"),
+    [(WorkloadKind.CUSTOMER_RENTAL, "pod_"), (WorkloadKind.FILLER, "filler_")],
+)
+def test_container_name_is_derived_when_the_delete_carries_none(
+    svc: DockerService, workload_kind: WorkloadKind, prefix: str
+) -> None:
+    # A delete racing an in-flight create arrives before the backend knows the name.
+    pod_id = str(uuid4())
+    payload = ContainerDeleteRequest(
+        miner_hotkey="miner", executor_id=str(uuid4()), pod_id=pod_id,
+        workload_kind=workload_kind, container_name="",
+    )
+
+    assert svc.get_container_name(payload) == f"{prefix}{pod_id}"


### PR DESCRIPTION
## Problem

A delete that lands while the create for the same pod is still in flight finds no container yet, so `_is_missing_docker_container_error` reads "No such container" as "already gone" and the pod is reported deleted. Nothing stops the create: it finishes minutes later, binds the host ports, and the orphan `filler_*` container blocks the next paying rental with `port is already allocated`.

Reference incident (2026-08-19, executor `d4093d0c`): filler create starts 18:35:03, delete at 18:35:09 skips the teardown, the create completes 18:37:36 — the customer pod burns 13 × `PORT_ALREADY_ALLOCATED_RETRY`, dies at 18:39:09 and only gets the H100 x8 back at 19:18:40.

## Fix

Only the create can undo itself, so the delete no longer guesses:

- `inflight_creates` — a small in-process registry of creates running right now. `MinerService.handle_container` registers the create before the miner handshake; `delete_container` flags the matching create instead of inferring absence.
- The create checks the flag at three checkpoints: before the image pull/build (nothing on the host yet, and this is where a cancelled create would otherwise spend its minutes), before the ports get bound, and after the container is up — the last one just before the pod is cached as rented. Each aborts through the cleanup path that is already there (`cleanup_failed_container_creation`) and fails the create with `failure_step=cancelled_by_delete`.
- A cancelled FILLER also restores its GPU power limits — the DAH-2356 cap is applied before `docker run`, and the delete that cancelled it had no record to restore.

A delete with no create in flight changes nothing, so a later create for the same pod id (edit-pod) is untouched. The registry is deliberately in-memory, not Redis: a create and its delete run in the same validator event loop, and a Redis outage must not break the cancellation.

The backend already expects this message — `DefaultJobLauncher.handle_failed` names "create failure of a preempted run" as expected fallout and ignores it for a terminal run, so the normal ordering (delete callback first) costs the provider nothing. If the create-failed callback wins the race the run is still STOPPING and becomes STOP_FAILED: a 15-min soft retry delay, not a launch strike.

## Not in this PR

- `wait_for_port_check_containers` still ignores `filler_*`. Adding the prefix would let any customer create force-remove a live filler on the box, skipping the power-cap restore and the wedged-GPU sweep — worth a separate decision.
- `renting_in_progress` still filters by pod id, not by executor.
- `redis_service.add_pending_pod` is a second, overlapping "a create is in flight" fact. It is registered too late (inside `create_container`, after the handshake) and its presence is load-bearing for the `RentingInProgress` decline gate, so it cannot carry the cancel bit — the two are deliberately separate.
- Residual race: a create that passes the last checkpoint in the same instant the delete probes for the container. Milliseconds now, minutes before.

## Tests

`tests/test_delete_cancels_inflight_create.py` — 5 new tests. Full validator suite: 1629 passed, 9 skipped (`test_sshd_bootstrap_script.py` fails the same way on a clean tree here — local env).