### PR TITLE
DAH-2757: confirm a Lium-named container with the backend before calling it foreign

### DIFF
--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -188,6 +188,11 @@ class RentedExecutorsResponse(BaseModel):
 
 class PodRentalActiveResponse(BaseModel):
     active: bool
+    # DAH-2757: the executor the pod belongs to. The answer is about the POD, not about where it
+    # runs, so without this a provider can name a squatter container after a live pod of their
+    # second node. Absent means a backend that predates the field — then the fleet snapshot is the
+    # only owner test we have.
+    executor_id: str | None = None
     rental_closed_at: datetime | None = None
     # DAH-2545: where an encrypted rental volume is mounted in plaintext inside the container.
     # Nothing on the host records it, so without this the validator cannot remount gocryptfs when
@@ -202,6 +207,7 @@ class PodHostRebootRecoveredResponse(BaseModel):
 
 class FillerRunActiveResponse(BaseModel):
     active: bool
+    executor_id: str | None = None  # DAH-2757: the executor the run belongs to, as for the pod above
     status: str | None = None
     started_at: datetime | None = None
 

--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -206,6 +206,14 @@ class FillerRunActiveResponse(BaseModel):
     started_at: datetime | None = None
 
 
+# DAH-2757: the states in which the backend still owns the container. `active` is not enough — the
+# backend sets it for RUNNING alone, and a filler the snapshot missed is usually still STARTING.
+# The terminal states (STOPPED, FAILED, STOP_FAILED, CLEANUP_FAILED) are absent on purpose: a
+# container that outlives its run is an orphan, not a workload we started. Mirrors FillerRunStatus
+# in the backend (models/filler_run.py) — a new transitional state there belongs here too.
+LIVE_FILLER_RUN_STATUSES = frozenset({"STARTING", "RUNNING", "STOPPING"})
+
+
 class ExecutorUptimeResponse(BaseModel):
     executor_ip_address: str
     executor_ip_port: str

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -237,6 +237,10 @@ PREFERRED_POD_PORTS = [20000, 20001, 20002, 20003, 20004, 20005, 20006, 20007, 2
 
 POD_CONTAINER_PREFIX = "pod_"
 FILLER_CONTAINER_PREFIX = "filler_"
+# DAH-2757: filler-run states in which the backend still owns the container. The terminal states
+# (STOPPED, FAILED, STOP_FAILED, CLEANUP_FAILED) are absent on purpose: a container that outlives
+# its run is an orphan, not a workload we started.
+LIVE_FILLER_RUN_STATUSES = frozenset({"STARTING", "RUNNING", "STOPPING"})
 # DAH-2475: prefix of the persistent DPHN model/runtime cache volumes. The backend builds the full
 # name with the model + runtime version baked in; the validator only needs the prefix, to recognise
 # which volumes belong to the cache when sweeping or reclaiming them.

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -237,10 +237,6 @@ PREFERRED_POD_PORTS = [20000, 20001, 20002, 20003, 20004, 20005, 20006, 20007, 2
 
 POD_CONTAINER_PREFIX = "pod_"
 FILLER_CONTAINER_PREFIX = "filler_"
-# DAH-2757: filler-run states in which the backend still owns the container. The terminal states
-# (STOPPED, FAILED, STOP_FAILED, CLEANUP_FAILED) are absent on purpose: a container that outlives
-# its run is an orphan, not a workload we started.
-LIVE_FILLER_RUN_STATUSES = frozenset({"STARTING", "RUNNING", "STOPPING"})
 # DAH-2475: prefix of the persistent DPHN model/runtime cache volumes. The backend builds the full
 # name with the model + runtime version baked in; the validator only needs the prefix, to recognise
 # which volumes belong to the cache when sweeping or reclaiming them.

--- a/neurons/validators/src/services/task/checks/gpu_usage.py
+++ b/neurons/validators/src/services/task/checks/gpu_usage.py
@@ -397,17 +397,21 @@ async def _the_backend_still_owns(ctx: Context, container_name: str) -> bool:
         filler_run: FillerRunActiveResponse | None = await ctx.services.backend.get_filler_run_active(
             backend_issued_id
         )
+        if filler_run is None:
+            return True
+        if not _the_answer_is_about_this_node(ctx, filler_run.executor_id):
+            return False
         # `active` alone means RUNNING. The status carries the two transitional states, which is
         # where a filler the snapshot missed usually sits — but a backend that sends no status
         # must not turn a run it calls active into a foreign workload.
-        if filler_run is None or filler_run.active:
-            return True
-        return filler_run.status in LIVE_FILLER_RUN_STATUSES
+        return filler_run.active or filler_run.status in LIVE_FILLER_RUN_STATUSES
 
     pod_rental: PodRentalActiveResponse | None = await ctx.services.backend.get_pod_rental_active(
         backend_issued_id
     )
-    return pod_rental is None or pod_rental.active
+    if pod_rental is None:
+        return True
+    return _the_answer_is_about_this_node(ctx, pod_rental.executor_id) and pod_rental.active
 
 
 def _uuid_after_prefix(container_name: str, prefix: str) -> str | None:
@@ -423,6 +427,18 @@ def _uuid_after_prefix(container_name: str, prefix: str) -> str | None:
     except ValueError:
         return None
     return canonical_uuid if canonical_uuid == suffix else None
+
+
+def _the_answer_is_about_this_node(ctx: Context, owning_executor_id: str | None) -> bool:
+    """Whether the run the backend described lives on the node the check is looking at.
+
+    The endpoints answer about a run id, which is public on its own host, so a provider with two
+    nodes could name a squatter container after a live run of their honest one. A backend that
+    predates the field sends nothing, and then the fleet snapshot is the only owner test we have.
+    """
+    if owning_executor_id is None:
+        return True
+    return str(owning_executor_id) == str(ctx.executor.uuid)
 
 
 def _containers_claimed_by_another_executor(ctx: Context) -> set[str]:

--- a/neurons/validators/src/services/task/checks/gpu_usage.py
+++ b/neurons/validators/src/services/task/checks/gpu_usage.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from core.config import settings
 from protocol.vc_protocol.compute_requests import (
+    LIVE_FILLER_RUN_STATUSES,
     FillerRunActiveResponse,
     PodRentalActiveResponse,
 )
@@ -14,7 +15,6 @@ from services.const import (
     GPU_MEMORY_UTILIZATION_LIMIT,
     GPU_UTILIZATION_LIMIT,
     GPU_WEDGE_MEMORY_MAX,
-    LIVE_FILLER_RUN_STATUSES,
     POD_CONTAINER_PREFIX,
 )
 from services.gpu_wedge import (
@@ -356,36 +356,46 @@ async def _drop_containers_the_backend_still_owns(
     as foreign at 0% load — 7 honest nodes hit this in the first prod shadow day. The name on
     its own still proves nothing, because `docker rename` forges it, so the id inside the name
     is confirmed against the backend, which disowns an id it never issued.
+
+    One question per container, not per process: a single container holds as many GPU processes
+    as it has workers (8 in one prod pod), and this check sits on the healthy path of every
+    executor in every cycle.
     """
-    confirmed: list[ForeignGpuProcess] = []
-    for process in foreign_processes:
-        if _carries_a_lium_prefix(process) and await _the_backend_still_owns(ctx, process):
-            continue
-        confirmed.append(process)
-    return confirmed
+    lium_named_containers: list[str] = sorted(
+        {process.container_name for process in foreign_processes if _carries_a_lium_prefix(process)}
+    )
+    if not lium_named_containers:
+        return foreign_processes
+
+    ownership_verdicts: list[bool] = await asyncio.gather(
+        *(_the_backend_still_owns(ctx, name) for name in lium_named_containers)
+    )
+    still_ours: set[str] = {
+        name for name, is_ours in zip(lium_named_containers, ownership_verdicts) if is_ours
+    }
+    return [process for process in foreign_processes if process.container_name not in still_ours]
 
 
-async def _the_backend_still_owns(ctx: Context, process: ForeignGpuProcess) -> bool:
+async def _the_backend_still_owns(ctx: Context, container_name: str) -> bool:
     """True when the backend confirms the id inside the container name as a live run of ours.
 
     Mirrors the filler re-check in rental_verification. Fail-open on an unreachable backend
     (a None response): an inability to measure never withholds money here.
     """
-    container_name: str = process.container_name or ""
     is_filler: bool = container_name.startswith(FILLER_CONTAINER_PREFIX)
     prefix: str = FILLER_CONTAINER_PREFIX if is_filler else POD_CONTAINER_PREFIX
-    lium_id: str | None = _uuid_after_prefix(container_name, prefix)
-    if lium_id is None:
+    backend_issued_id: str | None = _uuid_after_prefix(container_name, prefix)
+    if backend_issued_id is None:
         return False
 
     if is_filler:
         filler_run: FillerRunActiveResponse | None = await ctx.services.backend.get_filler_run_active(
-            lium_id
+            backend_issued_id
         )
         return filler_run is None or filler_run.status in LIVE_FILLER_RUN_STATUSES
 
     pod_rental: PodRentalActiveResponse | None = await ctx.services.backend.get_pod_rental_active(
-        lium_id
+        backend_issued_id
     )
     return pod_rental is None or pod_rental.active
 

--- a/neurons/validators/src/services/task/checks/gpu_usage.py
+++ b/neurons/validators/src/services/task/checks/gpu_usage.py
@@ -1,14 +1,20 @@
 import asyncio
 import logging
 from dataclasses import dataclass
+from uuid import UUID
 
 from core.config import settings
+from protocol.vc_protocol.compute_requests import (
+    FillerRunActiveResponse,
+    PodRentalActiveResponse,
+)
 from services.const import (
     FILLER_CONTAINER_PREFIX,
     GPU_HELD_VRAM_MB_LIMIT,
     GPU_MEMORY_UTILIZATION_LIMIT,
     GPU_UTILIZATION_LIMIT,
     GPU_WEDGE_MEMORY_MAX,
+    LIVE_FILLER_RUN_STATUSES,
     POD_CONTAINER_PREFIX,
 )
 from services.gpu_wedge import (
@@ -76,7 +82,9 @@ class GpuUsageCheck:
         Competitor marketplaces (Nodexo/SN106) idle below the percentage limits on purpose: a
         rental holding 22.4 GB at 0% load passes every utilization gate. The expected holders
         come from the backend (`rented_data`), never from a container-name prefix — the whole
-        point of the ticket is a verdict `docker rename` cannot defeat. Shadow by default like
+        point of the ticket is a verdict `docker rename` cannot defeat. A container named like
+        ours but missing from the snapshot is asked about directly (DAH-2757); the prefix only
+        decides whom to ask, the backend still gives the answer. Shadow by default like
         every other money-withholding gate: without FOREIGN_GPU_WORKLOAD_ENFORCEMENT_ENABLED
         the verdict is logged, not scored. Returns None when the card is clean, leaving the
         legacy verdict to the caller.
@@ -101,15 +109,15 @@ class GpuUsageCheck:
             if process.get("container_name") not in workload_containers
             and not _runs_in_the_executors_own_cgroup(process)
         ]
+        foreign_processes = await _drop_containers_the_backend_still_owns(ctx, foreign_processes)
 
         if foreign_processes:
             what = {
                 "foreign_processes": foreign_processes,
                 "process_count": len(gpu_processes),
-                # Review ask (PR #1242): the backend can start a filler AFTER this cycle's
-                # rented_data snapshot. Such a container carries our own prefix but is absent
-                # from the allowlist, so it reads as foreign. Count it separately, so the
-                # shadow week measures how often that race happens before enforcement goes on.
+                # Our own name on a container the backend disowns — the id inside it belongs
+                # to no run it ever issued. Counted separately, because that is the shape a
+                # forged name takes once the late-start race (DAH-2757) is out of the way.
                 "lium_named_outside_snapshot": [
                     process for process in foreign_processes if _carries_a_lium_prefix(process)
                 ],
@@ -336,6 +344,58 @@ def _carries_a_lium_prefix(process: ForeignGpuProcess) -> bool:
     """The container is named like one of ours, but the backend did not report it this cycle."""
     container_name: str = process.container_name or ""
     return container_name.startswith((POD_CONTAINER_PREFIX, FILLER_CONTAINER_PREFIX))
+
+
+async def _drop_containers_the_backend_still_owns(
+    ctx: Context, foreign_processes: list[ForeignGpuProcess]
+) -> list[ForeignGpuProcess]:
+    """Ask the backend about a Lium-named container that this cycle's snapshot does not hold.
+
+    DAH-2757: `rented_data` is read once, at cycle start. A filler or pod the backend starts
+    later in the same cycle carries our own name and is absent from the allowlist, so it reads
+    as foreign at 0% load — 7 honest nodes hit this in the first prod shadow day. The name on
+    its own still proves nothing, because `docker rename` forges it, so the id inside the name
+    is confirmed against the backend, which disowns an id it never issued.
+    """
+    confirmed: list[ForeignGpuProcess] = []
+    for process in foreign_processes:
+        if _carries_a_lium_prefix(process) and await _the_backend_still_owns(ctx, process):
+            continue
+        confirmed.append(process)
+    return confirmed
+
+
+async def _the_backend_still_owns(ctx: Context, process: ForeignGpuProcess) -> bool:
+    """True when the backend confirms the id inside the container name as a live run of ours.
+
+    Mirrors the filler re-check in rental_verification. Fail-open on an unreachable backend
+    (a None response): an inability to measure never withholds money here.
+    """
+    container_name: str = process.container_name or ""
+    is_filler: bool = container_name.startswith(FILLER_CONTAINER_PREFIX)
+    prefix: str = FILLER_CONTAINER_PREFIX if is_filler else POD_CONTAINER_PREFIX
+    lium_id: str | None = _uuid_after_prefix(container_name, prefix)
+    if lium_id is None:
+        return False
+
+    if is_filler:
+        filler_run: FillerRunActiveResponse | None = await ctx.services.backend.get_filler_run_active(
+            lium_id
+        )
+        return filler_run is None or filler_run.status in LIVE_FILLER_RUN_STATUSES
+
+    pod_rental: PodRentalActiveResponse | None = await ctx.services.backend.get_pod_rental_active(
+        lium_id
+    )
+    return pod_rental is None or pod_rental.active
+
+
+def _uuid_after_prefix(container_name: str, prefix: str) -> str | None:
+    """The uuid the backend issued, or None when the name carries something else."""
+    try:
+        return str(UUID(container_name.removeprefix(prefix)))
+    except ValueError:
+        return None
 
 
 def _runs_in_the_executors_own_cgroup(process: dict) -> bool:

--- a/neurons/validators/src/services/task/checks/gpu_usage.py
+++ b/neurons/validators/src/services/task/checks/gpu_usage.py
@@ -361,8 +361,13 @@ async def _drop_containers_the_backend_still_owns(
     as it has workers (8 in one prod pod), and this check sits on the healthy path of every
     executor in every cycle.
     """
+    claimed_elsewhere: set[str] = _containers_claimed_by_another_executor(ctx)
     lium_named_containers: list[str] = sorted(
-        {process.container_name for process in foreign_processes if _carries_a_lium_prefix(process)}
+        {
+            process.container_name
+            for process in foreign_processes
+            if _carries_a_lium_prefix(process) and process.container_name not in claimed_elsewhere
+        }
     )
     if not lium_named_containers:
         return foreign_processes
@@ -392,7 +397,12 @@ async def _the_backend_still_owns(ctx: Context, container_name: str) -> bool:
         filler_run: FillerRunActiveResponse | None = await ctx.services.backend.get_filler_run_active(
             backend_issued_id
         )
-        return filler_run is None or filler_run.status in LIVE_FILLER_RUN_STATUSES
+        # `active` alone means RUNNING. The status carries the two transitional states, which is
+        # where a filler the snapshot missed usually sits — but a backend that sends no status
+        # must not turn a run it calls active into a foreign workload.
+        if filler_run is None or filler_run.active:
+            return True
+        return filler_run.status in LIVE_FILLER_RUN_STATUSES
 
     pod_rental: PodRentalActiveResponse | None = await ctx.services.backend.get_pod_rental_active(
         backend_issued_id
@@ -401,11 +411,44 @@ async def _the_backend_still_owns(ctx: Context, container_name: str) -> bool:
 
 
 def _uuid_after_prefix(container_name: str, prefix: str) -> str | None:
-    """The uuid the backend issued, or None when the name carries something else."""
+    """The uuid the backend issued, or None when the name carries something else.
+
+    Only the canonical spelling counts. `UUID()` also reads an upper-case or dash-less form of
+    the same id, and both are legal docker names — without this test a provider could point a
+    second container at a live run of their own node and have the re-check clear it.
+    """
+    suffix: str = container_name.removeprefix(prefix)
     try:
-        return str(UUID(container_name.removeprefix(prefix)))
+        canonical_uuid: str = str(UUID(suffix))
     except ValueError:
         return None
+    return canonical_uuid if canonical_uuid == suffix else None
+
+
+def _containers_claimed_by_another_executor(ctx: Context) -> set[str]:
+    """Container names this cycle's snapshot gives to a DIFFERENT node of the fleet.
+
+    A run id is public on its own host (`docker ps`), and the backend answers about the RUN, not
+    about where it runs. So a provider with two nodes could name a foreign container after a live
+    filler of their honest node and have the re-check clear it. The snapshot is what separates
+    them: a name another executor already holds is never ours to clear.
+    """
+    rented_data = ctx.state.rented_data
+    our_executor_uuid: str = str(ctx.executor.uuid)
+    claimed: set[str] = set()
+
+    filler_executor_uuids: set[str] = set(rented_data.all_filler_containers_by_executor) | set(
+        rented_data.filler_containers_by_executor
+    )
+    for executor_uuid in filler_executor_uuids - {our_executor_uuid}:
+        claimed.update(rented_data.get_filler_containers(executor_uuid))
+
+    for executor_uuid, rented_executor in rented_data.executors.items():
+        if executor_uuid != our_executor_uuid:
+            claimed.update(pod.container_name for pod in rented_executor.pods)
+
+    claimed.discard("")
+    return claimed
 
 
 def _runs_in_the_executors_own_cgroup(process: dict) -> bool:

--- a/neurons/validators/tests/helpers.py
+++ b/neurons/validators/tests/helpers.py
@@ -6,6 +6,10 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 from datura.requests.miner_requests import ExecutorSSHInfo
+from neurons.validators.src.protocol.vc_protocol.compute_requests import (
+    FillerRunActiveResponse,
+    PodRentalActiveResponse,
+)
 from neurons.validators.src.services.task.pipeline import (
     Context,
     ContextConfig,
@@ -96,6 +100,10 @@ def build_services(**overrides) -> ContextServices:
     pod_recovery = AsyncMock()
     # A bare AsyncMock would report every pod as recovered; opt in per test instead.
     pod_recovery.recover_pod_after_stale_vloopback_mount.return_value = False
+    backend = AsyncMock()
+    # A bare AsyncMock would confirm every Lium-named container as ours (DAH-2757); opt in per test.
+    backend.get_filler_run_active.return_value = FillerRunActiveResponse(active=False)
+    backend.get_pod_rental_active.return_value = PodRentalActiveResponse(active=False)
     base = dict(
         ssh=None,
         redis=None,
@@ -106,7 +114,7 @@ def build_services(**overrides) -> ContextServices:
         connectivity=None,
         shell=None,
         score_calculator=DummyScoreCalc(),
-        backend=AsyncMock(),
+        backend=backend,
         container_cleanup=None,
         pod_recovery=pod_recovery,
     )

--- a/neurons/validators/tests/test_gpu_usage_check.py
+++ b/neurons/validators/tests/test_gpu_usage_check.py
@@ -11,7 +11,7 @@ from neurons.validators.src.services.const import FILLER_CONTAINER_PREFIX, POD_C
 from neurons.validators.src.services.task.checks.gpu_usage import GpuUsageCheck
 from neurons.validators.src.services.task.messages import GpuUsageMessages as Msg
 
-from tests.helpers import build_context_config, build_services, build_state
+from tests.helpers import build_context_config, build_services, build_state, default_executor
 
 
 @contextmanager
@@ -876,3 +876,65 @@ async def test_a_filler_the_backend_calls_active_without_a_status_is_ours(contex
 
     assert result.passed is True
     assert result.event.reason_code == Msg.USAGE_OK.reason
+
+
+@pytest.mark.asyncio
+async def test_a_run_the_backend_places_on_another_node_is_foreign(context_factory):
+    # DAH-2757 follow-up: a run wedged in STARTING leaves the fleet snapshot after 15 minutes, so
+    # the snapshot check cannot see who owns it. The backend now names the owner itself.
+    neighbours_filler = "filler_9622d623-dcb3-4a7c-92c6-ef6c937df3ae"
+    state = _idle_state(
+        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
+        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": neighbours_filler}],
+    )
+    services = build_services()
+    services.backend.get_filler_run_active.return_value = FillerRunActiveResponse(
+        active=True, status="RUNNING", executor_id="another-executor"
+    )
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.FOREIGN_PROCESS.reason
+
+
+@pytest.mark.asyncio
+async def test_a_run_the_backend_places_on_this_node_is_ours(context_factory):
+    late_filler = "filler_9622d623-dcb3-4a7c-92c6-ef6c937df3ae"
+    state = _idle_state(
+        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
+        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": late_filler}],
+    )
+    services = build_services()
+    services.backend.get_filler_run_active.return_value = FillerRunActiveResponse(
+        active=False, status="STARTING", executor_id=default_executor().uuid
+    )
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.USAGE_OK.reason
+
+
+@pytest.mark.asyncio
+async def test_a_pod_the_backend_places_on_another_node_is_foreign(context_factory):
+    neighbours_pod = f"{POD_CONTAINER_PREFIX}bfc8838d-7967-43b0-90b9-2917ffbffe5a"
+    state = _idle_state(
+        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
+        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": neighbours_pod}],
+    )
+    services = build_services()
+    services.backend.get_pod_rental_active.return_value = PodRentalActiveResponse(
+        active=True, executor_id="another-executor"
+    )
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.FOREIGN_PROCESS.reason

--- a/neurons/validators/tests/test_gpu_usage_check.py
+++ b/neurons/validators/tests/test_gpu_usage_check.py
@@ -688,15 +688,55 @@ async def test_failed_live_query_never_withholds(context_factory):
     assert result.event.reason_code == Msg.USAGE_OK.reason
 
 
+LATE_FILLER = "filler_9622d623-dcb3-4a7c-92c6-ef6c937df3ae"
+LATE_POD = f"{POD_CONTAINER_PREFIX}bfc8838d-7967-43b0-90b9-2917ffbffe5a"
+
+
+@pytest.mark.parametrize(
+    "container_name,filler_run,pod_rental,expected_pass",
+    [
+        # DAH-2757: the backend starts a filler or pod AFTER this cycle's rented_data snapshot, so
+        # its container is ours but absent from the allowlist. STARTING is the state the race
+        # usually produces; the backend reports active only for RUNNING.
+        (LATE_FILLER, FillerRunActiveResponse(active=True, status="RUNNING"), None, True),
+        (LATE_FILLER, FillerRunActiveResponse(active=False, status="STARTING"), None, True),
+        (LATE_POD, None, PodRentalActiveResponse(active=True), True),
+        # A container that outlives its run is an orphan. Terminal states buy no pass, or an old
+        # run id of the provider's own node would launder any workload they like.
+        (LATE_FILLER, FillerRunActiveResponse(active=False, status="STOPPED"), None, False),
+        # An id the backend never issued: `docker rename` still buys nothing.
+        (LATE_FILLER, FillerRunActiveResponse(active=False), None, False),
+        (LATE_POD, None, PodRentalActiveResponse(active=False), False),
+        # An unreachable backend is an inability to measure, which never withholds money.
+        (LATE_FILLER, None, None, True),
+    ],
+)
 @pytest.mark.asyncio
-async def test_a_filler_started_after_the_snapshot_is_not_foreign(context_factory):
-    # DAH-2757: the backend can start a filler after this cycle's rented_data snapshot. Its
-    # container is ours, so the backend re-check must clear it and leave only the squatter.
-    late_filler = "filler_9622d623-dcb3-4a7c-92c6-ef6c937df3ae"
+async def test_a_lium_named_container_is_judged_by_the_backend(
+    context_factory, container_name, filler_run, pod_rental, expected_pass
+):
+    state = _idle_state(
+        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
+        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": container_name}],
+        fillers=[FILLER],
+    )
+    services = build_services()
+    services.backend.get_filler_run_active.return_value = filler_run
+    services.backend.get_pod_rental_active.return_value = pod_rental
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is expected_pass
+
+
+@pytest.mark.asyncio
+async def test_only_the_squatter_survives_the_backend_re_check(context_factory):
     state = _idle_state(
         [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
         [
-            {"pid": 111, "info": "0::/../docker-a.scope", "container_name": late_filler},
+            {"pid": 111, "info": "0::/../docker-a.scope", "container_name": LATE_FILLER},
             {"pid": 222, "info": "0::/../docker-b.scope", "container_name": "nodexo-rental-1cd1ba2b"},
         ],
         fillers=[FILLER],
@@ -716,34 +756,15 @@ async def test_a_filler_started_after_the_snapshot_is_not_foreign(context_factor
 
 
 @pytest.mark.asyncio
-async def test_a_filler_mid_transition_is_not_foreign(context_factory):
-    # STARTING is exactly the state the race produces: the run exists, the container is up, and
-    # the cycle's snapshot predates both.
-    late_filler = "filler_9622d623-dcb3-4a7c-92c6-ef6c937df3ae"
+async def test_one_question_per_container_not_per_process(context_factory):
+    # One container holds as many GPU processes as it has workers (8 in one prod pod), and this
+    # check runs on the healthy path of every executor in every cycle.
     state = _idle_state(
         [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
-        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": late_filler}],
-        fillers=[FILLER],
-    )
-    services = build_services()
-    services.backend.get_filler_run_active.return_value = FillerRunActiveResponse(
-        active=False, status="STARTING"
-    )
-    ctx = context_factory(services=services, config=build_context_config(), state=state)
-
-    with foreign_gate():
-        result = await GpuUsageCheck().run(ctx)
-
-    assert result.passed is True
-    assert result.event.reason_code == Msg.USAGE_OK.reason
-
-
-@pytest.mark.asyncio
-async def test_a_pod_started_after_the_snapshot_is_not_foreign(context_factory):
-    late_pod = f"{POD_CONTAINER_PREFIX}bfc8838d-7967-43b0-90b9-2917ffbffe5a"
-    state = _idle_state(
-        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
-        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": late_pod}],
+        [
+            {"pid": pid, "info": "0::/../docker-a.scope", "container_name": LATE_POD}
+            for pid in range(1, 9)
+        ],
     )
     services = build_services()
     services.backend.get_pod_rental_active.return_value = PodRentalActiveResponse(active=True)
@@ -753,48 +774,7 @@ async def test_a_pod_started_after_the_snapshot_is_not_foreign(context_factory):
         result = await GpuUsageCheck().run(ctx)
 
     assert result.passed is True
-    assert result.event.reason_code == Msg.USAGE_OK.reason
-
-
-@pytest.mark.asyncio
-async def test_a_stopped_filler_container_is_still_foreign(context_factory):
-    # A container that outlives its run is an orphan. Only the live states buy a pass, or an old
-    # run id of the provider's own node would launder any workload they like.
-    stale_filler = "filler_9622d623-dcb3-4a7c-92c6-ef6c937df3ae"
-    state = _idle_state(
-        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
-        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": stale_filler}],
-    )
-    services = build_services()
-    services.backend.get_filler_run_active.return_value = FillerRunActiveResponse(
-        active=False, status="STOPPED"
-    )
-    ctx = context_factory(services=services, config=build_context_config(), state=state)
-
-    with foreign_gate():
-        result = await GpuUsageCheck().run(ctx)
-
-    assert result.passed is False
-    assert result.event.reason_code == Msg.FOREIGN_PROCESS.reason
-    assert [p.container_name for p in result.event.what_we_saw["lium_named_outside_snapshot"]] == [
-        stale_filler
-    ]
-
-
-@pytest.mark.asyncio
-async def test_a_forged_filler_id_the_backend_never_issued_still_fails(context_factory):
-    forged = "filler_9622d623-dcb3-4a7c-92c6-ef6c937df3ae"
-    state = _idle_state(
-        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 22400}],
-        [{"pid": 4242, "info": "0::/../docker-a.scope", "container_name": forged}],
-    )
-    ctx = context_factory(services=build_services(), config=build_context_config(), state=state)
-
-    with foreign_gate():
-        result = await GpuUsageCheck().run(ctx)
-
-    assert result.passed is False
-    assert result.event.reason_code == Msg.FOREIGN_PROCESS.reason
+    assert services.backend.get_pod_rental_active.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -812,22 +792,7 @@ async def test_a_lium_name_without_a_uuid_is_never_asked_about(context_factory):
         result = await GpuUsageCheck().run(ctx)
 
     assert result.passed is False
+    assert [p.container_name for p in result.event.what_we_saw["lium_named_outside_snapshot"]] == [
+        "filler_not-a-uuid"
+    ]
     services.backend.get_filler_run_active.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_an_unreachable_backend_never_judges_a_lium_named_container(context_factory):
-    late_filler = "filler_9622d623-dcb3-4a7c-92c6-ef6c937df3ae"
-    state = _idle_state(
-        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
-        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": late_filler}],
-    )
-    services = build_services()
-    services.backend.get_filler_run_active.return_value = None
-    ctx = context_factory(services=services, config=build_context_config(), state=state)
-
-    with foreign_gate():
-        result = await GpuUsageCheck().run(ctx)
-
-    assert result.passed is True
-    assert result.event.reason_code == Msg.USAGE_OK.reason

--- a/neurons/validators/tests/test_gpu_usage_check.py
+++ b/neurons/validators/tests/test_gpu_usage_check.py
@@ -2,7 +2,11 @@ from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from neurons.validators.src.protocol.vc_protocol.compute_requests import RentedExecutorsResponse
+from neurons.validators.src.protocol.vc_protocol.compute_requests import (
+    FillerRunActiveResponse,
+    PodRentalActiveResponse,
+    RentedExecutorsResponse,
+)
 from neurons.validators.src.services.const import POD_CONTAINER_PREFIX
 from neurons.validators.src.services.task.checks.gpu_usage import GpuUsageCheck
 from neurons.validators.src.services.task.messages import GpuUsageMessages as Msg
@@ -685,10 +689,10 @@ async def test_failed_live_query_never_withholds(context_factory):
 
 
 @pytest.mark.asyncio
-async def test_a_filler_started_after_the_snapshot_is_counted_separately(context_factory):
-    # Review ask (PR #1242): the backend can start a filler after this cycle's rented_data
-    # snapshot. It still reads as foreign, but the shadow week must be able to count the case.
-    late_filler = "filler_9622d623-dcb3-27dc-52c6-ef6c937df3ae"
+async def test_a_filler_started_after_the_snapshot_is_not_foreign(context_factory):
+    # DAH-2757: the backend can start a filler after this cycle's rented_data snapshot. Its
+    # container is ours, so the backend re-check must clear it and leave only the squatter.
+    late_filler = "filler_9622d623-dcb3-4a7c-92c6-ef6c937df3ae"
     state = _idle_state(
         [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
         [
@@ -697,11 +701,133 @@ async def test_a_filler_started_after_the_snapshot_is_counted_separately(context
         ],
         fillers=[FILLER],
     )
-    ctx = context_factory(services=build_services(), config=build_context_config(), state=state)
+    services = build_services()
+    services.backend.get_filler_run_active.return_value = FillerRunActiveResponse(
+        active=True, status="RUNNING"
+    )
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
 
     with foreign_gate():
         result = await GpuUsageCheck().run(ctx)
 
     seen = result.event.what_we_saw
-    assert [p.container_name for p in seen["foreign_processes"]] == [late_filler, "nodexo-rental-1cd1ba2b"]
-    assert [p.container_name for p in seen["lium_named_outside_snapshot"]] == [late_filler]
+    assert [p.container_name for p in seen["foreign_processes"]] == ["nodexo-rental-1cd1ba2b"]
+    assert seen["lium_named_outside_snapshot"] == []
+
+
+@pytest.mark.asyncio
+async def test_a_filler_mid_transition_is_not_foreign(context_factory):
+    # STARTING is exactly the state the race produces: the run exists, the container is up, and
+    # the cycle's snapshot predates both.
+    late_filler = "filler_9622d623-dcb3-4a7c-92c6-ef6c937df3ae"
+    state = _idle_state(
+        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
+        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": late_filler}],
+        fillers=[FILLER],
+    )
+    services = build_services()
+    services.backend.get_filler_run_active.return_value = FillerRunActiveResponse(
+        active=False, status="STARTING"
+    )
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.USAGE_OK.reason
+
+
+@pytest.mark.asyncio
+async def test_a_pod_started_after_the_snapshot_is_not_foreign(context_factory):
+    late_pod = f"{POD_CONTAINER_PREFIX}bfc8838d-7967-43b0-90b9-2917ffbffe5a"
+    state = _idle_state(
+        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
+        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": late_pod}],
+    )
+    services = build_services()
+    services.backend.get_pod_rental_active.return_value = PodRentalActiveResponse(active=True)
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.USAGE_OK.reason
+
+
+@pytest.mark.asyncio
+async def test_a_stopped_filler_container_is_still_foreign(context_factory):
+    # A container that outlives its run is an orphan. Only the live states buy a pass, or an old
+    # run id of the provider's own node would launder any workload they like.
+    stale_filler = "filler_9622d623-dcb3-4a7c-92c6-ef6c937df3ae"
+    state = _idle_state(
+        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
+        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": stale_filler}],
+    )
+    services = build_services()
+    services.backend.get_filler_run_active.return_value = FillerRunActiveResponse(
+        active=False, status="STOPPED"
+    )
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.FOREIGN_PROCESS.reason
+    assert [p.container_name for p in result.event.what_we_saw["lium_named_outside_snapshot"]] == [
+        stale_filler
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_forged_filler_id_the_backend_never_issued_still_fails(context_factory):
+    forged = "filler_9622d623-dcb3-4a7c-92c6-ef6c937df3ae"
+    state = _idle_state(
+        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 22400}],
+        [{"pid": 4242, "info": "0::/../docker-a.scope", "container_name": forged}],
+    )
+    ctx = context_factory(services=build_services(), config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.FOREIGN_PROCESS.reason
+
+
+@pytest.mark.asyncio
+async def test_a_lium_name_without_a_uuid_is_never_asked_about(context_factory):
+    # `filler_whatever` cannot be a run the backend issued, and asking would only earn a 422 —
+    # which the client reports as "unreachable" and the gate reads as a pass.
+    state = _idle_state(
+        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 22400}],
+        [{"pid": 4242, "info": "0::/../docker-a.scope", "container_name": "filler_not-a-uuid"}],
+    )
+    services = build_services()
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is False
+    services.backend.get_filler_run_active.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_an_unreachable_backend_never_judges_a_lium_named_container(context_factory):
+    late_filler = "filler_9622d623-dcb3-4a7c-92c6-ef6c937df3ae"
+    state = _idle_state(
+        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
+        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": late_filler}],
+    )
+    services = build_services()
+    services.backend.get_filler_run_active.return_value = None
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.USAGE_OK.reason

--- a/neurons/validators/tests/test_gpu_usage_check.py
+++ b/neurons/validators/tests/test_gpu_usage_check.py
@@ -7,7 +7,7 @@ from neurons.validators.src.protocol.vc_protocol.compute_requests import (
     PodRentalActiveResponse,
     RentedExecutorsResponse,
 )
-from neurons.validators.src.services.const import POD_CONTAINER_PREFIX
+from neurons.validators.src.services.const import FILLER_CONTAINER_PREFIX, POD_CONTAINER_PREFIX
 from neurons.validators.src.services.task.checks.gpu_usage import GpuUsageCheck
 from neurons.validators.src.services.task.messages import GpuUsageMessages as Msg
 
@@ -796,3 +796,83 @@ async def test_a_lium_name_without_a_uuid_is_never_asked_about(context_factory):
         "filler_not-a-uuid"
     ]
     services.backend.get_filler_run_active.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "container_name",
+    [
+        f"{FILLER_CONTAINER_PREFIX}9622D623-DCB3-4A7C-92C6-EF6C937DF3AE",
+        f"{FILLER_CONTAINER_PREFIX}9622d623dcb34a7c92c6ef6c937df3ae",
+    ],
+)
+@pytest.mark.asyncio
+async def test_a_non_canonical_spelling_of_a_live_run_id_is_still_foreign(
+    context_factory, container_name
+):
+    # Both spellings are legal docker names and both parse to the id of a live run, so without a
+    # canonical test a provider could point a second container at their own filler.
+    state = _idle_state(
+        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
+        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": container_name}],
+    )
+    services = build_services()
+    services.backend.get_filler_run_active.return_value = FillerRunActiveResponse(
+        active=True, status="RUNNING"
+    )
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is False
+    services.backend.get_filler_run_active.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_live_run_of_another_executor_is_still_foreign(context_factory):
+    # The backend answers about the run, not about where it runs. A provider with two nodes can
+    # read a live filler id off the honest one and name a foreign container after it.
+    neighbours_filler = "filler_9622d623-dcb3-4a7c-92c6-ef6c937df3ae"
+    state = build_state(
+        gpu_details=[{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
+        gpu_processes=[
+            {"pid": 111, "info": "0::/../docker-a.scope", "container_name": neighbours_filler}
+        ],
+        specs=_specs(),
+        rented_data=RentedExecutorsResponse(
+            executors={},
+            all_filler_containers_by_executor={"another-executor": [neighbours_filler]},
+        ),
+    )
+    services = build_services()
+    services.backend.get_filler_run_active.return_value = FillerRunActiveResponse(
+        active=True, status="RUNNING"
+    )
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.FOREIGN_PROCESS.reason
+    services.backend.get_filler_run_active.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_filler_the_backend_calls_active_without_a_status_is_ours(context_factory):
+    # The schema permits a status-free response. A backend that sends one must not have its own
+    # live filler turned into a foreign workload.
+    late_filler = "filler_9622d623-dcb3-4a7c-92c6-ef6c937df3ae"
+    state = _idle_state(
+        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
+        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": late_filler}],
+    )
+    services = build_services()
+    services.backend.get_filler_run_active.return_value = FillerRunActiveResponse(active=True)
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.USAGE_OK.reason


### PR DESCRIPTION
Follow-up to #1242. The first prod shadow day showed the race arhangel66 asked about in that review, so enforcement stays off until this lands.

**What happens now.** `rented_data` is read once, at cycle start. A filler or pod the backend starts later in the same cycle carries our own name but is absent from the allowlist, so it reads as foreign at 0% load. 7 events on 5 executors of 5 different miners in 24 h. One example: executor `a09d2771` (rented) flagged `filler_6c6be0dd-b698-4fdd-9dde-d0e7ec055519`, its own live filler.

**What this does.** A container named `filler_<uuid>` or `pod_<uuid>` that the snapshot misses is now asked about directly, with the same endpoints the filler-liveness check already uses. The name still proves nothing on its own — the prefix only decides whom to ask, the backend gives the answer:

- `filler_<uuid>` in STARTING, RUNNING or STOPPING is ours. Terminal states are not: a container that outlives its run is an orphan.
- `pod_<uuid>` is ours while the backend reports the rental active.
- An id the backend never issued comes back `active=false` and stays foreign. A suffix that is not a uuid is never asked about, because a 422 would read as "backend unreachable".
- An unreachable backend never withholds money.

**Verification.** Full validator suite: 1700 passed, 9 skipped. The 3 `test_sshd_bootstrap_script.py` failures also fail on `main`. 7 new cases cover the late filler, a filler mid-transition, a late pod, a stopped filler, a forged uuid, a non-uuid name, and an unreachable backend.

The gate is still shadow-only in prod (`FOREIGN_GPU_WORKLOAD_ENFORCEMENT_ENABLED=false`). The plan is another shadow week after this merges, then the flip.
