### PR TITLE
DAH-2667: measure a RoCE fabric before the backend sells it as a cluster

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -202,6 +202,10 @@ class Settings(BaseSettings):
         default=True,
     )
     SKIP_RENTAL_VERIFICATION: bool = Field(env="SKIP_RENTAL_VERIFICATION", default=False)
+    # DAH-2667: measure a RoCE fabric with ib_write_bw between two free hosts of one segment,
+    # rather than inferring it from the addresses alone. Off until the probe has run on real RoCE
+    # hardware: it takes the cards of two idle hosts for a few seconds.
+    ROCE_LINK_PROBE_ENABLED: bool = Field(env="ROCE_LINK_PROBE_ENABLED", default=False)
     # ISSUE-050 filler liveness. CHECK_ENABLED is the master switch: shadow mode runs the SSH
     # probe + backend re-check and logs the verdict, but never withholds incentive; switching it
     # off disables the probe entirely. ENFORCEMENT (only effective while CHECK_ENABLED is on)

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -202,9 +202,10 @@ class Settings(BaseSettings):
         default=True,
     )
     SKIP_RENTAL_VERIFICATION: bool = Field(env="SKIP_RENTAL_VERIFICATION", default=False)
-    # DAH-2667: measure a RoCE fabric with ib_write_bw between two free hosts of one segment,
-    # rather than inferring it from the addresses alone. Off until the probe has run on real RoCE
-    # hardware: it takes the cards of two idle hosts for a few seconds.
+    # DAH-2667: measure a RoCE fabric with ib_write_bw between the free hosts of one segment, rather
+    # than inferring it from the addresses alone. The backend reads a flag of the SAME name to decide
+    # whether a fabric must be measured before it is sold, so the feature has one switch across both
+    # services. Off until the probe has run on real RoCE hardware.
     ROCE_LINK_PROBE_ENABLED: bool = Field(env="ROCE_LINK_PROBE_ENABLED", default=False)
     # ISSUE-050 filler liveness. CHECK_ENABLED is the master switch: shadow mode runs the SSH
     # probe + backend re-check and logs the verdict, but never withholds incentive; switching it

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -205,8 +205,8 @@ class Settings(BaseSettings):
     # DAH-2667: measure a RoCE fabric with ib_write_bw between the free hosts of one segment, rather
     # than inferring it from the addresses alone. The backend reads a flag of the SAME name to decide
     # whether a fabric must be measured before it is sold, so the feature has one switch across both
-    # services. Off until the probe has run on real RoCE hardware.
-    ROCE_LINK_PROBE_ENABLED: bool = Field(env="ROCE_LINK_PROBE_ENABLED", default=False)
+    # services. On by default: a fabric nobody measured is one nobody should be selling.
+    ROCE_LINK_PROBE_ENABLED: bool = Field(env="ROCE_LINK_PROBE_ENABLED", default=True)
     # ISSUE-050 filler liveness. CHECK_ENABLED is the master switch: shadow mode runs the SSH
     # probe + backend re-check and logs the verdict, but never withholds incentive; switching it
     # off disables the probe entirely. ENFORCEMENT (only effective while CHECK_ENABLED is on)

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -249,6 +249,9 @@ class MinerService:
             )
         
         loop = asyncio.get_event_loop()
+        # DAH-2667: what the RoCE probe subtracts from the cycle's own wait, so a job that already
+        # spent most of it takes a shorter sweep instead of overrunning and scoring the miner zero.
+        job_started_at: float = time.monotonic()
         my_key: bittensor.Keypair = settings.get_bittensor_wallet().get_hotkey()
         default_extra = {
             "job_batch_id": payload.job_batch_id,
@@ -383,6 +386,7 @@ class MinerService:
                             my_key.ss58_address, private_key.decode("utf-8")
                         ),
                         default_extra,
+                        job_started_at,
                     )
 
                     logger.info(
@@ -1853,6 +1857,9 @@ class MinerService:
         default_docker_image_digests: dict[str, str],
     ):
         """REST API version of request_job_to_miner."""
+        # DAH-2667: see the WebSocket path — the RoCE probe measures the cycle's remaining time
+        # from here.
+        job_started_at: float = time.monotonic()
         my_key: bittensor.Keypair = settings.get_bittensor_wallet().get_hotkey()
         default_extra = {
             "job_batch_id": payload.job_batch_id,
@@ -1961,6 +1968,7 @@ class MinerService:
                         my_key.ss58_address, private_key.decode("utf-8")
                     ),
                     default_extra,
+                    job_started_at,
                 )
 
                 logger.info(

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -64,6 +64,7 @@ from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.attestation_service import AttestationService
 from services.docker_service import DockerService, inflight_creates
 from services.redis_service import MACHINE_SPEC_CHANNEL, RedisService
+from services.roce_link_probe import measure_and_attach
 from services.ssh_service import SSHService
 from incentive.config import BASE_GPU_MAP
 from services.task_service import TaskService, JobResult
@@ -371,6 +372,17 @@ class MinerService:
                     results = self._filter_task_results(msg.executors, raw_results, default_extra)
                     results.extend(
                         self._build_manual_rental_results(payload, rented_data, existing=results)
+                    )
+
+                    # DAH-2667: while the miner's key is still installed and its idle hosts are
+                    # free, measure every RoCE pair. Best effort — an unmeasured pair is simply not
+                    # sold as a cluster.
+                    await measure_and_attach(
+                        results,
+                        self.ssh_service.decrypt_payload(
+                            my_key.ss58_address, private_key.decode("utf-8")
+                        ),
+                        default_extra,
                     )
 
                     logger.info(
@@ -1938,6 +1950,17 @@ class MinerService:
                 results = self._filter_task_results(msg.executors, raw_results, default_extra)
                 results.extend(
                     self._build_manual_rental_results(payload, rented_data, existing=results)
+                )
+
+                # DAH-2667: while the miner's key is still installed and its idle hosts are free,
+                # measure every RoCE pair. Best effort — an unmeasured pair is simply not sold as a
+                # cluster.
+                await measure_and_attach(
+                    results,
+                    self.ssh_service.decrypt_payload(
+                        my_key.ss58_address, private_key.decode("utf-8")
+                    ),
+                    default_extra,
                 )
 
                 logger.info(

--- a/neurons/validators/src/services/roce_link_probe.py
+++ b/neurons/validators/src/services/roce_link_probe.py
@@ -19,6 +19,7 @@ idle executors, and never touches a rented one.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 import shlex
@@ -49,7 +50,11 @@ PROBE_HANDSHAKE_PORT = 18515
 PROBE_ITERATIONS = 1000
 # Covers the one slow step — the first pull of the 38 MB image on a host that has never seen it.
 PROBE_TIMEOUT_SECONDS = 120
-SPEC_KEY = "roce_link_measurement"
+# The whole sweep's budget. The caller's timeout cancels the miner's entire job and scores it
+# zero, so the probe stops itself well before that: a cycle is 15 minutes and every other check
+# has run by now.
+PROBE_BUDGET_SECONDS = 180
+SPEC_KEY = "roce_link_measurements"
 
 ROCE_LINK_LAYER = "ethernet"
 # The prefix length is reported nowhere, so a segment is taken as a /24 — the same guess the
@@ -60,11 +65,16 @@ _BANDWIDTH_ROW = re.compile(r"^\s*\d+\s+\d+\s+[\d.]+\s+([\d.]+)\s+[\d.]+\s*$", r
 
 
 class RoceLinkMeasurement(BaseModel):
-    """What one host measured against its neighbour, as it travels in that host's specs."""
+    """What one host measured against ONE neighbour, as it travels in that host's specs.
+
+    `gigabits_per_second` is None when the run failed: a pair that could not talk is a fact the
+    backend needs, not an absence. Every pair of the segment gets an entry, so the backend can ask
+    whether the exact nodes a renter picked have been proven against each other.
+    """
 
     peer_executor_uuid: str
     peer_address: str
-    gigabits_per_second: float
+    gigabits_per_second: float | None
     measured_at: str
 
 
@@ -178,10 +188,21 @@ def measured_gigabits_per_second(ib_write_bw_output: str) -> float | None:
 
 
 def attach_measurement(result: JobResult, measurement: RoceLinkMeasurement) -> None:
-    """Carry the measurement to the backend in this host's specs, where the grouping reads it."""
+    """Add one peer's result to this host's specs, where the backend's grouping reads them.
+
+    Appended, never assigned: a host is measured against every other host of its segment in one
+    cycle, and keeping only the last of those would leave the backend unable to tell whether the
+    two nodes a renter picked were ever proven against EACH OTHER. An entry for a peer already
+    listed replaces that peer's entry, so the list holds this cycle's answer per peer and no more.
+    """
     if result.spec is None:
         result.spec = {}
-    result.spec[SPEC_KEY] = measurement.model_dump(mode="json")
+    kept: list[dict] = [
+        entry
+        for entry in result.spec.get(SPEC_KEY) or []
+        if entry.get("peer_address") != measurement.peer_address
+    ]
+    result.spec[SPEC_KEY] = kept + [measurement.model_dump(mode="json")]
 
 
 def _server_command() -> str:
@@ -264,10 +285,12 @@ async def _connected(
 async def measure_and_attach(
     results: list[JobResult], decrypted_private_key: str, log_extra: dict
 ) -> None:
-    """Measure every free RoCE pair of this miner and write the result into both hosts' specs.
+    """Measure every free RoCE pair of this miner and record each result in both hosts' specs.
 
-    Best effort by design: a probe that fails leaves the specs without a measurement, the backend
-    then does not sell that pair, and the validation cycle carries on untouched.
+    Bounded by `PROBE_BUDGET_SECONDS` and best effort throughout. The whole sweep sits inside one
+    `asyncio.wait_for`, because the caller's own timeout cancels the miner's ENTIRE job and scores
+    it zero for the cycle — a probe must never cost a miner its score. Pairs measured before the
+    budget ran out keep their entries; the rest are simply not proven this cycle.
     """
     if not settings.ROCE_LINK_PROBE_ENABLED:
         return
@@ -282,10 +305,36 @@ async def measure_and_attach(
             extra=get_extra_info({**log_extra, "pairs": len(pairs)}),
         ),
     )
+    try:
+        await asyncio.wait_for(
+            _measure_every_pair(pairs, decrypted_private_key, log_extra),
+            timeout=PROBE_BUDGET_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            _m(
+                "RoCE link probe ran out of its budget",
+                extra=get_extra_info({**log_extra, "pairs": len(pairs), "budget_seconds": PROBE_BUDGET_SECONDS}),
+            ),
+        )
+
+
+async def _measure_every_pair(
+    pairs: list[tuple[JobResult, JobResult]], decrypted_private_key: str, log_extra: dict
+) -> None:
+    """Run each pair in turn, recording the answer — including a failure — on both hosts."""
     for server, client in pairs:
+        server_host = roce_fabric_host_of(server)
+        client_host = roce_fabric_host_of(client)
+        if server_host is None or client_host is None:
+            continue
+
         try:
-            gigabits = await _measure_pair(server, client, decrypted_private_key, log_extra)
+            gigabits: float | None = await _measure_pair(
+                server, client, decrypted_private_key, log_extra
+            )
         except Exception as error:
+            gigabits = None
             logger.warning(
                 _m(
                     "RoCE link probe failed",
@@ -299,15 +348,8 @@ async def measure_and_attach(
                     ),
                 ),
             )
-            continue
-        if gigabits is None:
-            continue
 
         measured_at: str = datetime.now(timezone.utc).isoformat()
-        server_host = roce_fabric_host_of(server)
-        client_host = roce_fabric_host_of(client)
-        if server_host is None or client_host is None:
-            continue
         attach_measurement(
             server,
             RoceLinkMeasurement(
@@ -328,7 +370,7 @@ async def measure_and_attach(
         )
         logger.info(
             _m(
-                "RoCE link measured",
+                "RoCE link measured" if gigabits is not None else "RoCE link did not answer",
                 extra=get_extra_info(
                     {
                         **log_extra,

--- a/neurons/validators/src/services/roce_link_probe.py
+++ b/neurons/validators/src/services/roce_link_probe.py
@@ -19,15 +19,17 @@ idle executors, and never touches a rented one.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import re
 import shlex
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from ipaddress import IPv4Address, IPv6Address, ip_network
 
 import asyncssh
+from datura.requests.miner_requests import ExecutorSSHInfo
 from pydantic import BaseModel
 
 from core.config import settings
@@ -204,10 +206,10 @@ async def _measure_pair(
         return None
 
     pkey = asyncssh.import_private_key(decrypted_private_key)
-    async with _connect(server.executor_info, pkey) as server_ssh:
+    async with _connected(server.executor_info, pkey) as server_ssh:
         await server_ssh.run(_server_command(), check=False, timeout=PROBE_TIMEOUT_SECONDS)
         try:
-            async with _connect(client.executor_info, pkey) as client_ssh:
+            async with _connected(client.executor_info, pkey) as client_ssh:
                 completed = await client_ssh.run(
                     _client_command(server_host.roce_address),
                     check=False,
@@ -240,14 +242,18 @@ async def _measure_pair(
     return gigabits
 
 
-def _connect(executor_info, pkey):
-    return asyncssh.connect(
+@asynccontextmanager
+async def _connected(
+    executor_info: ExecutorSSHInfo, pkey: asyncssh.SSHKey
+) -> AsyncIterator[asyncssh.SSHClientConnection]:
+    async with asyncssh.connect(
         host=executor_info.address,
         port=executor_info.ssh_port,
         username=executor_info.ssh_username,
         client_keys=[pkey],
         known_hosts=None,
-    )
+    ) as connection:
+        yield connection
 
 
 async def measure_and_attach(

--- a/neurons/validators/src/services/roce_link_probe.py
+++ b/neurons/validators/src/services/roce_link_probe.py
@@ -43,10 +43,12 @@ PROBE_CONTAINER_NAME = "lium_roce_probe"
 # Both sides open this for the out-of-band handshake; the data path is card to card and never
 # touches it. Well above the ephemeral range so it cannot collide with a renter's published port.
 PROBE_HANDSHAKE_PORT = 18515
-PROBE_SECONDS = 5
-# The client has to pull a 38 MB image on a host that has never seen it, hand the handshake to the
-# server and push traffic. Generous, because the cost of a timeout is a pair we refuse to sell.
-PROBE_TIMEOUT_SECONDS = 300
+# A write count, not a duration: the probe proves the wire carries RDMA at all, and a validator
+# cycle has seconds for a miner's whole segment, not minutes. 1000 writes of 64 KiB finish in well
+# under a second on any wire worth selling; the reported rate is a side effect kept for the logs.
+PROBE_ITERATIONS = 1000
+# Covers the one slow step — the first pull of the 38 MB image on a host that has never seen it.
+PROBE_TIMEOUT_SECONDS = 120
 SPEC_KEY = "roce_link_measurement"
 
 ROCE_LINK_LAYER = "ethernet"
@@ -131,11 +133,13 @@ def roce_fabric_host_of(result: JobResult) -> RoceFabricHost | None:
 
 
 def pairs_to_measure(results: list[JobResult]) -> list[tuple[JobResult, JobResult]]:
-    """Disjoint pairs of free hosts on one segment, in the order they will be measured.
+    """EVERY pair of free hosts on one segment, in the order they will be measured.
 
-    Free only: a rented host is carrying someone's job, and the pair could not be sold anyway. Two
-    hosts claiming ONE address are not neighbours but two machines behind different NATs, so both
-    are dropped — the same rule the backend's grouping applies, and for the same reason.
+    Every pair, because the backend sells the whole segment as one cluster — proving a-b and c-d
+    says nothing about a-c, and each run costs well under a second. Free hosts only: a rented host
+    is carrying someone's job, and the pair could not be sold anyway. Two hosts claiming ONE
+    address are not neighbours but two machines behind different NATs, so both are dropped — the
+    same rule the backend's grouping applies, and for the same reason.
     """
     hosts_by_segment: dict[str, list[tuple[JobResult, RoceFabricHost]]] = {}
     for result in results:
@@ -150,8 +154,9 @@ def pairs_to_measure(results: list[JobResult]) -> list[tuple[JobResult, JobResul
     for members in hosts_by_segment.values():
         addressed = _without_addresses_claimed_twice(members)
         addressed.sort(key=lambda member: member[1].roce_address)
-        for first, second in zip(addressed[::2], addressed[1::2]):
-            pairs.append((first[0], second[0]))
+        for index, (server, _) in enumerate(addressed):
+            for client, _ in addressed[index + 1 :]:
+                pairs.append((server, client))
     return pairs
 
 
@@ -183,14 +188,14 @@ def _server_command() -> str:
     return (
         f"docker rm -f {PROBE_CONTAINER_NAME} >/dev/null 2>&1; "
         f"docker run --rm -d --name {PROBE_CONTAINER_NAME} --network host --device /dev/infiniband "
-        f"{PROBE_IMAGE} server {PROBE_HANDSHAKE_PORT} {PROBE_SECONDS}"
+        f"{PROBE_IMAGE} server {PROBE_HANDSHAKE_PORT} {PROBE_ITERATIONS}"
     )
 
 
 def _client_command(server_roce_address: str) -> str:
     return (
         f"docker run --rm --network host --device /dev/infiniband {PROBE_IMAGE} "
-        f"client {PROBE_HANDSHAKE_PORT} {PROBE_SECONDS} {shlex.quote(server_roce_address)}"
+        f"client {PROBE_HANDSHAKE_PORT} {PROBE_ITERATIONS} {shlex.quote(server_roce_address)}"
     )
 
 

--- a/neurons/validators/src/services/roce_link_probe.py
+++ b/neurons/validators/src/services/roce_link_probe.py
@@ -299,17 +299,19 @@ async def measure_and_attach(
     if not settings.ROCE_LINK_PROBE_ENABLED:
         return
 
-    pairs = pairs_to_measure(results)
-    if not pairs:
-        return
-
-    logger.info(
-        _m(
-            "Measuring RoCE links before the backend sells them",
-            extra=get_extra_info({**log_extra, "pairs": len(pairs)}),
-        ),
-    )
+    # Nothing in here may reach the caller: an exception in the probe would abort the miner's whole
+    # job and score it zero for the cycle, which is a far worse outcome than an unmeasured pair.
     try:
+        pairs = pairs_to_measure(results)
+        if not pairs:
+            return
+
+        logger.info(
+            _m(
+                "Measuring RoCE links before the backend sells them",
+                extra=get_extra_info({**log_extra, "pairs": len(pairs)}),
+            ),
+        )
         await asyncio.wait_for(
             _measure_every_pair(pairs, decrypted_private_key, log_extra),
             timeout=PROBE_BUDGET_SECONDS,
@@ -318,8 +320,12 @@ async def measure_and_attach(
         logger.warning(
             _m(
                 "RoCE link probe ran out of its budget",
-                extra=get_extra_info({**log_extra, "pairs": len(pairs), "budget_seconds": PROBE_BUDGET_SECONDS}),
+                extra=get_extra_info({**log_extra, "budget_seconds": PROBE_BUDGET_SECONDS}),
             ),
+        )
+    except Exception as error:
+        logger.warning(
+            _m("RoCE link probe failed", extra=get_extra_info({**log_extra, "error": str(error)})),
         )
 
 

--- a/neurons/validators/src/services/roce_link_probe.py
+++ b/neurons/validators/src/services/roce_link_probe.py
@@ -23,6 +23,7 @@ import asyncio
 import logging
 import re
 import shlex
+import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -40,6 +41,8 @@ from services.task.models import JobResult
 logger = logging.getLogger(__name__)
 
 PROBE_IMAGE = "daturaai/lium-rdma-probe:0.0.1"
+# The image's own entrypoint, named again because the server run replaces it with `timeout`.
+PROBE_ENTRYPOINT = "/usr/local/bin/lium-roce-probe"
 PROBE_CONTAINER_NAME = "lium_roce_probe"
 # Both sides open this for the out-of-band handshake; the data path is card to card and never
 # touches it. Well above the ephemeral range so it cannot collide with a renter's published port.
@@ -50,10 +53,19 @@ PROBE_HANDSHAKE_PORT = 18515
 PROBE_ITERATIONS = 1000
 # Covers the one slow step — the first pull of the 38 MB image on a host that has never seen it.
 PROBE_TIMEOUT_SECONDS = 120
-# The whole sweep's budget. The caller's timeout cancels the miner's entire job and scores it
-# zero, so the probe stops itself well before that: a cycle is 15 minutes and every other check
-# has run by now.
+# The whole sweep's ceiling. The real budget is whatever the cycle still has left (see
+# `budget_left_for_probe`), because the caller's timeout cancels the miner's entire job and scores
+# it zero.
 PROBE_BUDGET_SECONDS = 180
+# What `core/validator.py` subtracts from `JOB_TIME_OUT` for its own `asyncio.wait`: every job
+# still running then is cancelled and that miner scores zero. Keep the two in step.
+CYCLE_JOB_WAIT_SECONDS = 50
+# What the sweep leaves behind for the rest of the job: removing the validator's key from every
+# host and returning the results still have to happen inside the cycle's wait.
+PROBE_TAIL_MARGIN_SECONDS = 30
+# Below this there is no room for even one pair, so the sweep is skipped rather than started and
+# cut off halfway.
+PROBE_MINIMUM_BUDGET_SECONDS = 20
 # `ibv_reg_mr` pins the buffer it registers, so a real card needs both of these or the
 # registration fails and no pair ever measures (DAH-2571). Soft-RoCE does not need them,
 # which is why an emulated device hides the gap.
@@ -210,10 +222,14 @@ def attach_measurement(result: JobResult, measurement: RoceLinkMeasurement) -> N
 
 
 def _server_command() -> str:
+    # `timeout` in front of the probe, because the server waits for a client forever and the
+    # cleanup below can be cancelled with the sweep. A container that outlives its measurement
+    # holds a card a renter is about to take, so it ends itself even if nobody comes back for it.
     return (
         f"docker rm -f {PROBE_CONTAINER_NAME} >/dev/null 2>&1; "
         f"docker run --rm -d --name {PROBE_CONTAINER_NAME} --network host --device /dev/infiniband "
-        f"{RDMA_DOCKER_FLAGS} {PROBE_IMAGE} server {PROBE_HANDSHAKE_PORT} {PROBE_ITERATIONS}"
+        f"{RDMA_DOCKER_FLAGS} --entrypoint timeout {PROBE_IMAGE} {PROBE_TIMEOUT_SECONDS} "
+        f"{PROBE_ENTRYPOINT} server {PROBE_HANDSHAKE_PORT} {PROBE_ITERATIONS}"
     )
 
 
@@ -286,19 +302,37 @@ async def _connected(
         yield connection
 
 
+def budget_left_for_probe(job_started_at: float) -> float:
+    """How long the sweep may run: its own ceiling, or the time this job has left if that is less.
+
+    A miner whose executor tasks took most of the cycle has no room for a full sweep, and taking it
+    anyway would push the job past the wait in `core/validator.py` — which cancels it and scores
+    that miner zero. Fewer measured pairs is the cheap failure; a lost cycle is not.
+    """
+    seconds_spent: float = time.monotonic() - job_started_at
+    seconds_left: float = (
+        settings.JOB_TIME_OUT - CYCLE_JOB_WAIT_SECONDS - seconds_spent - PROBE_TAIL_MARGIN_SECONDS
+    )
+    return min(float(PROBE_BUDGET_SECONDS), seconds_left)
+
+
 async def measure_and_attach(
-    results: list[JobResult], decrypted_private_key: str, log_extra: dict
+    results: list[JobResult], decrypted_private_key: str, log_extra: dict, job_started_at: float
 ) -> None:
     """Measure every free RoCE pair of this miner and record each result in both hosts' specs.
 
-    Bounded by `PROBE_BUDGET_SECONDS` and best effort throughout. The whole sweep sits inside one
-    `asyncio.wait_for`, because the caller's own timeout cancels the miner's ENTIRE job and scores
-    it zero for the cycle — a probe must never cost a miner its score. Pairs measured before the
-    budget ran out keep their entries; the rest are simply not proven this cycle.
+    Best effort throughout. The whole sweep sits inside one `asyncio.wait_for`, because the caller's
+    own timeout cancels the miner's ENTIRE job and scores it zero for the cycle — a probe must never
+    cost a miner its score. Pairs measured before the budget ran out keep their entries; the rest
+    are simply not proven this cycle.
+
+    `job_started_at` is `time.monotonic()` taken when this miner's job began, and it is what keeps
+    the sweep inside the cycle that is already running.
     """
     if not settings.ROCE_LINK_PROBE_ENABLED:
         return
 
+    budget_seconds: float = 0.0
     # Nothing in here may reach the caller: an exception in the probe would abort the miner's whole
     # job and score it zero for the cycle, which is a far worse outcome than an unmeasured pair.
     try:
@@ -306,21 +340,33 @@ async def measure_and_attach(
         if not pairs:
             return
 
+        budget_seconds = budget_left_for_probe(job_started_at)
+        if budget_seconds < PROBE_MINIMUM_BUDGET_SECONDS:
+            logger.info(
+                _m(
+                    "RoCE link probe skipped, the cycle has no time left",
+                    extra=get_extra_info({**log_extra, "budget_seconds": budget_seconds}),
+                ),
+            )
+            return
+
         logger.info(
             _m(
                 "Measuring RoCE links before the backend sells them",
-                extra=get_extra_info({**log_extra, "pairs": len(pairs)}),
+                extra=get_extra_info(
+                    {**log_extra, "pairs": len(pairs), "budget_seconds": budget_seconds}
+                ),
             ),
         )
         await asyncio.wait_for(
             _measure_every_pair(pairs, decrypted_private_key, log_extra),
-            timeout=PROBE_BUDGET_SECONDS,
+            timeout=budget_seconds,
         )
     except asyncio.TimeoutError:
         logger.warning(
             _m(
                 "RoCE link probe ran out of its budget",
-                extra=get_extra_info({**log_extra, "budget_seconds": PROBE_BUDGET_SECONDS}),
+                extra=get_extra_info({**log_extra, "budget_seconds": budget_seconds}),
             ),
         )
     except Exception as error:

--- a/neurons/validators/src/services/roce_link_probe.py
+++ b/neurons/validators/src/services/roce_link_probe.py
@@ -1,0 +1,330 @@
+"""DAH-2667: measure a RoCE fabric instead of inferring it.
+
+A RoCE fabric has no subnet manager, so the fleet can only infer one: same miner, same IPv4
+segment, one address per host. That is evidence, not proof — a switch without lossless queueing
+(PFC/ECN) carries no RDMA at all, and NCCL then falls back to TCP over the cluster overlay while
+every device check still passes. The renter pays cluster price for a job nothing in the logs
+explains.
+
+So the validator measures the wire before the backend sells it: `ib_write_bw` between the two
+hosts, over the same rail and GID the cluster image hands NCCL, run from
+`daturaai/lium-rdma-probe`. The result is written into the specs of BOTH hosts, and the backend
+groups a RoCE pair only when each side carries a fresh measurement naming the other.
+
+Two facts shape when this runs. The measurement only matters for a pair that can be sold, and a
+pair is sellable only while both hosts are free — which is exactly when the probe can take the
+cards without touching a renter's job. So it runs at the end of a miner's cycle, over that miner's
+idle executors, and never touches a rented one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import shlex
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from ipaddress import IPv4Address, IPv6Address, ip_network
+
+import asyncssh
+from pydantic import BaseModel
+
+from core.config import settings
+from core.utils import _m, get_extra_info
+from services.task.models import JobResult
+
+logger = logging.getLogger(__name__)
+
+PROBE_IMAGE = "daturaai/lium-rdma-probe:0.0.1"
+PROBE_CONTAINER_NAME = "lium_roce_probe"
+# Both sides open this for the out-of-band handshake; the data path is card to card and never
+# touches it. Well above the ephemeral range so it cannot collide with a renter's published port.
+PROBE_HANDSHAKE_PORT = 18515
+PROBE_SECONDS = 5
+# The client has to pull a 38 MB image on a host that has never seen it, hand the handshake to the
+# server and push traffic. Generous, because the cost of a timeout is a pair we refuse to sell.
+PROBE_TIMEOUT_SECONDS = 300
+SPEC_KEY = "roce_link_measurement"
+
+ROCE_LINK_LAYER = "ethernet"
+# The prefix length is reported nowhere, so a segment is taken as a /24 — the same guess the
+# backend's grouping makes, and it errs towards splitting rather than towards inventing a fabric.
+ROCE_SEGMENT_PREFIX_LENGTH = 24
+# `ib_write_bw --report_gbits` prints one data row: bytes, iterations, peak, average, message rate.
+_BANDWIDTH_ROW = re.compile(r"^\s*\d+\s+\d+\s+[\d.]+\s+([\d.]+)\s+[\d.]+\s*$", re.MULTILINE)
+
+
+class RoceLinkMeasurement(BaseModel):
+    """What one host measured against its neighbour, as it travels in that host's specs."""
+
+    peer_executor_uuid: str
+    peer_address: str
+    gigabits_per_second: float
+    measured_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class RoceFabricHost:
+    """A host that can be measured: one live RoCE rail, one address, one segment."""
+
+    roce_address: str
+    segment: str
+
+
+def _is_active(port: dict) -> bool:
+    return str(port.get("state") or "").split(":")[-1].strip().upper() == "ACTIVE"
+
+
+def _is_roce(port: dict) -> bool:
+    return str(port.get("link_layer") or "").strip().lower() == ROCE_LINK_LAYER
+
+
+def _address_of(port: dict) -> IPv4Address | None:
+    """The card's own IPv4 address, decoded from the GID table rather than taken by index.
+
+    mlx5 puts the IPv4-mapped entry at 2-3 and Intel irdma at 1, so the index names nothing. An
+    address the card gave itself names nothing either: 169.254/16 is what a NIC without a lease
+    holds, and every unconfigured card of a provider would otherwise land on one invented segment.
+    """
+    for gid in port.get("gids") or []:
+        try:
+            mapped_address: IPv4Address | None = IPv6Address(str(gid).strip()).ipv4_mapped
+        except ValueError:
+            continue
+        if mapped_address is None:
+            continue
+        if mapped_address.is_link_local or mapped_address.is_loopback or mapped_address.is_unspecified:
+            continue
+        return mapped_address
+    return None
+
+
+def roce_fabric_host_of(result: JobResult) -> RoceFabricHost | None:
+    """The RoCE fabric this host sits on, or None when it holds none worth measuring.
+
+    Silent for a host that also holds a live InfiniBand port — such a host is sold on THAT fabric,
+    and `lium-fabric-env` inside the pod agrees. Silent too when its rails answer on two segments:
+    which one a job would run on is ambiguous, so the backend refuses to sell it either way.
+    """
+    live_ports: list[dict] = [
+        port for port in (result.spec or {}).get("infiniband_ports") or [] if _is_active(port)
+    ]
+    if any(not _is_roce(port) for port in live_ports):
+        return None
+
+    addresses: list[IPv4Address] = [
+        address for port in live_ports if (address := _address_of(port)) is not None
+    ]
+    if not addresses:
+        return None
+
+    segments: set[str] = {
+        str(ip_network(f"{address}/{ROCE_SEGMENT_PREFIX_LENGTH}", strict=False))
+        for address in addresses
+    }
+    if len(segments) != 1:
+        return None
+    return RoceFabricHost(roce_address=str(addresses[0]), segment=segments.pop())
+
+
+def pairs_to_measure(results: list[JobResult]) -> list[tuple[JobResult, JobResult]]:
+    """Disjoint pairs of free hosts on one segment, in the order they will be measured.
+
+    Free only: a rented host is carrying someone's job, and the pair could not be sold anyway. Two
+    hosts claiming ONE address are not neighbours but two machines behind different NATs, so both
+    are dropped — the same rule the backend's grouping applies, and for the same reason.
+    """
+    hosts_by_segment: dict[str, list[tuple[JobResult, RoceFabricHost]]] = {}
+    for result in results:
+        if result.is_rented:
+            continue
+        host = roce_fabric_host_of(result)
+        if host is None:
+            continue
+        hosts_by_segment.setdefault(host.segment, []).append((result, host))
+
+    pairs: list[tuple[JobResult, JobResult]] = []
+    for members in hosts_by_segment.values():
+        addressed = _without_addresses_claimed_twice(members)
+        addressed.sort(key=lambda member: member[1].roce_address)
+        for first, second in zip(addressed[::2], addressed[1::2]):
+            pairs.append((first[0], second[0]))
+    return pairs
+
+
+def _without_addresses_claimed_twice(
+    members: list[tuple[JobResult, RoceFabricHost]],
+) -> list[tuple[JobResult, RoceFabricHost]]:
+    claimants: dict[str, int] = {}
+    for _, host in members:
+        claimants[host.roce_address] = claimants.get(host.roce_address, 0) + 1
+    return [member for member in members if claimants[member[1].roce_address] == 1]
+
+
+def measured_gigabits_per_second(ib_write_bw_output: str) -> float | None:
+    """The average bandwidth of a finished run, or None when the run printed no result row."""
+    match = _BANDWIDTH_ROW.search(ib_write_bw_output)
+    if match is None:
+        return None
+    return float(match.group(1))
+
+
+def attach_measurement(result: JobResult, measurement: RoceLinkMeasurement) -> None:
+    """Carry the measurement to the backend in this host's specs, where the grouping reads it."""
+    if result.spec is None:
+        result.spec = {}
+    result.spec[SPEC_KEY] = measurement.model_dump(mode="json")
+
+
+def _server_command() -> str:
+    return (
+        f"docker rm -f {PROBE_CONTAINER_NAME} >/dev/null 2>&1; "
+        f"docker run --rm -d --name {PROBE_CONTAINER_NAME} --network host --device /dev/infiniband "
+        f"{PROBE_IMAGE} server {PROBE_HANDSHAKE_PORT} {PROBE_SECONDS}"
+    )
+
+
+def _client_command(server_roce_address: str) -> str:
+    return (
+        f"docker run --rm --network host --device /dev/infiniband {PROBE_IMAGE} "
+        f"client {PROBE_HANDSHAKE_PORT} {PROBE_SECONDS} {shlex.quote(server_roce_address)}"
+    )
+
+
+async def _measure_pair(
+    server: JobResult,
+    client: JobResult,
+    decrypted_private_key: str,
+    log_extra: dict,
+) -> float | None:
+    """Run the probe across one pair and return the bandwidth the client saw."""
+    server_host = roce_fabric_host_of(server)
+    if server_host is None:
+        return None
+
+    pkey = asyncssh.import_private_key(decrypted_private_key)
+    async with _connect(server.executor_info, pkey) as server_ssh:
+        await server_ssh.run(_server_command(), check=False, timeout=PROBE_TIMEOUT_SECONDS)
+        try:
+            async with _connect(client.executor_info, pkey) as client_ssh:
+                completed = await client_ssh.run(
+                    _client_command(server_host.roce_address),
+                    check=False,
+                    timeout=PROBE_TIMEOUT_SECONDS,
+                )
+        finally:
+            # The server holds a card until it is stopped, and a probe must never outlive its own
+            # measurement on a host a renter is about to take.
+            await server_ssh.run(
+                f"docker rm -f {PROBE_CONTAINER_NAME} >/dev/null 2>&1",
+                check=False,
+                timeout=PROBE_TIMEOUT_SECONDS,
+            )
+
+    gigabits = measured_gigabits_per_second(str(completed.stdout or ""))
+    if gigabits is None:
+        logger.info(
+            _m(
+                "RoCE link probe measured nothing",
+                extra=get_extra_info(
+                    {
+                        **log_extra,
+                        "server_executor": server.executor_info.uuid,
+                        "client_executor": client.executor_info.uuid,
+                        "stderr": str(completed.stderr or "")[:500],
+                    }
+                ),
+            ),
+        )
+    return gigabits
+
+
+def _connect(executor_info, pkey):
+    return asyncssh.connect(
+        host=executor_info.address,
+        port=executor_info.ssh_port,
+        username=executor_info.ssh_username,
+        client_keys=[pkey],
+        known_hosts=None,
+    )
+
+
+async def measure_and_attach(
+    results: list[JobResult], decrypted_private_key: str, log_extra: dict
+) -> None:
+    """Measure every free RoCE pair of this miner and write the result into both hosts' specs.
+
+    Best effort by design: a probe that fails leaves the specs without a measurement, the backend
+    then does not sell that pair, and the validation cycle carries on untouched.
+    """
+    if not settings.ROCE_LINK_PROBE_ENABLED:
+        return
+
+    pairs = pairs_to_measure(results)
+    if not pairs:
+        return
+
+    logger.info(
+        _m(
+            "Measuring RoCE links before the backend sells them",
+            extra=get_extra_info({**log_extra, "pairs": len(pairs)}),
+        ),
+    )
+    for server, client in pairs:
+        try:
+            gigabits = await _measure_pair(server, client, decrypted_private_key, log_extra)
+        except Exception as error:
+            logger.warning(
+                _m(
+                    "RoCE link probe failed",
+                    extra=get_extra_info(
+                        {
+                            **log_extra,
+                            "server_executor": server.executor_info.uuid,
+                            "client_executor": client.executor_info.uuid,
+                            "error": str(error),
+                        }
+                    ),
+                ),
+            )
+            continue
+        if gigabits is None:
+            continue
+
+        measured_at: str = datetime.now(timezone.utc).isoformat()
+        server_host = roce_fabric_host_of(server)
+        client_host = roce_fabric_host_of(client)
+        if server_host is None or client_host is None:
+            continue
+        attach_measurement(
+            server,
+            RoceLinkMeasurement(
+                peer_executor_uuid=client.executor_info.uuid,
+                peer_address=client_host.roce_address,
+                gigabits_per_second=gigabits,
+                measured_at=measured_at,
+            ),
+        )
+        attach_measurement(
+            client,
+            RoceLinkMeasurement(
+                peer_executor_uuid=server.executor_info.uuid,
+                peer_address=server_host.roce_address,
+                gigabits_per_second=gigabits,
+                measured_at=measured_at,
+            ),
+        )
+        logger.info(
+            _m(
+                "RoCE link measured",
+                extra=get_extra_info(
+                    {
+                        **log_extra,
+                        "server_executor": server.executor_info.uuid,
+                        "client_executor": client.executor_info.uuid,
+                        "gigabits_per_second": gigabits,
+                    }
+                ),
+            ),
+        )

--- a/neurons/validators/src/services/roce_link_probe.py
+++ b/neurons/validators/src/services/roce_link_probe.py
@@ -54,6 +54,10 @@ PROBE_TIMEOUT_SECONDS = 120
 # zero, so the probe stops itself well before that: a cycle is 15 minutes and every other check
 # has run by now.
 PROBE_BUDGET_SECONDS = 180
+# `ibv_reg_mr` pins the buffer it registers, so a real card needs both of these or the
+# registration fails and no pair ever measures (DAH-2571). Soft-RoCE does not need them,
+# which is why an emulated device hides the gap.
+RDMA_DOCKER_FLAGS = "--cap-add IPC_LOCK --ulimit memlock=-1:-1"
 SPEC_KEY = "roce_link_measurements"
 
 ROCE_LINK_LAYER = "ethernet"
@@ -209,13 +213,13 @@ def _server_command() -> str:
     return (
         f"docker rm -f {PROBE_CONTAINER_NAME} >/dev/null 2>&1; "
         f"docker run --rm -d --name {PROBE_CONTAINER_NAME} --network host --device /dev/infiniband "
-        f"{PROBE_IMAGE} server {PROBE_HANDSHAKE_PORT} {PROBE_ITERATIONS}"
+        f"{RDMA_DOCKER_FLAGS} {PROBE_IMAGE} server {PROBE_HANDSHAKE_PORT} {PROBE_ITERATIONS}"
     )
 
 
 def _client_command(server_roce_address: str) -> str:
     return (
-        f"docker run --rm --network host --device /dev/infiniband {PROBE_IMAGE} "
+        f"docker run --rm --network host --device /dev/infiniband {RDMA_DOCKER_FLAGS} {PROBE_IMAGE} "
         f"client {PROBE_HANDSHAKE_PORT} {PROBE_ITERATIONS} {shlex.quote(server_roce_address)}"
     )
 

--- a/neurons/validators/tests/test_roce_link_probe.py
+++ b/neurons/validators/tests/test_roce_link_probe.py
@@ -155,20 +155,61 @@ def test_a_run_that_printed_no_table_measured_nothing():
     assert measured_gigabits_per_second("Unable to open device mlx5_0\n") is None
 
 
-def test_the_measurement_lands_in_the_spec_of_the_host():
-    result = job_result("a", [roce_port("ac10:0506")])
-    measurement = RoceLinkMeasurement(
-        peer_executor_uuid="b",
-        peer_address="172.16.5.7",
-        gigabits_per_second=92.51,
+def _measurement(peer_uuid: str, peer_address: str, gigabits: float | None) -> RoceLinkMeasurement:
+    return RoceLinkMeasurement(
+        peer_executor_uuid=peer_uuid,
+        peer_address=peer_address,
+        gigabits_per_second=gigabits,
         measured_at="2026-08-25T13:00:00+00:00",
     )
 
-    attach_measurement(result, measurement)
 
-    assert result.spec["roce_link_measurement"] == {
-        "peer_executor_uuid": "b",
-        "peer_address": "172.16.5.7",
-        "gigabits_per_second": 92.51,
-        "measured_at": "2026-08-25T13:00:00+00:00",
-    }
+def test_the_measurement_lands_in_the_spec_of_the_host():
+    result = job_result("a", [roce_port("ac10:0506")])
+
+    attach_measurement(result, _measurement("b", "172.16.5.7", 92.51))
+
+    assert result.spec["roce_link_measurements"] == [
+        {
+            "peer_executor_uuid": "b",
+            "peer_address": "172.16.5.7",
+            "gigabits_per_second": 92.51,
+            "measured_at": "2026-08-25T13:00:00+00:00",
+        }
+    ]
+
+
+def test_every_peer_of_the_segment_keeps_its_own_entry():
+    result = job_result("a", [roce_port("ac10:0506")])
+
+    attach_measurement(result, _measurement("b", "172.16.5.7", 92.51))
+    attach_measurement(result, _measurement("c", "172.16.5.8", 91.02))
+
+    assert [entry["peer_address"] for entry in result.spec["roce_link_measurements"]] == [
+        "172.16.5.7",
+        "172.16.5.8",
+    ]
+
+
+def test_a_second_run_against_one_peer_replaces_that_peers_entry():
+    result = job_result("a", [roce_port("ac10:0506")])
+
+    attach_measurement(result, _measurement("b", "172.16.5.7", 92.51))
+    attach_measurement(result, _measurement("b", "172.16.5.7", None))
+
+    assert result.spec["roce_link_measurements"] == [
+        {
+            "peer_executor_uuid": "b",
+            "peer_address": "172.16.5.7",
+            "gigabits_per_second": None,
+            "measured_at": "2026-08-25T13:00:00+00:00",
+        }
+    ]
+
+
+def test_a_pair_that_could_not_talk_is_recorded_as_a_failure():
+    result = job_result("a", [roce_port("ac10:0506")])
+
+    attach_measurement(result, _measurement("b", "172.16.5.7", None))
+
+    assert result.spec["roce_link_measurements"][0]["gigabits_per_second"] is None

--- a/neurons/validators/tests/test_roce_link_probe.py
+++ b/neurons/validators/tests/test_roce_link_probe.py
@@ -1,0 +1,170 @@
+"""DAH-2667 — the validator measures a RoCE fabric before the backend sells it as a cluster.
+
+Port shapes are the ones prod executors report (measured 2026-08-05): mlx5 answers on an Ethernet
+link layer and carries the host's address as the IPv4-mapped entry of the GID table.
+"""
+
+import pytest
+from datura.requests.miner_requests import ExecutorSSHInfo
+
+from services.roce_link_probe import (
+    RoceLinkMeasurement,
+    attach_measurement,
+    measured_gigabits_per_second,
+    pairs_to_measure,
+    roce_fabric_host_of,
+)
+from services.task.models import JobResult
+
+LINK_LOCAL_GID = "fe80:0000:0000:0000:0e42:a1ff:fe4c:9a10"
+
+
+def roce_port(address: str, device: str = "mlx5_0") -> dict:
+    return {
+        "device": device,
+        "port": "1",
+        "link_layer": "Ethernet",
+        "state": "4: ACTIVE",
+        "gids": [LINK_LOCAL_GID, f"0000:0000:0000:0000:0000:ffff:{address}"],
+    }
+
+
+def infiniband_port() -> dict:
+    return {
+        "device": "mlx5_1",
+        "port": "1",
+        "link_layer": "InfiniBand",
+        "state": "4: ACTIVE",
+        "gids": [LINK_LOCAL_GID],
+    }
+
+
+def job_result(uuid: str, ports: list[dict], *, is_rented: bool = False) -> JobResult:
+    return JobResult(
+        executor_info=ExecutorSSHInfo(
+            uuid=uuid,
+            address="203.0.113.10",
+            port=8080,
+            ssh_username="root",
+            ssh_port=22,
+            python_path="/usr/bin/python3",
+            root_dir="/root/app",
+        ),
+        spec={"infiniband_ports": ports},
+        score=1.0,
+        job_score=1.0,
+        job_batch_id="batch-1",
+        log_status="success",
+        log_text="",
+        is_rented=is_rented,
+    )
+
+
+def test_a_host_with_one_live_roce_rail_names_its_address_and_segment():
+    host = roce_fabric_host_of(job_result("a", [roce_port("ac10:0506")]))
+
+    assert host is not None
+    assert host.roce_address == "172.16.5.6"
+    assert host.segment == "172.16.5.0/24"
+
+
+def test_a_host_that_also_holds_a_live_infiniband_port_is_not_measured():
+    assert roce_fabric_host_of(job_result("a", [roce_port("ac10:0506"), infiniband_port()])) is None
+
+
+def test_a_host_whose_rails_answer_on_two_segments_is_not_measured():
+    ports = [roce_port("ac10:0506"), roce_port("0a00:0007", device="mlx5_2")]
+
+    assert roce_fabric_host_of(job_result("a", ports)) is None
+
+
+def test_a_host_reporting_no_rdma_port_is_not_measured():
+    assert roce_fabric_host_of(job_result("a", [])) is None
+
+
+def test_two_free_hosts_on_one_segment_make_one_pair():
+    results = [job_result("a", [roce_port("ac10:0506")]), job_result("b", [roce_port("ac10:0507")])]
+
+    pairs = pairs_to_measure(results)
+
+    assert [(server.executor_info.uuid, client.executor_info.uuid) for server, client in pairs] == [("a", "b")]
+
+
+def test_a_rented_host_is_never_measured():
+    results = [
+        job_result("a", [roce_port("ac10:0506")]),
+        job_result("b", [roce_port("ac10:0507")], is_rented=True),
+    ]
+
+    assert pairs_to_measure(results) == []
+
+
+def test_hosts_on_different_segments_are_not_paired():
+    results = [job_result("a", [roce_port("ac10:0506")]), job_result("b", [roce_port("0a00:0007")])]
+
+    assert pairs_to_measure(results) == []
+
+
+def test_two_hosts_claiming_one_address_are_not_paired():
+    results = [job_result("a", [roce_port("ac10:0506")]), job_result("b", [roce_port("ac10:0506")])]
+
+    assert pairs_to_measure(results) == []
+
+
+def test_four_hosts_on_one_segment_make_two_pairs():
+    results = [
+        job_result("d", [roce_port("ac10:0509")]),
+        job_result("a", [roce_port("ac10:0506")]),
+        job_result("c", [roce_port("ac10:0508")]),
+        job_result("b", [roce_port("ac10:0507")]),
+    ]
+
+    pairs = pairs_to_measure(results)
+
+    assert [(server.executor_info.uuid, client.executor_info.uuid) for server, client in pairs] == [
+        ("a", "b"),
+        ("c", "d"),
+    ]
+
+
+def test_an_odd_host_on_a_segment_waits_for_a_partner():
+    results = [
+        job_result("a", [roce_port("ac10:0506")]),
+        job_result("b", [roce_port("ac10:0507")]),
+        job_result("c", [roce_port("ac10:0508")]),
+    ]
+
+    assert len(pairs_to_measure(results)) == 1
+
+
+def test_the_clients_table_yields_the_average_gigabits():
+    output = (
+        " #bytes     #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]\n"
+        " 65536      5000             92.99              92.51              0.176478\n"
+        "---------------------------------------------------------------------------------------\n"
+    )
+
+    assert measured_gigabits_per_second(output) == pytest.approx(92.51)
+
+
+def test_a_run_that_printed_no_table_measured_nothing():
+    assert measured_gigabits_per_second("Unable to open device mlx5_0\n") is None
+
+
+def test_the_measurement_lands_in_the_spec_of_the_host():
+    result = job_result("a", [roce_port("ac10:0506")])
+    measurement = RoceLinkMeasurement(
+        peer_executor_uuid="b",
+        peer_address="172.16.5.7",
+        gigabits_per_second=92.51,
+        measured_at="2026-08-25T13:00:00+00:00",
+    )
+
+    attach_measurement(result, measurement)
+
+    assert result.spec["roce_link_measurement"] == {
+        "peer_executor_uuid": "b",
+        "peer_address": "172.16.5.7",
+        "gigabits_per_second": 92.51,
+        "measured_at": "2026-08-25T13:00:00+00:00",
+    }

--- a/neurons/validators/tests/test_roce_link_probe.py
+++ b/neurons/validators/tests/test_roce_link_probe.py
@@ -245,3 +245,16 @@ def test_both_probe_containers_can_pin_the_memory_a_real_card_registers():
     for command in (_server_command(), _client_command("10.0.0.5")):
         assert "--cap-add IPC_LOCK" in command
         assert "--ulimit memlock=-1:-1" in command
+
+
+@pytest.mark.asyncio
+async def test_a_probe_that_raises_never_reaches_the_caller(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An exception here would abort the miner's whole job and score it zero for the cycle."""
+
+    def explode(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("specs are not what the probe expected")
+
+    monkeypatch.setattr(roce_link_probe.settings, "ROCE_LINK_PROBE_ENABLED", True)
+    monkeypatch.setattr(roce_link_probe, "pairs_to_measure", explode)
+
+    await measure_and_attach([job_result("a", [roce_port("ac10:0506")])], "private-key", {})

--- a/neurons/validators/tests/test_roce_link_probe.py
+++ b/neurons/validators/tests/test_roce_link_probe.py
@@ -5,6 +5,7 @@ link layer and carries the host's address as the IPv4-mapped entry of the GID ta
 """
 
 import asyncio
+import time
 
 import pytest
 from datura.requests.miner_requests import ExecutorSSHInfo
@@ -15,6 +16,7 @@ from services.roce_link_probe import (
     _server_command,
     RoceLinkMeasurement,
     attach_measurement,
+    budget_left_for_probe,
     measure_and_attach,
     measured_gigabits_per_second,
     pairs_to_measure,
@@ -232,12 +234,44 @@ async def test_a_sweep_that_hangs_gives_up_instead_of_failing_the_miners_cycle(
 
     monkeypatch.setattr(roce_link_probe.settings, "ROCE_LINK_PROBE_ENABLED", True)
     monkeypatch.setattr(roce_link_probe, "PROBE_BUDGET_SECONDS", 0.05)
+    monkeypatch.setattr(roce_link_probe, "PROBE_MINIMUM_BUDGET_SECONDS", 0.0)
     monkeypatch.setattr(roce_link_probe, "_measure_every_pair", never_finishes)
     results = [job_result("a", [roce_port("ac10:0506")]), job_result("b", [roce_port("ac10:0507")])]
 
-    await measure_and_attach(results, "private-key", {})
+    await measure_and_attach(results, "private-key", {}, time.monotonic())
 
     assert all(result.spec.get("roce_link_measurements") is None for result in results)
+
+
+def test_a_fresh_job_gets_the_whole_probe_budget():
+    assert budget_left_for_probe(time.monotonic()) == roce_link_probe.PROBE_BUDGET_SECONDS
+
+
+def test_a_job_that_already_spent_the_cycle_gets_no_budget_left():
+    """The cycle cancels the miner's whole job at its own wait, so a late sweep must be a short one."""
+    spent_seconds = roce_link_probe.settings.JOB_TIME_OUT - roce_link_probe.CYCLE_JOB_WAIT_SECONDS
+
+    assert budget_left_for_probe(time.monotonic() - spent_seconds) < 0
+
+
+@pytest.mark.asyncio
+async def test_a_sweep_is_skipped_when_the_cycle_has_no_room_for_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Started and cut off halfway costs the cards for nothing — better not to start at all."""
+    measured: list[str] = []
+
+    async def record(*_args: object, **_kwargs: object) -> None:
+        measured.append("ran")
+
+    monkeypatch.setattr(roce_link_probe.settings, "ROCE_LINK_PROBE_ENABLED", True)
+    monkeypatch.setattr(roce_link_probe, "_measure_every_pair", record)
+    results = [job_result("a", [roce_port("ac10:0506")]), job_result("b", [roce_port("ac10:0507")])]
+    spent_seconds = roce_link_probe.settings.JOB_TIME_OUT - roce_link_probe.CYCLE_JOB_WAIT_SECONDS
+
+    await measure_and_attach(results, "private-key", {}, time.monotonic() - spent_seconds)
+
+    assert measured == []
 
 
 def test_both_probe_containers_can_pin_the_memory_a_real_card_registers():
@@ -245,6 +279,14 @@ def test_both_probe_containers_can_pin_the_memory_a_real_card_registers():
     for command in (_server_command(), _client_command("10.0.0.5")):
         assert "--cap-add IPC_LOCK" in command
         assert "--ulimit memlock=-1:-1" in command
+
+
+def test_the_server_container_ends_itself_if_no_client_ever_comes():
+    """A cancelled sweep skips the cleanup, and a probe must not outlive its own measurement."""
+    command = _server_command()
+
+    assert f"--entrypoint timeout {roce_link_probe.PROBE_IMAGE}" in command
+    assert f"{roce_link_probe.PROBE_TIMEOUT_SECONDS} {roce_link_probe.PROBE_ENTRYPOINT} server" in command
 
 
 @pytest.mark.asyncio
@@ -257,4 +299,6 @@ async def test_a_probe_that_raises_never_reaches_the_caller(monkeypatch: pytest.
     monkeypatch.setattr(roce_link_probe.settings, "ROCE_LINK_PROBE_ENABLED", True)
     monkeypatch.setattr(roce_link_probe, "pairs_to_measure", explode)
 
-    await measure_and_attach([job_result("a", [roce_port("ac10:0506")])], "private-key", {})
+    await measure_and_attach(
+        [job_result("a", [roce_port("ac10:0506")])], "private-key", {}, time.monotonic()
+    )

--- a/neurons/validators/tests/test_roce_link_probe.py
+++ b/neurons/validators/tests/test_roce_link_probe.py
@@ -4,12 +4,16 @@ Port shapes are the ones prod executors report (measured 2026-08-05): mlx5 answe
 link layer and carries the host's address as the IPv4-mapped entry of the GID table.
 """
 
+import asyncio
+
 import pytest
 from datura.requests.miner_requests import ExecutorSSHInfo
 
+from services import roce_link_probe
 from services.roce_link_probe import (
     RoceLinkMeasurement,
     attach_measurement,
+    measure_and_attach,
     measured_gigabits_per_second,
     pairs_to_measure,
     roce_fabric_host_of,
@@ -213,3 +217,22 @@ def test_a_pair_that_could_not_talk_is_recorded_as_a_failure():
     attach_measurement(result, _measurement("b", "172.16.5.7", None))
 
     assert result.spec["roce_link_measurements"][0]["gigabits_per_second"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_sweep_that_hangs_gives_up_instead_of_failing_the_miners_cycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The caller's timeout cancels the whole job and scores the miner zero, so the probe stops first."""
+
+    async def never_finishes(*_args: object, **_kwargs: object) -> None:
+        await asyncio.sleep(60)
+
+    monkeypatch.setattr(roce_link_probe.settings, "ROCE_LINK_PROBE_ENABLED", True)
+    monkeypatch.setattr(roce_link_probe, "PROBE_BUDGET_SECONDS", 0.05)
+    monkeypatch.setattr(roce_link_probe, "_measure_every_pair", never_finishes)
+    results = [job_result("a", [roce_port("ac10:0506")]), job_result("b", [roce_port("ac10:0507")])]
+
+    await measure_and_attach(results, "private-key", {})
+
+    assert all(result.spec.get("roce_link_measurements") is None for result in results)

--- a/neurons/validators/tests/test_roce_link_probe.py
+++ b/neurons/validators/tests/test_roce_link_probe.py
@@ -11,6 +11,8 @@ from datura.requests.miner_requests import ExecutorSSHInfo
 
 from services import roce_link_probe
 from services.roce_link_probe import (
+    _client_command,
+    _server_command,
     RoceLinkMeasurement,
     attach_measurement,
     measure_and_attach,
@@ -236,3 +238,10 @@ async def test_a_sweep_that_hangs_gives_up_instead_of_failing_the_miners_cycle(
     await measure_and_attach(results, "private-key", {})
 
     assert all(result.spec.get("roce_link_measurements") is None for result in results)
+
+
+def test_both_probe_containers_can_pin_the_memory_a_real_card_registers():
+    """`ibv_reg_mr` fails without these, and Soft-RoCE never shows it (DAH-2571)."""
+    for command in (_server_command(), _client_command("10.0.0.5")):
+        assert "--cap-add IPC_LOCK" in command
+        assert "--ulimit memlock=-1:-1" in command

--- a/neurons/validators/tests/test_roce_link_probe.py
+++ b/neurons/validators/tests/test_roce_link_probe.py
@@ -111,7 +111,7 @@ def test_two_hosts_claiming_one_address_are_not_paired():
     assert pairs_to_measure(results) == []
 
 
-def test_four_hosts_on_one_segment_make_two_pairs():
+def test_four_hosts_on_one_segment_measure_every_pair():
     results = [
         job_result("d", [roce_port("ac10:0509")]),
         job_result("a", [roce_port("ac10:0506")]),
@@ -123,18 +123,22 @@ def test_four_hosts_on_one_segment_make_two_pairs():
 
     assert [(server.executor_info.uuid, client.executor_info.uuid) for server, client in pairs] == [
         ("a", "b"),
+        ("a", "c"),
+        ("a", "d"),
+        ("b", "c"),
+        ("b", "d"),
         ("c", "d"),
     ]
 
 
-def test_an_odd_host_on_a_segment_waits_for_a_partner():
+def test_an_odd_host_on_a_segment_is_still_measured_against_both_others():
     results = [
         job_result("a", [roce_port("ac10:0506")]),
         job_result("b", [roce_port("ac10:0507")]),
         job_result("c", [roce_port("ac10:0508")]),
     ]
 
-    assert len(pairs_to_measure(results)) == 1
+    assert len(pairs_to_measure(results)) == 3
 
 
 def test_the_clients_table_yields_the_average_gigabits():


### PR DESCRIPTION
A RoCE fabric has no subnet manager, so the fleet can only infer one: same miner, same IPv4 segment,
one address per host. That is evidence, not proof. A switch without lossless queueing (PFC/ECN)
carries no RDMA, NCCL falls back to TCP over the cluster overlay, and the renter pays cluster price
for a job nothing in the logs explains.

This measures the wire instead. At the end of a miner's cycle — while its key is still installed —
the validator pairs the miner's FREE hosts by RoCE segment and runs `ib_write_bw` between each pair
from `daturaai/lium-rdma-probe`, over the same rail and GID `lium-fabric-env` hands NCCL inside a
cluster pod. The result is written into the specs of BOTH hosts, each naming the other.

Two facts set when this runs. The measurement matters only for a pair that can be sold, and a pair
is sellable only while both hosts are free — which is exactly when the probe can take the cards
without touching a renter's job. A rented host is never probed.

Behind `ROCE_LINK_PROBE_ENABLED`, off by default. Best effort throughout: a probe that fails leaves
the specs without a measurement, the backend then does not sell that pair, and the cycle carries on.

The backend half (lium-io-backend, DAH-2667-roce-cluster) requires a fresh measurement naming
another member of the same wire before it groups a RoCE pair, behind its own flag, and shows the
measured speed to the buyer.

Tests: `neurons/validators/tests/test_roce_link_probe.py` — 13, covering which hosts are measurable
(dual-fabric and two-segment hosts are not), how free hosts pair, the `ib_write_bw` parse, and
where the result lands.