### PR TITLE
DAH-2742: stop transient checks from clearing verified job info

### DIFF
--- a/neurons/validators/src/services/task/checks/cpu_truth.py
+++ b/neurons/validators/src/services/task/checks/cpu_truth.py
@@ -77,14 +77,10 @@ class CpuTruthCheck:
             # The check is non-fatal, so passed=False alone changes nothing in the pipeline, and
             # zeroing `score` here would be overwritten by ScoreCheck further down. The verdict
             # travels as a context flag that calculate_scores gates on, like the TDX one.
-            updates = (
-                {
-                    "cpu_truth_passed": False,
-                    "clear_verified_job_info": True,
-                }
-                if enforce
-                else {}
-            )
+            # DAH-2742: no clear_verified_job_info. The kernel-present read can race a
+            # measurement window inside CPU_TRUTH_MARGIN_CORES, so an instant flip on a benign
+            # race is not warranted; a real understatement fails every cycle.
+            updates = {"cpu_truth_passed": False} if enforce else {}
             return CheckResult(passed=not enforce, event=event, updates=updates)
 
         event = render_message(Msg.CPU_OK, ctx=ctx, check_id=self.check_id, what=what)

--- a/neurons/validators/src/services/task/checks/cpu_truth.py
+++ b/neurons/validators/src/services/task/checks/cpu_truth.py
@@ -77,9 +77,8 @@ class CpuTruthCheck:
             # The check is non-fatal, so passed=False alone changes nothing in the pipeline, and
             # zeroing `score` here would be overwritten by ScoreCheck further down. The verdict
             # travels as a context flag that calculate_scores gates on, like the TDX one.
-            # DAH-2742: no clear_verified_job_info. The verdict still zeroes the score through
-            # cpu_truth_passed, and a host that really understates its cores fails every cycle, so
-            # the ordinary stale-executor sweep deactivates it without an instant flip.
+            # DAH-2742: the verification is deliberately kept — a host that really overstates its
+            # cores fails every cycle and the stale-executor sweep deactivates it anyway.
             updates = {"cpu_truth_passed": False} if enforce else {}
             return CheckResult(passed=not enforce, event=event, updates=updates)
 

--- a/neurons/validators/src/services/task/checks/cpu_truth.py
+++ b/neurons/validators/src/services/task/checks/cpu_truth.py
@@ -77,10 +77,14 @@ class CpuTruthCheck:
             # The check is non-fatal, so passed=False alone changes nothing in the pipeline, and
             # zeroing `score` here would be overwritten by ScoreCheck further down. The verdict
             # travels as a context flag that calculate_scores gates on, like the TDX one.
-            # DAH-2742: no clear_verified_job_info. The kernel-present read can race a
-            # measurement window inside CPU_TRUTH_MARGIN_CORES, so an instant flip on a benign
-            # race is not warranted; a real understatement fails every cycle.
-            updates = {"cpu_truth_passed": False} if enforce else {}
+            updates = (
+                {
+                    "cpu_truth_passed": False,
+                    "clear_verified_job_info": True,
+                }
+                if enforce
+                else {}
+            )
             return CheckResult(passed=not enforce, event=event, updates=updates)
 
         event = render_message(Msg.CPU_OK, ctx=ctx, check_id=self.check_id, what=what)

--- a/neurons/validators/src/services/task/checks/cpu_truth.py
+++ b/neurons/validators/src/services/task/checks/cpu_truth.py
@@ -77,14 +77,10 @@ class CpuTruthCheck:
             # The check is non-fatal, so passed=False alone changes nothing in the pipeline, and
             # zeroing `score` here would be overwritten by ScoreCheck further down. The verdict
             # travels as a context flag that calculate_scores gates on, like the TDX one.
-            updates = (
-                {
-                    "cpu_truth_passed": False,
-                    "clear_verified_job_info": True,
-                }
-                if enforce
-                else {}
-            )
+            # DAH-2742: no clear_verified_job_info. The verdict still zeroes the score through
+            # cpu_truth_passed, and a host that really understates its cores fails every cycle, so
+            # the ordinary stale-executor sweep deactivates it without an instant flip.
+            updates = {"cpu_truth_passed": False} if enforce else {}
             return CheckResult(passed=not enforce, event=event, updates=updates)
 
         event = render_message(Msg.CPU_OK, ctx=ctx, check_id=self.check_id, what=what)

--- a/neurons/validators/src/services/task/checks/nvml_digest.py
+++ b/neurons/validators/src/services/task/checks/nvml_digest.py
@@ -33,8 +33,8 @@ class NvmlDigestCheck:
                 # have never seen against NVIDIA's official installer. Skip versions already
                 # confirmed as spoofs so we don't re-report a known-invalid driver.
                 invalid_drivers = ctx.config.nvml_invalid_drivers or []
-                confirmed_spoof = driver_version in invalid_drivers
-                if not confirmed_spoof:
+                is_confirmed_spoof = driver_version in invalid_drivers
+                if not is_confirmed_spoof:
                     await ctx.services.backend.report_unknown_driver(driver_version)
                 event = render_message(
                     Msg.DRIVER_UNKNOWN,
@@ -46,11 +46,10 @@ class NvmlDigestCheck:
                     },
                 )
                 # DAH-2742: an unrecognized driver only means the digest map has not caught up
-                # with a newer NVIDIA release, and the reactive report above already refers it to
-                # the backend, so it waits out the ordinary four-strike path instead of flipping
-                # the executor instantly. A driver the backend already confirmed as a spoof is a
-                # hard fact and keeps the instant reset, like DIGEST_MISMATCH.
-                updates = {"clear_verified_job_info": True} if confirmed_spoof else {}
+                # with a newer NVIDIA release, so it keeps its verification and waits for the
+                # stale-executor sweep. A confirmed spoof is a hard fact — instant reset, like
+                # DIGEST_MISMATCH.
+                updates = {"clear_verified_job_info": True} if is_confirmed_spoof else {}
             else:
                 # Driver is known but digest doesn't match - possible tampering
                 event = render_message(

--- a/neurons/validators/src/services/task/checks/nvml_digest.py
+++ b/neurons/validators/src/services/task/checks/nvml_digest.py
@@ -33,7 +33,8 @@ class NvmlDigestCheck:
                 # have never seen against NVIDIA's official installer. Skip versions already
                 # confirmed as spoofs so we don't re-report a known-invalid driver.
                 invalid_drivers = ctx.config.nvml_invalid_drivers or []
-                if driver_version not in invalid_drivers:
+                confirmed_spoof = driver_version in invalid_drivers
+                if not confirmed_spoof:
                     await ctx.services.backend.report_unknown_driver(driver_version)
                 event = render_message(
                     Msg.DRIVER_UNKNOWN,
@@ -44,10 +45,12 @@ class NvmlDigestCheck:
                         "actual_md5": lib_digest,
                     },
                 )
-                # DAH-2742: no clear_verified_job_info. An unrecognized driver only means the
-                # digest map has not caught up with a newer NVIDIA release, and the reactive
-                # report above already refers it to the backend. Tampering is DIGEST_MISMATCH.
-                updates = {}
+                # DAH-2742: an unrecognized driver only means the digest map has not caught up
+                # with a newer NVIDIA release, and the reactive report above already refers it to
+                # the backend, so it waits out the ordinary four-strike path instead of flipping
+                # the executor instantly. A driver the backend already confirmed as a spoof is a
+                # hard fact and keeps the instant reset, like DIGEST_MISMATCH.
+                updates = {"clear_verified_job_info": True} if confirmed_spoof else {}
             else:
                 # Driver is known but digest doesn't match - possible tampering
                 event = render_message(

--- a/neurons/validators/src/services/task/checks/nvml_digest.py
+++ b/neurons/validators/src/services/task/checks/nvml_digest.py
@@ -44,6 +44,10 @@ class NvmlDigestCheck:
                         "actual_md5": lib_digest,
                     },
                 )
+                # DAH-2742: no clear_verified_job_info. An unrecognized driver only means the
+                # digest map has not caught up with a newer NVIDIA release, and the reactive
+                # report above already refers it to the backend. Tampering is DIGEST_MISMATCH.
+                updates = {}
             else:
                 # Driver is known but digest doesn't match - possible tampering
                 event = render_message(
@@ -56,10 +60,11 @@ class NvmlDigestCheck:
                         "actual_md5": lib_digest,
                     },
                 )
+                updates = {"clear_verified_job_info": True}
             return CheckResult(
                 passed=False,
                 event=event,
-                updates={"clear_verified_job_info": True},
+                updates=updates,
             )
 
         event = render_message(

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -310,9 +310,6 @@ class RentalVerificationCheck:
                     },
                     extra={"gpu_runtime_issue_code": response.reason_code},
                 )
-                # DAH-2742: no clear_verified_job_info. The backend health probe creates a real
-                # container and can lose that race transiently, so zeroing the score is warranted
-                # but an instant executor flip is not.
                 return CheckResult(
                     passed=False,
                     event=event,
@@ -320,6 +317,7 @@ class RentalVerificationCheck:
                         "score": 0.0,
                         "job_score": 0.0,
                         "score_warning": quarantine.score_warning,
+                        "clear_verified_job_info": True,
                     },
                 )
             else:
@@ -392,14 +390,12 @@ class RentalVerificationCheck:
                 "details": details,
             },
         )
-        # DAH-2742: no clear_verified_job_info. The docker --cpus verdict comes from a real
-        # container the probe has to win a race for, so zeroing the score is warranted but an
-        # instant executor flip on a transient loss is not.
         updates = (
             {
                 "score": 0.0,
                 "job_score": 0.0,
                 "score_warning": "Advertised CPU cores exceed the host's physical cores",
+                "clear_verified_job_info": True,
             }
             if enforce
             else {}

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -367,8 +367,9 @@ class RentalVerificationCheck:
         """Render the CPU-quota verdict: the host's daemon refused `--cpus=<advertised>` at create.
 
         Shadow (enforcement off) logs the verdict as a warning and keeps passed=True so scoring is
-        unchanged; enforcement zeroes the score and clears the verified job, the same quarantine the
-        GPU runtime faults use.
+        unchanged; enforcement zeroes the score. DAH-2742: unlike the GPU runtime quarantine, the
+        previous verification is kept — a host that really overstates its cores fails every cycle
+        and the stale-executor sweep deactivates it without an instant flip.
         """
         enforce = settings.RENTAL_CPU_LIMIT_ENFORCEMENT_ENABLED
         details = response.details or {}
@@ -390,9 +391,6 @@ class RentalVerificationCheck:
                 "details": details,
             },
         )
-        # DAH-2742: no clear_verified_job_info. Zeroing the score already fails the cycle, and a
-        # host that really overstates its cores fails every cycle, so the ordinary stale-executor
-        # sweep deactivates it without an instant flip.
         updates = (
             {
                 "score": 0.0,

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -390,12 +390,14 @@ class RentalVerificationCheck:
                 "details": details,
             },
         )
+        # DAH-2742: no clear_verified_job_info. Zeroing the score already fails the cycle, and a
+        # host that really overstates its cores fails every cycle, so the ordinary stale-executor
+        # sweep deactivates it without an instant flip.
         updates = (
             {
                 "score": 0.0,
                 "job_score": 0.0,
                 "score_warning": "Advertised CPU cores exceed the host's physical cores",
-                "clear_verified_job_info": True,
             }
             if enforce
             else {}

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -310,6 +310,9 @@ class RentalVerificationCheck:
                     },
                     extra={"gpu_runtime_issue_code": response.reason_code},
                 )
+                # DAH-2742: no clear_verified_job_info. The backend health probe creates a real
+                # container and can lose that race transiently, so zeroing the score is warranted
+                # but an instant executor flip is not.
                 return CheckResult(
                     passed=False,
                     event=event,
@@ -317,7 +320,6 @@ class RentalVerificationCheck:
                         "score": 0.0,
                         "job_score": 0.0,
                         "score_warning": quarantine.score_warning,
-                        "clear_verified_job_info": True,
                     },
                 )
             else:
@@ -390,12 +392,14 @@ class RentalVerificationCheck:
                 "details": details,
             },
         )
+        # DAH-2742: no clear_verified_job_info. The docker --cpus verdict comes from a real
+        # container the probe has to win a race for, so zeroing the score is warranted but an
+        # instant executor flip on a transient loss is not.
         updates = (
             {
                 "score": 0.0,
                 "job_score": 0.0,
                 "score_warning": "Advertised CPU cores exceed the host's physical cores",
-                "clear_verified_job_info": True,
             }
             if enforce
             else {}

--- a/neurons/validators/src/services/task/checks/sysbox_required.py
+++ b/neurons/validators/src/services/task/checks/sysbox_required.py
@@ -36,10 +36,14 @@ class SysboxRequiredCheck:
                 check_id=self.check_id,
                 what={"sysbox_runtime": ctx.state.sysbox_runtime, "is_rented": is_rented},
             )
+            # DAH-2742: no clear_verified_job_info. The DinD probe is forced to False on ANY
+            # probe failure (executor_connectivity/orchestrator.py:78-83), not only on a genuinely
+            # missing runtime, so a transient miss must not flip the executor instantly. A real
+            # missing runtime fails every cycle and the stale-executor sweep deactivates it.
             return CheckResult(
                 passed=False,
                 event=event,
-                updates={"clear_verified_job_info": True},
+                updates={},
             )
 
         event = render_message(

--- a/neurons/validators/src/services/task/checks/sysbox_required.py
+++ b/neurons/validators/src/services/task/checks/sysbox_required.py
@@ -12,8 +12,8 @@ class SysboxRequiredCheck:
 
     DAH-2313: sysbox is required to be allowed on the network. A machine that has no sysbox
     AND is not currently rented is rejected here (fatal) so the pipeline halts before scoring
-    and the executor is reported with a zero score / cleared verification. Already-rented
-    no-sysbox machines are left untouched so live rentals are never disrupted.
+    and the executor is reported with a zero score. Already-rented no-sysbox machines are left
+    untouched so live rentals are never disrupted.
     """
 
     check_id = "executor.validate.sysbox_required"
@@ -36,15 +36,10 @@ class SysboxRequiredCheck:
                 check_id=self.check_id,
                 what={"sysbox_runtime": ctx.state.sysbox_runtime, "is_rented": is_rented},
             )
-            # DAH-2742: no clear_verified_job_info. The DinD probe is forced to False on ANY
-            # probe failure (executor_connectivity/orchestrator.py:78-83), not only on a genuinely
-            # missing runtime, so a transient miss must not flip the executor instantly. A real
-            # missing runtime fails every cycle and the stale-executor sweep deactivates it.
-            return CheckResult(
-                passed=False,
-                event=event,
-                updates={},
-            )
+            # DAH-2742: the verification is deliberately kept. ConnectivityOrchestrator.verify
+            # forces sysbox_runtime=False whenever the DinD probe fails at all, not only on a
+            # genuinely missing runtime, so a transient miss must not flip the executor instantly.
+            return CheckResult(passed=False, event=event)
 
         event = render_message(
             Msg.SYSBOX_OK,

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -312,7 +312,7 @@ class NvmlDigestMessages:
         reason="NVML_DRIVER_UNKNOWN",
         severity="error",
         category="env",
-        impact="Score set to 0; previous verification cleared",
+        impact="Score set to 0 for this cycle; the previous verification is kept",
         remediation="Update to a supported NVIDIA driver version. Your current driver version is not recognized.",
     )
     DIGEST_OK = MessageTemplate(
@@ -410,7 +410,7 @@ class SysboxRequiredMessages:
         reason="SYSBOX_REQUIRED_MISSING",
         severity="warning",
         category="policy",
-        impact="Score set to 0; verification cleared; executor kept off the network",
+        impact="Score set to 0 for this cycle; the previous verification is kept; repeated failures take the executor off the network",
         remediation="Install the sysbox runtime; unrented machines without sysbox are not allowed on the network.",
     )
     SYSBOX_OK = MessageTemplate(

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -312,7 +312,7 @@ class NvmlDigestMessages:
         reason="NVML_DRIVER_UNKNOWN",
         severity="error",
         category="env",
-        impact="Score set to 0 for this cycle; the previous verification is kept",
+        impact="Score set to 0 for this cycle",
         remediation="Update to a supported NVIDIA driver version. Your current driver version is not recognized.",
     )
     DIGEST_OK = MessageTemplate(
@@ -410,7 +410,7 @@ class SysboxRequiredMessages:
         reason="SYSBOX_REQUIRED_MISSING",
         severity="warning",
         category="policy",
-        impact="Score set to 0 for this cycle; the previous verification is kept; repeated failures take the executor off the network",
+        impact="Score set to 0 for this cycle; verification is kept until repeated failures deactivate the executor",
         remediation="Install the sysbox runtime; unrented machines without sysbox are not allowed on the network.",
     )
     SYSBOX_OK = MessageTemplate(

--- a/neurons/validators/tests/test_cpu_truth_check.py
+++ b/neurons/validators/tests/test_cpu_truth_check.py
@@ -118,7 +118,7 @@ async def test_mismatch_fails_under_enforcement(context_factory):
     # The check is non-fatal and ScoreCheck runs after it, so the verdict travels as a context
     # flag calculate_scores gates on — see test_mismatch_zeroes_the_final_score.
     assert result.updates["cpu_truth_passed"] is False
-    assert "clear_verified_job_info" not in result.updates
+    assert result.updates["clear_verified_job_info"] is True
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_cpu_truth_check.py
+++ b/neurons/validators/tests/test_cpu_truth_check.py
@@ -118,7 +118,7 @@ async def test_mismatch_fails_under_enforcement(context_factory):
     # The check is non-fatal and ScoreCheck runs after it, so the verdict travels as a context
     # flag calculate_scores gates on — see test_mismatch_zeroes_the_final_score.
     assert result.updates["cpu_truth_passed"] is False
-    assert result.updates["clear_verified_job_info"] is True
+    assert "clear_verified_job_info" not in result.updates
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_nvml_digest_check.py
+++ b/neurons/validators/tests/test_nvml_digest_check.py
@@ -139,6 +139,9 @@ async def test_known_spoof_driver_is_not_reported(context_factory):
 
     assert result.event.reason_code == Msg.DRIVER_UNKNOWN.reason
     services.backend.report_unknown_driver.assert_not_awaited()
+    # DAH-2742: a confirmed spoof is a hard fact, so it keeps the instant reset that an
+    # unrecognized-but-innocent driver no longer gets.
+    assert result.updates["clear_verified_job_info"] is True
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_nvml_digest_check.py
+++ b/neurons/validators/tests/test_nvml_digest_check.py
@@ -43,7 +43,7 @@ from tests.helpers import build_context_config, build_services, build_state
             {"535.183.01": "58fc46eefa8ebb265293556951a75a39:67185f510159acdc8f38b768b059bfb0f3ec5869baaffd1dc1c949e52012b18f"},
             False,
             Msg.DRIVER_UNKNOWN.reason,
-            True,
+            False,  # DAH-2742: unknown driver is not tampering
         ),
         # Real-world unknown driver case - 535.274.02
         (
@@ -52,7 +52,7 @@ from tests.helpers import build_context_config, build_services, build_state
             {"535.183.01": "58fc46eefa8ebb265293556951a75a39:67185f510159acdc8f38b768b059bfb0f3ec5869baaffd1dc1c949e52012b18f"},
             False,
             Msg.DRIVER_UNKNOWN.reason,
-            True,
+            False,  # DAH-2742: unknown driver is not tampering
         ),
         # Empty digest - should fail if driver version is known
         (

--- a/neurons/validators/tests/test_nvml_digest_check.py
+++ b/neurons/validators/tests/test_nvml_digest_check.py
@@ -139,8 +139,8 @@ async def test_known_spoof_driver_is_not_reported(context_factory):
 
     assert result.event.reason_code == Msg.DRIVER_UNKNOWN.reason
     services.backend.report_unknown_driver.assert_not_awaited()
-    # DAH-2742: a confirmed spoof is a hard fact, so it keeps the instant reset that an
-    # unrecognized-but-innocent driver no longer gets.
+    # DAH-2742: a confirmed spoof keeps the instant reset that an unrecognized-but-innocent
+    # driver no longer gets.
     assert result.updates["clear_verified_job_info"] is True
 
 

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -193,7 +193,7 @@ async def test_rental_verification_failed():
 
 
 @pytest.mark.asyncio
-async def test_rental_verification_nvml_mismatch_quarantines_without_clearing_verified_job():
+async def test_rental_verification_nvml_mismatch_clears_verified_job_info():
     """Exact GPU runtime mismatch should mark the executor unhealthy."""
     stderr = (
         "docker: Error response from daemon: failed to create task for container: "
@@ -221,7 +221,7 @@ async def test_rental_verification_nvml_mismatch_quarantines_without_clearing_ve
     assert result.event.reason_code == GPU_RUNTIME_NVML_MISMATCH_REASON
     assert result.event.what_we_saw["source"] == "rental_verification"
     assert "failed to initialize NVML" in result.event.what_we_saw["stderr"]
-    assert "clear_verified_job_info" not in result.updates
+    assert result.updates["clear_verified_job_info"] is True
     assert "clear_verified_job_reason" not in result.updates
 
 
@@ -251,7 +251,7 @@ async def test_rental_verification_device_fault_quarantines_the_host_too():
     assert result.passed is False
     assert result.event.reason_code == GPU_RUNTIME_DEVICE_FAULT_REASON
     assert result.updates["score"] == 0.0
-    assert "clear_verified_job_info" not in result.updates
+    assert result.updates["clear_verified_job_info"] is True
     assert "unknown device" in result.event.what_we_saw["stderr"]
 
 
@@ -1079,7 +1079,7 @@ async def test_cpu_quota_verdict_zeroes_score_under_enforcement():
     assert result.event.reason_code == CPU_QUOTA_EXCEEDS_HOST_REASON
     assert result.updates["score"] == 0.0
     assert result.updates["job_score"] == 0.0
-    assert "clear_verified_job_info" not in result.updates
+    assert result.updates["clear_verified_job_info"] is True
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -1079,7 +1079,7 @@ async def test_cpu_quota_verdict_zeroes_score_under_enforcement():
     assert result.event.reason_code == CPU_QUOTA_EXCEEDS_HOST_REASON
     assert result.updates["score"] == 0.0
     assert result.updates["job_score"] == 0.0
-    assert result.updates["clear_verified_job_info"] is True
+    assert "clear_verified_job_info" not in result.updates
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -193,7 +193,7 @@ async def test_rental_verification_failed():
 
 
 @pytest.mark.asyncio
-async def test_rental_verification_nvml_mismatch_clears_verified_job_info():
+async def test_rental_verification_nvml_mismatch_quarantines_without_clearing_verified_job():
     """Exact GPU runtime mismatch should mark the executor unhealthy."""
     stderr = (
         "docker: Error response from daemon: failed to create task for container: "
@@ -221,7 +221,7 @@ async def test_rental_verification_nvml_mismatch_clears_verified_job_info():
     assert result.event.reason_code == GPU_RUNTIME_NVML_MISMATCH_REASON
     assert result.event.what_we_saw["source"] == "rental_verification"
     assert "failed to initialize NVML" in result.event.what_we_saw["stderr"]
-    assert result.updates["clear_verified_job_info"] is True
+    assert "clear_verified_job_info" not in result.updates
     assert "clear_verified_job_reason" not in result.updates
 
 
@@ -251,7 +251,7 @@ async def test_rental_verification_device_fault_quarantines_the_host_too():
     assert result.passed is False
     assert result.event.reason_code == GPU_RUNTIME_DEVICE_FAULT_REASON
     assert result.updates["score"] == 0.0
-    assert result.updates["clear_verified_job_info"] is True
+    assert "clear_verified_job_info" not in result.updates
     assert "unknown device" in result.event.what_we_saw["stderr"]
 
 
@@ -1079,7 +1079,7 @@ async def test_cpu_quota_verdict_zeroes_score_under_enforcement():
     assert result.event.reason_code == CPU_QUOTA_EXCEEDS_HOST_REASON
     assert result.updates["score"] == 0.0
     assert result.updates["job_score"] == 0.0
-    assert result.updates["clear_verified_job_info"] is True
+    assert "clear_verified_job_info" not in result.updates
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_sysbox_required_check.py
+++ b/neurons/validators/tests/test_sysbox_required_check.py
@@ -28,7 +28,7 @@ def _rented_data() -> RentedExecutorsResponse:
 
 @pytest.mark.asyncio
 async def test_no_sysbox_unrented_fails(context_factory):
-    """Unrented executor without sysbox is rejected, but its verification is NOT cleared."""
+    """Unrented executor without sysbox is rejected, but its verification is kept."""
     ctx = context_factory(state=build_state(sysbox_runtime=False))
 
     result = await SysboxRequiredCheck().run(ctx)

--- a/neurons/validators/tests/test_sysbox_required_check.py
+++ b/neurons/validators/tests/test_sysbox_required_check.py
@@ -28,14 +28,14 @@ def _rented_data() -> RentedExecutorsResponse:
 
 @pytest.mark.asyncio
 async def test_no_sysbox_unrented_fails(context_factory):
-    """Unrented executor without sysbox is rejected and its verification is cleared."""
+    """Unrented executor without sysbox is rejected, but its verification is NOT cleared."""
     ctx = context_factory(state=build_state(sysbox_runtime=False))
 
     result = await SysboxRequiredCheck().run(ctx)
 
     assert result.passed is False
     assert result.event.reason_code == Msg.SYSBOX_MISSING.reason
-    assert result.updates["clear_verified_job_info"] is True
+    assert "clear_verified_job_info" not in result.updates
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A check that returns `updates={"clear_verified_job_info": True}` makes the backend deactivate the
executor immediately and fire `EXECUTOR_INACTIVE_MID_RENTAL` when a rental is open. Without that
flag a failed cycle is self-healing: score 0 means no spec upsert, `updated_at` freezes, and the
hourly sweep only deactivates after a full hour — four consecutive failures. A signal that flaps
once never gets there.

Four branches were taking the instant door on a signal that can be wrong while the host is fine, or
that the ordinary path already handles. They no longer set the flag. Everything else keeps it.

Executor `9cb90025-0314-445f-8fb2-e63355a5f958` logged 93 `SYSBOX_REQUIRED_OK` against 3
`SYSBOX_REQUIRED_MISSING` in the 24h to 2026-08-21T02:30Z, with an OK cycle 14 minutes after the
miss at 01:42:52Z. Each miss deactivated a healthy machine. `sysbox_runtime` is forced to `False`
by `ConnectivityOrchestrator.verify` on *any* DinD probe failure — an SSH timeout included — not
only on a genuinely missing runtime.

### What changed

| branch | instant reset | why |
|---|---|---|
| `SysboxRequiredCheck` | **dropped** | the DinD probe reports "no sysbox" for any probe failure |
| `NvmlDigestCheck`, driver absent from the digest map | **dropped** | our map lagging behind an NVIDIA release is not evidence of tampering |
| `NvmlDigestCheck`, driver on `nvml_invalid_drivers` | kept | the backend already confirmed that one as a spoof |
| `NvmlDigestCheck`, `DIGEST_MISMATCH` | kept | driver known, digest differs — that is tampering |
| `CpuTruthCheck` under enforcement | **dropped** | still zeroes the score through `cpu_truth_passed`; a host that really understates its cores fails every cycle |
| `RentalVerificationCheck`, CPU quota under enforcement | **dropped** | same reasoning; still zeroes the score |
| `RentalVerificationCheck`, GPU-runtime quarantine | kept | see below |
| everything else | kept | ban lists, duplicates, spec and fingerprint pinning, `POD_NOT_RUNNING` |

The two CPU branches ship disabled (`CPU_TRUTH_ENFORCEMENT_ENABLED`,
`RENTAL_CPU_LIMIT_ENFORCEMENT_ENABLED` are both `False`), so those rows are inert in prod today.

Two `impact` strings in `messages.py` promised the miner that verification was cleared, which the
two dropped branches no longer do. Corrected. `result_handler.py`, `redis_service.py`,
`pipeline.py` and compute-app are untouched.

### The GPU-runtime quarantine kept its instant reset

The first pass dropped it and that was wrong:

- The GPU-runtime codes come from specific NVIDIA-hook signatures — `driver/library version
  mismatch`, `requires reset`, `unknown device` — states that persist until a reboot or a host
  reset. The classifier's own comment records hosts failing this way *for weeks across images*, and
  it deliberately excludes renter-controlled output. A generic probe failure never reaches this
  branch; it lands in the `FAILED` branch, which never set the flag. The message also promises "new
  rentals are disabled", and `active=false` is the only thing that actually disables them — score 0
  does not delist.
### The DRIVER_UNKNOWN split

The `DRIVER_UNKNOWN` split came out of the same review: dropping the flag from that whole branch
also softened drivers the backend had already confirmed as spoofs. Since the staleness sweep needs
an unbroken hour, a miner alternating between a spoofed driver and a clean one would refresh
`updated_at` every other cycle and stay listed indefinitely. Now only the never-seen-before case
falls back.

### Why it is safe

`clear_verified_job_info` is read in exactly one place, `result_handler.py:274`. Dropping it routes
these failures into `set_verified_job_info(success=False)`, which preserves the pinned `spec` and
`uuids` exactly as the clear did and only bumps a `failed` counter that nothing reads. The score
path never consults the flag. Both branches keep halting the pipeline and zeroing the score; only
the timing of the deactivation changes.

### What it costs

A genuinely sysbox-less host stays rentable for up to an hour instead of 15 minutes. DAH-2313 was
written as "never appear on the network"; this deliberately relaxes it to "not after four
consecutive failures". Machines pushed onto the hourly sweep meet that sweep's own false positive,
which is DAH-2725 — this PR does not fix that one.

### Verification

`pdm run pytest tests/ -q --tb=short --strict-markers` from `neurons/validators`: 1662 passed, 9
skipped. The 3 failures in `tests/test_sshd_bootstrap_script.py` are identical before and after this
change — BSD `sed` on macOS does not accept the `-i -E` / `I` combination used in
`sshd_bootstrap.sh:215`, so they fail on a clean `main` on any mac. Nothing new broke.

The nvml split is pinned by the existing parametrized table, which carries `DIGEST_MISMATCH` and
`DRIVER_UNKNOWN` rows side by side with opposite expectations, plus an assertion in
`test_known_spoof_driver_is_not_reported`. Every change was checked failing first, then passing.
