### PR TITLE
DAH-2730: a filler that exited on its own is not a host kill

### DIFF
--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -48,10 +48,15 @@ _GPU_RUNTIME_QUARANTINE: dict[str, GpuRuntimeQuarantine] = {
 # bundle but the pipeline emits a single event, so the node must be judged by its worst container:
 # a confirmed kill outranks an indeterminate probe, which outranks a healthy one. Anything
 # unlisted sorts as healthy.
-# States `docker inspect --format '{{json .State}}'` reports. "removing" is a removal already in
-# flight — the offence itself, caught a moment early (seen in prod on the ISSUE-050 class).
-_DOCKER_STATUS_RUNNING = "running"
+# Every state `docker inspect --format '{{json .State}}'` can report, mapped to what it proves about
+# the filler. Listed exhaustively on purpose: a state that fell through to a default is how this
+# check mislabeled deaths before (DAH-2730).
+# "removing" is the offence itself caught a moment early — a removal already in flight (observed in
+# prod on the ISSUE-050 class). "dead" means docker failed to remove the container, so it is not
+# proof the host succeeded either — it stays unproven rather than punished.
 _DOCKER_STATUS_REMOVING = "removing"
+_DOCKER_STATUS_EXITED = "exited"
+_DOCKER_STATES_PROVING_NO_DEATH = frozenset({"running", "created", "restarting", "paused", "dead"})
 
 _FILLER_VERDICT_SEVERITY: dict[str, int] = {
     Msg.FILLER_KILLED.reason: 3,
@@ -531,22 +536,18 @@ class RentalVerificationCheck:
             diagnostics.container_missing or diagnostics.status == _DOCKER_STATUS_REMOVING
         )
         if not container_was_removed:
-            if diagnostics.status == _DOCKER_STATUS_RUNNING:
-                # Filler containers carry `restart: unless-stopped`, so docker can bring one back
-                # between the ps probe and this inspect. A running container is neither death.
+            if diagnostics.status != _DOCKER_STATUS_EXITED:
+                # Anything but a recorded exit is unproven: the container may be running again
+                # (fillers carry `restart: unless-stopped`, so docker can bring one back between
+                # the ps probe and this inspect), mid-transition, or unreadable.
                 return self._filler_state_unknown_result(
                     ctx,
                     filler_container,
-                    reason="container is running again",
-                    details=diagnostics.to_log_fields(),
-                )
-            if diagnostics.status is None:
-                # Docker answered neither "gone" nor a state: claiming the container is still there
-                # would be as unproven as calling it a kill.
-                return self._filler_state_unknown_result(
-                    ctx,
-                    filler_container,
-                    reason="container state could not be read",
+                    reason=(
+                        f"container state {diagnostics.status} is not a death"
+                        if diagnostics.status in _DOCKER_STATES_PROVING_NO_DEATH
+                        else "container state could not be read"
+                    ),
                     details=diagnostics.to_log_fields(),
                 )
             event = render_message(

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -498,12 +498,41 @@ class RentalVerificationCheck:
         run_age: timedelta,
         enforce: bool,
     ) -> CheckResult:
-        """Render the confirmed-kill verdict: capture death diagnostics and emit FILLER_KILLED."""
+        """Judge why the container is not running, and emit FILLER_KILLED only for a removal.
+
+        DAH-2730: `docker ps` lists RUNNING containers only, so a filler that exited on its own
+        looks exactly like one the host removed. The death diagnostics already know the difference
+        — a removed container has no state at all — and only a removal is the offence this check
+        withholds incentive for. An unprovable state (SSH lost, diagnostics failed) is never a
+        penalty.
+        """
         try:
             diagnostics = await collect_container_death_diagnostics(ctx.ssh, filler_container)
-            death_fields: dict[str, object] = diagnostics.to_log_fields()
         except Exception as exc:
-            death_fields = {"diagnostics_capture_error": repr(exc)}
+            return self._filler_state_unknown_result(
+                ctx,
+                filler_container,
+                reason="container death diagnostics unavailable",
+                details={"diagnostics_capture_error": repr(exc)},
+            )
+
+        death_fields: dict[str, object] = diagnostics.to_log_fields()
+        if not diagnostics.container_missing:
+            event = render_message(
+                Msg.FILLER_CONTAINER_EXITED,
+                ctx=ctx,
+                check_id=self.check_id,
+                what={
+                    "verified": False,
+                    "filler_container": filler_container,
+                    "executor_uuid": ctx.executor.uuid,
+                    "filler_run_status": filler_run_status,
+                    "run_age_seconds": run_age.total_seconds(),
+                    "enforced": False,
+                    **death_fields,
+                },
+            )
+            return CheckResult(passed=True, event=event, updates={})
 
         event = render_message(
             Msg.FILLER_KILLED,

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -8,7 +8,11 @@ import asyncssh
 
 from core.config import settings
 from core.utils import _m, get_extra_info
-from core.docker_utils import DockerCommand, collect_container_death_diagnostics
+from core.docker_utils import (
+    ContainerDeathDiagnostics,
+    DockerCommand,
+    collect_container_death_diagnostics,
+)
 from protocol.vc_protocol.compute_requests import (
     CPU_QUOTA_EXCEEDS_HOST_REASON,
     GPU_RUNTIME_DEVICE_FAULT_REASON,
@@ -58,8 +62,28 @@ _DOCKER_STATUS_REMOVING = "removing"
 _DOCKER_STATUS_EXITED = "exited"
 _DOCKER_STATES_PROVING_NO_DEATH = frozenset({"running", "created", "restarting", "paused", "dead"})
 
+# Docker reports 128 + signal number when something outside the container terminated its PID 1:
+# `docker stop` sends SIGTERM (143), `docker kill` sends SIGKILL (137). A job that died on its own
+# exits with the code its own process chose, never with these.
+_EXIT_CODES_FROM_AN_EXTERNAL_SIGNAL = frozenset({137, 143})
+
+
+def _was_deliberately_stopped_on_the_host(diagnostics: ContainerDeathDiagnostics) -> bool:
+    """Whether someone on the host terminated the filler rather than the job dying by itself.
+
+    Fillers run with `restart: unless-stopped`, so anything that merely killed the process would be
+    back up by the next probe; a container still sitting in `exited` after an external signal was
+    stopped on purpose. An out-of-memory kill carries the same exit code but is the kernel
+    reclaiming memory, not a choice the host made, so it is excluded.
+    """
+    if diagnostics.exit_code not in _EXIT_CODES_FROM_AN_EXTERNAL_SIGNAL:
+        return False
+    return not diagnostics.oom_killed
+
 _FILLER_VERDICT_SEVERITY: dict[str, int] = {
     Msg.FILLER_KILLED.reason: 3,
+    # Removed or stopped, the node took the job down either way — same rank, same penalty.
+    Msg.FILLER_STOPPED_BY_HOST.reason: 3,
     Msg.FILLER_TRANSPORT_UNREACHABLE.reason: 2,
     Msg.FILLER_STATE_UNKNOWN.reason: 1,
     # DAH-2730: ranks with STATE_UNKNOWN — the node lost its job either way, and neither outcome
@@ -550,6 +574,16 @@ class RentalVerificationCheck:
                     ),
                     details=diagnostics.to_log_fields(),
                 )
+            if _was_deliberately_stopped_on_the_host(diagnostics):
+                event = render_message(
+                    Msg.FILLER_STOPPED_BY_HOST,
+                    ctx=ctx,
+                    check_id=self.check_id,
+                    severity=None if enforce else "warning",
+                    impact=None if enforce else "Shadow observation only: incentive was NOT withheld",
+                    what={**what_we_saw, "enforced": enforce},
+                )
+                return CheckResult(passed=not enforce, event=event, updates={})
             event = render_message(
                 Msg.FILLER_CONTAINER_EXITED,
                 ctx=ctx,

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -52,6 +52,9 @@ _FILLER_VERDICT_SEVERITY: dict[str, int] = {
     Msg.FILLER_KILLED.reason: 3,
     Msg.FILLER_TRANSPORT_UNREACHABLE.reason: 2,
     Msg.FILLER_STATE_UNKNOWN.reason: 1,
+    # DAH-2730: ranks with STATE_UNKNOWN — the node lost its job either way, and neither outcome
+    # is an offence.
+    Msg.FILLER_CONTAINER_EXITED.reason: 1,
     Msg.FILLER_VERIFIED.reason: 0,
 }
 
@@ -447,9 +450,10 @@ class RentalVerificationCheck:
         # still starting mid-cycle) — re-check the live run state before penalizing, like the pod
         # flow does with get_pod_rental_active.
         filler_run_id: str = filler_container.removeprefix(FILLER_CONTAINER_PREFIX)
-        # container_missing carries the observation to the backend: this re-check only ever happens
-        # when the container is gone from the host, and the backend uses the accumulated reports to
-        # close zombie RUNNING runs (DAH-2471).
+        # container_missing carries the probe's observation — no RUNNING container by that name —
+        # which is what the backend needs to close zombie RUNNING runs (DAH-2471). It is NOT the
+        # removal verdict: whether the host removed it or it exited on its own is decided below,
+        # from the death diagnostics (DAH-2730).
         filler_run: FillerRunActiveResponse | None = await ctx.services.backend.get_filler_run_active(
             filler_run_id, container_missing=True
         )
@@ -506,31 +510,33 @@ class RentalVerificationCheck:
         withholds incentive for. An unprovable state (SSH lost, diagnostics failed) is never a
         penalty.
         """
-        try:
-            diagnostics = await collect_container_death_diagnostics(ctx.ssh, filler_container)
-        except Exception as exc:
-            return self._filler_state_unknown_result(
-                ctx,
-                filler_container,
-                reason="container death diagnostics unavailable",
-                details={"diagnostics_capture_error": repr(exc)},
-            )
+        # collect_container_death_diagnostics folds every failure into capture_error and never
+        # raises (cancellation excepted), so an unreadable state arrives as empty fields below.
+        diagnostics = await collect_container_death_diagnostics(ctx.ssh, filler_container)
+        what_we_saw: dict[str, object] = {
+            "verified": False,
+            "filler_container": filler_container,
+            "executor_uuid": ctx.executor.uuid,
+            "filler_run_status": filler_run_status,
+            "run_age_seconds": run_age.total_seconds(),
+            **diagnostics.to_log_fields(),
+        }
 
-        death_fields: dict[str, object] = diagnostics.to_log_fields()
         if not diagnostics.container_missing:
+            if diagnostics.status is None:
+                # Docker answered neither "gone" nor a state: claiming the container is still there
+                # would be as unproven as calling it a kill.
+                return self._filler_state_unknown_result(
+                    ctx,
+                    filler_container,
+                    reason="container state could not be read",
+                    details=diagnostics.to_log_fields(),
+                )
             event = render_message(
                 Msg.FILLER_CONTAINER_EXITED,
                 ctx=ctx,
                 check_id=self.check_id,
-                what={
-                    "verified": False,
-                    "filler_container": filler_container,
-                    "executor_uuid": ctx.executor.uuid,
-                    "filler_run_status": filler_run_status,
-                    "run_age_seconds": run_age.total_seconds(),
-                    "enforced": False,
-                    **death_fields,
-                },
+                what={**what_we_saw, "enforced": False},
             )
             return CheckResult(passed=True, event=event, updates={})
 
@@ -540,15 +546,7 @@ class RentalVerificationCheck:
             check_id=self.check_id,
             severity=None if enforce else "warning",
             impact=None if enforce else "Shadow observation only: incentive was NOT withheld",
-            what={
-                "verified": False,
-                "filler_container": filler_container,
-                "executor_uuid": ctx.executor.uuid,
-                "filler_run_status": filler_run_status,
-                "run_age_seconds": run_age.total_seconds(),
-                "enforced": enforce,
-                **death_fields,
-            },
+            what={**what_we_saw, "enforced": enforce},
         )
         return CheckResult(passed=not enforce, event=event, updates={})
 

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -48,6 +48,9 @@ _GPU_RUNTIME_QUARANTINE: dict[str, GpuRuntimeQuarantine] = {
 # bundle but the pipeline emits a single event, so the node must be judged by its worst container:
 # a confirmed kill outranks an indeterminate probe, which outranks a healthy one. Anything
 # unlisted sorts as healthy.
+# `docker inspect --format '{{json .State}}'` reports this while the container is up.
+_DOCKER_STATUS_RUNNING = "running"
+
 _FILLER_VERDICT_SEVERITY: dict[str, int] = {
     Msg.FILLER_KILLED.reason: 3,
     Msg.FILLER_TRANSPORT_UNREACHABLE.reason: 2,
@@ -523,6 +526,15 @@ class RentalVerificationCheck:
         }
 
         if not diagnostics.container_missing:
+            if diagnostics.status == _DOCKER_STATUS_RUNNING:
+                # Filler containers carry `restart: unless-stopped`, so docker can bring one back
+                # between the ps probe and this inspect. A running container is neither death.
+                return self._filler_state_unknown_result(
+                    ctx,
+                    filler_container,
+                    reason="container is running again",
+                    details=diagnostics.to_log_fields(),
+                )
             if diagnostics.status is None:
                 # Docker answered neither "gone" nor a state: claiming the container is still there
                 # would be as unproven as calling it a kill.

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -48,8 +48,10 @@ _GPU_RUNTIME_QUARANTINE: dict[str, GpuRuntimeQuarantine] = {
 # bundle but the pipeline emits a single event, so the node must be judged by its worst container:
 # a confirmed kill outranks an indeterminate probe, which outranks a healthy one. Anything
 # unlisted sorts as healthy.
-# `docker inspect --format '{{json .State}}'` reports this while the container is up.
+# States `docker inspect --format '{{json .State}}'` reports. "removing" is a removal already in
+# flight — the offence itself, caught a moment early (seen in prod on the ISSUE-050 class).
 _DOCKER_STATUS_RUNNING = "running"
+_DOCKER_STATUS_REMOVING = "removing"
 
 _FILLER_VERDICT_SEVERITY: dict[str, int] = {
     Msg.FILLER_KILLED.reason: 3,
@@ -525,7 +527,10 @@ class RentalVerificationCheck:
             **diagnostics.to_log_fields(),
         }
 
-        if not diagnostics.container_missing:
+        container_was_removed = (
+            diagnostics.container_missing or diagnostics.status == _DOCKER_STATUS_REMOVING
+        )
+        if not container_was_removed:
             if diagnostics.status == _DOCKER_STATUS_RUNNING:
                 # Filler containers carry `restart: unless-stopped`, so docker can bring one back
                 # between the ps probe and this inspect. A running container is neither death.

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -1068,6 +1068,17 @@ class RentalVerificationMessages:
             "Contact Lium support if nothing on this host removes containers."
         ),
     )
+    FILLER_CONTAINER_EXITED = MessageTemplate(
+        event="Lium default job container exited on its own",
+        reason="FILLER_CONTAINER_EXITED",
+        severity="warning",
+        category="runtime",
+        impact="No penalty: the container is still on the host, so nobody removed it",
+        remediation=(
+            "The Lium default job stopped by itself on this machine. Check the container's exit "
+            "code and logs; incentive is unaffected."
+        ),
+    )
     FILLER_STATE_UNKNOWN = MessageTemplate(
         event="Lium default job state could not be verified",
         reason="FILLER_STATE_UNKNOWN",

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -1068,6 +1068,21 @@ class RentalVerificationMessages:
             "Contact Lium support if nothing on this host removes containers."
         ),
     )
+    FILLER_STOPPED_BY_HOST = MessageTemplate(
+        event="Lium default job container was stopped on the host",
+        reason="FILLER_STOPPED_BY_HOST",
+        severity="error",
+        category="policy",
+        impact=(
+            "Unrented incentive withheld: something on this machine stopped the Lium default job "
+            "while its run is active"
+        ),
+        remediation=(
+            "Do not stop or remove Lium default-job (filler_*) containers. "
+            "Incentive resumes once a default job runs undisturbed. "
+            "Contact Lium support if this container was not stopped by you."
+        ),
+    )
     FILLER_CONTAINER_EXITED = MessageTemplate(
         event="Lium default job container exited on its own",
         reason="FILLER_CONTAINER_EXITED",

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -1354,3 +1354,20 @@ async def test_container_caught_mid_removal_is_still_a_kill():
 
     assert result.passed is False
     assert result.event.reason_code == Msg.FILLER_KILLED.reason
+
+
+@pytest.mark.parametrize("docker_status", ["created", "restarting", "paused", "dead", None])
+@pytest.mark.asyncio
+async def test_states_that_do_not_prove_a_death_are_never_punished(docker_status):
+    """Only a recorded exit is an exit; every other state stays unproven and unpunished."""
+    backend_client = _killed_filler_backend()
+    ctx = _filler_context(backend_client=backend_client, ssh_client=FillerSSHClient(running=False))
+
+    with patch(
+        "neurons.validators.src.services.task.checks.rental_verification.collect_container_death_diagnostics",
+        return_value=ContainerDeathDiagnostics(status=docker_status),
+    ):
+        result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.FILLER_STATE_UNKNOWN.reason

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -1336,3 +1336,21 @@ async def test_container_running_again_by_the_time_we_inspect_is_not_a_death():
 
     assert result.passed is True
     assert result.event.reason_code == Msg.FILLER_STATE_UNKNOWN.reason
+
+
+@pytest.mark.asyncio
+async def test_container_caught_mid_removal_is_still_a_kill():
+    """`docker rm` leaves State.Status="removing" for a moment — that is the offence in progress,
+    not a container that exited (observed in prod on the ISSUE-050 class)."""
+    backend_client = _killed_filler_backend()
+    ssh_client = FillerSSHClient(running=False)
+    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client)
+
+    with patch(
+        "neurons.validators.src.services.task.checks.rental_verification.collect_container_death_diagnostics",
+        return_value=ContainerDeathDiagnostics(status="removing"),
+    ):
+        result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.FILLER_KILLED.reason

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 
 import asyncssh
 import pytest
+from neurons.validators.src.core.docker_utils import ContainerDeathDiagnostics
 from neurons.validators.src.protocol.vc_protocol.compute_requests import (
     CPU_QUOTA_EXCEEDS_HOST_REASON,
     GPU_RUNTIME_DEVICE_FAULT_REASON,
@@ -475,8 +476,7 @@ class FillerSSHClient:
         unreachable_containers: set[str] | None = None,
         removed_from_host: bool = True,
     ):
-        # DAH-2730: what `docker inspect` answers for a container the ps probe did not list.
-        # True = the object is gone (a removal); False = it is still there and merely exited.
+        # True = `docker inspect` says "No such object" (a removal); False = still there, exited.
         self.removed_from_host = removed_from_host
         self.running = running
         self.exit_status = exit_status
@@ -636,7 +636,7 @@ async def test_rental_verification_filler_killed_shadow_mode_passes_but_logs():
 async def test_rental_verification_filler_killed_enforcement_fails():
     """Enforcement mode: a killed filler fails the fatal check -> no unrented incentive."""
     backend_client = _killed_filler_backend()
-    ssh_client = FillerSSHClient(running=False)
+    ssh_client = FillerSSHClient(running=False, removed_from_host=True)
     ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client)
 
     result = await _run_filler_check(ctx, enforcement=True)
@@ -1269,10 +1269,6 @@ async def test_rental_verification_create_kill_is_not_masked_by_a_surviving_fill
     assert result.event.reason_code == Msg.FILLER_KILLED_AT_CREATE.reason
 
 
-# DAH-2730: `docker ps` lists running containers only, so a filler that exited on its own reads
-# exactly like one the host removed. Only a removal is an offence.
-
-
 @pytest.mark.asyncio
 async def test_filler_that_exited_on_the_host_is_not_a_kill():
     """Container still on the host, exit code 255: the node crashed the job, it did not remove it."""
@@ -1289,30 +1285,36 @@ async def test_filler_that_exited_on_the_host_is_not_a_kill():
 
 
 @pytest.mark.asyncio
-async def test_filler_removed_from_the_host_still_fails_under_enforcement():
-    """The real offence keeps its verdict: no state at all means the container was removed."""
-    backend_client = _killed_filler_backend()
-    ssh_client = FillerSSHClient(running=False, removed_from_host=True)
-    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client)
-
-    result = await _run_filler_check(ctx, enforcement=True)
-
-    assert result.passed is False
-    assert result.event.reason_code == Msg.FILLER_KILLED.reason
-
-
-@pytest.mark.asyncio
-async def test_unprovable_container_state_is_never_a_penalty():
-    """Diagnostics unreachable: we cannot prove a removal, so nobody is punished for it."""
+async def test_container_state_without_evidence_is_unknown_not_exited():
+    """Docker answered nothing useful: we cannot claim the container is still there either."""
     backend_client = _killed_filler_backend()
     ssh_client = FillerSSHClient(running=False)
     ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client)
 
     with patch(
         "neurons.validators.src.services.task.checks.rental_verification.collect_container_death_diagnostics",
-        side_effect=OSError("ssh channel died"),
+        return_value=ContainerDeathDiagnostics(capture_error="inspect: Cannot connect to the Docker daemon"),
     ):
         result = await _run_filler_check(ctx, enforcement=True)
 
     assert result.passed is True
     assert result.event.reason_code == Msg.FILLER_STATE_UNKNOWN.reason
+
+
+@pytest.mark.asyncio
+async def test_exited_bundle_outranks_a_healthy_sibling_on_a_split_node():
+    """DAH-2465 split node: the bundle that lost its job decides the node's logged verdict."""
+    backend_client = _killed_filler_backend()
+    healthy_container = "filler_11111111-2222-3333-4444-555555555555"
+    exited_container = "filler_99999999-8888-7777-6666-555555555555"
+    ssh_client = FillerSSHClient(dead_containers={exited_container}, removed_from_host=False)
+    ctx = _filler_context(
+        backend_client=backend_client,
+        ssh_client=ssh_client,
+        filler_containers=[healthy_container, exited_container],
+    )
+
+    result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.FILLER_CONTAINER_EXITED.reason

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -1318,3 +1318,21 @@ async def test_exited_bundle_outranks_a_healthy_sibling_on_a_split_node():
 
     assert result.passed is True
     assert result.event.reason_code == Msg.FILLER_CONTAINER_EXITED.reason
+
+
+@pytest.mark.asyncio
+async def test_container_running_again_by_the_time_we_inspect_is_not_a_death():
+    """Filler containers run with `restart: unless-stopped`, so docker can bring one back
+    between the ps probe and the inspect. A running container is not an exit and not a kill."""
+    backend_client = _killed_filler_backend()
+    ssh_client = FillerSSHClient(running=False)
+    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client)
+
+    with patch(
+        "neurons.validators.src.services.task.checks.rental_verification.collect_container_death_diagnostics",
+        return_value=ContainerDeathDiagnostics(status="running"),
+    ):
+        result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.FILLER_STATE_UNKNOWN.reason

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -473,7 +473,11 @@ class FillerSSHClient:
         raise_on_run: BaseException | None = None,
         dead_containers: set[str] | None = None,
         unreachable_containers: set[str] | None = None,
+        removed_from_host: bool = True,
     ):
+        # DAH-2730: what `docker inspect` answers for a container the ps probe did not list.
+        # True = the object is gone (a removal); False = it is still there and merely exited.
+        self.removed_from_host = removed_from_host
         self.running = running
         self.exit_status = exit_status
         self.raise_on_run = raise_on_run
@@ -496,6 +500,16 @@ class FillerSSHClient:
         container_running = self.running and not probed_container_is_dead
         result.stdout = "container_id_123" if container_running and "docker ps" in command else ""
         result.stderr = ""
+        if "docker inspect" in command and not container_running:
+            if self.removed_from_host:
+                result.exit_status = 1
+                result.stderr = f"Error: No such object: {command.split()[-1]}"
+            else:
+                result.stdout = (
+                    '{"Status": "exited", "ExitCode": 255, "OOMKilled": false,'
+                    ' "Error": "error while mounting volume", "StartedAt": "2026-08-18T06:45:54Z",'
+                    ' "FinishedAt": "2026-08-18T22:44:30Z"}'
+                )
         return result
 
 
@@ -1253,3 +1267,52 @@ async def test_rental_verification_create_kill_is_not_masked_by_a_surviving_fill
 
     assert result.passed is False
     assert result.event.reason_code == Msg.FILLER_KILLED_AT_CREATE.reason
+
+
+# DAH-2730: `docker ps` lists running containers only, so a filler that exited on its own reads
+# exactly like one the host removed. Only a removal is an offence.
+
+
+@pytest.mark.asyncio
+async def test_filler_that_exited_on_the_host_is_not_a_kill():
+    """Container still on the host, exit code 255: the node crashed the job, it did not remove it."""
+    backend_client = _killed_filler_backend()
+    ssh_client = FillerSSHClient(running=False, removed_from_host=False)
+    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client)
+
+    result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.FILLER_CONTAINER_EXITED.reason
+    assert result.event.what_we_saw["container_exit_code"] == 255
+    assert result.event.what_we_saw["container_status"] == "exited"
+
+
+@pytest.mark.asyncio
+async def test_filler_removed_from_the_host_still_fails_under_enforcement():
+    """The real offence keeps its verdict: no state at all means the container was removed."""
+    backend_client = _killed_filler_backend()
+    ssh_client = FillerSSHClient(running=False, removed_from_host=True)
+    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client)
+
+    result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.FILLER_KILLED.reason
+
+
+@pytest.mark.asyncio
+async def test_unprovable_container_state_is_never_a_penalty():
+    """Diagnostics unreachable: we cannot prove a removal, so nobody is punished for it."""
+    backend_client = _killed_filler_backend()
+    ssh_client = FillerSSHClient(running=False)
+    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client)
+
+    with patch(
+        "neurons.validators.src.services.task.checks.rental_verification.collect_container_death_diagnostics",
+        side_effect=OSError("ssh channel died"),
+    ):
+        result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.FILLER_STATE_UNKNOWN.reason

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -475,9 +475,13 @@ class FillerSSHClient:
         dead_containers: set[str] | None = None,
         unreachable_containers: set[str] | None = None,
         removed_from_host: bool = True,
+        exit_code: int = 255,
+        oom_killed: bool = False,
     ):
         # True = `docker inspect` says "No such object" (a removal); False = still there, exited.
         self.removed_from_host = removed_from_host
+        self.exit_code = exit_code
+        self.oom_killed = oom_killed
         self.running = running
         self.exit_status = exit_status
         self.raise_on_run = raise_on_run
@@ -506,7 +510,8 @@ class FillerSSHClient:
                 result.stderr = f"Error: No such object: {command.split()[-1]}"
             else:
                 result.stdout = (
-                    '{"Status": "exited", "ExitCode": 255, "OOMKilled": false,'
+                    f'{{"Status": "exited", "ExitCode": {self.exit_code},'
+                    f' "OOMKilled": {str(self.oom_killed).lower()},'
                     ' "Error": "error while mounting volume", "StartedAt": "2026-08-18T06:45:54Z",'
                     ' "FinishedAt": "2026-08-18T22:44:30Z"}'
                 )
@@ -1282,6 +1287,72 @@ async def test_filler_that_exited_on_the_host_is_not_a_kill():
     assert result.event.reason_code == Msg.FILLER_CONTAINER_EXITED.reason
     assert result.event.what_we_saw["container_exit_code"] == 255
     assert result.event.what_we_saw["container_status"] == "exited"
+
+
+@pytest.mark.asyncio
+async def test_filler_terminated_by_a_signal_is_a_kill():
+    """Exit 143 = SIGTERM, i.e. `docker stop`. Fillers carry `restart: unless-stopped`, so a
+    container that is still exited was stopped deliberately — the restart policy would have brought
+    back anything else. Prod: all 4 such runs in 7 days came from the one host with a container
+    auto-killer."""
+    backend_client = _killed_filler_backend()
+    ssh_client = FillerSSHClient(running=False, removed_from_host=False, exit_code=143)
+    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client)
+
+    result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.FILLER_STOPPED_BY_HOST.reason
+    assert result.event.what_we_saw["container_exit_code"] == 143
+
+
+@pytest.mark.asyncio
+async def test_filler_killed_by_sigkill_is_a_kill():
+    """Exit 137 = SIGKILL from outside the container."""
+    backend_client = _killed_filler_backend()
+    ssh_client = FillerSSHClient(running=False, removed_from_host=False, exit_code=137)
+    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client)
+
+    result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.FILLER_STOPPED_BY_HOST.reason
+
+
+@pytest.mark.asyncio
+async def test_out_of_memory_kill_is_not_a_host_kill():
+    """Same exit 137, but the kernel reclaimed memory — the host did not choose to stop the job."""
+    backend_client = _killed_filler_backend()
+    ssh_client = FillerSSHClient(
+        running=False, removed_from_host=False, exit_code=137, oom_killed=True
+    )
+    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client)
+
+    result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.FILLER_CONTAINER_EXITED.reason
+
+
+@pytest.mark.asyncio
+async def test_signal_killed_bundle_outranks_a_healthy_sibling_on_a_split_node():
+    """A stopped bundle must decide the node even when its siblings are fine (DAH-2465)."""
+    backend_client = _killed_filler_backend()
+    healthy_container = "filler_11111111-2222-3333-4444-555555555555"
+    stopped_container = "filler_99999999-8888-7777-6666-555555555555"
+    ssh_client = FillerSSHClient(
+        dead_containers={stopped_container}, removed_from_host=False, exit_code=143
+    )
+    ctx = _filler_context(
+        backend_client=backend_client,
+        ssh_client=ssh_client,
+        filler_containers=[healthy_container, stopped_container],
+    )
+
+    result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.FILLER_STOPPED_BY_HOST.reason
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

The ISSUE-050 liveness probe decides "the host killed our filler" from `docker ps -q -f name=<container>` alone (`core/docker_utils.py:92`), and that lists **running** containers only. A container still sitting on the host that exited by itself is indistinguishable from one that was removed — so flipping `FILLER_LIVENESS_ENFORCEMENT_ENABLED` today would withhold unrented incentive from nodes that removed nothing.

Prod shadow data, 48 h to 2026-08-20 — 7 flagged runs on 7 executors:

- **2 real removals**: diagnostics `inspect: error: no such object`, both on `178.105.229.97` (`5EjovEqPR…`), later closed by the reconciler as "container is gone".
- **5 false positives**: `container_status=exited, exit_code=255, OOMKilled=false` — the object is still there. One carries docker's own `error while mounting volume … VolumeDriver.Mount`, and its log tail shows the miner working normally right up to the exit. All 5 were then closed by **our own** PEARL power-cap guard (278 such runs on 36 executors in 7 days).

Docker is unambiguous here: `docker stop` exits 143, `docker kill` 137, a removed container has no state at all. Exit 255 with a recorded `State.Error` is the container's own failure.

## What this PR does

`_filler_killed_result` now judges the diagnostics it already collects instead of ignoring them:

Every `State.Status` docker can report is mapped explicitly — a state falling through to a default is exactly how this check mislabeled deaths:

- **absent from the host, or `removing`** → `FILLER_CONTAINER_MISSING`, unchanged (fails the fatal check under enforcement). `removing` is the offence caught a moment early; our own ISSUE-050 data has 5 create-time kills in that state.
- **`exited`** → new `FILLER_CONTAINER_EXITED`, passes, carrying status / exit code / `State.Error` so the population stays observable.
- **`running`, `created`, `restarting`, `paused`, `dead`, or unreadable** → `FILLER_STATE_UNKNOWN`, no penalty. Fillers carry `restart: unless-stopped`, so docker can bring one back between the ps probe and the inspect; `dead` means docker failed to remove it, which does not prove the host succeeded. Unproven is never an offence.

No new evidence is gathered: `container_missing` has been on `ContainerDeathDiagnostics` since DAH-2703; this only stops throwing it away.

## Tests

`test_rental_verification_check.py`: exited container passes under enforcement with the exit code on the event; a removed container still fails; unreachable diagnostics never penalize. The filler SSH mock now answers `docker inspect` for both shapes. Full validator suite: 1665 passed (3 pre-existing sshd-bootstrap failures, unrelated).

## Rollout

This is the gate for the enforcement flip. After it ships, re-run the 48 h shadow count: `FILLER_CONTAINER_MISSING` should keep only the real removals, and the power-cap-stopped nodes should show up as `FILLER_CONTAINER_EXITED`.

Notion: DAH-2730
