### PR TITLE
DAH-2732, probe ports through an unlimited connector and log wave timing

### DIFF
--- a/neurons/validators/src/services/executor_connectivity/port_tester.py
+++ b/neurons/validators/src/services/executor_connectivity/port_tester.py
@@ -56,12 +56,12 @@ class PortTester:
         successful = [p for p, ok in zip(ports, results) if ok]
         failed = [p for p, ok in zip(ports, results) if not ok]
 
-        ordered = sorted(durations)
-        p95 = ordered[min(int(len(ordered) * 0.95), len(ordered) - 1)]
+        sorted_durations = sorted(durations)
+        p95 = sorted_durations[min(int(len(sorted_durations) * 0.95), len(sorted_durations) - 1)]
         logger.info(
             _m(
                 f"probed {len(ports)} ports in {wall:.2f}s: {len(successful)} ok, "
-                f"per-probe med={statistics.median(ordered):.2f}s p95={p95:.2f}s max={ordered[-1]:.2f}s",
+                f"per-probe med={statistics.median(sorted_durations):.2f}s p95={p95:.2f}s max={sorted_durations[-1]:.2f}s",
                 extra=get_extra_info(log_ctx or {}),
             )
         )

--- a/neurons/validators/src/services/executor_connectivity/port_tester.py
+++ b/neurons/validators/src/services/executor_connectivity/port_tester.py
@@ -1,8 +1,19 @@
 import asyncio
+import logging
+import statistics
+import time
 
 import aiohttp
 
+from core.utils import _m, get_extra_info
 from services.executor_connectivity.models import PortPair
+
+logger = logging.getLogger(__name__)
+
+# per-operation budget instead of a cumulative one: aiohttp's `total` clock starts before the
+# connector hands out a socket, so a probe queued behind a full pool burned its budget waiting
+# and was recorded as a dead port without ever putting a packet on the wire
+PROBE_TIMEOUT = aiohttp.ClientTimeout(sock_connect=3, sock_read=3)
 
 
 class PortTester:
@@ -14,7 +25,7 @@ class PortTester:
         expected = f"{token}:{port.internal}"
 
         try:
-            async with session.get(url, timeout=aiohttp.ClientTimeout(total=3)) as resp:
+            async with session.get(url, timeout=PROBE_TIMEOUT) as resp:
                 text = await resp.text()
                 return text.strip() == expected
         except Exception:
@@ -26,9 +37,32 @@ class PortTester:
         host: str,
         ports: list[PortPair],
         token: str,
+        log_ctx: dict | None = None,
     ) -> tuple[list[PortPair], list[PortPair]]:
         """Test multiple ports concurrently."""
-        results = await asyncio.gather(*[self.test_one(session, host, p, token) for p in ports])
+        durations: list[float] = []
+
+        async def timed(port: PortPair) -> bool:
+            started = time.monotonic()
+            try:
+                return await self.test_one(session, host, port, token)
+            finally:
+                durations.append(time.monotonic() - started)
+
+        wall_started = time.monotonic()
+        results = await asyncio.gather(*[timed(p) for p in ports])
+        wall = time.monotonic() - wall_started
+
         successful = [p for p, ok in zip(ports, results) if ok]
         failed = [p for p, ok in zip(ports, results) if not ok]
+
+        ordered = sorted(durations)
+        p95 = ordered[min(int(len(ordered) * 0.95), len(ordered) - 1)]
+        logger.info(
+            _m(
+                f"probed {len(ports)} ports in {wall:.2f}s: {len(successful)} ok, "
+                f"per-probe med={statistics.median(ordered):.2f}s p95={p95:.2f}s max={ordered[-1]:.2f}s",
+                extra=get_extra_info(log_ctx or {}),
+            )
+        )
         return successful, failed

--- a/neurons/validators/src/services/executor_connectivity/port_verifiers.py
+++ b/neurons/validators/src/services/executor_connectivity/port_verifiers.py
@@ -106,8 +106,8 @@ class BatchVerifier:
             return [], ports
 
         try:
-            async with aiohttp.ClientSession() as session:
-                successful, failed = await self.port_tester.test_many(session, host, ports, token)
+            async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=0)) as session:
+                successful, failed = await self.port_tester.test_many(session, host, ports, token, log_ctx)
                 logger.info(
                     _m(f"progress: {len(successful)}/{len(ports)} verified", extra=get_extra_info(log_ctx))
                 )
@@ -290,8 +290,8 @@ class SemiBatchVerifier:
                 return [], ports
 
             started = True
-            async with aiohttp.ClientSession() as session:
-                return await self.port_tester.test_many(session, host, ports, token)
+            async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=0)) as session:
+                return await self.port_tester.test_many(session, host, ports, token, log_ctx)
 
         except Exception as e:
             logger.error(

--- a/neurons/validators/tests/executor_connectivity/test_port_verifiers.py
+++ b/neurons/validators/tests/executor_connectivity/test_port_verifiers.py
@@ -62,7 +62,7 @@ async def test_semi_batch_caps_at_max_ports(mocker):
     runner.cleanup = mocker.AsyncMock()
 
     port_tester = mocker.Mock()
-    port_tester.test_many = mocker.AsyncMock(side_effect=lambda session, host, tested, token: (tested, []))
+    port_tester.test_many = mocker.AsyncMock(side_effect=lambda session, host, tested, token, log_ctx=None: (tested, []))
 
     verifier = SemiBatchVerifier(port_tester, runner)
 
@@ -110,7 +110,7 @@ async def test_semi_batch_busy_port_fails_only_its_own_chunk(mocker):
     runner.cleanup = mocker.AsyncMock()
 
     port_tester = mocker.Mock()
-    port_tester.test_many = mocker.AsyncMock(side_effect=lambda session, host, tested, token: (tested, []))
+    port_tester.test_many = mocker.AsyncMock(side_effect=lambda session, host, tested, token, log_ctx=None: (tested, []))
 
     verifier = SemiBatchVerifier(port_tester, runner)
 


### PR DESCRIPTION
## Summary

`specs.verified_ports` does not measure the executor. It measures whether the validator's HTTP
client can hold 300 concurrent connections on a 100-slot pool, which it cannot. This PR widens the
connector, replaces the cumulative per-request timeout with a per-operation one, and logs how long
each probe wave actually took.

### Task Link

[DAH-2732](https://www.notion.so/3c2b8bfdbde9815daaabf94101ee3134)

---

## Problem

Across unrented snapshots in `executor_specs_history` the verified-port counts do not spread — they
land on exactly 100 / 200 / 300 in 78.7% of samples, and within +/-2 of one of those in 87%.
Measured against each node's own baseline (deviation threshold 20 ports, unrented snapshots only):

| window | nodes | never deviate | snapshots losing ports |
|---|---|---|---|
| 24 h | 129 | 62.8% | 6.9% (508 / 7 336) |
| 7 days | 287 | 44.9% | 8.2% (4 968 / 60 667) |

The median machine is fine on almost every cycle, but over a week more than half the fleet is hit
at least once, and a hit costs a third or two thirds of its ports at a stroke. A node that has just
lost 200 ports is published to the market with a port count it does not have.

Root cause: `PortTester.test_many` gathers 300 independent HTTP GETs over a bare
`aiohttp.ClientSession()`. With no connector passed, the session gets the default
`TCPConnector(limit=100)` — at most 100 sockets are open at a time, and the other 200 requests sit
in the connector's queue. Each request carried `ClientTimeout(total=3)`, and `total` is cumulative:
its clock starts *before* pool acquisition, not when a socket is handed out. A queued request
therefore burns its whole 3-second budget waiting for a slot and is recorded as a dead port without
a packet ever leaving the validator; `except Exception: return False` in `test_one` hides it.

If one probe takes R seconds, wave 2 finishes near 2R and wave 3 near 3R, so the shared deadline
picks the count: R < 1.0 s gives 300, R 1.0-1.5 s gives exactly 200, R 1.5-3.0 s gives exactly 100.
R is a latency measurement, not a health measurement — TCP handshake plus HTTP request/response
answered by a busybox `nc -l -p` on a loaded GPU box. Machines flip bands because R sits near a
boundary and ordinary jitter carries it across.

Two competing explanations were tested and refuted: silent ports do not starve later waves (30
silent ports out of 300 cost exactly 30 verified ports and nothing more), and there is no
fleet-wide synchronised dip by hour, which rules out validator-side load.

## Solution

1. Both concurrent verifiers get a connector wide enough for the batch —
   `aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=0))`. With no queue there is no
   queue wait.
2. `ClientTimeout(total=3)` becomes `ClientTimeout(sock_connect=3, sock_read=3)`, so the clock only
   runs on real network operations. The timeout is deliberately **not** removed: without one a
   probe would hang until the outer 60-second `asyncio.wait_for` in `BatchVerifier.verify` fires,
   and that path returns zero verified ports — strictly worse than the current behaviour.
3. `test_many` now times the whole wave and every individual probe, and logs it with executor
   context, so R becomes directly observable in Loki instead of being inferred from port counts:

   ```
   probed 300 ports in 1.84s: 300 ok, per-probe med=0.61s p95=0.94s max=1.12s
   ```

## Changes

- `port_tester.py`: module-level `PROBE_TIMEOUT` with per-operation budgets; `test_many` takes an
  optional `log_ctx`, measures wall clock and per-probe durations, and logs med / p95 / max.
- `port_verifiers.py`: `BatchVerifier._attempt` and `SemiBatchVerifier._verify_chunk` build their
  session with `TCPConnector(limit=0)` and pass `log_ctx` through to `test_many`.
  `FallbackVerifier` is untouched — it is sequential over at most 10 ports, so the pool never
  mattered there.
- `tests/executor_connectivity/test_port_verifiers.py`: two `test_many` mocks accept the new
  `log_ctx` argument.

## Deployment Steps

Use GitHub Action. No migration, no config change, no coordinated release with other repos.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

None — the change is contained in the validator.

## Risks

- **300 simultaneous sockets per executor instead of 100.** The validator probes executors
  concurrently, so peak file-descriptor usage on the validator pod rises. The listeners on the far
  side already exist (one container forks `nc -l -p` on all 300 ports regardless), so this adds no
  load on the executor.
- **Worst-case probe time per port rises from 3 s to ~6 s** (`sock_connect` and `sock_read` are
  separate budgets). The outer `asyncio.wait_for(..., 60)` in `BatchVerifier.verify` still bounds
  the attempt, and the whole wave now runs in parallel rather than in three serial batches, so the
  wave should finish sooner, not later.
- **Port counts will jump upward on rollout** for machines that were reporting 100 or 200. That is
  the intended correction, but anything downstream that treats a rising port count as suspicious
  (miner scoring, spec-truth alerts) will see a step change fleet-wide in the first cycle after
  deploy.
- Low blast radius otherwise: the gate is `MIN_PORT_COUNT = 3` and only applies to unrented
  machines, so the old behaviour was not delisting anyone — it was corrupting the stored spec.

## Test Cases

### Test Case 1 — the quantisation disappears

**Actions**

`untracked/scripts/check_port_probe_pool.py` (monorepo, not this repo) starts 300 local listeners
that answer after R seconds and probes them with the old shape and the shipped shape.

**Expected Output**

```
  R (s) | old (total=3) |  shipped
   0.05 |           300 |      300
   0.90 |           300 |      300
   1.10 |           200 |      300
   1.60 |           100 |      300
   2.00 |           100 |      300
```

The old shape collapses to 200 and then 100 as R crosses 1.0 s and 1.5 s; the shipped shape holds
300 throughout.

### Test Case 2 — the silent-port hypothesis stays refuted

**Actions**

`untracked/scripts/check_port_probe_deadports.py` spreads 0 / 1 / 3 / 10 / 30 silent ports (accept,
never answer) across the 300 and probes with both shapes.

**Expected Output**

Each silent port costs exactly one verified port and nothing more — 300 / 299 / 297 / 290 / 270 in
both shapes. A handful of dead ports does not starve the remaining probes.

### Test Case 3 — regression suite

**Actions**

`cd neurons/validators && pdm run pytest`

**Expected Output**

1662 passed, 9 skipped. The 3 failures in `tests/test_sshd_bootstrap_script.py` are pre-existing —
verified they fail identically on `main` at `e1198c41`.

### Test Case 4 — the new log line on staging

**Actions**

Deploy to staging, wait for a validation round, then query Loki:
`{namespace="staging-subnet"} |= "probed" |= "per-probe"`.

**Expected Output**

One line per executor per round carrying the wave wall clock and the med / p95 / max per-probe
latency, with the executor id in the structured extras.

## Checklist

- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
- [ ] Proper labels — `ready-review` / `require-qa` / `breaking-changes` do not exist in
  `Datura-ai/lium-io` (only `bug`, `enhancement`, `possible-revisit`, `ready_for_deploy`, and the
  GitHub defaults), so none were added.
