### PR TITLE
DAH-2792, websocket keepalive limits and delivery stamps on the connector

### DIFF
--- a/neurons/validators/src/clients/compute_client.py
+++ b/neurons/validators/src/clients/compute_client.py
@@ -87,6 +87,15 @@ from clients.handlers.backup_handler import BackupHandler
 
 logger = logging.getLogger(__name__)
 
+# DAH-2792: the backend drains a scoring cycle (~550 specs, ~4 MB) one message at a time. With the
+# library defaults (16-32 queued messages, pong within 20 s) its transport stopped reading, our
+# keepalive ping waited unread behind the burst, and we closed the socket mid-cycle with 1011.
+# 1024 holds a whole cycle; ping_timeout=40 doubles the deadline in case it does not.
+# Mirror of ws_* in compute-app src/core/uvicorn_worker.py.
+WS_MAX_QUEUE = 1024
+WS_PING_INTERVAL = 20
+WS_PING_TIMEOUT = 40
+
 
 class AuthenticationError(Exception):
     def __init__(self, reason: str, errors: list[Error]):
@@ -130,7 +139,12 @@ class ComputeClient:
                 extra=get_extra_info(self.logging_extra)
             )
         )
-        return websockets.connect(self.compute_app_uri)
+        return websockets.connect(
+            self.compute_app_uri,
+            max_queue=WS_MAX_QUEUE,
+            ping_interval=WS_PING_INTERVAL,
+            ping_timeout=WS_PING_TIMEOUT,
+        )
 
     async def miner_driver_awaiter(self):
         """avoid memory leak by awaiting miner driver tasks"""
@@ -336,6 +350,8 @@ class ComputeClient:
                             attestation_digest=data.get("attestation_digest"),
                             tdx_attestation_passed=data.get("tdx_attestation_passed"),
                             gpu_attestation_passed=data.get("gpu_attestation_passed"),
+                            sent_at=data.get("sent_at"),
+                            batch_total=data.get("batch_total"),
                         )
 
                         async with self.lock:
@@ -445,6 +461,8 @@ class ComputeClient:
                     log_to_send = self.message_queue.pop(0)
 
                 if log_to_send:
+                    log_to_send.forwarded_at = time.time()
+                    log_to_send.queue_depth = len(self.message_queue)
                     try:
                         await self.send_model(log_to_send)
                     except Exception as exc:

--- a/neurons/validators/src/clients/compute_client.py
+++ b/neurons/validators/src/clients/compute_client.py
@@ -12,6 +12,7 @@ import websockets
 from datura.requests.base import BaseRequest
 from payload_models.payloads import (
     BackupContainerRequest,
+    DeliveryStamps,
     CancelStorageOperationRequest,
     RestoreContainerRequest,
     BaseServerRequest,
@@ -87,12 +88,8 @@ from clients.handlers.backup_handler import BackupHandler
 
 logger = logging.getLogger(__name__)
 
-# DAH-2792: the backend drains a scoring cycle (~550 specs, ~4 MB) one message at a time. With the
-# library defaults (16-32 queued messages, pong within 20 s) its transport stopped reading, our
-# keepalive ping waited unread behind the burst, and we closed the socket mid-cycle with 1011.
-# 1024 holds a whole cycle; ping_timeout=40 doubles the deadline in case it does not.
-# Mirror of ws_* in compute-app src/core/uvicorn_worker.py.
-WS_MAX_QUEUE = 1024
+# DAH-2792: the keepalive pong queues behind a scoring-cycle burst and missed the 20 s default;
+# mirrors ws_ping_* in compute-app apps/server/src/core/uvicorn_worker.py, which holds the burst.
 WS_PING_INTERVAL = 20
 WS_PING_TIMEOUT = 40
 
@@ -117,7 +114,7 @@ class ComputeClient:
         self.miner_driver_awaiter_task = asyncio.create_task(self.miner_driver_awaiter())
         # self.heartbeat_task = asyncio.create_task(self.heartbeat())
         self.miner_service = miner_service
-        self.message_queue = []
+        self.message_queue: list[DeliveryStamps] = []
         self.lock = asyncio.Lock()
 
         self.logging_extra = {
@@ -141,7 +138,6 @@ class ComputeClient:
         )
         return websockets.connect(
             self.compute_app_uri,
-            max_queue=WS_MAX_QUEUE,
             ping_interval=WS_PING_INTERVAL,
             ping_timeout=WS_PING_TIMEOUT,
         )

--- a/neurons/validators/src/clients/compute_client.py
+++ b/neurons/validators/src/clients/compute_client.py
@@ -63,7 +63,6 @@ from protocol.vc_protocol.validator_requests import (
     RevenuePerGpuTypeRequest,
     ScorePortionPerGpuTypeRequest,
 )
-from pydantic import BaseModel
 from websockets.asyncio.client import ClientConnection
 
 from core.config import settings
@@ -443,7 +442,10 @@ class ComputeClient:
         wait=tenacity.wait_exponential(multiplier=1, exp_base=2, min=1, max=10),
         retry=tenacity.retry_if_exception_type(websockets.ConnectionClosed),
     )
-    async def send_model(self, msg: BaseModel):
+    async def send_model(self, msg: DeliveryStamps):
+        # stamped inside the retry so a message resent after a reconnect reports its own delay
+        msg.forwarded_at = time.time()
+        msg.queue_depth = len(self.message_queue)
         await self.ws.send(msg.model_dump_json())
 
     async def handle_send_messages(self):
@@ -457,8 +459,6 @@ class ComputeClient:
                     log_to_send = self.message_queue.pop(0)
 
                 if log_to_send:
-                    log_to_send.forwarded_at = time.time()
-                    log_to_send.queue_depth = len(self.message_queue)
                     try:
                         await self.send_model(log_to_send)
                     except Exception as exc:

--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -483,7 +483,15 @@ class ContainerResponseType(enum.Enum):
     JupyterInstallationFailed = "JupyterInstallationFailed"
 
 
-class BaseValidatorResponse(BaseRequest):
+class DeliveryStamps(BaseModel):
+    # DAH-2792: epoch seconds; sent_at by the producer, forwarded_at/queue_depth by the connector
+    # before ws.send(). Mixed into every model the connector queues, since its send loop stamps them all.
+    sent_at: float | None = None
+    forwarded_at: float | None = None
+    queue_depth: int | None = None
+
+
+class BaseValidatorResponse(BaseRequest, DeliveryStamps):
     message_type: ContainerResponseType
     miner_hotkey: str
     executor_id: str

--- a/neurons/validators/src/protocol/vc_protocol/validator_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/validator_requests.py
@@ -29,6 +29,12 @@ class RequestType(enum.Enum):
 
 class BaseValidatorRequest(BaseRequest):
     message_type: RequestType
+    # DAH-2792: delivery stamps, epoch seconds. sent_at is set where the message is produced
+    # (the validator for specs), forwarded_at and queue_depth by the connector right before
+    # ws.send(); compute-app turns the gaps into delay histograms. None on unstamped messages.
+    sent_at: float | None = None
+    forwarded_at: float | None = None
+    queue_depth: int | None = None
 
 
 class AuthenticationPayload(pydantic.BaseModel):
@@ -94,6 +100,9 @@ class ExecutorSpecRequest(BaseValidatorRequest):
     gpu_attestation_passed: bool | None = None
     # None = publisher did not report the field; [] = no catalogued reason was recorded.
     incentive_reasons: list[IncentiveReason] | None = None
+    # DAH-2792: specs published for this miner in this job_batch_id, so the backend can count
+    # expected against received and see a truncated cycle as a number, not as a dashboard dip.
+    batch_total: int | None = None
 
 
 class RentedMachineRequest(BaseValidatorRequest):

--- a/neurons/validators/src/protocol/vc_protocol/validator_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/validator_requests.py
@@ -9,6 +9,7 @@ import pydantic
 from datura.requests.base import BaseRequest
 
 from incentive.miner_incentive_log import IncentiveReason
+from payload_models.payloads import DeliveryStamps
 
 
 class RequestType(enum.Enum):
@@ -27,14 +28,8 @@ class RequestType(enum.Enum):
     EstimateResponse = "EstimateResponse"
 
 
-class BaseValidatorRequest(BaseRequest):
+class BaseValidatorRequest(BaseRequest, DeliveryStamps):
     message_type: RequestType
-    # DAH-2792: delivery stamps, epoch seconds. sent_at is set where the message is produced
-    # (the validator for specs), forwarded_at and queue_depth by the connector right before
-    # ws.send(); compute-app turns the gaps into delay histograms. None on unstamped messages.
-    sent_at: float | None = None
-    forwarded_at: float | None = None
-    queue_depth: int | None = None
 
 
 class AuthenticationPayload(pydantic.BaseModel):
@@ -100,8 +95,8 @@ class ExecutorSpecRequest(BaseValidatorRequest):
     gpu_attestation_passed: bool | None = None
     # None = publisher did not report the field; [] = no catalogued reason was recorded.
     incentive_reasons: list[IncentiveReason] | None = None
-    # DAH-2792: specs published for this miner in this job_batch_id, so the backend can count
-    # expected against received and see a truncated cycle as a number, not as a dashboard dip.
+    # DAH-2792: specs the validator scored for this miner in this job_batch_id, counting the ones
+    # whose redis publish failed; the backend reads expected minus received as lost on the websocket.
     batch_total: int | None = None
 
 

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -758,6 +758,7 @@ class MinerService:
                 extra=get_extra_info({**default_extra, "job_batch_id": results[0].job_batch_id, "results": len(results)}),
             ),
         )
+        batch_total = len(results)
         for result in results:
             try:
                 await self.redis_service.publish(
@@ -796,7 +797,7 @@ class MinerService:
                         "tdx_attestation_passed": result.tdx_attestation_passed,
                         "gpu_attestation_passed": result.gpu_attestation_passed,
                         "sent_at": time.time(),
-                        "batch_total": len(results),
+                        "batch_total": batch_total,
                     },
                 )
             except Exception as e:

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -795,6 +795,8 @@ class MinerService:
                         "tee_type": result.tee_type,
                         "tdx_attestation_passed": result.tdx_attestation_passed,
                         "gpu_attestation_passed": result.gpu_attestation_passed,
+                        "sent_at": time.time(),
+                        "batch_total": len(results),
                     },
                 )
             except Exception as e:

--- a/neurons/validators/tests/test_ws_delivery_stamps.py
+++ b/neurons/validators/tests/test_ws_delivery_stamps.py
@@ -9,6 +9,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import websockets
 from payload_models.payloads import ContainerCreated, DeliveryStamps
 
 from clients.compute_client import WS_PING_INTERVAL, WS_PING_TIMEOUT, ComputeClient
@@ -139,6 +140,29 @@ async def test_send_loop_stamps_container_responses_too() -> None:
     # Assert
     assert [message["message_type"] for message in sent] == ["ContainerCreated", "RentedMachineRequest"]
     assert [message["queue_depth"] for message in sent] == [1, 0]
+
+
+@pytest.mark.asyncio
+async def test_resent_message_is_stamped_again_by_the_retry() -> None:
+    # Arrange: the first attempt dies on a closed socket, tenacity sends the same object again
+    message = RentedMachineRequest()
+    client = _client()
+    stamps: list[float] = []
+
+    async def send(raw_message: str) -> None:
+        stamps.append(json.loads(raw_message)["forwarded_at"])
+        if len(stamps) == 1:
+            raise websockets.ConnectionClosedError(None, None)
+
+    client.ws = MagicMock(send=send)
+
+    # Act
+    with patch("clients.compute_client.time.time", side_effect=[100.0, 110.0]):
+        await client.send_model(message)
+
+    # Assert: the retry reports its own moment, not the first attempt's
+    assert stamps == [100.0, 110.0]
+    assert message.forwarded_at == 110.0
 
 
 def test_connect_sets_keepalive_ping_interval_and_timeout() -> None:

--- a/neurons/validators/tests/test_ws_delivery_stamps.py
+++ b/neurons/validators/tests/test_ws_delivery_stamps.py
@@ -1,0 +1,147 @@
+"""DAH-2792: the validator -> connector -> backend path carries delivery stamps so the backend
+can measure how long a message waited at each hop, and the connector opens the websocket with
+limits that survive a whole scoring cycle pushed in one burst.
+"""
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from clients.compute_client import WS_MAX_QUEUE, WS_PING_INTERVAL, WS_PING_TIMEOUT, ComputeClient
+from protocol.vc_protocol.validator_requests import ExecutorSpecRequest, RentedMachineRequest
+from services.miner_service import MinerService
+from services.redis_service import MACHINE_SPEC_CHANNEL
+
+pytest_plugins = ["fixtures.incentive_fixtures"]
+
+
+def _client(message_queue: list | None = None) -> ComputeClient:
+    client = ComputeClient.__new__(ComputeClient)
+    client.keypair = MagicMock(ss58_address="validator-hotkey")
+    client.lock = asyncio.Lock()
+    client.message_queue = message_queue or []
+    client.logging_extra = {"validator_hotkey": "validator-hotkey"}
+    client.compute_app_uri = "wss://backend.example/validator"
+    client.miner_service = MagicMock()
+    return client
+
+
+async def _bridge_machine_spec(payload: dict[str, Any]) -> ExecutorSpecRequest:
+    async def listen():
+        yield {"channel": MACHINE_SPEC_CHANNEL.encode(), "data": json.dumps(payload).encode()}
+        raise asyncio.CancelledError
+
+    pubsub = MagicMock(listen=listen, aclose=AsyncMock())
+    client = _client()
+    client.miner_service.redis_service.subscribe = AsyncMock(return_value=pubsub)
+    with pytest.raises(asyncio.CancelledError):
+        await client.subscribe_mesages_from_redis()
+    return client.message_queue[0]
+
+
+@pytest.mark.asyncio
+async def test_publisher_stamps_sent_at_and_batch_total(create_job_result, mock_settings) -> None:
+    # Arrange
+    jobs = [create_job_result(), create_job_result()]
+    redis_service = MagicMock()
+    redis_service.publish = AsyncMock()
+    service = MinerService(
+        ssh_service=MagicMock(),
+        task_service=MagicMock(),
+        redis_service=redis_service,
+        attestation_service=MagicMock(),
+    )
+
+    # Act
+    await service.publish_machine_specs(jobs, miner_hotkey="hk", miner_coldkey="ck")
+
+    # Assert
+    payloads = [call.args[1] for call in redis_service.publish.await_args_list]
+    assert [payload["batch_total"] for payload in payloads] == [2, 2]
+    assert all(isinstance(payload["sent_at"], float) for payload in payloads)
+
+
+@pytest.mark.asyncio
+async def test_bridge_carries_sent_at_and_batch_total(create_job_result, mock_settings) -> None:
+    # Arrange
+    redis_service = MagicMock()
+    redis_service.publish = AsyncMock()
+    service = MinerService(
+        ssh_service=MagicMock(),
+        task_service=MagicMock(),
+        redis_service=redis_service,
+        attestation_service=MagicMock(),
+    )
+    await service.publish_machine_specs([create_job_result()], miner_hotkey="hk", miner_coldkey="ck")
+    _, payload = redis_service.publish.await_args.args
+
+    # Act
+    spec = await _bridge_machine_spec(payload)
+
+    # Assert
+    assert spec.sent_at == payload["sent_at"]
+    assert spec.batch_total == 1
+
+
+@pytest.mark.asyncio
+async def test_bridge_tolerates_payload_without_stamps(create_job_result, mock_settings) -> None:
+    # Arrange
+    redis_service = MagicMock()
+    redis_service.publish = AsyncMock()
+    service = MinerService(
+        ssh_service=MagicMock(),
+        task_service=MagicMock(),
+        redis_service=redis_service,
+        attestation_service=MagicMock(),
+    )
+    await service.publish_machine_specs([create_job_result()], miner_hotkey="hk", miner_coldkey="ck")
+    _, payload = redis_service.publish.await_args.args
+    del payload["sent_at"]
+    del payload["batch_total"]
+
+    # Act
+    spec = await _bridge_machine_spec(payload)
+
+    # Assert
+    assert spec.sent_at is None
+    assert spec.batch_total is None
+
+
+@pytest.mark.asyncio
+async def test_send_loop_stamps_forwarded_at_and_messages_still_waiting_behind() -> None:
+    # Arrange
+    client = _client([RentedMachineRequest(), RentedMachineRequest()])
+    client.ws = MagicMock()
+    client.ws.send = AsyncMock()
+    task = asyncio.create_task(client.handle_send_messages())
+
+    # Act
+    while client.ws.send.await_count < 2:
+        await asyncio.sleep(0)
+    task.cancel()
+
+    # Assert
+    sent = [json.loads(call.args[0]) for call in client.ws.send.await_args_list]
+    assert [message["queue_depth"] for message in sent] == [1, 0]
+    assert all(isinstance(message["forwarded_at"], float) for message in sent)
+
+
+def test_connect_opens_the_socket_with_burst_sized_limits() -> None:
+    # Arrange
+    client = _client()
+
+    # Act
+    with patch("clients.compute_client.websockets.connect") as connect:
+        client.connect()
+
+    # Assert
+    connect.assert_called_once_with(
+        "wss://backend.example/validator",
+        max_queue=WS_MAX_QUEUE,
+        ping_interval=WS_PING_INTERVAL,
+        ping_timeout=WS_PING_TIMEOUT,
+    )
+    assert WS_MAX_QUEUE >= 1024
+    assert WS_PING_TIMEOUT > WS_PING_INTERVAL

--- a/neurons/validators/tests/test_ws_delivery_stamps.py
+++ b/neurons/validators/tests/test_ws_delivery_stamps.py
@@ -1,15 +1,17 @@
 """DAH-2792: the validator -> connector -> backend path carries delivery stamps so the backend
-can measure how long a message waited at each hop, and the connector opens the websocket with
-limits that survive a whole scoring cycle pushed in one burst.
+can measure how long a message waited at each hop, and the connector opens the websocket with a
+pong timeout long enough for the keepalive to survive a scoring-cycle burst.
 """
 import asyncio
 import json
+from collections.abc import AsyncIterator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from payload_models.payloads import ContainerCreated, DeliveryStamps
 
-from clients.compute_client import WS_MAX_QUEUE, WS_PING_INTERVAL, WS_PING_TIMEOUT, ComputeClient
+from clients.compute_client import WS_PING_INTERVAL, WS_PING_TIMEOUT, ComputeClient
 from protocol.vc_protocol.validator_requests import ExecutorSpecRequest, RentedMachineRequest
 from services.miner_service import MinerService
 from services.redis_service import MACHINE_SPEC_CHANNEL
@@ -17,7 +19,7 @@ from services.redis_service import MACHINE_SPEC_CHANNEL
 pytest_plugins = ["fixtures.incentive_fixtures"]
 
 
-def _client(message_queue: list | None = None) -> ComputeClient:
+def _client(message_queue: list[DeliveryStamps] | None = None) -> ComputeClient:
     client = ComputeClient.__new__(ComputeClient)
     client.keypair = MagicMock(ss58_address="validator-hotkey")
     client.lock = asyncio.Lock()
@@ -29,7 +31,7 @@ def _client(message_queue: list | None = None) -> ComputeClient:
 
 
 async def _bridge_machine_spec(payload: dict[str, Any]) -> ExecutorSpecRequest:
-    async def listen():
+    async def listen() -> AsyncIterator[dict[str, bytes]]:
         yield {"channel": MACHINE_SPEC_CHANNEL.encode(), "data": json.dumps(payload).encode()}
         raise asyncio.CancelledError
 
@@ -41,10 +43,7 @@ async def _bridge_machine_spec(payload: dict[str, Any]) -> ExecutorSpecRequest:
     return client.message_queue[0]
 
 
-@pytest.mark.asyncio
-async def test_publisher_stamps_sent_at_and_batch_total(create_job_result, mock_settings) -> None:
-    # Arrange
-    jobs = [create_job_result(), create_job_result()]
+async def _published_payloads(jobs: list[Any]) -> list[dict[str, Any]]:
     redis_service = MagicMock()
     redis_service.publish = AsyncMock()
     service = MinerService(
@@ -53,12 +52,19 @@ async def test_publisher_stamps_sent_at_and_batch_total(create_job_result, mock_
         redis_service=redis_service,
         attestation_service=MagicMock(),
     )
+    await service.publish_machine_specs(jobs, miner_hotkey="hk", miner_coldkey="ck")
+    return [call.args[1] for call in redis_service.publish.await_args_list]
+
+
+@pytest.mark.asyncio
+async def test_publisher_stamps_sent_at_and_batch_total(create_job_result, mock_settings) -> None:
+    # Arrange
+    jobs = [create_job_result(), create_job_result()]
 
     # Act
-    await service.publish_machine_specs(jobs, miner_hotkey="hk", miner_coldkey="ck")
+    payloads = await _published_payloads(jobs)
 
     # Assert
-    payloads = [call.args[1] for call in redis_service.publish.await_args_list]
     assert [payload["batch_total"] for payload in payloads] == [2, 2]
     assert all(isinstance(payload["sent_at"], float) for payload in payloads)
 
@@ -66,16 +72,7 @@ async def test_publisher_stamps_sent_at_and_batch_total(create_job_result, mock_
 @pytest.mark.asyncio
 async def test_bridge_carries_sent_at_and_batch_total(create_job_result, mock_settings) -> None:
     # Arrange
-    redis_service = MagicMock()
-    redis_service.publish = AsyncMock()
-    service = MinerService(
-        ssh_service=MagicMock(),
-        task_service=MagicMock(),
-        redis_service=redis_service,
-        attestation_service=MagicMock(),
-    )
-    await service.publish_machine_specs([create_job_result()], miner_hotkey="hk", miner_coldkey="ck")
-    _, payload = redis_service.publish.await_args.args
+    [payload] = await _published_payloads([create_job_result()])
 
     # Act
     spec = await _bridge_machine_spec(payload)
@@ -87,17 +84,8 @@ async def test_bridge_carries_sent_at_and_batch_total(create_job_result, mock_se
 
 @pytest.mark.asyncio
 async def test_bridge_tolerates_payload_without_stamps(create_job_result, mock_settings) -> None:
-    # Arrange
-    redis_service = MagicMock()
-    redis_service.publish = AsyncMock()
-    service = MinerService(
-        ssh_service=MagicMock(),
-        task_service=MagicMock(),
-        redis_service=redis_service,
-        attestation_service=MagicMock(),
-    )
-    await service.publish_machine_specs([create_job_result()], miner_hotkey="hk", miner_coldkey="ck")
-    _, payload = redis_service.publish.await_args.args
+    # Arrange: a validator from before DAH-2792 publishes no stamps
+    [payload] = await _published_payloads([create_job_result()])
     del payload["sent_at"]
     del payload["batch_total"]
 
@@ -109,26 +97,51 @@ async def test_bridge_tolerates_payload_without_stamps(create_job_result, mock_s
     assert spec.batch_total is None
 
 
+async def _drain_send_loop(client: ComputeClient, expected_sends: int) -> list[dict[str, Any]]:
+    # the loop never returns on its own; the mocked socket stops it after the expected sends
+    sent_messages: list[dict[str, Any]] = []
+
+    async def send(raw_message: str) -> None:
+        sent_messages.append(json.loads(raw_message))
+        if len(sent_messages) == expected_sends:
+            raise asyncio.CancelledError
+
+    client.ws = MagicMock(send=send)
+    with pytest.raises(asyncio.CancelledError):
+        await client.handle_send_messages()
+    return sent_messages
+
+
 @pytest.mark.asyncio
 async def test_send_loop_stamps_forwarded_at_and_messages_still_waiting_behind() -> None:
     # Arrange
     client = _client([RentedMachineRequest(), RentedMachineRequest()])
-    client.ws = MagicMock()
-    client.ws.send = AsyncMock()
-    task = asyncio.create_task(client.handle_send_messages())
 
     # Act
-    while client.ws.send.await_count < 2:
-        await asyncio.sleep(0)
-    task.cancel()
+    sent = await _drain_send_loop(client, expected_sends=2)
 
     # Assert
-    sent = [json.loads(call.args[0]) for call in client.ws.send.await_args_list]
     assert [message["queue_depth"] for message in sent] == [1, 0]
     assert all(isinstance(message["forwarded_at"], float) for message in sent)
 
 
-def test_connect_opens_the_socket_with_burst_sized_limits() -> None:
+@pytest.mark.asyncio
+async def test_send_loop_stamps_container_responses_too() -> None:
+    # Arrange: the queue mixes container responses (payload_models) with validator requests
+    container_created = ContainerCreated(
+        miner_hotkey="hk", executor_id="ex", pod_id="pod", container_name="c", volume_name="v", port_maps=[]
+    )
+    client = _client([container_created, RentedMachineRequest()])
+
+    # Act
+    sent = await _drain_send_loop(client, expected_sends=2)
+
+    # Assert
+    assert [message["message_type"] for message in sent] == ["ContainerCreated", "RentedMachineRequest"]
+    assert [message["queue_depth"] for message in sent] == [1, 0]
+
+
+def test_connect_sets_keepalive_ping_interval_and_timeout() -> None:
     # Arrange
     client = _client()
 
@@ -139,9 +152,6 @@ def test_connect_opens_the_socket_with_burst_sized_limits() -> None:
     # Assert
     connect.assert_called_once_with(
         "wss://backend.example/validator",
-        max_queue=WS_MAX_QUEUE,
         ping_interval=WS_PING_INTERVAL,
         ping_timeout=WS_PING_TIMEOUT,
     )
-    assert WS_MAX_QUEUE >= 1024
-    assert WS_PING_TIMEOUT > WS_PING_INTERVAL


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2792](https://app.notion.com/p/Validator-spec-stream-drops-on-websocket-keepalive-timeout-3cab8bfdbde98150b3ece3852fcdd56c)

---

## Problem

The connector pushes a whole scoring cycle (~550 `ExecutorSpecRequest`, ~4 MB) to compute-app over one websocket in a single burst. compute-app drains it one message at a time (`receive_text` → `celery.delay` per spec): 7–16 s in normal conditions, 20–27 s when the backend is congested.

Both ends run the `websockets` keepalive with library defaults: ping every 20 s, pong expected within 20 s. compute-app stops reading the socket once 32 unconsumed messages sit in its queue (uvicorn `ws_max_queue`), so our ping frame waits unread behind the burst. When the drain takes longer than 20 s the connector closes the socket with `1011 keepalive ping timeout` and the rest of the cycle is never re-sent: `prod_executors` got 215 rows out of 551 for `job_batch_id 2026-08-27 08:41:12`, the GPU inventory dashboard dips, and executors in the lost tail keep a stale `updated_at`.

2026-08-26..28 on prod: 53 connector disconnects, 25 keepalive timeouts, 15 of them truncated a cycle. Full analysis lives in the lium workspace: `untracked/epics/executor-health/spec-stream-loss-2026-08.md`.

Nothing on either side measured this; the only trace was the free-text close reason in one log line.

## Solution

1. Open the socket with `ping_interval=20`, `ping_timeout=40` (`WS_PING_*` in `compute_client.py`, mirrored by `LiumUvicornWorker` on the backend). The client's own `max_queue` only bounds the small backend → connector direction, so it stays at the library default; the burst itself is held by `ws_max_queue=1024` on the backend.
2. Stamp every message so the backend can measure where it waited:
   - `sent_at` — set by the validator when it publishes a spec to redis (`miner_service.publish_machine_specs`);
   - `forwarded_at`, `queue_depth` — set by the connector right before `ws.send()`, `queue_depth` = messages still waiting behind this one in `message_queue`;
   - `batch_total` on `ExecutorSpecRequest` — specs scored for this miner in this `job_batch_id` (a failed redis publish still counts), so the backend can count expected vs received.

The stamps live in a `DeliveryStamps` mixin on both `BaseValidatorRequest` (protocol) and `BaseValidatorResponse` (payload_models): the send loop stamps everything it pops, and `message_queue` also carries container responses (`ContainerCreated`, `SshPubKeyAdded`, …). A stamp on a model without the field is a pydantic `ValueError` outside the loop's `try`, which would kill the send task silently — `message_queue: list[DeliveryStamps]` declares the invariant.

All fields are optional and additive; both sides ignore unknown fields (pydantic v2 default), so the two PRs can ship in any order.

## Changes

- `clients/compute_client.py`: `WS_PING_INTERVAL`/`WS_PING_TIMEOUT` passed to `websockets.connect`; bridge carries `sent_at`/`batch_total` from the redis payload; send loop stamps `forwarded_at`/`queue_depth`; `message_queue` typed as `list[DeliveryStamps]`.
- `payload_models/payloads.py`: `DeliveryStamps` mixin (`sent_at`, `forwarded_at`, `queue_depth`), mixed into `BaseValidatorResponse`.
- `protocol/vc_protocol/validator_requests.py`: `BaseValidatorRequest` mixes in `DeliveryStamps`; `batch_total` on `ExecutorSpecRequest`.
- `services/miner_service.py`: publish payload gets `sent_at` and `batch_total`.
- `tests/test_ws_delivery_stamps.py`: publisher stamps, bridge round trip (with and without stamps), send loop stamps requests and container responses alike, connect kwargs.

## Deployment Steps

Use GitHub Action (validator release flow). Order does not matter relative to the backend PR: an old backend ignores the new fields, a new backend records nothing for unstamped messages. The keepalive fix that matters most is the backend `ws_max_queue`; this side only raises its own tolerance.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

- compute-app: Datura-ai/lium-io-backend#981 — `ws_max_queue`/`ping_timeout` on the gunicorn worker, prometheus series from the stamps.

## Risks

- `ping_timeout=40` means a genuinely dead peer is detected in up to 60 s instead of 40 s. Container requests wait that much longer before the reconnect loop kicks in.
- New fields ride on every message type via `DeliveryStamps`; `AuthenticateRequest` signing is unaffected (it signs `payload` only, test-covered by the existing auth tests).
- `forwarded_at` is stamped once before `send_model`, whose tenacity retries (up to 3 on `ConnectionClosed`) keep the first stamp — a retried message reports the delay of its first attempt.
- Not in this PR: only specs get `sent_at`, so the `queue` stage exists only for them; container responses stuck behind a burst show up in `transport` only. A single `enqueue()` stamping `sent_at` for every queued message is the follow-up.

## Test Cases

### Test Case 1

**Actions**

`cd neurons/validators && pdm run pytest tests/test_ws_delivery_stamps.py`

**Expected Output**

6 passed: publisher writes `sent_at`/`batch_total`, the bridge carries them (and tolerates their absence), the send loop stamps `forwarded_at` with `queue_depth` = messages left behind it for validator requests and for container responses, `connect()` passes the keepalive limits.

### Test Case 2

**Actions**

Full suite `pdm run pytest --ignore=tests/prod_snapshot` plus `pdm run pytest tests/prod_snapshot/`.

**Expected Output**

1800 passed, 15 skipped with `tests/test_sshd_bootstrap_script.py` deselected — its 3 failures (`watchdog_spawned()`, macOS bootstrap harness) reproduce on `origin/main` on this machine, unrelated.

## Checklist

- [ ] Proper labels added — `ready-review` / `require-qa` / `breaking-changes` do not exist in `Datura-ai/lium-io`
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
