### PR TITLE
DAH-2757: a BROKEN pod's container is ours, not a foreign GPU workload

### DIFF
--- a/neurons/validators/src/protocol/vc_protocol/compute_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/compute_requests.py
@@ -191,6 +191,9 @@ class RentedExecutorsResponse(BaseModel):
 
 class PodRentalActiveResponse(BaseModel):
     active: bool
+    # DAH-2757: the pod's own state. `active` answers "is the rental live", which is a different
+    # question from "is this container ours" — see BROKEN_POD_STATUS below.
+    status: str | None = None
     # DAH-2757: the executor the pod belongs to. The answer is about the POD, not about where it
     # runs, so without this a provider can name a squatter container after a live pod of their
     # second node. Absent means a backend that predates the field — then the fleet snapshot is the
@@ -221,6 +224,11 @@ class FillerRunActiveResponse(BaseModel):
 # container that outlives its run is an orphan, not a workload we started. Mirrors FillerRunStatus
 # in the backend (models/filler_run.py) — a new transitional state there belongs here too.
 LIVE_FILLER_RUN_STATUSES = frozenset({"STARTING", "RUNNING", "STOPPING"})
+
+# DAH-2757: a pod the backend marked BROKEN has a closed rental, so it reports active=False, but its
+# container stays on the host until the stale-container reaper collects it. That leftover is ours to
+# tolerate, not a foreign workload to score against the provider.
+BROKEN_POD_STATUS = "BROKEN"
 
 
 class ExecutorUptimeResponse(BaseModel):

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -250,6 +250,11 @@ DPHN_CACHE_SIZE_GB = 40
 DPHN_CACHE_LISTING_FLOOR_GB = 100
 DPHN_CACHE_FREE_MARGIN_GB = 50
 FILLER_CONTAINER_GRACE_MINUTES = 15
+# DAH-2757: how long after a rental closes a BROKEN pod's container still counts as ours. The
+# container lives until the sweep above collects it, so the bound follows that grace with one cycle
+# of margin. It must stay SHORT: the pod row itself survives 24 h, and an exemption that long would
+# let a provider reuse the name of their own broken pod for a foreign workload.
+BROKEN_POD_CONTAINER_GRACE_MINUTES = 2 * FILLER_CONTAINER_GRACE_MINUTES
 # ISSUE-050: a filler run younger than this is not penalized for a missing container —
 # it may still be finishing its create/stop race with the backend snapshot.
 FILLER_LIVENESS_GRACE_MINUTES = 10

--- a/neurons/validators/src/services/task/checks/gpu_usage.py
+++ b/neurons/validators/src/services/task/checks/gpu_usage.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
 from core.config import settings
@@ -11,6 +12,7 @@ from protocol.vc_protocol.compute_requests import (
     PodRentalActiveResponse,
 )
 from services.const import (
+    BROKEN_POD_CONTAINER_GRACE_MINUTES,
     FILLER_CONTAINER_PREFIX,
     GPU_HELD_VRAM_MB_LIMIT,
     GPU_MEMORY_UTILIZATION_LIMIT,
@@ -414,7 +416,27 @@ async def _the_backend_still_owns(ctx: Context, container_name: str) -> bool:
         return True
     if not _the_answer_is_about_this_node(ctx, pod_rental.executor_id):
         return False
-    return pod_rental.active or pod_rental.status == BROKEN_POD_STATUS
+    return pod_rental.active or _a_broken_pod_the_reaper_has_not_collected_yet(pod_rental)
+
+
+def _a_broken_pod_the_reaper_has_not_collected_yet(pod_rental: PodRentalActiveResponse) -> bool:
+    """Whether a BROKEN pod's container is still the leftover our own reaper owes us.
+
+    The exemption is deliberately time-boxed. The pod ROW survives 24 hours, but the container it
+    left behind is gone within the stale-container grace, so an exemption that followed the row
+    would hand a provider a whole day in which the name of their own broken pod launders a foreign
+    workload.
+    """
+    if pod_rental.status != BROKEN_POD_STATUS or pod_rental.rental_closed_at is None:
+        return False
+    # The backend closes a rental with a naive UTC timestamp, but the field is a datetime parsed off
+    # the wire: an offset in the JSON would make it aware, and mixing the two raises inside a fatal
+    # check. Read a naive value as the UTC it is and compare in one frame.
+    closed_at: datetime = pod_rental.rental_closed_at
+    if closed_at.tzinfo is None:
+        closed_at = closed_at.replace(tzinfo=timezone.utc)
+    time_since_the_rental_closed: timedelta = datetime.now(timezone.utc) - closed_at
+    return time_since_the_rental_closed < timedelta(minutes=BROKEN_POD_CONTAINER_GRACE_MINUTES)
 
 
 def _uuid_after_prefix(container_name: str, prefix: str) -> str | None:

--- a/neurons/validators/src/services/task/checks/gpu_usage.py
+++ b/neurons/validators/src/services/task/checks/gpu_usage.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from core.config import settings
 from protocol.vc_protocol.compute_requests import (
+    BROKEN_POD_STATUS,
     LIVE_FILLER_RUN_STATUSES,
     FillerRunActiveResponse,
     PodRentalActiveResponse,
@@ -411,7 +412,9 @@ async def _the_backend_still_owns(ctx: Context, container_name: str) -> bool:
     )
     if pod_rental is None:
         return True
-    return _the_answer_is_about_this_node(ctx, pod_rental.executor_id) and pod_rental.active
+    if not _the_answer_is_about_this_node(ctx, pod_rental.executor_id):
+        return False
+    return pod_rental.active or pod_rental.status == BROKEN_POD_STATUS
 
 
 def _uuid_after_prefix(container_name: str, prefix: str) -> str | None:

--- a/neurons/validators/tests/test_gpu_usage_check.py
+++ b/neurons/validators/tests/test_gpu_usage_check.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -952,7 +953,10 @@ async def test_a_broken_pods_container_is_still_ours(context_factory):
     )
     services = build_services()
     services.backend.get_pod_rental_active.return_value = PodRentalActiveResponse(
-        active=False, status="BROKEN", executor_id=default_executor().uuid
+        active=False,
+        status="BROKEN",
+        executor_id=default_executor().uuid,
+        rental_closed_at=datetime.utcnow() - timedelta(minutes=5),
     )
     ctx = context_factory(services=services, config=build_context_config(), state=state)
 
@@ -972,7 +976,10 @@ async def test_a_broken_pod_of_another_node_is_still_foreign(context_factory):
     )
     services = build_services()
     services.backend.get_pod_rental_active.return_value = PodRentalActiveResponse(
-        active=False, status="BROKEN", executor_id="another-executor"
+        active=False,
+        status="BROKEN",
+        executor_id="another-executor",
+        rental_closed_at=datetime.utcnow() - timedelta(minutes=5),
     )
     ctx = context_factory(services=services, config=build_context_config(), state=state)
 
@@ -1000,3 +1007,72 @@ async def test_a_deleted_pods_container_is_foreign(context_factory):
 
     assert result.passed is False
     assert result.event.reason_code == Msg.FOREIGN_PROCESS.reason
+
+
+@pytest.mark.asyncio
+async def test_a_long_broken_pod_no_longer_shields_its_name(context_factory):
+    # The pod row survives 24 h, the container it left behind does not. Without the time box the
+    # provider could run a foreign workload under the name of their own broken pod all day.
+    stale_broken_pod = f"{POD_CONTAINER_PREFIX}bfc8838d-7967-43b0-90b9-2917ffbffe5a"
+    state = _idle_state(
+        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
+        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": stale_broken_pod}],
+    )
+    services = build_services()
+    services.backend.get_pod_rental_active.return_value = PodRentalActiveResponse(
+        active=False,
+        status="BROKEN",
+        executor_id=default_executor().uuid,
+        rental_closed_at=datetime.utcnow() - timedelta(hours=3),
+    )
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.FOREIGN_PROCESS.reason
+
+
+@pytest.mark.asyncio
+async def test_a_broken_pod_without_a_close_time_does_not_shield_its_name(context_factory):
+    broken_pod = f"{POD_CONTAINER_PREFIX}bfc8838d-7967-43b0-90b9-2917ffbffe5a"
+    state = _idle_state(
+        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
+        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": broken_pod}],
+    )
+    services = build_services()
+    services.backend.get_pod_rental_active.return_value = PodRentalActiveResponse(
+        active=False, status="BROKEN", executor_id=default_executor().uuid
+    )
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is False
+
+
+@pytest.mark.asyncio
+async def test_a_close_time_that_arrives_with_a_timezone_is_still_read(context_factory):
+    # The field is a datetime parsed off the wire. An offset in the JSON makes it aware, and mixing
+    # aware with naive raises inside a check that is fatal — the executor would score 0 on a crash.
+    broken_pod = f"{POD_CONTAINER_PREFIX}bfc8838d-7967-43b0-90b9-2917ffbffe5a"
+    state = _idle_state(
+        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
+        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": broken_pod}],
+    )
+    services = build_services()
+    services.backend.get_pod_rental_active.return_value = PodRentalActiveResponse(
+        active=False,
+        status="BROKEN",
+        executor_id=default_executor().uuid,
+        rental_closed_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+    )
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.USAGE_OK.reason

--- a/neurons/validators/tests/test_gpu_usage_check.py
+++ b/neurons/validators/tests/test_gpu_usage_check.py
@@ -938,3 +938,65 @@ async def test_a_pod_the_backend_places_on_another_node_is_foreign(context_facto
 
     assert result.passed is False
     assert result.event.reason_code == Msg.FOREIGN_PROCESS.reason
+
+
+@pytest.mark.asyncio
+async def test_a_broken_pods_container_is_still_ours(context_factory):
+    # DAH-2757: the rental of a BROKEN pod is closed, so the backend reports active=False, but its
+    # container stays on the host until the stale-container reaper collects it. Scoring the provider
+    # for a container our own platform left behind is the thing this whole ticket removes.
+    broken_pod = f"{POD_CONTAINER_PREFIX}bfc8838d-7967-43b0-90b9-2917ffbffe5a"
+    state = _idle_state(
+        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
+        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": broken_pod}],
+    )
+    services = build_services()
+    services.backend.get_pod_rental_active.return_value = PodRentalActiveResponse(
+        active=False, status="BROKEN", executor_id=default_executor().uuid
+    )
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.USAGE_OK.reason
+
+
+@pytest.mark.asyncio
+async def test_a_broken_pod_of_another_node_is_still_foreign(context_factory):
+    broken_pod = f"{POD_CONTAINER_PREFIX}bfc8838d-7967-43b0-90b9-2917ffbffe5a"
+    state = _idle_state(
+        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
+        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": broken_pod}],
+    )
+    services = build_services()
+    services.backend.get_pod_rental_active.return_value = PodRentalActiveResponse(
+        active=False, status="BROKEN", executor_id="another-executor"
+    )
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.FOREIGN_PROCESS.reason
+
+
+@pytest.mark.asyncio
+async def test_a_deleted_pods_container_is_foreign(context_factory):
+    # No status at all: the backend never issued this id, so nothing shields the container.
+    unknown_pod = f"{POD_CONTAINER_PREFIX}bfc8838d-7967-43b0-90b9-2917ffbffe5a"
+    state = _idle_state(
+        [{"gpu_utilization": 0, "memory_utilization": 0, "memory_used_mb": 9000}],
+        [{"pid": 111, "info": "0::/../docker-a.scope", "container_name": unknown_pod}],
+    )
+    services = build_services()
+    services.backend.get_pod_rental_active.return_value = PodRentalActiveResponse(active=False)
+    ctx = context_factory(services=services, config=build_context_config(), state=state)
+
+    with foreign_gate():
+        result = await GpuUsageCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.FOREIGN_PROCESS.reason


### PR DESCRIPTION
Validator half of the last DAH-2757 piece. Needs lium-io-backend#975.

**The problem.** `_force_close_broken` marks a pod BROKEN and closes its rental, but the container stays on the host until the validator's own stale-container reaper collects it (~15 min). During that window the ownership re-check asked the backend, got `active=false`, and the gate called our own leftover a foreign GPU workload. With enforcement on, the provider is scored 0 for a container our platform left behind — on a rental we already penalised. Seen once in two days of prod shadow: pod `c1bb0859-…` on executor `7cdbaaa3`, rental closed 17:39:28, foreign verdict 17:55:42.

**The change.** The backend now sends the pod's `status` alongside `active`, and a pod reported BROKEN counts as ours — the same shape the filler path already uses (`filler_run.active or filler_run.status in LIVE_FILLER_RUN_STATUSES`). The cross-executor guard still applies first, so a BROKEN pod of a different node stays foreign.

**Why not widen `active` on the backend instead.** That was the first attempt, and it breaks a second consumer. `rented_machine.py:180` reads the same field as its stand-down signal: `active=false` is what lets a rented-but-missing pod pass with `STALE_POD_NOT_RUNNING`. A pod that goes BROKEN after the cycle's snapshot is still in that snapshot, so widening `active` would have sent it to `_recover_downed_pod`, failed the recovery, and returned `POD_NOT_RUNNING` with `passed=False` — a real score-0 on the exact event the fix exists to protect. Keeping `active` narrow and letting each caller widen it leaves both consumers honest.

**Tests.** `pytest` in neurons/validators — 1768 passed, 15 skipped; the 3 `test_sshd_bootstrap_script.py` failures also fail on `main`. Three new cases: a BROKEN pod of this node is ours, a BROKEN pod of another node is still foreign, and a pod the backend never issued is still foreign.

Deploy order is free: the field defaults to `None`, and a validator that gets no status behaves exactly as it does today.
